### PR TITLE
Add AST and parser support for postfix await expressions

### DIFF
--- a/internal/diagfmt/ast_expr.go
+++ b/internal/diagfmt/ast_expr.go
@@ -127,6 +127,14 @@ func formatExprInlineDepth(builder *ast.Builder, exprID ast.ExprID, depth int) s
 			field = builder.StringsInterner.MustLookup(data.Field)
 		}
 		return fmt.Sprintf("%s.%s", target, field)
+	case ast.ExprAwait:
+		data, ok := builder.Exprs.Await(exprID)
+		if !ok {
+			return "<invalid-await>"
+		}
+		target := formatExprInlineDepth(builder, data.Value, depth+1)
+		target = wrapExprIfNeeded(builder, data.Value, target)
+		return target + ".await"
 	case ast.ExprGroup:
 		data, ok := builder.Exprs.Group(exprID)
 		if !ok {


### PR DESCRIPTION
## Summary
- add a dedicated `ExprAwait` AST node with arena storage
- parse `.await` in the postfix expression loop and update diagnostics/formatters
- cover await chaining and error cases with parser tests

## Testing
- go test ./...
- make lint (fails: unable to download golangci-lint)
- ./check_file_sizes.sh


------
https://chatgpt.com/codex/tasks/task_e_6904a24a0af483219b03b98a715d3dcb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for await expressions, enabling users to apply `.await` syntax to asynchronous operations.
  * Implemented proper formatting and display of await expressions in output.

* **Tests**
  * Added comprehensive test coverage for await expression parsing, error scenarios, and postfix patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->