### PR TITLE
Prevent overriding core intrinsic extern methods

### DIFF
--- a/internal/symbols/resolve_declarations.go
+++ b/internal/symbols/resolve_declarations.go
@@ -286,8 +286,12 @@ func (fr *fileResolver) declareFunctionWithAttrs(fnItem *ast.FnItem, span, keywo
 			}
 			// Разрешаем объявлять функции поверх предлюдов/импортов из core,
 			// чтобы они не требовали @override и не блокировали stdlib.
+			// Встроенные символы (в том числе методы из core/intrinsics) остаются,
+			// чтобы предотвратить их переопределение или дублирование.
 			if sym.Flags&SymbolFlagImported != 0 && sym.Decl.ASTFile == 0 {
-				continue
+				if sym.Flags&SymbolFlagBuiltin == 0 || sym.Flags&SymbolFlagMethod == 0 || !isCoreIntrinsicsModule(sym.ModulePath) {
+					continue
+				}
 			}
 			filtered = append(filtered, id)
 		}


### PR DESCRIPTION
## Summary
- ensure imported builtin methods from core/intrinsics are considered when checking for duplicate declarations
- add resolve tests covering duplicate and override attempts for intrinsic extern methods

## Testing
- SURGE_STDLIB=/workspace/surge go test ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924bea549548321952bb526dab30fdd)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved symbol resolution logic to more accurately distinguish and preserve imported built-in and method symbols from core intrinsics, reducing scenarios where these symbols could be unintentionally overridden or duplicated.

* **Tests**
  * Added comprehensive test coverage for built-in intrinsic method resolution and override prevention scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->