### PR TITLE
Handle wildcard identifier bindings

### DIFF
--- a/internal/diag/codes.go
+++ b/internal/diag/codes.go
@@ -113,6 +113,8 @@ const (
 	SemaExternUnknownAttr          Code = 3045
 	SemaNoOverload                 Code = 3046
 	SemaAmbiguousOverload          Code = 3047
+	SemaWildcardValue              Code = 3048
+	SemaWildcardMut                Code = 3049
 
 	// Ошибки I/O
 	IOLoadFileError Code = 4001
@@ -230,6 +232,8 @@ var ( // todo расширить описания и использовать к
 		SemaExternUnknownAttr:          "Unsupported extern attribute",
 		SemaNoOverload:                 "No matching overload found",
 		SemaAmbiguousOverload:          "Ambiguous overload resolution",
+		SemaWildcardValue:              "Wildcard used as value",
+		SemaWildcardMut:                "Wildcard mutability",
 		IOLoadFileError:                "I/O load file error",
 		ProjInfo:                       "Project information",
 		ProjDuplicateModule:            "Duplicate module definition",

--- a/internal/parser/expression.go
+++ b/internal/parser/expression.go
@@ -261,7 +261,7 @@ func (p *Parser) parsePostfixExpr() (ast.ExprID, bool) {
 // parsePrimaryExpr парсит основные (атомарные) выражения
 func (p *Parser) parsePrimaryExpr() (ast.ExprID, bool) {
 	switch p.lx.Peek().Kind {
-	case token.Ident:
+	case token.Ident, token.Underscore:
 		return p.parseIdentOrStructLiteral()
 
 	case token.IntLit, token.UintLit, token.FloatLit:

--- a/internal/parser/expression_base_parsers.go
+++ b/internal/parser/expression_base_parsers.go
@@ -14,12 +14,12 @@ import (
 // parseIdentOrStructLiteral parses either a plain identifier expression or a typed struct literal.
 func (p *Parser) parseIdentOrStructLiteral() (ast.ExprID, bool) {
 	tok := p.advance()
-	if tok.Kind != token.Ident {
+	if tok.Kind != token.Ident && tok.Kind != token.Underscore {
 		p.err(diag.SynExpectIdentifier, "expected identifier")
 		return ast.NoExprID, false
 	}
 	nameID := p.arenas.StringsInterner.Intern(tok.Text)
-	if p.isTypeLiteralName(tok.Text) && p.at(token.LBrace) {
+	if tok.Kind == token.Ident && p.isTypeLiteralName(tok.Text) && p.at(token.LBrace) {
 		segments := []ast.TypePathSegment{{
 			Name:     nameID,
 			Generics: nil,

--- a/internal/sema/binding_types.go
+++ b/internal/sema/binding_types.go
@@ -42,7 +42,7 @@ func (tc *typeChecker) registerFnParamTypes(fnID ast.ItemID, fnItem *ast.FnItem)
 	paramIDs := tc.builder.Items.GetFnParamIDs(fnItem)
 	for _, pid := range paramIDs {
 		param := tc.builder.Items.FnParam(pid)
-		if param == nil || param.Name == source.NoStringID {
+		if param == nil || param.Name == source.NoStringID || tc.isWildcardName(param.Name) {
 			continue
 		}
 		paramType := tc.resolveTypeExprWithScope(param.Type, scope)
@@ -51,6 +51,10 @@ func (tc *typeChecker) registerFnParamTypes(fnID ast.ItemID, fnItem *ast.FnItem)
 			tc.setBindingType(symID, paramType)
 		}
 	}
+}
+
+func (tc *typeChecker) isWildcardName(name source.StringID) bool {
+	return name != source.NoStringID && tc.lookupName(name) == "_"
 }
 
 func (tc *typeChecker) symbolInScope(scope symbols.ScopeID, name source.StringID, kind symbols.SymbolKind) symbols.SymbolID {

--- a/internal/symbols/resolve_declarations.go
+++ b/internal/symbols/resolve_declarations.go
@@ -20,6 +20,12 @@ func (fr *fileResolver) declareLet(itemID ast.ItemID, letItem *ast.LetItem) {
 	if letItem.Value.IsValid() {
 		fr.walkExpr(letItem.Value)
 	}
+	if fr.isWildcard(letItem.Name) {
+		if letItem.IsMut {
+			fr.reportWildcardMut(preferSpan(letItem.MutSpan, letItem.Span))
+		}
+		return
+	}
 	flags := SymbolFlags(0)
 	if letItem.Visibility == ast.VisPublic {
 		flags |= SymbolFlagPublic

--- a/internal/symbols/wildcard_test.go
+++ b/internal/symbols/wildcard_test.go
@@ -1,0 +1,138 @@
+package symbols
+
+import (
+	"testing"
+
+	"surge/internal/diag"
+)
+
+func TestWildcardLetDeclarationsAllowed(t *testing.T) {
+	src := `
+            fn main() {
+                let _ = 1;
+                let _ = 2;
+            }
+        `
+	builder, fileID, parseBag := parseSnippet(t, src)
+	if parseBag.Len() != 0 {
+		t.Fatalf("unexpected parse diagnostics: %d", parseBag.Len())
+	}
+
+	bag := diag.NewBag(4)
+	_ = ResolveFile(builder, fileID, &ResolveOptions{Reporter: &diag.BagReporter{Bag: bag}, Validate: true})
+
+	if bag.Len() != 0 {
+		t.Fatalf("expected no diagnostics, got %d", bag.Len())
+	}
+}
+
+func TestWildcardParamsAllowed(t *testing.T) {
+	src := `
+            fn f(_ : int) {}
+            fn g(x: int, _ : string) {}
+
+            fn main() {
+                f(1);
+                g(1, "hello");
+            }
+        `
+	builder, fileID, parseBag := parseSnippet(t, src)
+	if parseBag.Len() != 0 {
+		t.Fatalf("unexpected parse diagnostics: %d", parseBag.Len())
+	}
+
+	bag := diag.NewBag(4)
+	_ = ResolveFile(builder, fileID, &ResolveOptions{Reporter: &diag.BagReporter{Bag: bag}, Validate: true})
+
+	if bag.Len() != 0 {
+		t.Fatalf("expected no diagnostics, got %d", bag.Len())
+	}
+}
+
+func TestWildcardAsValueIsError(t *testing.T) {
+	src := `
+            fn main() {
+                let _ = 1;
+                let x = _;
+            }
+        `
+	builder, fileID, parseBag := parseSnippet(t, src)
+	if parseBag.Len() != 0 {
+		t.Fatalf("unexpected parse diagnostics: %d", parseBag.Len())
+	}
+
+	bag := diag.NewBag(4)
+	_ = ResolveFile(builder, fileID, &ResolveOptions{Reporter: &diag.BagReporter{Bag: bag}, Validate: true})
+
+	if bag.Len() != 1 {
+		t.Fatalf("expected 1 diagnostic, got %d", bag.Len())
+	}
+	if bag.Items()[0].Code != diag.SemaWildcardValue {
+		t.Fatalf("expected SemaWildcardValue, got %v", bag.Items()[0].Code)
+	}
+}
+
+func TestWildcardMutIsError(t *testing.T) {
+	src := `
+            fn main() {
+                let mut _ = 1;
+            }
+        `
+	builder, fileID, parseBag := parseSnippet(t, src)
+	if parseBag.Len() != 0 {
+		t.Fatalf("unexpected parse diagnostics: %d", parseBag.Len())
+	}
+
+	bag := diag.NewBag(4)
+	_ = ResolveFile(builder, fileID, &ResolveOptions{Reporter: &diag.BagReporter{Bag: bag}, Validate: true})
+
+	if bag.Len() != 1 {
+		t.Fatalf("expected 1 diagnostic, got %d", bag.Len())
+	}
+	if bag.Items()[0].Code != diag.SemaWildcardMut {
+		t.Fatalf("expected SemaWildcardMut, got %v", bag.Items()[0].Code)
+	}
+}
+
+func TestTopLevelWildcardLetsAllowed(t *testing.T) {
+	src := `
+            fn init_logging() {}
+            fn register_metrics() {}
+            let _ = init_logging();
+            let _ = register_metrics();
+            fn main() {}
+        `
+	builder, fileID, parseBag := parseSnippet(t, src)
+	if parseBag.Len() != 0 {
+		t.Fatalf("unexpected parse diagnostics: %d", parseBag.Len())
+	}
+
+	bag := diag.NewBag(4)
+	_ = ResolveFile(builder, fileID, &ResolveOptions{Reporter: &diag.BagReporter{Bag: bag}, Validate: true})
+
+	if bag.Len() != 0 {
+		t.Fatalf("expected no diagnostics, got %d", bag.Len())
+	}
+}
+
+func TestWildcardAssignmentRemainsError(t *testing.T) {
+	src := `
+            fn main() {
+                _ = 42;
+            }
+        `
+	builder, fileID, parseBag := parseSnippet(t, src)
+	if parseBag.Len() != 0 {
+		t.Fatalf("unexpected parse diagnostics: %d", parseBag.Len())
+	}
+
+	bag := diag.NewBag(4)
+	_ = ResolveFile(builder, fileID, &ResolveOptions{Reporter: &diag.BagReporter{Bag: bag}, Validate: true})
+
+	if bag.Len() != 1 {
+		t.Fatalf("expected 1 diagnostic, got %d", bag.Len())
+	}
+	if bag.Items()[0].Code != diag.SemaWildcardValue {
+		t.Fatalf("expected SemaWildcardValue, got %v", bag.Items()[0].Code)
+	}
+}


### PR DESCRIPTION
## Summary
- treat the underscore identifier as a wildcard binding that is skipped by symbol creation while still walking types and values
- emit dedicated diagnostics when wildcard bindings are marked mutable or used as values, and allow underscores in expression parsing
- add resolver regression tests covering wildcard lets, parameters, and invalid usages

## Testing
- `SURGE_STDLIB=$(pwd) make check` *(fails while installing golangci-lint because external downloads are blocked)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925fc38cbf48321ad444a8b72c4a3a0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced wildcard (`_`) support for function parameters and variable bindings to mark unused placeholders.
  * Added semantic error detection when wildcards are used in value expressions or mutation contexts where not permitted.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->