### PR TITLE
Lowering ast

### DIFF
--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -1111,6 +1111,75 @@ Each target type gets its own overload; primitives in `core/intrinsics.sg` (modu
 * Reference and pointer types cannot define or consume casts.
 * Casts never participate in function overload resolution; insert them explicitly when needed.
 
+#### 6.6.1. Implicit Conversions
+
+The compiler automatically applies `__to` conversions in specific coercion sites when the target type is known and exactly one applicable `__to` method exists. This eliminates boilerplate explicit casts while preserving type safety.
+
+**Coercion sites (automatic `__to` application):**
+
+1. **Variable bindings:** `let x: T = expr` where `expr` has type `U` and `__to(U, T)` exists
+2. **Function arguments:** `foo(arg)` where `arg` has type `U`, parameter expects type `T`, and `__to(U, T)` exists
+3. **Return statements:** `return expr` where `expr` has type `U`, function returns `T`, and `__to(U, T)` exists
+4. **Struct field initialization:** `Struct { field: expr }` where `expr` has type `U`, field expects type `T`, and `__to(U, T)` exists
+5. **Array elements:** `[expr1, expr2]` where elements have type `U`, array expects type `T[]`, and `__to(U, T)` exists
+
+**Resolution rules:**
+
+* Only applied when the target type is explicitly known from context (type annotation, function signature, etc.)
+* Exactly one `__to(source, target)` method must exist; ambiguity or absence reports an error
+* No conversion chaining: `T -> U -> V` is never attempted; only single-step `T -> U` conversions
+* Conversions are never applied in binary/unary operator resolution
+* In function overload resolution, implicit conversion has lower priority (cost = 2) than:
+  - Exact type match (cost = 0)
+  - Literal coercion (cost = 1)
+  - Numeric widening (cost = 1)
+
+**Examples:**
+
+```sg
+type Meters = float;
+type Feet = float;
+
+extern<Meters> {
+  fn __to(self: Meters, _: Feet) -> Feet {
+    return (self * 3.28084) as Feet;
+  }
+}
+
+// Implicit conversion in variable binding
+let distance_m: Meters = 100.0;
+let distance_ft: Feet = distance_m;  // Calls __to(Meters, Feet) implicitly
+
+// Implicit conversion in function argument
+fn display_feet(f: Feet) { print(f); }
+display_feet(distance_m);  // Calls __to(Meters, Feet) implicitly
+
+// Implicit conversion in return
+fn convert_to_feet(m: Meters) -> Feet {
+  return m;  // Calls __to(Meters, Feet) implicitly
+}
+
+// Implicit conversion in struct field
+type Measurement = { value_ft: Feet };
+let m = Measurement { value_ft: distance_m };  // Calls __to implicitly
+
+// Implicit conversion in array elements
+let measurements: Feet[] = [distance_m, distance_m * 2.0];  // Each element converted
+```
+
+**Diagnostic codes:**
+
+* `SemaNoConversion` (3098): No `__to(T, U)` conversion exists for required coercion
+* `SemaAmbiguousConversion` (3099): Multiple `__to(T, U)` candidates found (should not occur in well-formed code due to Surge's overload/override semantics)
+
+**Built-in implicit conversions:**
+
+The prelude provides `@intrinsic __to` methods for common conversions:
+
+* Numeric: `string -> int/uint/float`, `int -> string/float`, `uint -> string/int/float`, `float -> string/int/uint`, plus fixed-width conversions
+* Boolean: `bool -> string/int`
+* Within numeric families: `intN -> int`, `uintN -> uint`, `floatN -> float` (lossless widening)
+
 **Examples:**
 ```sg
 type UserId = uint64;

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -1107,9 +1107,9 @@ Each target type gets its own overload; primitives in `core/intrinsics.sg` (modu
 4. Multiple matches yield `E_AMBIGUOUS_CAST`; no match yields `E_NO_CAST`.
 
 **Restrictions:**
-* Direct calls to `__to` are forbidden; only `expr to Type` may invoke it.
+* Direct calls to `__to` are forbidden; only `expr to Type` or implicit conversion may invoke it.
 * Reference and pointer types cannot define or consume casts.
-* Casts never participate in function overload resolution; insert them explicitly when needed.
+* Explicit casts (`expr to Type` or `expr: Type`) never participate in function overload resolution; insert them explicitly when needed. However, implicit conversions (§6.6.1) do participate with lower priority.
 
 #### 6.6.1. Implicit Conversions
 
@@ -1142,7 +1142,7 @@ type Feet = float;
 
 extern<Meters> {
   fn __to(self: Meters, _: Feet) -> Feet {
-    return (self * 3.28084) as Feet;
+    return (self * 3.28084): Feet;
   }
 }
 

--- a/internal/diag/codes.go
+++ b/internal/diag/codes.go
@@ -173,6 +173,10 @@ const (
 	SemaEnumDuplicateVariant  Code = 3096 // Duplicate enum variant name
 	SemaEnumInvalidBaseType   Code = 3097 // Invalid base type for enum
 
+	// Implicit conversion errors (3098-3099)
+	SemaNoConversion        Code = 3098 // No conversion from T to U
+	SemaAmbiguousConversion Code = 3099 // Ambiguous conversion from T to U
+
 	// Ошибки I/O
 	IOLoadFileError Code = 4001
 
@@ -351,6 +355,8 @@ var ( // todo расширить описания и использовать к
 		SemaEnumValueTypeMismatch:      "enum value type mismatch",
 		SemaEnumDuplicateVariant:       "duplicate enum variant name",
 		SemaEnumInvalidBaseType:        "invalid base type for enum",
+		SemaNoConversion:               "no conversion from source to target type",
+		SemaAmbiguousConversion:        "ambiguous conversion from source to target type",
 		IOLoadFileError:                "I/O load file error",
 		ProjInfo:                       "Project information",
 		ProjDuplicateModule:            "Duplicate module definition",

--- a/internal/sema/call_resolver_test.go
+++ b/internal/sema/call_resolver_test.go
@@ -95,8 +95,9 @@ func TestCallResolverReportsNoOverload(t *testing.T) {
 	paramName := intern(builder, "x")
 	addSimpleFn(builder, file, "baz", []ast.FnParam{{Name: paramName, Type: intType}}, intType, nil)
 
-	strLit := builder.Exprs.NewLiteral(source.Span{}, ast.ExprLitString, intern(builder, "\"hi\""))
-	call := builder.Exprs.NewCall(source.Span{}, builder.Exprs.NewIdent(source.Span{}, intern(builder, "baz")), []ast.CallArg{{Name: source.NoStringID, Value: strLit}}, nil, nil, false)
+	// Use nothing literal - there's no builtin nothing -> int conversion
+	nothingLit := builder.Exprs.NewLiteral(source.Span{}, ast.ExprLitNothing, intern(builder, "nothing"))
+	call := builder.Exprs.NewCall(source.Span{}, builder.Exprs.NewIdent(source.Span{}, intern(builder, "baz")), []ast.CallArg{{Name: source.NoStringID, Value: nothingLit}}, nil, nil, false)
 	addTopLevelLet(builder, file, call)
 
 	semaBag := runSema(t, builder, file)

--- a/internal/sema/check.go
+++ b/internal/sema/check.go
@@ -25,6 +25,7 @@ type Result struct {
 	ExprBorrows            map[ast.ExprID]BorrowID
 	Borrows                []BorrowInfo
 	FunctionInstantiations map[symbols.SymbolID][][]types.TypeID
+	ImplicitConversions    map[ast.ExprID]ImplicitConversion // Tracks implicit __to calls
 }
 
 // Check performs semantic analysis (type inference, borrow checks, etc.).
@@ -34,6 +35,7 @@ func Check(ctx context.Context, builder *ast.Builder, fileID ast.FileID, opts Op
 		ExprTypes:              make(map[ast.ExprID]types.TypeID),
 		ExprBorrows:            make(map[ast.ExprID]BorrowID),
 		FunctionInstantiations: make(map[symbols.SymbolID][][]types.TypeID),
+		ImplicitConversions:    make(map[ast.ExprID]ImplicitConversion),
 	}
 	if opts.Types != nil {
 		res.TypeInterner = opts.Types

--- a/internal/sema/implicit_conversion.go
+++ b/internal/sema/implicit_conversion.go
@@ -64,9 +64,10 @@ func (tc *typeChecker) collectToMethods(src, target types.TypeID) []*symbols.Fun
 			if sig == nil || len(sig.Params) < 2 {
 				continue
 			}
-			// Check if second parameter matches target type
+			// Check if second parameter matches target type AND result matches target type
+			// __to signature must be: fn __to(self: source, _: target) -> target
 			for _, tgt := range targetCandidates {
-				if tgt.key != "" && typeKeyEqual(sig.Params[1], tgt.key) {
+				if tgt.key != "" && typeKeyEqual(sig.Params[1], tgt.key) && typeKeyEqual(sig.Result, tgt.key) {
 					// Deduplicate: only add each signature once
 					if _, dup := seen[sig]; !dup {
 						seen[sig] = struct{}{}

--- a/internal/sema/implicit_conversion.go
+++ b/internal/sema/implicit_conversion.go
@@ -1,0 +1,98 @@
+package sema
+
+import (
+	"surge/internal/ast"
+	"surge/internal/source"
+	"surge/internal/symbols"
+	"surge/internal/types"
+)
+
+// ImplicitConversion records an implicit __to call for an expression.
+// This information is used by later compilation phases (such as codegen) to emit
+// the actual __to function call.
+type ImplicitConversion struct {
+	Source types.TypeID // Original type T
+	Target types.TypeID // Target type U
+	Span   source.Span  // Location of the expression
+}
+
+// tryImplicitConversion attempts to find a __to conversion from source to target.
+// It returns:
+//   - (target, true, false) if exactly one __to(source -> target) exists
+//   - (NoTypeID, false, true) if multiple candidates exist (ambiguous)
+//   - (NoTypeID, false, false) if no candidate found
+//
+// This function only attempts implicit conversion if the types are not already
+// assignable. It does NOT chain conversions (T -> X -> U is not allowed).
+func (tc *typeChecker) tryImplicitConversion(source, target types.TypeID) (types.TypeID, bool, bool) {
+	if source == types.NoTypeID || target == types.NoTypeID {
+		return types.NoTypeID, false, false
+	}
+
+	// Fast path: already assignable (don't use conversion)
+	// This ensures we don't apply conversion when types already match
+	if tc.typesAssignable(target, source, true) {
+		return target, false, false // found=false because no conversion needed
+	}
+
+	candidates := tc.collectToMethods(source, target)
+	switch len(candidates) {
+	case 0:
+		return types.NoTypeID, false, false
+	case 1:
+		return target, true, false
+	default:
+		return types.NoTypeID, false, true // ambiguous
+	}
+}
+
+// collectToMethods collects all __to methods for (source -> target) pair.
+// It looks up __to functions with signature: fn __to(self: source, _: target) -> target
+// This includes both @intrinsic and user-defined __to functions from the current
+// module and all visible imports.
+func (tc *typeChecker) collectToMethods(source, target types.TypeID) []*symbols.FunctionSignature {
+	var results []*symbols.FunctionSignature
+	seen := make(map[*symbols.FunctionSignature]struct{})
+	targetCandidates := tc.typeKeyCandidates(target)
+
+	for _, sc := range tc.typeKeyCandidates(source) {
+		if sc.key == "" {
+			continue
+		}
+		methods := tc.lookupMagicMethods(sc.key, "__to")
+		for _, sig := range methods {
+			if sig == nil || len(sig.Params) < 2 {
+				continue
+			}
+			// Check if second parameter matches target type
+			for _, tgt := range targetCandidates {
+				if tgt.key != "" && typeKeyEqual(sig.Params[1], tgt.key) {
+					// Deduplicate: only add each signature once
+					if _, dup := seen[sig]; !dup {
+						seen[sig] = struct{}{}
+						results = append(results, sig)
+					}
+					break // Found a match for this sig, no need to check other target candidates
+				}
+			}
+		}
+	}
+	return results
+}
+
+// recordImplicitConversion records an implicit conversion for codegen.
+// This stores the conversion in Result.ImplicitConversions so that later
+// phases can emit the actual __to function call.
+func (tc *typeChecker) recordImplicitConversion(expr ast.ExprID, source, target types.TypeID) {
+	if !expr.IsValid() || source == types.NoTypeID || target == types.NoTypeID {
+		return
+	}
+	if tc.result.ImplicitConversions == nil {
+		tc.result.ImplicitConversions = make(map[ast.ExprID]ImplicitConversion)
+	}
+	tc.result.ImplicitConversions[expr] = ImplicitConversion{
+		Source: source,
+		Target: target,
+		Span:   tc.exprSpan(expr),
+	}
+}

--- a/internal/sema/type_expr_call_inference.go
+++ b/internal/sema/type_expr_call_inference.go
@@ -592,6 +592,10 @@ func (tc *typeChecker) conversionCost(actual, expected types.TypeID, isLiteral b
 			}
 		}
 	}
+	// Try implicit conversion (cost 2, lower priority than other conversions)
+	if _, found, _ := tc.tryImplicitConversion(actual, expected); found {
+		return 2, true
+	}
 	return 0, false
 }
 

--- a/testdata/golden/sema/invalid/fn_return_type_mismatch.ast
+++ b/testdata/golden/sema/invalid/fn_return_type_mismatch.ast
@@ -1,9 +1,9 @@
-fn_return_type_mismatch.sg (span: 2:1-5:1)
-└─ Item[0]: Fn (span: 2:1-4:2)
+fn_return_type_mismatch.sg (span: 3:1-6:1)
+└─ Item[0]: Fn (span: 3:1-5:2)
    ├─ Name: wrong_return
    ├─ Params: ()
    ├─ Return: int
    └─ Body:
-      └─ Stmt[0]: Block (span: 2:26-4:2)
-         └─ Stmt[0]: Return (span: 3:5-3:19)
-            └─ Expr: expr#1: "nope"
+      └─ Stmt[0]: Block (span: 3:26-5:2)
+         └─ Stmt[0]: Return (span: 4:5-4:20)
+            └─ Expr: expr#1: nothing

--- a/testdata/golden/sema/invalid/fn_return_type_mismatch.diag
+++ b/testdata/golden/sema/invalid/fn_return_type_mismatch.diag
@@ -1,1 +1,1 @@
-error SEM3015 testdata/golden/sema/invalid/fn_return_type_mismatch.sg:3:5 return type mismatch: expected int, got string
+error SEM3015 testdata/golden/sema/invalid/fn_return_type_mismatch.sg:4:5 return type mismatch: expected int, got nothing

--- a/testdata/golden/sema/invalid/fn_return_type_mismatch.fmt
+++ b/testdata/golden/sema/invalid/fn_return_type_mismatch.fmt
@@ -1,4 +1,5 @@
 // scenario: returned expression type does not match the function signature
+// Updated to use 'nothing' which has no __to conversion to int
 fn wrong_return() -> int {
-    return "nope";
+    return nothing;
 }

--- a/testdata/golden/sema/invalid/fn_return_type_mismatch.sg
+++ b/testdata/golden/sema/invalid/fn_return_type_mismatch.sg
@@ -1,4 +1,5 @@
 // scenario: returned expression type does not match the function signature
+// Updated to use 'nothing' which has no __to conversion to int
 fn wrong_return() -> int {
-    return "nope";
+    return nothing;
 }

--- a/testdata/golden/sema/invalid/fn_return_type_mismatch.tokens
+++ b/testdata/golden/sema/invalid/fn_return_type_mismatch.tokens
@@ -1,12 +1,12 @@
-  1: KwFn            "fn" at 2:1-2:3 (leading: LineComment, Newline)
-  2: Ident           "wrong_return" at 2:4-2:16 (leading: Space)
-  3: LParen          "(" at 2:16-2:17
-  4: RParen          ")" at 2:17-2:18
-  5: Arrow           "->" at 2:19-2:21 (leading: Space)
-  6: Ident           "int" at 2:22-2:25 (leading: Space)
-  7: LBrace          "{" at 2:26-2:27 (leading: Space)
-  8: KwReturn        "return" at 3:5-3:11 (leading: Newline, Space)
-  9: StringLit       "\"nope\"" at 3:12-3:18 (leading: Space)
- 10: Semicolon       ";" at 3:18-3:19
- 11: RBrace          "}" at 4:1-4:2 (leading: Newline)
- 12: EOF             at 5:1-5:1
+  1: KwFn            "fn" at 3:1-3:3 (leading: LineComment, Newline, LineComment, Newline)
+  2: Ident           "wrong_return" at 3:4-3:16 (leading: Space)
+  3: LParen          "(" at 3:16-3:17
+  4: RParen          ")" at 3:17-3:18
+  5: Arrow           "->" at 3:19-3:21 (leading: Space)
+  6: Ident           "int" at 3:22-3:25 (leading: Space)
+  7: LBrace          "{" at 3:26-3:27 (leading: Space)
+  8: KwReturn        "return" at 4:5-4:11 (leading: Newline, Space)
+  9: NothingLit      "nothing" at 4:12-4:19 (leading: Space)
+ 10: Semicolon       ";" at 4:19-4:20
+ 11: RBrace          "}" at 5:1-5:2 (leading: Newline)
+ 12: EOF             at 6:1-6:1

--- a/testdata/golden/sema/invalid/implicit_conversion_none.ast
+++ b/testdata/golden/sema/invalid/implicit_conversion_none.ast
@@ -1,0 +1,87 @@
+implicit_conversion_none.sg (span: 1:1-32:1)
+├─ Item[0]: Type (span: 1:1-1:29)
+│  ├─ Name: MyType
+│  ├─ Kind: Struct
+│  ├─ Visibility: private
+│  └─ Struct:
+│     └─ Field[0]: dummy: int
+├─ Item[1]: Type (span: 2:1-2:32)
+│  ├─ Name: OtherType
+│  ├─ Kind: Struct
+│  ├─ Visibility: private
+│  └─ Struct:
+│     └─ Field[0]: value: int
+├─ Item[2]: Extern (span: 4:1-8:2)
+│  ├─ Target: OtherType
+│  ├─ Members:
+│  │  └─ Fn[0]: __to
+│  │     ├─ Params: (self: OtherType, _: int)
+│  │     ├─ Return: int
+│  │     └─ Body:
+│  │        Stmt[0]: Block (span: 5:45-7:6)
+│  │        └─ Stmt[0]: Return (span: 6:9-6:27)
+│  │           └─ Expr: expr#2: self.value
+├─ Item[3]: Fn (span: 10:1-13:2)
+│  ├─ Name: test_no_conversion
+│  ├─ Params: ()
+│  ├─ Return: nothing
+│  └─ Body:
+│     └─ Stmt[0]: Block (span: 10:25-13:2)
+│        ├─ Stmt[0]: Let (span: 11:5-11:35)
+│        │  ├─ Name: mt
+│        │  ├─ Mutable: false
+│        │  ├─ Type: MyType
+│        │  └─ Value: expr#4: <ExprKind(18)>
+│        └─ Stmt[1]: Let (span: 12:5-12:24)
+│           ├─ Name: s
+│           ├─ Mutable: false
+│           ├─ Type: string
+│           └─ Value: expr#5: mt
+├─ Item[4]: Fn (span: 15:1-18:2)
+│  ├─ Name: test_wrong_conversion
+│  ├─ Params: ()
+│  ├─ Return: nothing
+│  └─ Body:
+│     └─ Stmt[0]: Block (span: 15:28-18:2)
+│        ├─ Stmt[0]: Let (span: 16:5-16:42)
+│        │  ├─ Name: ot
+│        │  ├─ Mutable: false
+│        │  ├─ Type: OtherType
+│        │  └─ Value: expr#7: <ExprKind(18)>
+│        └─ Stmt[1]: Let (span: 17:5-17:24)
+│           ├─ Name: s
+│           ├─ Mutable: false
+│           ├─ Type: string
+│           └─ Value: expr#8: ot
+├─ Item[5]: Fn (span: 20:1-21:2)
+│  ├─ Name: takes_bool
+│  ├─ Params: (x: bool)
+│  ├─ Return: nothing
+│  └─ Body:
+│     └─ Stmt[0]: Block (span: 20:24-21:2)
+├─ Item[6]: Fn (span: 23:1-26:2)
+│  ├─ Name: test_function_arg_no_conversion
+│  ├─ Params: ()
+│  ├─ Return: nothing
+│  └─ Body:
+│     └─ Stmt[0]: Block (span: 23:38-26:2)
+│        ├─ Stmt[0]: Let (span: 24:5-24:35)
+│        │  ├─ Name: mt
+│        │  ├─ Mutable: false
+│        │  ├─ Type: MyType
+│        │  └─ Value: expr#10: <ExprKind(18)>
+│        └─ Stmt[1]: Expr (span: 25:5-25:20)
+│           └─ Expr: expr#13: takes_bool(mt)
+└─ Item[7]: Fn (span: 28:1-31:2)
+   ├─ Name: returns_float
+   ├─ Params: ()
+   ├─ Return: float
+   └─ Body:
+      └─ Stmt[0]: Block (span: 28:29-31:2)
+         ├─ Stmt[0]: Let (span: 29:5-29:35)
+         │  ├─ Name: mt
+         │  ├─ Mutable: false
+         │  ├─ Type: MyType
+         │  └─ Value: expr#15: <ExprKind(18)>
+         └─ Stmt[1]: Return (span: 30:5-30:15)
+            └─ Expr: expr#16: mt

--- a/testdata/golden/sema/invalid/implicit_conversion_none.diag
+++ b/testdata/golden/sema/invalid/implicit_conversion_none.diag
@@ -1,0 +1,4 @@
+error SEM3015 testdata/golden/sema/invalid/implicit_conversion_none.sg:12:21 cannot assign MyType to string
+error SEM3015 testdata/golden/sema/invalid/implicit_conversion_none.sg:17:21 cannot assign OtherType to string
+error SEM3046 testdata/golden/sema/invalid/implicit_conversion_none.sg:25:5 no matching overload for takes_bool
+error SEM3015 testdata/golden/sema/invalid/implicit_conversion_none.sg:30:5 return type mismatch: expected float, got MyType

--- a/testdata/golden/sema/invalid/implicit_conversion_none.fmt
+++ b/testdata/golden/sema/invalid/implicit_conversion_none.fmt
@@ -1,0 +1,31 @@
+type MyType = { dummy: int }
+type OtherType = { value: int }
+
+extern<OtherType> {
+    fn __to(self: OtherType, _: int) -> int {
+        return self.value;
+    }
+}
+
+fn test_no_conversion() {
+    let mt: MyType = MyType { 0 };
+    let s: string = mt;
+}
+
+fn test_wrong_conversion() {
+    let ot: OtherType = OtherType { 42 };
+    let s: string = ot;
+}
+
+fn takes_bool(x: bool) {
+}
+
+fn test_function_arg_no_conversion() {
+    let mt: MyType = MyType { 0 };
+    takes_bool(mt);
+}
+
+fn returns_float() -> float {
+    let mt: MyType = MyType { 0 };
+    return mt;
+}

--- a/testdata/golden/sema/invalid/implicit_conversion_none.sg
+++ b/testdata/golden/sema/invalid/implicit_conversion_none.sg
@@ -1,0 +1,31 @@
+type MyType = { dummy: int }
+type OtherType = { value: int }
+
+extern<OtherType> {
+    fn __to(self: OtherType, _: int) -> int {
+        return self.value;
+    }
+}
+
+fn test_no_conversion() {
+    let mt: MyType = MyType { 0 };
+    let s: string = mt;
+}
+
+fn test_wrong_conversion() {
+    let ot: OtherType = OtherType { 42 };
+    let s: string = ot;
+}
+
+fn takes_bool(x: bool) {
+}
+
+fn test_function_arg_no_conversion() {
+    let mt: MyType = MyType { 0 };
+    takes_bool(mt);
+}
+
+fn returns_float() -> float {
+    let mt: MyType = MyType { 0 };
+    return mt;
+}

--- a/testdata/golden/sema/invalid/implicit_conversion_none.tokens
+++ b/testdata/golden/sema/invalid/implicit_conversion_none.tokens
@@ -1,0 +1,140 @@
+  1: KwType          "type" at 1:1-1:5
+  2: Ident           "MyType" at 1:6-1:12 (leading: Space)
+  3: Assign          "=" at 1:13-1:14 (leading: Space)
+  4: LBrace          "{" at 1:15-1:16 (leading: Space)
+  5: Ident           "dummy" at 1:17-1:22 (leading: Space)
+  6: Colon           ":" at 1:22-1:23
+  7: Ident           "int" at 1:24-1:27 (leading: Space)
+  8: RBrace          "}" at 1:28-1:29 (leading: Space)
+  9: KwType          "type" at 2:1-2:5 (leading: Newline)
+ 10: Ident           "OtherType" at 2:6-2:15 (leading: Space)
+ 11: Assign          "=" at 2:16-2:17 (leading: Space)
+ 12: LBrace          "{" at 2:18-2:19 (leading: Space)
+ 13: Ident           "value" at 2:20-2:25 (leading: Space)
+ 14: Colon           ":" at 2:25-2:26
+ 15: Ident           "int" at 2:27-2:30 (leading: Space)
+ 16: RBrace          "}" at 2:31-2:32 (leading: Space)
+ 17: KwExtern        "extern" at 4:1-4:7 (leading: Newline)
+ 18: Lt              "<" at 4:7-4:8
+ 19: Ident           "OtherType" at 4:8-4:17
+ 20: Gt              ">" at 4:17-4:18
+ 21: LBrace          "{" at 4:19-4:20 (leading: Space)
+ 22: KwFn            "fn" at 5:5-5:7 (leading: Newline, Space)
+ 23: Ident           "__to" at 5:8-5:12 (leading: Space)
+ 24: LParen          "(" at 5:12-5:13
+ 25: Ident           "self" at 5:13-5:17
+ 26: Colon           ":" at 5:17-5:18
+ 27: Ident           "OtherType" at 5:19-5:28 (leading: Space)
+ 28: Comma           "," at 5:28-5:29
+ 29: Underscore      "_" at 5:30-5:31 (leading: Space)
+ 30: Colon           ":" at 5:31-5:32
+ 31: Ident           "int" at 5:33-5:36 (leading: Space)
+ 32: RParen          ")" at 5:36-5:37
+ 33: Arrow           "->" at 5:38-5:40 (leading: Space)
+ 34: Ident           "int" at 5:41-5:44 (leading: Space)
+ 35: LBrace          "{" at 5:45-5:46 (leading: Space)
+ 36: KwReturn        "return" at 6:9-6:15 (leading: Newline, Space)
+ 37: Ident           "self" at 6:16-6:20 (leading: Space)
+ 38: Dot             "." at 6:20-6:21
+ 39: Ident           "value" at 6:21-6:26
+ 40: Semicolon       ";" at 6:26-6:27
+ 41: RBrace          "}" at 7:5-7:6 (leading: Newline, Space)
+ 42: RBrace          "}" at 8:1-8:2 (leading: Newline)
+ 43: KwFn            "fn" at 10:1-10:3 (leading: Newline)
+ 44: Ident           "test_no_conversion" at 10:4-10:22 (leading: Space)
+ 45: LParen          "(" at 10:22-10:23
+ 46: RParen          ")" at 10:23-10:24
+ 47: LBrace          "{" at 10:25-10:26 (leading: Space)
+ 48: KwLet           "let" at 11:5-11:8 (leading: Newline, Space)
+ 49: Ident           "mt" at 11:9-11:11 (leading: Space)
+ 50: Colon           ":" at 11:11-11:12
+ 51: Ident           "MyType" at 11:13-11:19 (leading: Space)
+ 52: Assign          "=" at 11:20-11:21 (leading: Space)
+ 53: Ident           "MyType" at 11:22-11:28 (leading: Space)
+ 54: LBrace          "{" at 11:29-11:30 (leading: Space)
+ 55: IntLit          "0" at 11:31-11:32 (leading: Space)
+ 56: RBrace          "}" at 11:33-11:34 (leading: Space)
+ 57: Semicolon       ";" at 11:34-11:35
+ 58: KwLet           "let" at 12:5-12:8 (leading: Newline, Space)
+ 59: Ident           "s" at 12:9-12:10 (leading: Space)
+ 60: Colon           ":" at 12:10-12:11
+ 61: Ident           "string" at 12:12-12:18 (leading: Space)
+ 62: Assign          "=" at 12:19-12:20 (leading: Space)
+ 63: Ident           "mt" at 12:21-12:23 (leading: Space)
+ 64: Semicolon       ";" at 12:23-12:24
+ 65: RBrace          "}" at 13:1-13:2 (leading: Newline)
+ 66: KwFn            "fn" at 15:1-15:3 (leading: Newline)
+ 67: Ident           "test_wrong_conversion" at 15:4-15:25 (leading: Space)
+ 68: LParen          "(" at 15:25-15:26
+ 69: RParen          ")" at 15:26-15:27
+ 70: LBrace          "{" at 15:28-15:29 (leading: Space)
+ 71: KwLet           "let" at 16:5-16:8 (leading: Newline, Space)
+ 72: Ident           "ot" at 16:9-16:11 (leading: Space)
+ 73: Colon           ":" at 16:11-16:12
+ 74: Ident           "OtherType" at 16:13-16:22 (leading: Space)
+ 75: Assign          "=" at 16:23-16:24 (leading: Space)
+ 76: Ident           "OtherType" at 16:25-16:34 (leading: Space)
+ 77: LBrace          "{" at 16:35-16:36 (leading: Space)
+ 78: IntLit          "42" at 16:37-16:39 (leading: Space)
+ 79: RBrace          "}" at 16:40-16:41 (leading: Space)
+ 80: Semicolon       ";" at 16:41-16:42
+ 81: KwLet           "let" at 17:5-17:8 (leading: Newline, Space)
+ 82: Ident           "s" at 17:9-17:10 (leading: Space)
+ 83: Colon           ":" at 17:10-17:11
+ 84: Ident           "string" at 17:12-17:18 (leading: Space)
+ 85: Assign          "=" at 17:19-17:20 (leading: Space)
+ 86: Ident           "ot" at 17:21-17:23 (leading: Space)
+ 87: Semicolon       ";" at 17:23-17:24
+ 88: RBrace          "}" at 18:1-18:2 (leading: Newline)
+ 89: KwFn            "fn" at 20:1-20:3 (leading: Newline)
+ 90: Ident           "takes_bool" at 20:4-20:14 (leading: Space)
+ 91: LParen          "(" at 20:14-20:15
+ 92: Ident           "x" at 20:15-20:16
+ 93: Colon           ":" at 20:16-20:17
+ 94: Ident           "bool" at 20:18-20:22 (leading: Space)
+ 95: RParen          ")" at 20:22-20:23
+ 96: LBrace          "{" at 20:24-20:25 (leading: Space)
+ 97: RBrace          "}" at 21:1-21:2 (leading: Newline)
+ 98: KwFn            "fn" at 23:1-23:3 (leading: Newline)
+ 99: Ident           "test_function_arg_no_conversion" at 23:4-23:35 (leading: Space)
+100: LParen          "(" at 23:35-23:36
+101: RParen          ")" at 23:36-23:37
+102: LBrace          "{" at 23:38-23:39 (leading: Space)
+103: KwLet           "let" at 24:5-24:8 (leading: Newline, Space)
+104: Ident           "mt" at 24:9-24:11 (leading: Space)
+105: Colon           ":" at 24:11-24:12
+106: Ident           "MyType" at 24:13-24:19 (leading: Space)
+107: Assign          "=" at 24:20-24:21 (leading: Space)
+108: Ident           "MyType" at 24:22-24:28 (leading: Space)
+109: LBrace          "{" at 24:29-24:30 (leading: Space)
+110: IntLit          "0" at 24:31-24:32 (leading: Space)
+111: RBrace          "}" at 24:33-24:34 (leading: Space)
+112: Semicolon       ";" at 24:34-24:35
+113: Ident           "takes_bool" at 25:5-25:15 (leading: Newline, Space)
+114: LParen          "(" at 25:15-25:16
+115: Ident           "mt" at 25:16-25:18
+116: RParen          ")" at 25:18-25:19
+117: Semicolon       ";" at 25:19-25:20
+118: RBrace          "}" at 26:1-26:2 (leading: Newline)
+119: KwFn            "fn" at 28:1-28:3 (leading: Newline)
+120: Ident           "returns_float" at 28:4-28:17 (leading: Space)
+121: LParen          "(" at 28:17-28:18
+122: RParen          ")" at 28:18-28:19
+123: Arrow           "->" at 28:20-28:22 (leading: Space)
+124: Ident           "float" at 28:23-28:28 (leading: Space)
+125: LBrace          "{" at 28:29-28:30 (leading: Space)
+126: KwLet           "let" at 29:5-29:8 (leading: Newline, Space)
+127: Ident           "mt" at 29:9-29:11 (leading: Space)
+128: Colon           ":" at 29:11-29:12
+129: Ident           "MyType" at 29:13-29:19 (leading: Space)
+130: Assign          "=" at 29:20-29:21 (leading: Space)
+131: Ident           "MyType" at 29:22-29:28 (leading: Space)
+132: LBrace          "{" at 29:29-29:30 (leading: Space)
+133: IntLit          "0" at 29:31-29:32 (leading: Space)
+134: RBrace          "}" at 29:33-29:34 (leading: Space)
+135: Semicolon       ";" at 29:34-29:35
+136: KwReturn        "return" at 30:5-30:11 (leading: Newline, Space)
+137: Ident           "mt" at 30:12-30:14 (leading: Space)
+138: Semicolon       ";" at 30:14-30:15
+139: RBrace          "}" at 31:1-31:2 (leading: Newline)
+140: EOF             at 32:1-32:1

--- a/testdata/golden/sema/valid/implicit_conversion.ast
+++ b/testdata/golden/sema/valid/implicit_conversion.ast
@@ -1,0 +1,141 @@
+implicit_conversion.sg (span: 1:1-57:1)
+├─ Item[0]: Type (span: 1:1-1:28)
+│  ├─ Name: MyInt
+│  ├─ Kind: Struct
+│  ├─ Visibility: private
+│  └─ Struct:
+│     └─ Field[0]: value: int
+├─ Item[1]: Type (span: 2:1-2:32)
+│  ├─ Name: Wrapper
+│  ├─ Kind: Struct
+│  ├─ Visibility: private
+│  └─ Struct:
+│     └─ Field[0]: data: string
+├─ Item[2]: Extern (span: 4:1-8:2)
+│  ├─ Target: MyInt
+│  ├─ Members:
+│  │  └─ Fn[0]: __to
+│  │     ├─ Params: (self: MyInt, _: int)
+│  │     ├─ Return: int
+│  │     └─ Body:
+│  │        Stmt[0]: Block (span: 5:41-7:6)
+│  │        └─ Stmt[0]: Return (span: 6:9-6:27)
+│  │           └─ Expr: expr#2: self.value
+├─ Item[3]: Extern (span: 10:1-14:2)
+│  ├─ Target: Wrapper
+│  ├─ Members:
+│  │  └─ Fn[0]: __to
+│  │     ├─ Params: (self: Wrapper, _: string)
+│  │     ├─ Return: string
+│  │     └─ Body:
+│  │        Stmt[0]: Block (span: 11:49-13:6)
+│  │        └─ Stmt[0]: Return (span: 12:9-12:26)
+│  │           └─ Expr: expr#4: self.data
+├─ Item[4]: Fn (span: 16:1-19:2)
+│  ├─ Name: test_variable_binding
+│  ├─ Params: ()
+│  ├─ Return: nothing
+│  └─ Body:
+│     └─ Stmt[0]: Block (span: 16:28-19:2)
+│        ├─ Stmt[0]: Let (span: 17:5-17:41)
+│        │  ├─ Name: w
+│        │  ├─ Mutable: false
+│        │  ├─ Type: Wrapper
+│        │  └─ Value: expr#6: <ExprKind(18)>
+│        └─ Stmt[1]: Let (span: 18:5-18:23)
+│           ├─ Name: s
+│           ├─ Mutable: false
+│           ├─ Type: string
+│           └─ Value: expr#7: w
+├─ Item[5]: Fn (span: 21:1-22:2)
+│  ├─ Name: takes_int
+│  ├─ Params: (x: int)
+│  ├─ Return: nothing
+│  └─ Body:
+│     └─ Stmt[0]: Block (span: 21:22-22:2)
+├─ Item[6]: Fn (span: 24:1-27:2)
+│  ├─ Name: test_function_args
+│  ├─ Params: ()
+│  ├─ Return: nothing
+│  └─ Body:
+│     └─ Stmt[0]: Block (span: 24:25-27:2)
+│        ├─ Stmt[0]: Let (span: 25:5-25:34)
+│        │  ├─ Name: mi
+│        │  ├─ Mutable: false
+│        │  ├─ Type: MyInt
+│        │  └─ Value: expr#9: <ExprKind(18)>
+│        └─ Stmt[1]: Expr (span: 26:5-26:19)
+│           └─ Expr: expr#12: takes_int(mi)
+├─ Item[7]: Fn (span: 29:1-32:2)
+│  ├─ Name: returns_string
+│  ├─ Params: ()
+│  ├─ Return: string
+│  └─ Body:
+│     └─ Stmt[0]: Block (span: 29:31-32:2)
+│        ├─ Stmt[0]: Let (span: 30:5-30:42)
+│        │  ├─ Name: w
+│        │  ├─ Mutable: false
+│        │  ├─ Type: Wrapper
+│        │  └─ Value: expr#14: <ExprKind(18)>
+│        └─ Stmt[1]: Return (span: 31:5-31:14)
+│           └─ Expr: expr#15: w
+├─ Item[8]: Type (span: 34:1-37:2)
+│  ├─ Name: Point
+│  ├─ Kind: Struct
+│  ├─ Visibility: private
+│  └─ Struct:
+│     ├─ Field[0]: x: int
+│     └─ Field[1]: y: int
+├─ Item[9]: Fn (span: 39:1-45:2)
+│  ├─ Name: test_struct_field
+│  ├─ Params: ()
+│  ├─ Return: nothing
+│  └─ Body:
+│     └─ Stmt[0]: Block (span: 39:24-45:2)
+│        ├─ Stmt[0]: Let (span: 40:5-40:34)
+│        │  ├─ Name: mi
+│        │  ├─ Mutable: false
+│        │  ├─ Type: MyInt
+│        │  └─ Value: expr#17: <ExprKind(18)>
+│        └─ Stmt[1]: Let (span: 41:5-44:7)
+│           ├─ Name: p
+│           ├─ Mutable: false
+│           ├─ Type: Point
+│           └─ Value: expr#22: <ExprKind(18)>
+├─ Item[10]: Fn (span: 47:1-51:2)
+│  ├─ Name: test_array_elements
+│  ├─ Params: ()
+│  ├─ Return: nothing
+│  └─ Body:
+│     └─ Stmt[0]: Block (span: 47:26-51:2)
+│        ├─ Stmt[0]: Let (span: 48:5-48:34)
+│        │  ├─ Name: mi1
+│        │  ├─ Mutable: false
+│        │  ├─ Type: MyInt
+│        │  └─ Value: expr#24: <ExprKind(18)>
+│        ├─ Stmt[1]: Let (span: 49:5-49:34)
+│        │  ├─ Name: mi2
+│        │  ├─ Mutable: false
+│        │  ├─ Type: MyInt
+│        │  └─ Value: expr#26: <ExprKind(18)>
+│        └─ Stmt[2]: Let (span: 50:5-50:34)
+│           ├─ Name: arr
+│           ├─ Mutable: false
+│           ├─ Type: int[2]
+│           └─ Value: expr#29: <ExprKind(8)>
+└─ Item[11]: Fn (span: 53:1-56:2)
+   ├─ Name: test_explicit_conversion
+   ├─ Params: ()
+   ├─ Return: nothing
+   └─ Body:
+      └─ Stmt[0]: Block (span: 53:31-56:2)
+         ├─ Stmt[0]: Let (span: 54:5-54:45)
+         │  ├─ Name: w
+         │  ├─ Mutable: false
+         │  ├─ Type: Wrapper
+         │  └─ Value: expr#31: <ExprKind(18)>
+         └─ Stmt[1]: Let (span: 55:5-55:33)
+            ├─ Name: s
+            ├─ Mutable: false
+            ├─ Type: string
+            └─ Value: expr#33: w to string

--- a/testdata/golden/sema/valid/implicit_conversion.fmt
+++ b/testdata/golden/sema/valid/implicit_conversion.fmt
@@ -1,0 +1,56 @@
+type MyInt = { value: int }
+type Wrapper = { data: string }
+
+extern<MyInt> {
+    fn __to(self: MyInt, _: int) -> int {
+        return self.value;
+    }
+}
+
+extern<Wrapper> {
+    fn __to(self: Wrapper, _: string) -> string {
+        return self.data;
+    }
+}
+
+fn test_variable_binding() {
+    let w: Wrapper = Wrapper { "test" };
+    let s: string = w;
+}
+
+fn takes_int(x: int) {
+}
+
+fn test_function_args() {
+    let mi: MyInt = MyInt { 42 };
+    takes_int(mi);
+}
+
+fn returns_string() -> string {
+    let w: Wrapper = Wrapper { "hello" };
+    return w;
+}
+
+type Point = {
+    x: int,
+    y: int,
+}
+
+fn test_struct_field() {
+    let mi: MyInt = MyInt { 10 };
+    let p: Point = Point {
+        x: mi,
+        y: 0,
+    };
+}
+
+fn test_array_elements() {
+    let mi1: MyInt = MyInt { 1 };
+    let mi2: MyInt = MyInt { 2 };
+    let arr: int[2] = [mi1, mi2];
+}
+
+fn test_explicit_conversion() {
+    let w: Wrapper = Wrapper { "explicit" };
+    let s: string = w to string;
+}

--- a/testdata/golden/sema/valid/implicit_conversion.sg
+++ b/testdata/golden/sema/valid/implicit_conversion.sg
@@ -1,0 +1,56 @@
+type MyInt = { value: int }
+type Wrapper = { data: string }
+
+extern<MyInt> {
+    fn __to(self: MyInt, _: int) -> int {
+        return self.value;
+    }
+}
+
+extern<Wrapper> {
+    fn __to(self: Wrapper, _: string) -> string {
+        return self.data;
+    }
+}
+
+fn test_variable_binding() {
+    let w: Wrapper = Wrapper { "test" };
+    let s: string = w;
+}
+
+fn takes_int(x: int) {
+}
+
+fn test_function_args() {
+    let mi: MyInt = MyInt { 42 };
+    takes_int(mi);
+}
+
+fn returns_string() -> string {
+    let w: Wrapper = Wrapper { "hello" };
+    return w;
+}
+
+type Point = {
+    x: int,
+    y: int,
+}
+
+fn test_struct_field() {
+    let mi: MyInt = MyInt { 10 };
+    let p: Point = Point {
+        x: mi,
+        y: 0,
+    };
+}
+
+fn test_array_elements() {
+    let mi1: MyInt = MyInt { 1 };
+    let mi2: MyInt = MyInt { 2 };
+    let arr: int[2] = [mi1, mi2];
+}
+
+fn test_explicit_conversion() {
+    let w: Wrapper = Wrapper { "explicit" };
+    let s: string = w to string;
+}

--- a/testdata/golden/sema/valid/implicit_conversion.tokens
+++ b/testdata/golden/sema/valid/implicit_conversion.tokens
@@ -1,0 +1,254 @@
+  1: KwType          "type" at 1:1-1:5
+  2: Ident           "MyInt" at 1:6-1:11 (leading: Space)
+  3: Assign          "=" at 1:12-1:13 (leading: Space)
+  4: LBrace          "{" at 1:14-1:15 (leading: Space)
+  5: Ident           "value" at 1:16-1:21 (leading: Space)
+  6: Colon           ":" at 1:21-1:22
+  7: Ident           "int" at 1:23-1:26 (leading: Space)
+  8: RBrace          "}" at 1:27-1:28 (leading: Space)
+  9: KwType          "type" at 2:1-2:5 (leading: Newline)
+ 10: Ident           "Wrapper" at 2:6-2:13 (leading: Space)
+ 11: Assign          "=" at 2:14-2:15 (leading: Space)
+ 12: LBrace          "{" at 2:16-2:17 (leading: Space)
+ 13: Ident           "data" at 2:18-2:22 (leading: Space)
+ 14: Colon           ":" at 2:22-2:23
+ 15: Ident           "string" at 2:24-2:30 (leading: Space)
+ 16: RBrace          "}" at 2:31-2:32 (leading: Space)
+ 17: KwExtern        "extern" at 4:1-4:7 (leading: Newline)
+ 18: Lt              "<" at 4:7-4:8
+ 19: Ident           "MyInt" at 4:8-4:13
+ 20: Gt              ">" at 4:13-4:14
+ 21: LBrace          "{" at 4:15-4:16 (leading: Space)
+ 22: KwFn            "fn" at 5:5-5:7 (leading: Newline, Space)
+ 23: Ident           "__to" at 5:8-5:12 (leading: Space)
+ 24: LParen          "(" at 5:12-5:13
+ 25: Ident           "self" at 5:13-5:17
+ 26: Colon           ":" at 5:17-5:18
+ 27: Ident           "MyInt" at 5:19-5:24 (leading: Space)
+ 28: Comma           "," at 5:24-5:25
+ 29: Underscore      "_" at 5:26-5:27 (leading: Space)
+ 30: Colon           ":" at 5:27-5:28
+ 31: Ident           "int" at 5:29-5:32 (leading: Space)
+ 32: RParen          ")" at 5:32-5:33
+ 33: Arrow           "->" at 5:34-5:36 (leading: Space)
+ 34: Ident           "int" at 5:37-5:40 (leading: Space)
+ 35: LBrace          "{" at 5:41-5:42 (leading: Space)
+ 36: KwReturn        "return" at 6:9-6:15 (leading: Newline, Space)
+ 37: Ident           "self" at 6:16-6:20 (leading: Space)
+ 38: Dot             "." at 6:20-6:21
+ 39: Ident           "value" at 6:21-6:26
+ 40: Semicolon       ";" at 6:26-6:27
+ 41: RBrace          "}" at 7:5-7:6 (leading: Newline, Space)
+ 42: RBrace          "}" at 8:1-8:2 (leading: Newline)
+ 43: KwExtern        "extern" at 10:1-10:7 (leading: Newline)
+ 44: Lt              "<" at 10:7-10:8
+ 45: Ident           "Wrapper" at 10:8-10:15
+ 46: Gt              ">" at 10:15-10:16
+ 47: LBrace          "{" at 10:17-10:18 (leading: Space)
+ 48: KwFn            "fn" at 11:5-11:7 (leading: Newline, Space)
+ 49: Ident           "__to" at 11:8-11:12 (leading: Space)
+ 50: LParen          "(" at 11:12-11:13
+ 51: Ident           "self" at 11:13-11:17
+ 52: Colon           ":" at 11:17-11:18
+ 53: Ident           "Wrapper" at 11:19-11:26 (leading: Space)
+ 54: Comma           "," at 11:26-11:27
+ 55: Underscore      "_" at 11:28-11:29 (leading: Space)
+ 56: Colon           ":" at 11:29-11:30
+ 57: Ident           "string" at 11:31-11:37 (leading: Space)
+ 58: RParen          ")" at 11:37-11:38
+ 59: Arrow           "->" at 11:39-11:41 (leading: Space)
+ 60: Ident           "string" at 11:42-11:48 (leading: Space)
+ 61: LBrace          "{" at 11:49-11:50 (leading: Space)
+ 62: KwReturn        "return" at 12:9-12:15 (leading: Newline, Space)
+ 63: Ident           "self" at 12:16-12:20 (leading: Space)
+ 64: Dot             "." at 12:20-12:21
+ 65: Ident           "data" at 12:21-12:25
+ 66: Semicolon       ";" at 12:25-12:26
+ 67: RBrace          "}" at 13:5-13:6 (leading: Newline, Space)
+ 68: RBrace          "}" at 14:1-14:2 (leading: Newline)
+ 69: KwFn            "fn" at 16:1-16:3 (leading: Newline)
+ 70: Ident           "test_variable_binding" at 16:4-16:25 (leading: Space)
+ 71: LParen          "(" at 16:25-16:26
+ 72: RParen          ")" at 16:26-16:27
+ 73: LBrace          "{" at 16:28-16:29 (leading: Space)
+ 74: KwLet           "let" at 17:5-17:8 (leading: Newline, Space)
+ 75: Ident           "w" at 17:9-17:10 (leading: Space)
+ 76: Colon           ":" at 17:10-17:11
+ 77: Ident           "Wrapper" at 17:12-17:19 (leading: Space)
+ 78: Assign          "=" at 17:20-17:21 (leading: Space)
+ 79: Ident           "Wrapper" at 17:22-17:29 (leading: Space)
+ 80: LBrace          "{" at 17:30-17:31 (leading: Space)
+ 81: StringLit       "\"test\"" at 17:32-17:38 (leading: Space)
+ 82: RBrace          "}" at 17:39-17:40 (leading: Space)
+ 83: Semicolon       ";" at 17:40-17:41
+ 84: KwLet           "let" at 18:5-18:8 (leading: Newline, Space)
+ 85: Ident           "s" at 18:9-18:10 (leading: Space)
+ 86: Colon           ":" at 18:10-18:11
+ 87: Ident           "string" at 18:12-18:18 (leading: Space)
+ 88: Assign          "=" at 18:19-18:20 (leading: Space)
+ 89: Ident           "w" at 18:21-18:22 (leading: Space)
+ 90: Semicolon       ";" at 18:22-18:23
+ 91: RBrace          "}" at 19:1-19:2 (leading: Newline)
+ 92: KwFn            "fn" at 21:1-21:3 (leading: Newline)
+ 93: Ident           "takes_int" at 21:4-21:13 (leading: Space)
+ 94: LParen          "(" at 21:13-21:14
+ 95: Ident           "x" at 21:14-21:15
+ 96: Colon           ":" at 21:15-21:16
+ 97: Ident           "int" at 21:17-21:20 (leading: Space)
+ 98: RParen          ")" at 21:20-21:21
+ 99: LBrace          "{" at 21:22-21:23 (leading: Space)
+100: RBrace          "}" at 22:1-22:2 (leading: Newline)
+101: KwFn            "fn" at 24:1-24:3 (leading: Newline)
+102: Ident           "test_function_args" at 24:4-24:22 (leading: Space)
+103: LParen          "(" at 24:22-24:23
+104: RParen          ")" at 24:23-24:24
+105: LBrace          "{" at 24:25-24:26 (leading: Space)
+106: KwLet           "let" at 25:5-25:8 (leading: Newline, Space)
+107: Ident           "mi" at 25:9-25:11 (leading: Space)
+108: Colon           ":" at 25:11-25:12
+109: Ident           "MyInt" at 25:13-25:18 (leading: Space)
+110: Assign          "=" at 25:19-25:20 (leading: Space)
+111: Ident           "MyInt" at 25:21-25:26 (leading: Space)
+112: LBrace          "{" at 25:27-25:28 (leading: Space)
+113: IntLit          "42" at 25:29-25:31 (leading: Space)
+114: RBrace          "}" at 25:32-25:33 (leading: Space)
+115: Semicolon       ";" at 25:33-25:34
+116: Ident           "takes_int" at 26:5-26:14 (leading: Newline, Space)
+117: LParen          "(" at 26:14-26:15
+118: Ident           "mi" at 26:15-26:17
+119: RParen          ")" at 26:17-26:18
+120: Semicolon       ";" at 26:18-26:19
+121: RBrace          "}" at 27:1-27:2 (leading: Newline)
+122: KwFn            "fn" at 29:1-29:3 (leading: Newline)
+123: Ident           "returns_string" at 29:4-29:18 (leading: Space)
+124: LParen          "(" at 29:18-29:19
+125: RParen          ")" at 29:19-29:20
+126: Arrow           "->" at 29:21-29:23 (leading: Space)
+127: Ident           "string" at 29:24-29:30 (leading: Space)
+128: LBrace          "{" at 29:31-29:32 (leading: Space)
+129: KwLet           "let" at 30:5-30:8 (leading: Newline, Space)
+130: Ident           "w" at 30:9-30:10 (leading: Space)
+131: Colon           ":" at 30:10-30:11
+132: Ident           "Wrapper" at 30:12-30:19 (leading: Space)
+133: Assign          "=" at 30:20-30:21 (leading: Space)
+134: Ident           "Wrapper" at 30:22-30:29 (leading: Space)
+135: LBrace          "{" at 30:30-30:31 (leading: Space)
+136: StringLit       "\"hello\"" at 30:32-30:39 (leading: Space)
+137: RBrace          "}" at 30:40-30:41 (leading: Space)
+138: Semicolon       ";" at 30:41-30:42
+139: KwReturn        "return" at 31:5-31:11 (leading: Newline, Space)
+140: Ident           "w" at 31:12-31:13 (leading: Space)
+141: Semicolon       ";" at 31:13-31:14
+142: RBrace          "}" at 32:1-32:2 (leading: Newline)
+143: KwType          "type" at 34:1-34:5 (leading: Newline)
+144: Ident           "Point" at 34:6-34:11 (leading: Space)
+145: Assign          "=" at 34:12-34:13 (leading: Space)
+146: LBrace          "{" at 34:14-34:15 (leading: Space)
+147: Ident           "x" at 35:5-35:6 (leading: Newline, Space)
+148: Colon           ":" at 35:6-35:7
+149: Ident           "int" at 35:8-35:11 (leading: Space)
+150: Comma           "," at 35:11-35:12
+151: Ident           "y" at 36:5-36:6 (leading: Newline, Space)
+152: Colon           ":" at 36:6-36:7
+153: Ident           "int" at 36:8-36:11 (leading: Space)
+154: Comma           "," at 36:11-36:12
+155: RBrace          "}" at 37:1-37:2 (leading: Newline)
+156: KwFn            "fn" at 39:1-39:3 (leading: Newline)
+157: Ident           "test_struct_field" at 39:4-39:21 (leading: Space)
+158: LParen          "(" at 39:21-39:22
+159: RParen          ")" at 39:22-39:23
+160: LBrace          "{" at 39:24-39:25 (leading: Space)
+161: KwLet           "let" at 40:5-40:8 (leading: Newline, Space)
+162: Ident           "mi" at 40:9-40:11 (leading: Space)
+163: Colon           ":" at 40:11-40:12
+164: Ident           "MyInt" at 40:13-40:18 (leading: Space)
+165: Assign          "=" at 40:19-40:20 (leading: Space)
+166: Ident           "MyInt" at 40:21-40:26 (leading: Space)
+167: LBrace          "{" at 40:27-40:28 (leading: Space)
+168: IntLit          "10" at 40:29-40:31 (leading: Space)
+169: RBrace          "}" at 40:32-40:33 (leading: Space)
+170: Semicolon       ";" at 40:33-40:34
+171: KwLet           "let" at 41:5-41:8 (leading: Newline, Space)
+172: Ident           "p" at 41:9-41:10 (leading: Space)
+173: Colon           ":" at 41:10-41:11
+174: Ident           "Point" at 41:12-41:17 (leading: Space)
+175: Assign          "=" at 41:18-41:19 (leading: Space)
+176: Ident           "Point" at 41:20-41:25 (leading: Space)
+177: LBrace          "{" at 41:26-41:27 (leading: Space)
+178: Ident           "x" at 42:9-42:10 (leading: Newline, Space)
+179: Colon           ":" at 42:10-42:11
+180: Ident           "mi" at 42:12-42:14 (leading: Space)
+181: Comma           "," at 42:14-42:15
+182: Ident           "y" at 43:9-43:10 (leading: Newline, Space)
+183: Colon           ":" at 43:10-43:11
+184: IntLit          "0" at 43:12-43:13 (leading: Space)
+185: Comma           "," at 43:13-43:14
+186: RBrace          "}" at 44:5-44:6 (leading: Newline, Space)
+187: Semicolon       ";" at 44:6-44:7
+188: RBrace          "}" at 45:1-45:2 (leading: Newline)
+189: KwFn            "fn" at 47:1-47:3 (leading: Newline)
+190: Ident           "test_array_elements" at 47:4-47:23 (leading: Space)
+191: LParen          "(" at 47:23-47:24
+192: RParen          ")" at 47:24-47:25
+193: LBrace          "{" at 47:26-47:27 (leading: Space)
+194: KwLet           "let" at 48:5-48:8 (leading: Newline, Space)
+195: Ident           "mi1" at 48:9-48:12 (leading: Space)
+196: Colon           ":" at 48:12-48:13
+197: Ident           "MyInt" at 48:14-48:19 (leading: Space)
+198: Assign          "=" at 48:20-48:21 (leading: Space)
+199: Ident           "MyInt" at 48:22-48:27 (leading: Space)
+200: LBrace          "{" at 48:28-48:29 (leading: Space)
+201: IntLit          "1" at 48:30-48:31 (leading: Space)
+202: RBrace          "}" at 48:32-48:33 (leading: Space)
+203: Semicolon       ";" at 48:33-48:34
+204: KwLet           "let" at 49:5-49:8 (leading: Newline, Space)
+205: Ident           "mi2" at 49:9-49:12 (leading: Space)
+206: Colon           ":" at 49:12-49:13
+207: Ident           "MyInt" at 49:14-49:19 (leading: Space)
+208: Assign          "=" at 49:20-49:21 (leading: Space)
+209: Ident           "MyInt" at 49:22-49:27 (leading: Space)
+210: LBrace          "{" at 49:28-49:29 (leading: Space)
+211: IntLit          "2" at 49:30-49:31 (leading: Space)
+212: RBrace          "}" at 49:32-49:33 (leading: Space)
+213: Semicolon       ";" at 49:33-49:34
+214: KwLet           "let" at 50:5-50:8 (leading: Newline, Space)
+215: Ident           "arr" at 50:9-50:12 (leading: Space)
+216: Colon           ":" at 50:12-50:13
+217: Ident           "int" at 50:14-50:17 (leading: Space)
+218: LBracket        "[" at 50:17-50:18
+219: IntLit          "2" at 50:18-50:19
+220: RBracket        "]" at 50:19-50:20
+221: Assign          "=" at 50:21-50:22 (leading: Space)
+222: LBracket        "[" at 50:23-50:24 (leading: Space)
+223: Ident           "mi1" at 50:24-50:27
+224: Comma           "," at 50:27-50:28
+225: Ident           "mi2" at 50:29-50:32 (leading: Space)
+226: RBracket        "]" at 50:32-50:33
+227: Semicolon       ";" at 50:33-50:34
+228: RBrace          "}" at 51:1-51:2 (leading: Newline)
+229: KwFn            "fn" at 53:1-53:3 (leading: Newline)
+230: Ident           "test_explicit_conversion" at 53:4-53:28 (leading: Space)
+231: LParen          "(" at 53:28-53:29
+232: RParen          ")" at 53:29-53:30
+233: LBrace          "{" at 53:31-53:32 (leading: Space)
+234: KwLet           "let" at 54:5-54:8 (leading: Newline, Space)
+235: Ident           "w" at 54:9-54:10 (leading: Space)
+236: Colon           ":" at 54:10-54:11
+237: Ident           "Wrapper" at 54:12-54:19 (leading: Space)
+238: Assign          "=" at 54:20-54:21 (leading: Space)
+239: Ident           "Wrapper" at 54:22-54:29 (leading: Space)
+240: LBrace          "{" at 54:30-54:31 (leading: Space)
+241: StringLit       "\"explicit\"" at 54:32-54:42 (leading: Space)
+242: RBrace          "}" at 54:43-54:44 (leading: Space)
+243: Semicolon       ";" at 54:44-54:45
+244: KwLet           "let" at 55:5-55:8 (leading: Newline, Space)
+245: Ident           "s" at 55:9-55:10 (leading: Space)
+246: Colon           ":" at 55:10-55:11
+247: Ident           "string" at 55:12-55:18 (leading: Space)
+248: Assign          "=" at 55:19-55:20 (leading: Space)
+249: Ident           "w" at 55:21-55:22 (leading: Space)
+250: KwTo            "to" at 55:23-55:25 (leading: Space)
+251: Ident           "string" at 55:26-55:32 (leading: Space)
+252: Semicolon       ";" at 55:32-55:33
+253: RBrace          "}" at 56:1-56:2 (leading: Newline)
+254: EOF             at 57:1-57:1

--- a/testdata/golden/sema/valid/implicit_conversion_not_applied.ast
+++ b/testdata/golden/sema/valid/implicit_conversion_not_applied.ast
@@ -1,0 +1,81 @@
+implicit_conversion_not_applied.sg (span: 1:1-32:1)
+├─ Item[0]: Type (span: 1:1-1:28)
+│  ├─ Name: MyInt
+│  ├─ Kind: Struct
+│  ├─ Visibility: private
+│  └─ Struct:
+│     └─ Field[0]: value: int
+├─ Item[1]: Type (span: 2:1-2:25)
+│  ├─ Name: ChainA
+│  ├─ Kind: Struct
+│  ├─ Visibility: private
+│  └─ Struct:
+│     └─ Field[0]: a: int
+├─ Item[2]: Type (span: 3:1-3:25)
+│  ├─ Name: ChainB
+│  ├─ Kind: Struct
+│  ├─ Visibility: private
+│  └─ Struct:
+│     └─ Field[0]: b: int
+├─ Item[3]: Extern (span: 5:1-9:2)
+│  ├─ Target: MyInt
+│  ├─ Members:
+│  │  └─ Fn[0]: __to
+│  │     ├─ Params: (self: MyInt, _: int)
+│  │     ├─ Return: int
+│  │     └─ Body:
+│  │        Stmt[0]: Block (span: 6:41-8:6)
+│  │        └─ Stmt[0]: Return (span: 7:9-7:27)
+│  │           └─ Expr: expr#2: self.value
+├─ Item[4]: Extern (span: 11:1-15:2)
+│  ├─ Target: ChainA
+│  ├─ Members:
+│  │  └─ Fn[0]: __to
+│  │     ├─ Params: (self: ChainA, _: ChainB)
+│  │     ├─ Return: ChainB
+│  │     └─ Body:
+│  │        Stmt[0]: Block (span: 12:48-14:6)
+│  │        └─ Stmt[0]: Return (span: 13:9-13:34)
+│  │           └─ Expr: expr#5: <ExprKind(18)>
+├─ Item[5]: Extern (span: 17:1-21:2)
+│  ├─ Target: ChainB
+│  ├─ Members:
+│  │  └─ Fn[0]: __to
+│  │     ├─ Params: (self: ChainB, _: int)
+│  │     ├─ Return: int
+│  │     └─ Body:
+│  │        Stmt[0]: Block (span: 18:42-20:6)
+│  │        └─ Stmt[0]: Return (span: 19:9-19:23)
+│  │           └─ Expr: expr#7: self.b
+├─ Item[6]: Fn (span: 23:1-24:43)
+│  ├─ Name: overloaded
+│  ├─ Params: (x: int)
+│  ├─ Return: int
+│  └─ Body:
+│     └─ Stmt[0]: Block (span: 24:30-24:43)
+│        └─ Stmt[0]: Return (span: 24:32-24:41)
+│           └─ Expr: expr#8: 1
+├─ Item[7]: Fn (span: 25:1-26:46)
+│  ├─ Name: overloaded
+│  ├─ Params: (x: string)
+│  ├─ Return: int
+│  └─ Body:
+│     └─ Stmt[0]: Block (span: 26:33-26:46)
+│        └─ Stmt[0]: Return (span: 26:35-26:44)
+│           └─ Expr: expr#9: 2
+└─ Item[8]: Fn (span: 28:1-31:2)
+   ├─ Name: test_overload_selection
+   ├─ Params: ()
+   ├─ Return: nothing
+   └─ Body:
+      └─ Stmt[0]: Block (span: 28:30-31:2)
+         ├─ Stmt[0]: Let (span: 29:5-29:34)
+         │  ├─ Name: mi
+         │  ├─ Mutable: false
+         │  ├─ Type: MyInt
+         │  └─ Value: expr#11: <ExprKind(18)>
+         └─ Stmt[1]: Let (span: 30:5-30:38)
+            ├─ Name: result
+            ├─ Mutable: false
+            ├─ Type: int
+            └─ Value: expr#14: overloaded(mi)

--- a/testdata/golden/sema/valid/implicit_conversion_not_applied.fmt
+++ b/testdata/golden/sema/valid/implicit_conversion_not_applied.fmt
@@ -1,0 +1,31 @@
+type MyInt = { value: int }
+type ChainA = { a: int }
+type ChainB = { b: int }
+
+extern<MyInt> {
+    fn __to(self: MyInt, _: int) -> int {
+        return self.value;
+    }
+}
+
+extern<ChainA> {
+    fn __to(self: ChainA, _: ChainB) -> ChainB {
+        return ChainB { self.a };
+    }
+}
+
+extern<ChainB> {
+    fn __to(self: ChainB, _: int) -> int {
+        return self.b;
+    }
+}
+
+@overload
+fn overloaded(x: int) -> int { return 1; }
+@overload
+fn overloaded(x: string) -> int { return 2; }
+
+fn test_overload_selection() {
+    let mi: MyInt = MyInt { 42 };
+    let result: int = overloaded(mi);
+}

--- a/testdata/golden/sema/valid/implicit_conversion_not_applied.sg
+++ b/testdata/golden/sema/valid/implicit_conversion_not_applied.sg
@@ -1,0 +1,31 @@
+type MyInt = { value: int }
+type ChainA = { a: int }
+type ChainB = { b: int }
+
+extern<MyInt> {
+    fn __to(self: MyInt, _: int) -> int {
+        return self.value;
+    }
+}
+
+extern<ChainA> {
+    fn __to(self: ChainA, _: ChainB) -> ChainB {
+        return ChainB { self.a };
+    }
+}
+
+extern<ChainB> {
+    fn __to(self: ChainB, _: int) -> int {
+        return self.b;
+    }
+}
+
+@overload
+fn overloaded(x: int) -> int { return 1; }
+@overload
+fn overloaded(x: string) -> int { return 2; }
+
+fn test_overload_selection() {
+    let mi: MyInt = MyInt { 42 };
+    let result: int = overloaded(mi);
+}

--- a/testdata/golden/sema/valid/implicit_conversion_not_applied.tokens
+++ b/testdata/golden/sema/valid/implicit_conversion_not_applied.tokens
@@ -1,0 +1,164 @@
+  1: KwType          "type" at 1:1-1:5
+  2: Ident           "MyInt" at 1:6-1:11 (leading: Space)
+  3: Assign          "=" at 1:12-1:13 (leading: Space)
+  4: LBrace          "{" at 1:14-1:15 (leading: Space)
+  5: Ident           "value" at 1:16-1:21 (leading: Space)
+  6: Colon           ":" at 1:21-1:22
+  7: Ident           "int" at 1:23-1:26 (leading: Space)
+  8: RBrace          "}" at 1:27-1:28 (leading: Space)
+  9: KwType          "type" at 2:1-2:5 (leading: Newline)
+ 10: Ident           "ChainA" at 2:6-2:12 (leading: Space)
+ 11: Assign          "=" at 2:13-2:14 (leading: Space)
+ 12: LBrace          "{" at 2:15-2:16 (leading: Space)
+ 13: Ident           "a" at 2:17-2:18 (leading: Space)
+ 14: Colon           ":" at 2:18-2:19
+ 15: Ident           "int" at 2:20-2:23 (leading: Space)
+ 16: RBrace          "}" at 2:24-2:25 (leading: Space)
+ 17: KwType          "type" at 3:1-3:5 (leading: Newline)
+ 18: Ident           "ChainB" at 3:6-3:12 (leading: Space)
+ 19: Assign          "=" at 3:13-3:14 (leading: Space)
+ 20: LBrace          "{" at 3:15-3:16 (leading: Space)
+ 21: Ident           "b" at 3:17-3:18 (leading: Space)
+ 22: Colon           ":" at 3:18-3:19
+ 23: Ident           "int" at 3:20-3:23 (leading: Space)
+ 24: RBrace          "}" at 3:24-3:25 (leading: Space)
+ 25: KwExtern        "extern" at 5:1-5:7 (leading: Newline)
+ 26: Lt              "<" at 5:7-5:8
+ 27: Ident           "MyInt" at 5:8-5:13
+ 28: Gt              ">" at 5:13-5:14
+ 29: LBrace          "{" at 5:15-5:16 (leading: Space)
+ 30: KwFn            "fn" at 6:5-6:7 (leading: Newline, Space)
+ 31: Ident           "__to" at 6:8-6:12 (leading: Space)
+ 32: LParen          "(" at 6:12-6:13
+ 33: Ident           "self" at 6:13-6:17
+ 34: Colon           ":" at 6:17-6:18
+ 35: Ident           "MyInt" at 6:19-6:24 (leading: Space)
+ 36: Comma           "," at 6:24-6:25
+ 37: Underscore      "_" at 6:26-6:27 (leading: Space)
+ 38: Colon           ":" at 6:27-6:28
+ 39: Ident           "int" at 6:29-6:32 (leading: Space)
+ 40: RParen          ")" at 6:32-6:33
+ 41: Arrow           "->" at 6:34-6:36 (leading: Space)
+ 42: Ident           "int" at 6:37-6:40 (leading: Space)
+ 43: LBrace          "{" at 6:41-6:42 (leading: Space)
+ 44: KwReturn        "return" at 7:9-7:15 (leading: Newline, Space)
+ 45: Ident           "self" at 7:16-7:20 (leading: Space)
+ 46: Dot             "." at 7:20-7:21
+ 47: Ident           "value" at 7:21-7:26
+ 48: Semicolon       ";" at 7:26-7:27
+ 49: RBrace          "}" at 8:5-8:6 (leading: Newline, Space)
+ 50: RBrace          "}" at 9:1-9:2 (leading: Newline)
+ 51: KwExtern        "extern" at 11:1-11:7 (leading: Newline)
+ 52: Lt              "<" at 11:7-11:8
+ 53: Ident           "ChainA" at 11:8-11:14
+ 54: Gt              ">" at 11:14-11:15
+ 55: LBrace          "{" at 11:16-11:17 (leading: Space)
+ 56: KwFn            "fn" at 12:5-12:7 (leading: Newline, Space)
+ 57: Ident           "__to" at 12:8-12:12 (leading: Space)
+ 58: LParen          "(" at 12:12-12:13
+ 59: Ident           "self" at 12:13-12:17
+ 60: Colon           ":" at 12:17-12:18
+ 61: Ident           "ChainA" at 12:19-12:25 (leading: Space)
+ 62: Comma           "," at 12:25-12:26
+ 63: Underscore      "_" at 12:27-12:28 (leading: Space)
+ 64: Colon           ":" at 12:28-12:29
+ 65: Ident           "ChainB" at 12:30-12:36 (leading: Space)
+ 66: RParen          ")" at 12:36-12:37
+ 67: Arrow           "->" at 12:38-12:40 (leading: Space)
+ 68: Ident           "ChainB" at 12:41-12:47 (leading: Space)
+ 69: LBrace          "{" at 12:48-12:49 (leading: Space)
+ 70: KwReturn        "return" at 13:9-13:15 (leading: Newline, Space)
+ 71: Ident           "ChainB" at 13:16-13:22 (leading: Space)
+ 72: LBrace          "{" at 13:23-13:24 (leading: Space)
+ 73: Ident           "self" at 13:25-13:29 (leading: Space)
+ 74: Dot             "." at 13:29-13:30
+ 75: Ident           "a" at 13:30-13:31
+ 76: RBrace          "}" at 13:32-13:33 (leading: Space)
+ 77: Semicolon       ";" at 13:33-13:34
+ 78: RBrace          "}" at 14:5-14:6 (leading: Newline, Space)
+ 79: RBrace          "}" at 15:1-15:2 (leading: Newline)
+ 80: KwExtern        "extern" at 17:1-17:7 (leading: Newline)
+ 81: Lt              "<" at 17:7-17:8
+ 82: Ident           "ChainB" at 17:8-17:14
+ 83: Gt              ">" at 17:14-17:15
+ 84: LBrace          "{" at 17:16-17:17 (leading: Space)
+ 85: KwFn            "fn" at 18:5-18:7 (leading: Newline, Space)
+ 86: Ident           "__to" at 18:8-18:12 (leading: Space)
+ 87: LParen          "(" at 18:12-18:13
+ 88: Ident           "self" at 18:13-18:17
+ 89: Colon           ":" at 18:17-18:18
+ 90: Ident           "ChainB" at 18:19-18:25 (leading: Space)
+ 91: Comma           "," at 18:25-18:26
+ 92: Underscore      "_" at 18:27-18:28 (leading: Space)
+ 93: Colon           ":" at 18:28-18:29
+ 94: Ident           "int" at 18:30-18:33 (leading: Space)
+ 95: RParen          ")" at 18:33-18:34
+ 96: Arrow           "->" at 18:35-18:37 (leading: Space)
+ 97: Ident           "int" at 18:38-18:41 (leading: Space)
+ 98: LBrace          "{" at 18:42-18:43 (leading: Space)
+ 99: KwReturn        "return" at 19:9-19:15 (leading: Newline, Space)
+100: Ident           "self" at 19:16-19:20 (leading: Space)
+101: Dot             "." at 19:20-19:21
+102: Ident           "b" at 19:21-19:22
+103: Semicolon       ";" at 19:22-19:23
+104: RBrace          "}" at 20:5-20:6 (leading: Newline, Space)
+105: RBrace          "}" at 21:1-21:2 (leading: Newline)
+106: At              "@" at 23:1-23:2 (leading: Newline)
+107: Ident           "overload" at 23:2-23:10
+108: KwFn            "fn" at 24:1-24:3 (leading: Newline)
+109: Ident           "overloaded" at 24:4-24:14 (leading: Space)
+110: LParen          "(" at 24:14-24:15
+111: Ident           "x" at 24:15-24:16
+112: Colon           ":" at 24:16-24:17
+113: Ident           "int" at 24:18-24:21 (leading: Space)
+114: RParen          ")" at 24:21-24:22
+115: Arrow           "->" at 24:23-24:25 (leading: Space)
+116: Ident           "int" at 24:26-24:29 (leading: Space)
+117: LBrace          "{" at 24:30-24:31 (leading: Space)
+118: KwReturn        "return" at 24:32-24:38 (leading: Space)
+119: IntLit          "1" at 24:39-24:40 (leading: Space)
+120: Semicolon       ";" at 24:40-24:41
+121: RBrace          "}" at 24:42-24:43 (leading: Space)
+122: At              "@" at 25:1-25:2 (leading: Newline)
+123: Ident           "overload" at 25:2-25:10
+124: KwFn            "fn" at 26:1-26:3 (leading: Newline)
+125: Ident           "overloaded" at 26:4-26:14 (leading: Space)
+126: LParen          "(" at 26:14-26:15
+127: Ident           "x" at 26:15-26:16
+128: Colon           ":" at 26:16-26:17
+129: Ident           "string" at 26:18-26:24 (leading: Space)
+130: RParen          ")" at 26:24-26:25
+131: Arrow           "->" at 26:26-26:28 (leading: Space)
+132: Ident           "int" at 26:29-26:32 (leading: Space)
+133: LBrace          "{" at 26:33-26:34 (leading: Space)
+134: KwReturn        "return" at 26:35-26:41 (leading: Space)
+135: IntLit          "2" at 26:42-26:43 (leading: Space)
+136: Semicolon       ";" at 26:43-26:44
+137: RBrace          "}" at 26:45-26:46 (leading: Space)
+138: KwFn            "fn" at 28:1-28:3 (leading: Newline)
+139: Ident           "test_overload_selection" at 28:4-28:27 (leading: Space)
+140: LParen          "(" at 28:27-28:28
+141: RParen          ")" at 28:28-28:29
+142: LBrace          "{" at 28:30-28:31 (leading: Space)
+143: KwLet           "let" at 29:5-29:8 (leading: Newline, Space)
+144: Ident           "mi" at 29:9-29:11 (leading: Space)
+145: Colon           ":" at 29:11-29:12
+146: Ident           "MyInt" at 29:13-29:18 (leading: Space)
+147: Assign          "=" at 29:19-29:20 (leading: Space)
+148: Ident           "MyInt" at 29:21-29:26 (leading: Space)
+149: LBrace          "{" at 29:27-29:28 (leading: Space)
+150: IntLit          "42" at 29:29-29:31 (leading: Space)
+151: RBrace          "}" at 29:32-29:33 (leading: Space)
+152: Semicolon       ";" at 29:33-29:34
+153: KwLet           "let" at 30:5-30:8 (leading: Newline, Space)
+154: Ident           "result" at 30:9-30:15 (leading: Space)
+155: Colon           ":" at 30:15-30:16
+156: Ident           "int" at 30:17-30:20 (leading: Space)
+157: Assign          "=" at 30:21-30:22 (leading: Space)
+158: Ident           "overloaded" at 30:23-30:33 (leading: Space)
+159: LParen          "(" at 30:33-30:34
+160: Ident           "mi" at 30:34-30:36
+161: RParen          ")" at 30:36-30:37
+162: Semicolon       ";" at 30:37-30:38
+163: RBrace          "}" at 31:1-31:2 (leading: Newline)
+164: EOF             at 32:1-32:1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Implicit type conversions via __to are now applied automatically at coercion sites (bindings, args, returns, struct fields, array elements) when exactly one conversion exists.

* **Documentation**
  * Added detailed docs describing resolution rules, builtin implicit conversions, diagnostics, and examples.

* **Tests**
  * Added multiple new golden tests covering valid, invalid, and overload-selection implicit-conversion scenarios.

* **Chores**
  * Added two new semantic diagnostics for missing and ambiguous conversions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->