### PR TITLE
Add tests for diagnosing dependency errors in the `driver` package. I…

### DIFF
--- a/internal/driver/diagnose_test.go
+++ b/internal/driver/diagnose_test.go
@@ -1,0 +1,39 @@
+package driver
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"surge/internal/diag"
+)
+
+func TestDiagnose_NoDependencyErrorForCleanImport(t *testing.T) {
+	opts := DiagnoseOptions{
+		Stage:          DiagnoseStageSyntax,
+		MaxDiagnostics: 10,
+	}
+
+	origWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	defer func() { _ = os.Chdir(origWD) }()
+
+	if err := os.Chdir(filepath.Join("..", "..")); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	path := filepath.Join("testdata", "test_fixes", "empty_import_group.sg")
+
+	res, err := DiagnoseWithOptions(path, opts)
+	if err != nil {
+		t.Fatalf("DiagnoseWithOptions error: %v", err)
+	}
+
+	for _, d := range res.Bag.Items() {
+		if d.Code == diag.ProjDependencyFailed {
+			t.Fatalf("unexpected dependency failure diagnostic: %+v", d)
+		}
+	}
+}

--- a/internal/driver/project.go
+++ b/internal/driver/project.go
@@ -25,14 +25,21 @@ func buildModuleMeta(
 	fileSpan := fileNode.Span
 	srcFile := fs.Get(fileSpan.File)
 
-	fullModulePath, err := project.NormalizeModulePath(srcFile.Path)
+	modulePath := srcFile.Path
+	if baseDir != "" {
+		if rel, err := source.RelativePath(modulePath, baseDir); err == nil {
+			modulePath = rel
+		}
+	}
+
+	fullModulePath, err := project.NormalizeModulePath(modulePath)
 	if err != nil {
 		if reporter != nil {
 			reporter.Report(
 				diag.ProjInvalidModulePath,
 				diag.SevError,
 				fileSpan,
-				fmt.Sprintf("invalid module path %q: %v", srcFile.Path, err),
+				fmt.Sprintf("invalid module path %q: %v", modulePath, err),
 				nil,
 				nil,
 			)

--- a/internal/project/modulemeta.go
+++ b/internal/project/modulemeta.go
@@ -28,6 +28,9 @@ func NormalizeModulePath(path string) (string, error) {
 	if len(path) >= len(ext) && path[len(path)-len(ext):] == ext {
 		path = path[:len(path)-len(ext)]
 	}
+	for len(path) > 0 && (path[0] == '/' || path[0] == '\\') {
+		path = path[1:]
+	}
 	// filepath.Clean нормализует слэши и убирает ./, ../, но нам нужно проверить сегменты
 	// Разделяем путь на сегменты
 	cleaned := []string{}

--- a/testdata/test_fixes/empty_import_group.sg
+++ b/testdata/test_fixes/empty_import_group.sg
@@ -1,1 +1,1 @@
-import foo; // surge fix должен заменить '::{}' на ''
+import foo::{}; // surge fix должен заменить '::{}' на ''


### PR DESCRIPTION
…mplement `TestDiagnose_NoDependencyErrorForCleanImport` to validate that no dependency failure diagnostics are reported for clean imports. Update the `project` package to improve module path normalization by handling leading slashes. Modify the `empty_import_group.sg` test data to reflect the expected syntax for imports. This enhances the reliability of diagnostic reporting and ensures comprehensive test coverage for import scenarios.