### PR TITLE
Add preview mode to fix command

### DIFF
--- a/cmd/surge/fix.go
+++ b/cmd/surge/fix.go
@@ -4,6 +4,7 @@ package main
 // флаг --interactive/--tui включает интерактивный режим замен
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -27,6 +28,8 @@ func init() {
 	fixCmd.Flags().Bool("all", false, "apply all safe fixes")
 	fixCmd.Flags().Bool("once", false, "apply the first available fix (default)")
 	fixCmd.Flags().String("id", "", "apply fix with a specific identifier")
+	fixCmd.Flags().Bool("preview", false, "preview changes without modifying files")
+	fixCmd.Flags().String("format", "pretty", "preview output format (pretty|json)")
 }
 
 func runFix(cmd *cobra.Command, args []string) error {
@@ -43,6 +46,20 @@ func runFix(cmd *cobra.Command, args []string) error {
 	targetID, err := cmd.Flags().GetString("id")
 	if err != nil {
 		return err
+	}
+	preview, err := cmd.Flags().GetBool("preview")
+	if err != nil {
+		return err
+	}
+	previewFormat, err := cmd.Flags().GetString("format")
+	if err != nil {
+		return err
+	}
+	if !preview && previewFormat != "pretty" {
+		return fmt.Errorf("--format is only supported in preview mode")
+	}
+	if preview && previewFormat != "pretty" && previewFormat != "json" {
+		return fmt.Errorf("unknown preview format: %s", previewFormat)
 	}
 
 	if targetID != "" && (applyAll || applyOnceFlag) {
@@ -61,6 +78,7 @@ func runFix(cmd *cobra.Command, args []string) error {
 	opts := fix.ApplyOptions{
 		Mode:     mode,
 		TargetID: targetID,
+		Preview:  preview,
 	}
 
 	maxDiagnostics, err := cmd.Root().PersistentFlags().GetInt("max-diagnostics")
@@ -85,12 +103,12 @@ func runFix(cmd *cobra.Command, args []string) error {
 	}
 
 	if !info.IsDir() {
-		return runFixFile(targetPath, driverOpts, opts)
+		return runFixFile(targetPath, driverOpts, opts, preview, previewFormat)
 	}
-	return runFixDir(cmd, targetPath, driverOpts, opts)
+	return runFixDir(cmd, targetPath, driverOpts, opts, preview, previewFormat)
 }
 
-func runFixFile(path string, driverOpts driver.DiagnoseOptions, opts fix.ApplyOptions) error {
+func runFixFile(path string, driverOpts driver.DiagnoseOptions, opts fix.ApplyOptions, preview bool, format string) error {
 	result, err := driver.DiagnoseWithOptions(path, driverOpts)
 	if err != nil {
 		return fmt.Errorf("fix: diagnose failed: %w", err)
@@ -101,10 +119,10 @@ func runFixFile(path string, driverOpts driver.DiagnoseOptions, opts fix.ApplyOp
 		diagnostics = append(diagnostics, result.Bag.Items()...)
 	}
 	res, applyErr := fix.Apply(result.FileSet, diagnostics, opts)
-	return handleApplyResult(res, applyErr)
+	return handleApplyResult(res, applyErr, preview, format)
 }
 
-func runFixDir(cmd *cobra.Command, path string, driverOpts driver.DiagnoseOptions, opts fix.ApplyOptions) error {
+func runFixDir(cmd *cobra.Command, path string, driverOpts driver.DiagnoseOptions, opts fix.ApplyOptions, preview bool, format string) error {
 	fs, results, err := driver.DiagnoseDirWithOptions(cmd.Context(), path, driverOpts, 0)
 	if err != nil {
 		return fmt.Errorf("fix: diagnose dir failed: %w", err)
@@ -120,12 +138,16 @@ func runFixDir(cmd *cobra.Command, path string, driverOpts driver.DiagnoseOption
 	}
 
 	res, applyErr := fix.Apply(fs, allDiagnostics, opts)
-	return handleApplyResult(res, applyErr)
+	return handleApplyResult(res, applyErr, preview, format)
 }
 
-func handleApplyResult(res *fix.ApplyResult, applyErr error) error {
+func handleApplyResult(res *fix.ApplyResult, applyErr error, preview bool, format string) error {
 	if res == nil {
 		return applyErr
+	}
+
+	if preview {
+		return handlePreviewResult(res, applyErr, format)
 	}
 
 	if len(res.Applied) > 0 {
@@ -181,4 +203,216 @@ func handleApplyResult(res *fix.ApplyResult, applyErr error) error {
 		fmt.Fprintln(os.Stdout, "No fixes applied.")
 	}
 	return nil
+}
+
+func handlePreviewResult(res *fix.ApplyResult, applyErr error, format string) error {
+	switch format {
+	case "json":
+		return handlePreviewJSON(res, applyErr)
+	default:
+		return handlePreviewPretty(res, applyErr)
+	}
+}
+
+func handlePreviewPretty(res *fix.ApplyResult, applyErr error) error {
+	if errors.Is(applyErr, fix.ErrNoFixes) && len(res.Applied) == 0 {
+		fmt.Fprintln(os.Stdout, "No applicable fixes found.")
+		return nil
+	}
+	if applyErr != nil {
+		return applyErr
+	}
+
+	if len(res.Applied) == 0 {
+		fmt.Fprintln(os.Stdout, "No fixes selected for preview.")
+		fmt.Fprintln(os.Stdout, "No files were modified (preview mode).")
+	} else {
+		fmt.Fprintf(os.Stdout, "Previewing %d fix(es):\n", len(res.Applied))
+		for _, item := range res.Applied {
+			location := item.PrimaryPath
+			if location == "" {
+				location = "(unknown location)"
+			}
+			fmt.Fprintf(
+				os.Stdout,
+				"  %s [%s] — %s (%d edits, %s)\n",
+				item.Title,
+				item.ID,
+				location,
+				item.EditCount,
+				item.Applicability.String(),
+			)
+			if len(item.Previews) == 0 {
+				fmt.Fprintln(os.Stdout, "    (no preview available)")
+				continue
+			}
+			for _, h := range item.Previews {
+				fmt.Fprintf(
+					os.Stdout,
+					"    @@ %s:%d-%d ⇒ %d-%d @@\n",
+					h.Path,
+					h.Before.StartLine,
+					h.Before.EndLine,
+					h.After.StartLine,
+					h.After.EndLine,
+				)
+				fmt.Fprintln(os.Stdout, "    --- before ---")
+				if len(h.Before.Lines) == 0 {
+					fmt.Fprintln(os.Stdout, "    -")
+				} else {
+					for _, line := range h.Before.Lines {
+						fmt.Fprintf(os.Stdout, "    - %s\n", line)
+					}
+				}
+				fmt.Fprintln(os.Stdout, "    +++ after +++")
+				if len(h.After.Lines) == 0 {
+					fmt.Fprintln(os.Stdout, "    +")
+				} else {
+					for _, line := range h.After.Lines {
+						fmt.Fprintf(os.Stdout, "    + %s\n", line)
+					}
+				}
+				fmt.Fprintln(os.Stdout)
+			}
+		}
+		if len(res.FileChanges) > 0 {
+			fmt.Fprintln(os.Stdout, "Files that would change:")
+			for _, change := range res.FileChanges {
+				fmt.Fprintf(os.Stdout, "  %s (%d edits)\n", change.Path, change.EditCount)
+			}
+		}
+		fmt.Fprintln(os.Stdout, "No files were modified (preview mode).")
+	}
+
+	if len(res.Skipped) > 0 {
+		fmt.Fprintln(os.Stdout, "Skipped fixes:")
+		for _, skip := range res.Skipped {
+			id := skip.ID
+			if id == "" {
+				id = "(unnamed)"
+			}
+			if skip.Title != "" {
+				fmt.Fprintf(os.Stdout, "  %s [%s]: %s\n", skip.Title, id, skip.Reason)
+			} else {
+				fmt.Fprintf(os.Stdout, "  [%s]: %s\n", id, skip.Reason)
+			}
+		}
+	}
+	return nil
+}
+
+func handlePreviewJSON(res *fix.ApplyResult, applyErr error) error {
+	status := "ok"
+	var errMsg string
+	if errors.Is(applyErr, fix.ErrNoFixes) && len(res.Applied) == 0 {
+		status = "no_fixes"
+	} else if applyErr != nil {
+		status = "error"
+		errMsg = applyErr.Error()
+	}
+
+	output := previewOutput{
+		Status:      status,
+		Applied:     make([]appliedPreviewJSON, 0, len(res.Applied)),
+		Skipped:     make([]skippedPreviewJSON, 0, len(res.Skipped)),
+		FileChanges: make([]fileChangePreviewJSON, 0, len(res.FileChanges)),
+		Error:       errMsg,
+	}
+
+	for _, item := range res.Applied {
+		previewItem := appliedPreviewJSON{
+			ID:            item.ID,
+			Title:         item.Title,
+			Code:          item.Code.ID(),
+			Message:       item.Message,
+			Applicability: item.Applicability.String(),
+			PrimaryPath:   item.PrimaryPath,
+			EditCount:     item.EditCount,
+			Previews:      make([]previewHunkJSON, 0, len(item.Previews)),
+		}
+		for _, h := range item.Previews {
+			previewItem.Previews = append(previewItem.Previews, previewHunkJSON{
+				Path: h.Path,
+				Before: previewRangeJSON{
+					StartLine: h.Before.StartLine,
+					EndLine:   h.Before.EndLine,
+					Lines:     append([]string(nil), h.Before.Lines...),
+				},
+				After: previewRangeJSON{
+					StartLine: h.After.StartLine,
+					EndLine:   h.After.EndLine,
+					Lines:     append([]string(nil), h.After.Lines...),
+				},
+			})
+		}
+		output.Applied = append(output.Applied, previewItem)
+	}
+
+	for _, skip := range res.Skipped {
+		output.Skipped = append(output.Skipped, skippedPreviewJSON{
+			ID:     skip.ID,
+			Title:  skip.Title,
+			Reason: skip.Reason,
+		})
+	}
+
+	for _, change := range res.FileChanges {
+		output.FileChanges = append(output.FileChanges, fileChangePreviewJSON{
+			Path:      change.Path,
+			EditCount: change.EditCount,
+		})
+	}
+
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(output); err != nil {
+		return err
+	}
+
+	if applyErr != nil && !errors.Is(applyErr, fix.ErrNoFixes) {
+		return applyErr
+	}
+	return nil
+}
+
+type previewOutput struct {
+	Status      string                  `json:"status"`
+	Applied     []appliedPreviewJSON    `json:"applied"`
+	Skipped     []skippedPreviewJSON    `json:"skipped"`
+	FileChanges []fileChangePreviewJSON `json:"file_changes"`
+	Error       string                  `json:"error,omitempty"`
+}
+
+type appliedPreviewJSON struct {
+	ID            string            `json:"id"`
+	Title         string            `json:"title"`
+	Code          string            `json:"code"`
+	Message       string            `json:"message"`
+	Applicability string            `json:"applicability"`
+	PrimaryPath   string            `json:"primary_path"`
+	EditCount     int               `json:"edit_count"`
+	Previews      []previewHunkJSON `json:"previews"`
+}
+
+type skippedPreviewJSON struct {
+	ID     string `json:"id,omitempty"`
+	Title  string `json:"title,omitempty"`
+	Reason string `json:"reason"`
+}
+
+type fileChangePreviewJSON struct {
+	Path      string `json:"path"`
+	EditCount int    `json:"edit_count"`
+}
+
+type previewHunkJSON struct {
+	Path   string           `json:"path"`
+	Before previewRangeJSON `json:"before"`
+	After  previewRangeJSON `json:"after"`
+}
+
+type previewRangeJSON struct {
+	StartLine uint32   `json:"start_line"`
+	EndLine   uint32   `json:"end_line"`
+	Lines     []string `json:"lines"`
 }


### PR DESCRIPTION
## Summary
- add --preview and --format flags to the fix CLI command and render diff-style output for pretty and JSON modes
- extend the fix engine to collect before/after previews while avoiding file writes in preview mode

## Testing
- go test ./...
- ./check_file_sizes.sh

------
https://chatgpt.com/codex/tasks/task_e_68fbbae2e4a08321988b59364e99dfac

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--preview` flag to view proposed changes before applying fixes
  * Added `--format` flag to output previews in either 'pretty' (human-readable) or 'json' (structured) format
  * Preview mode operates without modifying files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->