### PR TITLE
Refine function parsing and AST data structures

### DIFF
--- a/internal/ast/attr.go
+++ b/internal/ast/attr.go
@@ -1,0 +1,10 @@
+package ast
+
+import "surge/internal/source"
+
+// Attr описывает пользовательский атрибут вида `@name(args...)`.
+type Attr struct {
+	Name source.StringID
+	Args []ExprID
+	Span source.Span
+}

--- a/internal/ast/builder.go
+++ b/internal/ast/builder.go
@@ -77,11 +77,13 @@ func (b *Builder) NewFnParam(name source.StringID, typ TypeID, def ExprID) FnPar
 
 func (b *Builder) NewFn(
 	name source.StringID,
+	generics []source.StringID,
 	params []FnParam,
 	returnType TypeID,
 	body StmtID,
-	attr FnAttr,
+	flags FnAttr,
+	attrs []Attr,
 	span source.Span,
 ) ItemID {
-	return b.Items.NewFn(name, params, returnType, body, attr, span)
+	return b.Items.NewFn(name, generics, params, returnType, body, flags, attrs, span)
 }

--- a/internal/ast/ids.go
+++ b/internal/ast/ids.go
@@ -8,24 +8,27 @@ type (
 	ExprID uint32
 	TypeID uint32
 	// подсущности
-	PayloadID  uint32
-	FnParamID  uint32
+	PayloadID uint32
+	FnParamID uint32
+	AttrID    uint32
 )
 
 const (
-	NoFileID     FileID     = 0
-	NoItemID     ItemID     = 0
-	NoStmtID     StmtID     = 0
-	NoExprID     ExprID     = 0
-	NoTypeID     TypeID     = 0
-	NoPayloadID  PayloadID  = 0
-	NoFnParamID  FnParamID  = 0
+	NoFileID    FileID    = 0
+	NoItemID    ItemID    = 0
+	NoStmtID    StmtID    = 0
+	NoExprID    ExprID    = 0
+	NoTypeID    TypeID    = 0
+	NoPayloadID PayloadID = 0
+	NoFnParamID FnParamID = 0
+	NoAttrID    AttrID    = 0
 )
 
-func (id FileID) IsValid() bool     { return id != NoFileID }
-func (id ItemID) IsValid() bool     { return id != NoItemID }
-func (id StmtID) IsValid() bool     { return id != NoStmtID }
-func (id ExprID) IsValid() bool     { return id != NoExprID }
-func (id TypeID) IsValid() bool     { return id != NoTypeID }
-func (id PayloadID) IsValid() bool  { return id != NoPayloadID }
-func (id FnParamID) IsValid() bool  { return id != NoFnParamID }
+func (id FileID) IsValid() bool    { return id != NoFileID }
+func (id ItemID) IsValid() bool    { return id != NoItemID }
+func (id StmtID) IsValid() bool    { return id != NoStmtID }
+func (id ExprID) IsValid() bool    { return id != NoExprID }
+func (id TypeID) IsValid() bool    { return id != NoTypeID }
+func (id PayloadID) IsValid() bool { return id != NoPayloadID }
+func (id FnParamID) IsValid() bool { return id != NoFnParamID }
+func (id AttrID) IsValid() bool    { return id != NoAttrID }

--- a/internal/ast/item.go
+++ b/internal/ast/item.go
@@ -31,6 +31,7 @@ type Items struct {
 	Imports  *Arena[ImportItem]
 	Fns      *Arena[FnItem]
 	FnParams *Arena[FnParam]
+	Attrs    *Arena[Attr]
 	Lets     *Arena[LetItem]
 }
 
@@ -43,6 +44,7 @@ func NewItems(capHint uint) *Items {
 		Imports:  NewArena[ImportItem](capHint),
 		Fns:      NewArena[FnItem](capHint),
 		FnParams: NewArena[FnParam](capHint),
+		Attrs:    NewArena[Attr](capHint),
 		Lets:     NewArena[LetItem](capHint),
 	}
 }

--- a/internal/parser/import.go
+++ b/internal/parser/import.go
@@ -291,7 +291,7 @@ func (p *Parser) parseImportItem() (ast.ItemID, bool) {
 			return ast.NoItemID, false
 		}
 
-		_, ok := p.parseIdent()
+		moduleAlias, ok = p.parseIdent()
 		if !ok {
 			p.resyncStatement()
 			return ast.NoItemID, false


### PR DESCRIPTION
## Summary
- extend function AST payloads with slots for generic parameters and attribute ranges
- rework the function parser to parse generics, require parameter type annotations, and tighten delimiter handling
- fix import alias parsing so module-level aliases are preserved

## Testing
- ./check_file_sizes.sh
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68fa27b071c48321b1283f5a1d5c0bdd