### PR TITLE
Fix parser recovery loops to keep fuzzers responsive

### DIFF
--- a/internal/parser/helpers.go
+++ b/internal/parser/helpers.go
@@ -236,6 +236,9 @@ func (p *Parser) resyncStatement() {
 				break
 			}
 			if parenDepth == 0 && bracketDepth == 0 {
+				if !p.at(token.EOF) {
+					p.advance()
+				}
 				return
 			}
 		case token.LParen:
@@ -246,6 +249,9 @@ func (p *Parser) resyncStatement() {
 				break
 			}
 			if braceDepth == 0 && bracketDepth == 0 {
+				if !p.at(token.EOF) {
+					p.advance()
+				}
 				return
 			}
 		case token.LBracket:
@@ -256,6 +262,9 @@ func (p *Parser) resyncStatement() {
 				break
 			}
 			if braceDepth == 0 && parenDepth == 0 {
+				if !p.at(token.EOF) {
+					p.advance()
+				}
 				return
 			}
 		default:


### PR DESCRIPTION
## Summary
- ensure the top-level parser loop always consumes tokens when a malformed item prevents progress
- consume stray closing delimiters during statement resynchronization to avoid getting stuck in blocks

## Testing
- go test ./internal/fuzz -run=FuzzParserBuildsAST -count=1 -timeout=30s
- go test ./internal/fuzz -run=FuzzLexerTokens -count=1 -timeout=30s

------
https://chatgpt.com/codex/tasks/task_e_69050051c22883218c89c7c32f3d9231