### PR TITLE
Concurrency v1 phase 1

### DIFF
--- a/internal/diag/codes.go
+++ b/internal/diag/codes.go
@@ -177,6 +177,10 @@ const (
 	SemaNoConversion        Code = 3098 // No conversion from T to U
 	SemaAmbiguousConversion Code = 3099 // Ambiguous conversion from T to U
 
+	// Additional concurrency attribute validation (3100-3101)
+	SemaAttrWaitsOnNotCondition Code = 3100 // @waits_on field must be Condition/Semaphore
+	SemaAttrAtomicInvalidType   Code = 3101 // @atomic field must be int/uint/bool/*T
+
 	// Ошибки I/O
 	IOLoadFileError Code = 4001
 
@@ -357,6 +361,8 @@ var ( // todo расширить описания и использовать к
 		SemaEnumInvalidBaseType:        "invalid base type for enum",
 		SemaNoConversion:               "no conversion from source to target type",
 		SemaAmbiguousConversion:        "ambiguous conversion from source to target type",
+		SemaAttrWaitsOnNotCondition:    "@waits_on field must be Condition or Semaphore",
+		SemaAttrAtomicInvalidType:      "@atomic field must be int, uint, bool, or *T",
 		IOLoadFileError:                "I/O load file error",
 		ProjInfo:                       "Project information",
 		ProjDuplicateModule:            "Duplicate module definition",

--- a/internal/sema/extern_functions.go
+++ b/internal/sema/extern_functions.go
@@ -60,6 +60,9 @@ func (tc *typeChecker) typecheckExternFn(memberID ast.ExternMemberID, fn *ast.Fn
 		tc.pushReturnContext(returnType, returnSpan, nil)
 		pushed := tc.pushScope(scope)
 		tc.walkStmt(fn.Body)
+		// Perform lock analysis after walking the body
+		selfSym := tc.findSelfSymbol(fn, scope)
+		tc.analyzeFunctionLocks(fn, selfSym)
 		if pushed {
 			tc.leaveScope()
 		}

--- a/internal/sema/lock_analysis.go
+++ b/internal/sema/lock_analysis.go
@@ -1,0 +1,513 @@
+package sema
+
+import (
+	"surge/internal/ast"
+	"surge/internal/diag"
+	"surge/internal/source"
+	"surge/internal/symbols"
+)
+
+// LockKind represents the type of lock operation
+type LockKind int
+
+const (
+	LockKindMutex   LockKind = iota // Mutex.lock()
+	LockKindRwRead                  // RwLock.read_lock()
+	LockKindRwWrite                 // RwLock.write_lock()
+)
+
+func (k LockKind) String() string {
+	switch k {
+	case LockKindMutex:
+		return "mutex"
+	case LockKindRwRead:
+		return "read"
+	case LockKindRwWrite:
+		return "write"
+	default:
+		return "unknown"
+	}
+}
+
+// LockKey uniquely identifies a held lock
+type LockKey struct {
+	Base      symbols.SymbolID // Root variable (self, parameter, local)
+	FieldName source.StringID  // Field name of the lock
+	Kind      LockKind
+}
+
+// LockAcquisition records where a lock was acquired
+type LockAcquisition struct {
+	Key  LockKey
+	Span source.Span // Location where lock was acquired
+}
+
+// LockState tracks currently held locks within a function
+type LockState struct {
+	held []LockAcquisition // Stack of held locks (in acquisition order)
+}
+
+// NewLockState creates a new empty lock state
+func NewLockState() *LockState {
+	return &LockState{
+		held: make([]LockAcquisition, 0, 4),
+	}
+}
+
+// Clone creates a copy of the lock state (for future branch analysis)
+func (s *LockState) Clone() *LockState {
+	clone := &LockState{
+		held: make([]LockAcquisition, len(s.held)),
+	}
+	copy(clone.held, s.held)
+	return clone
+}
+
+// IsHeld checks if a lock is currently held
+func (s *LockState) IsHeld(key LockKey) bool {
+	for _, acq := range s.held {
+		if acq.Key == key {
+			return true
+		}
+	}
+	return false
+}
+
+// FindAcquisition returns the acquisition info for a held lock, if any
+func (s *LockState) FindAcquisition(key LockKey) (LockAcquisition, bool) {
+	for _, acq := range s.held {
+		if acq.Key == key {
+			return acq, true
+		}
+	}
+	return LockAcquisition{}, false
+}
+
+// Acquire attempts to acquire a lock. Returns error info if double-lock detected.
+func (s *LockState) Acquire(key LockKey, span source.Span) (prevSpan source.Span, doubleLock bool) {
+	if prev, found := s.FindAcquisition(key); found {
+		return prev.Span, true
+	}
+	s.held = append(s.held, LockAcquisition{Key: key, Span: span})
+	return source.Span{}, false
+}
+
+// Release attempts to release a lock. Returns false if lock was not held.
+func (s *LockState) Release(key LockKey) bool {
+	for i, acq := range s.held {
+		if acq.Key == key {
+			// Remove from held list
+			s.held = append(s.held[:i], s.held[i+1:]...)
+			return true
+		}
+	}
+	return false
+}
+
+// HeldLocks returns all currently held locks
+func (s *LockState) HeldLocks() []LockAcquisition {
+	return s.held
+}
+
+// IsEmpty returns true if no locks are held
+func (s *LockState) IsEmpty() bool {
+	return len(s.held) == 0
+}
+
+// lockAnalyzer performs lock analysis on function bodies
+type lockAnalyzer struct {
+	tc          *typeChecker
+	state       *LockState
+	selfSym     symbols.SymbolID // Symbol for 'self' parameter if method
+	hasTryLocks bool             // True if function uses try_lock methods (skip linear analysis)
+}
+
+// newLockAnalyzer creates a new lock analyzer for a function
+func (tc *typeChecker) newLockAnalyzer() *lockAnalyzer {
+	return &lockAnalyzer{
+		tc:    tc,
+		state: NewLockState(),
+	}
+}
+
+// findSelfSymbol finds the 'self' parameter symbol for a function/method
+func (tc *typeChecker) findSelfSymbol(fnItem *ast.FnItem, scope symbols.ScopeID) symbols.SymbolID {
+	if fnItem == nil {
+		return symbols.NoSymbolID
+	}
+
+	// Get parameters
+	paramIDs := tc.builder.Items.GetFnParamIDs(fnItem)
+	if len(paramIDs) == 0 {
+		return symbols.NoSymbolID
+	}
+
+	// Check first parameter for 'self'
+	firstParam := tc.builder.Items.FnParam(paramIDs[0])
+	if firstParam == nil {
+		return symbols.NoSymbolID
+	}
+
+	// Check if it's named 'self'
+	paramName := tc.lookupName(firstParam.Name)
+	if paramName != "self" {
+		return symbols.NoSymbolID
+	}
+
+	// Find the symbol for 'self' in the function's scope
+	return tc.symbolInScope(scope, firstParam.Name, symbols.SymbolParam)
+}
+
+// initFromAttributes initializes lock state from function attributes
+// @requires_lock and @releases_lock both mean lock is held on entry
+func (la *lockAnalyzer) initFromAttributes(fnItem *ast.FnItem, selfSym symbols.SymbolID) {
+	la.selfSym = selfSym
+
+	infos := la.tc.collectAttrs(fnItem.AttrStart, fnItem.AttrCount)
+
+	// @requires_lock("field") - lock is held on entry (and remains held)
+	// @releases_lock("field") - lock is held on entry (and will be released)
+	for _, info := range infos {
+		if (info.Spec.Name == "requires_lock" || info.Spec.Name == "releases_lock") && len(info.Args) > 0 {
+			fieldName := la.extractFieldName(info)
+			if fieldName != 0 {
+				key := LockKey{
+					Base:      la.selfSym,
+					FieldName: fieldName,
+					Kind:      LockKindMutex, // Assume mutex for now
+				}
+				la.state.Acquire(key, info.Span)
+			}
+		}
+	}
+}
+
+// extractFieldName extracts the field name StringID from an attribute argument
+func (la *lockAnalyzer) extractFieldName(info AttrInfo) source.StringID {
+	if len(info.Args) == 0 {
+		return 0
+	}
+	argExpr := la.tc.builder.Exprs.Get(info.Args[0])
+	if argExpr == nil || argExpr.Kind != ast.ExprLit {
+		return 0
+	}
+	lit, ok := la.tc.builder.Exprs.Literal(info.Args[0])
+	if !ok || lit.Kind != ast.ExprLitString {
+		return 0
+	}
+	// Get the field name - strip quotes
+	fieldNameRaw := la.tc.lookupName(lit.Value)
+	if len(fieldNameRaw) < 2 {
+		return 0
+	}
+	fieldNameStr := fieldNameRaw[1 : len(fieldNameRaw)-1] // Remove quotes
+	return la.tc.builder.StringsInterner.Intern(fieldNameStr)
+}
+
+// analyzeFunctionLocks performs LINEAR lock analysis on a function body
+// This is Step A - no branch analysis, just sequential tracking
+func (tc *typeChecker) analyzeFunctionLocks(fnItem *ast.FnItem, selfSym symbols.SymbolID) {
+	if fnItem == nil || !fnItem.Body.IsValid() {
+		return
+	}
+
+	la := tc.newLockAnalyzer()
+	la.initFromAttributes(fnItem, selfSym)
+
+	// Walk the function body looking for lock/unlock calls
+	tc.walkStmtForLocks(la, fnItem.Body)
+
+	// Check for unreleased locks at function exit
+	// But only if function doesn't have @acquires_lock (which means it intentionally holds)
+	infos := tc.collectAttrs(fnItem.AttrStart, fnItem.AttrCount)
+	_, hasAcquires := hasAttr(infos, "acquires_lock")
+
+	if !hasAcquires {
+		for _, acq := range la.state.HeldLocks() {
+			// Check if this lock was from @requires_lock (those are expected to be held)
+			_, hasRequires := hasAttr(infos, "requires_lock")
+			if hasRequires {
+				// Lock from @requires_lock is expected to remain held
+				continue
+			}
+			fieldName := tc.lookupName(acq.Key.FieldName)
+			tc.report(diag.SemaLockNotReleasedOnExit, acq.Span,
+				"lock '%s' acquired here but not released before function exit", fieldName)
+		}
+	}
+}
+
+// walkStmtForLocks analyzes a statement for lock operations
+func (tc *typeChecker) walkStmtForLocks(la *lockAnalyzer, stmtID ast.StmtID) {
+	if !stmtID.IsValid() {
+		return
+	}
+
+	stmt := tc.builder.Stmts.Get(stmtID)
+	if stmt == nil {
+		return
+	}
+
+	switch stmt.Kind {
+	case ast.StmtExpr:
+		// Expression statement - check for lock/unlock calls
+		if exprStmt := tc.builder.Stmts.Expr(stmtID); exprStmt != nil {
+			tc.checkExprForLockOps(la, exprStmt.Expr)
+		}
+
+	case ast.StmtLet:
+		// Let statement - check initializer for lock calls
+		if letStmt := tc.builder.Stmts.Let(stmtID); letStmt != nil && letStmt.Value.IsValid() {
+			tc.checkExprForLockOps(la, letStmt.Value)
+		}
+
+	case ast.StmtBlock:
+		// Nested block
+		if block := tc.builder.Stmts.Block(stmtID); block != nil {
+			for _, child := range block.Stmts {
+				tc.walkStmtForLocks(la, child)
+			}
+		}
+
+	case ast.StmtIf:
+		// For Step A (linear), we just walk both branches sequentially
+		// Real branch analysis is Step Б
+		if ifStmt := tc.builder.Stmts.If(stmtID); ifStmt != nil {
+			tc.walkStmtForLocks(la, ifStmt.Then)
+			if ifStmt.Else.IsValid() {
+				tc.walkStmtForLocks(la, ifStmt.Else)
+			}
+		}
+
+	case ast.StmtWhile:
+		// Walk while body (linear analysis - no loop semantics)
+		if whileStmt := tc.builder.Stmts.While(stmtID); whileStmt != nil {
+			tc.walkStmtForLocks(la, whileStmt.Body)
+		}
+
+	case ast.StmtForClassic:
+		// Walk for body
+		if forStmt := tc.builder.Stmts.ForClassic(stmtID); forStmt != nil {
+			tc.walkStmtForLocks(la, forStmt.Body)
+		}
+
+	case ast.StmtForIn:
+		// Walk for-in body
+		if forIn := tc.builder.Stmts.ForIn(stmtID); forIn != nil {
+			tc.walkStmtForLocks(la, forIn.Body)
+		}
+
+	case ast.StmtReturn:
+		// On return, check for unreleased locks
+		// (handled at function level for now)
+	}
+}
+
+// checkExprForLockOps checks an expression for lock/unlock method calls
+func (tc *typeChecker) checkExprForLockOps(la *lockAnalyzer, exprID ast.ExprID) {
+	if !exprID.IsValid() {
+		return
+	}
+
+	expr := tc.builder.Exprs.Get(exprID)
+	if expr == nil {
+		return
+	}
+
+	// Look for method calls: expr.method()
+	if expr.Kind == ast.ExprCall {
+		call, ok := tc.builder.Exprs.Call(exprID)
+		if !ok || call == nil {
+			return
+		}
+
+		// Check if callee is a member access (e.g., self.lock.lock())
+		calleeExpr := tc.builder.Exprs.Get(call.Target)
+		if calleeExpr != nil && calleeExpr.Kind == ast.ExprMember {
+			member, ok := tc.builder.Exprs.Member(call.Target)
+			if !ok || member == nil {
+				return
+			}
+
+			methodName := tc.lookupName(member.Field)
+
+			// Check for lock methods
+			switch methodName {
+			case "lock":
+				tc.handleLockAcquire(la, member.Target, LockKindMutex, expr.Span)
+			case "read_lock":
+				tc.handleLockAcquire(la, member.Target, LockKindRwRead, expr.Span)
+			case "write_lock":
+				tc.handleLockAcquire(la, member.Target, LockKindRwWrite, expr.Span)
+			case "unlock", "read_unlock", "write_unlock":
+				tc.handleLockRelease(la, member.Target, expr.Span)
+			case "try_lock", "try_read_lock", "try_write_lock":
+				// try_ methods require branch analysis (Step Б)
+				// Mark that this function uses conditional locking
+				la.hasTryLocks = true
+			}
+		}
+	}
+
+	// Recursively check sub-expressions
+	tc.walkExprForLockOps(la, exprID)
+}
+
+// walkExprForLockOps recursively walks expression children
+func (tc *typeChecker) walkExprForLockOps(la *lockAnalyzer, exprID ast.ExprID) {
+	if !exprID.IsValid() {
+		return
+	}
+
+	expr := tc.builder.Exprs.Get(exprID)
+	if expr == nil {
+		return
+	}
+
+	switch expr.Kind {
+	case ast.ExprCall:
+		call, ok := tc.builder.Exprs.Call(exprID)
+		if ok && call != nil {
+			for _, arg := range call.Args {
+				tc.checkExprForLockOps(la, arg.Value)
+			}
+		}
+
+	case ast.ExprBinary:
+		binData, ok := tc.builder.Exprs.Binary(exprID)
+		if ok && binData != nil {
+			tc.checkExprForLockOps(la, binData.Left)
+			tc.checkExprForLockOps(la, binData.Right)
+		}
+
+	case ast.ExprUnary:
+		unaryData, ok := tc.builder.Exprs.Unary(exprID)
+		if ok && unaryData != nil {
+			tc.checkExprForLockOps(la, unaryData.Operand)
+		}
+
+	case ast.ExprMember:
+		memberData, ok := tc.builder.Exprs.Member(exprID)
+		if ok && memberData != nil {
+			tc.checkExprForLockOps(la, memberData.Target)
+		}
+
+	case ast.ExprIndex:
+		indexData, ok := tc.builder.Exprs.Index(exprID)
+		if ok && indexData != nil {
+			tc.checkExprForLockOps(la, indexData.Target)
+			tc.checkExprForLockOps(la, indexData.Index)
+		}
+	}
+}
+
+// handleLockAcquire handles a lock acquisition (e.g., self.lock.lock())
+func (tc *typeChecker) handleLockAcquire(la *lockAnalyzer, targetExpr ast.ExprID, kind LockKind, span source.Span) {
+	key, ok := tc.extractLockKey(targetExpr, kind)
+	if !ok {
+		return // Could not determine lock - skip analysis
+	}
+
+	if prevSpan, doubleLock := la.state.Acquire(key, span); doubleLock {
+		fieldName := tc.lookupName(key.FieldName)
+		tc.report(diag.SemaLockDoubleAcquire, span,
+			"lock '%s' is already held (acquired at %s)", fieldName, prevSpan.String())
+	}
+}
+
+// handleLockRelease handles a lock release (e.g., self.lock.unlock())
+func (tc *typeChecker) handleLockRelease(la *lockAnalyzer, targetExpr ast.ExprID, span source.Span) {
+	// Try all lock kinds since unlock() applies to any
+	for _, kind := range []LockKind{LockKindMutex, LockKindRwRead, LockKindRwWrite} {
+		key, ok := tc.extractLockKey(targetExpr, kind)
+		if !ok {
+			continue
+		}
+
+		if la.state.Release(key) {
+			return // Successfully released
+		}
+	}
+
+	// Skip error if function uses try_lock methods (requires branch analysis)
+	if la.hasTryLocks {
+		return
+	}
+
+	// Lock was not held - report error
+	// Try to get field name for better error message
+	if key, ok := tc.extractLockKey(targetExpr, LockKindMutex); ok {
+		fieldName := tc.lookupName(key.FieldName)
+		tc.report(diag.SemaLockReleaseNotHeld, span,
+			"lock '%s' is not currently held", fieldName)
+	} else {
+		tc.report(diag.SemaLockReleaseNotHeld, span,
+			"attempting to release lock that is not held")
+	}
+}
+
+// extractLockKey extracts a LockKey from a lock expression
+// Handles both local variable locks (mtx.lock()) and field locks (self.lock.lock())
+func (tc *typeChecker) extractLockKey(targetExpr ast.ExprID, kind LockKind) (LockKey, bool) {
+	if !targetExpr.IsValid() {
+		return LockKey{}, false
+	}
+
+	expr := tc.builder.Exprs.Get(targetExpr)
+	if expr == nil {
+		return LockKey{}, false
+	}
+
+	switch expr.Kind {
+	case ast.ExprIdent:
+		// Local variable lock (e.g., mtx.lock())
+		// Use the variable's symbol directly, with no field name
+		sym := tc.getExprSymbol(targetExpr)
+		if !sym.IsValid() {
+			return LockKey{}, false
+		}
+		return LockKey{
+			Base:      sym,
+			FieldName: 0, // No field - it's the variable itself
+			Kind:      kind,
+		}, true
+
+	case ast.ExprMember:
+		// Field lock (e.g., self.lock.lock())
+		memberData, ok := tc.builder.Exprs.Member(targetExpr)
+		if !ok || memberData == nil {
+			return LockKey{}, false
+		}
+
+		// Get base symbol
+		baseSym := tc.getExprSymbol(memberData.Target)
+		if !baseSym.IsValid() {
+			return LockKey{}, false
+		}
+
+		return LockKey{
+			Base:      baseSym,
+			FieldName: memberData.Field,
+			Kind:      kind,
+		}, true
+
+	default:
+		return LockKey{}, false
+	}
+}
+
+// getExprSymbol returns the symbol for a simple expression (identifier or self)
+func (tc *typeChecker) getExprSymbol(exprID ast.ExprID) symbols.SymbolID {
+	if !exprID.IsValid() {
+		return symbols.NoSymbolID
+	}
+
+	// Check if we have a symbol recorded for this expression
+	if tc.symbols != nil && tc.symbols.ExprSymbols != nil {
+		if sym, ok := tc.symbols.ExprSymbols[exprID]; ok {
+			return sym
+		}
+	}
+
+	return symbols.NoSymbolID
+}

--- a/internal/sema/type_checker_walk.go
+++ b/internal/sema/type_checker_walk.go
@@ -89,6 +89,9 @@ func (tc *typeChecker) walkItem(id ast.ItemID) {
 			if returnType != tc.types.Builtins().Nothing && tc.returnStatus(fnItem.Body) != returnClosed {
 				tc.report(diag.SemaMissingReturn, returnSpan, "function returning %s is missing a return", tc.typeLabel(returnType))
 			}
+			// Perform lock analysis after walking the body
+			selfSym := tc.findSelfSymbol(fnItem, scope)
+			tc.analyzeFunctionLocks(fnItem, selfSym)
 			if pushed {
 				tc.leaveScope()
 			}

--- a/testdata/golden/sema/invalid/attrs/conflicts.diag
+++ b/testdata/golden/sema/invalid/attrs/conflicts.diag
@@ -2,4 +2,3 @@ error SEM3061 testdata/golden/sema/invalid/attrs/conflicts.sg:4:1 @packed confli
 error SEM3061 testdata/golden/sema/invalid/attrs/conflicts.sg:5:1 @align conflicts with @packed on the same declaration
 error SEM3062 testdata/golden/sema/invalid/attrs/conflicts.sg:12:1 attribute '@nosend' conflicts with '@send'
 error SEM3063 testdata/golden/sema/invalid/attrs/conflicts.sg:24:5 attribute '@waits_on' conflicts with '@nonblocking'
-error SEM3071 testdata/golden/sema/invalid/attrs/conflicts.sg:24:15 field '"condition"' not found in type

--- a/testdata/golden/sema/invalid/attrs/invalid_parameters.diag
+++ b/testdata/golden/sema/invalid/attrs/invalid_parameters.diag
@@ -4,5 +4,5 @@ error SEM3064 testdata/golden/sema/invalid/attrs/invalid_parameters.sg:14:8 @ali
 error SEM3066 testdata/golden/sema/invalid/attrs/invalid_parameters.sg:20:10 unknown backend target 'quantum'; known targets: cpu, gpu, tpu, wasm, native
 error SEM3066 testdata/golden/sema/invalid/attrs/invalid_parameters.sg:24:10 unknown backend target 'fpga'; known targets: cpu, gpu, tpu, wasm, native
 error SEM3001 testdata/golden/sema/invalid/attrs/invalid_parameters.sg:34:5 attribute '@guarded_by' is not allowed here
-error SEM3071 testdata/golden/sema/invalid/attrs/invalid_parameters.sg:41:15 field '"nonexistent_condition"' not found in type
-error SEM3070 testdata/golden/sema/invalid/attrs/invalid_parameters.sg:48:20 field '"nonexistent_lock"' not found in type
+error SEM3071 testdata/golden/sema/invalid/attrs/invalid_parameters.sg:41:15 field 'nonexistent_condition' not found in type
+error SEM3070 testdata/golden/sema/invalid/attrs/invalid_parameters.sg:48:20 field 'nonexistent_lock' not found in type

--- a/testdata/golden/sema/invalid/concurrency/atomic_invalid_type.ast
+++ b/testdata/golden/sema/invalid/concurrency/atomic_invalid_type.ast
@@ -1,0 +1,8 @@
+atomic_invalid_type.sg (span: 3:1-7:1)
+└─ Item[0]: Type (span: 3:1-6:2)
+   ├─ Name: BadAtomic
+   ├─ Kind: Struct
+   ├─ Visibility: private
+   └─ Struct:
+      ├─ Field[0]: name: string [@atomic]
+      └─ Field[1]: data: float [@atomic]

--- a/testdata/golden/sema/invalid/concurrency/atomic_invalid_type.diag
+++ b/testdata/golden/sema/invalid/concurrency/atomic_invalid_type.diag
@@ -1,0 +1,2 @@
+error SEM3101 testdata/golden/sema/invalid/concurrency/atomic_invalid_type.sg:4:5 @atomic field must be of type int, uint, bool, or *T; got 'string'
+error SEM3101 testdata/golden/sema/invalid/concurrency/atomic_invalid_type.sg:5:5 @atomic field must be of type int, uint, bool, or *T; got 'float'

--- a/testdata/golden/sema/invalid/concurrency/atomic_invalid_type.fmt
+++ b/testdata/golden/sema/invalid/concurrency/atomic_invalid_type.fmt
@@ -1,0 +1,6 @@
+// Invalid @atomic - field type is not int, uint, bool, or *T
+
+type BadAtomic = {
+    @atomicname: string,
+    @atomicdata: float,
+}

--- a/testdata/golden/sema/invalid/concurrency/atomic_invalid_type.sg
+++ b/testdata/golden/sema/invalid/concurrency/atomic_invalid_type.sg
@@ -1,0 +1,6 @@
+// Invalid @atomic - field type is not int, uint, bool, or *T
+
+type BadAtomic = {
+    @atomic name: string,
+    @atomic data: float,
+}

--- a/testdata/golden/sema/invalid/concurrency/atomic_invalid_type.tokens
+++ b/testdata/golden/sema/invalid/concurrency/atomic_invalid_type.tokens
@@ -1,0 +1,18 @@
+  1: KwType          "type" at 3:1-3:5 (leading: LineComment, Newline)
+  2: Ident           "BadAtomic" at 3:6-3:15 (leading: Space)
+  3: Assign          "=" at 3:16-3:17 (leading: Space)
+  4: LBrace          "{" at 3:18-3:19 (leading: Space)
+  5: At              "@" at 4:5-4:6 (leading: Newline, Space)
+  6: Ident           "atomic" at 4:6-4:12
+  7: Ident           "name" at 4:13-4:17 (leading: Space)
+  8: Colon           ":" at 4:17-4:18
+  9: Ident           "string" at 4:19-4:25 (leading: Space)
+ 10: Comma           "," at 4:25-4:26
+ 11: At              "@" at 5:5-5:6 (leading: Newline, Space)
+ 12: Ident           "atomic" at 5:6-5:12
+ 13: Ident           "data" at 5:13-5:17 (leading: Space)
+ 14: Colon           ":" at 5:17-5:18
+ 15: Ident           "float" at 5:19-5:24 (leading: Space)
+ 16: Comma           "," at 5:24-5:25
+ 17: RBrace          "}" at 6:1-6:2 (leading: Newline)
+ 18: EOF             at 7:1-7:1

--- a/testdata/golden/sema/invalid/concurrency/double_lock.ast
+++ b/testdata/golden/sema/invalid/concurrency/double_lock.ast
@@ -1,0 +1,42 @@
+double_lock.sg (span: 3:1-23:1)
+├─ Item[0]: Fn (span: 3:1-9:2)
+│  ├─ Name: test_double_lock
+│  ├─ Params: ()
+│  ├─ Return: nothing
+│  └─ Body:
+│     └─ Stmt[0]: Block (span: 3:38-9:2)
+│        ├─ Stmt[0]: Let (span: 4:5-4:38)
+│        │  ├─ Name: mtx
+│        │  ├─ Mutable: true
+│        │  ├─ Type: Mutex
+│        │  └─ Value: expr#3: Mutex.new()
+│        ├─ Stmt[1]: Expr (span: 5:5-5:16)
+│        │  └─ Expr: expr#6: mtx.lock()
+│        ├─ Stmt[2]: Expr (span: 6:5-6:16)
+│        │  └─ Expr: expr#9: mtx.lock()
+│        ├─ Stmt[3]: Expr (span: 7:5-7:18)
+│        │  └─ Expr: expr#12: mtx.unlock()
+│        └─ Stmt[4]: Expr (span: 8:5-8:18)
+│           └─ Expr: expr#15: mtx.unlock()
+├─ Item[1]: Type (span: 11:1-13:2)
+│  ├─ Name: Data
+│  ├─ Kind: Struct
+│  ├─ Visibility: private
+│  └─ Struct:
+│     └─ Field[0]: lock: Mutex
+└─ Item[2]: Extern (span: 15:1-22:2)
+   ├─ Target: Data
+   ├─ Members:
+   │  └─ Fn[0]: bad_double_lock
+   │     ├─ Params: (self: &mut Data)
+   │     ├─ Return: nothing
+   │     └─ Body:
+   │        Stmt[0]: Block (span: 16:56-21:6)
+   │        ├─ Stmt[0]: Expr (span: 17:9-17:26)
+   │        │  └─ Expr: expr#19: self.lock.lock()
+   │        ├─ Stmt[1]: Expr (span: 18:9-18:26)
+   │        │  └─ Expr: expr#23: self.lock.lock()
+   │        ├─ Stmt[2]: Expr (span: 19:9-19:28)
+   │        │  └─ Expr: expr#27: self.lock.unlock()
+   │        └─ Stmt[3]: Expr (span: 20:9-20:28)
+   │           └─ Expr: expr#31: self.lock.unlock()

--- a/testdata/golden/sema/invalid/concurrency/double_lock.diag
+++ b/testdata/golden/sema/invalid/concurrency/double_lock.diag
@@ -1,0 +1,4 @@
+error SEM3079 testdata/golden/sema/invalid/concurrency/double_lock.sg:6:5 lock '' is already held (acquired at 0:118-128)
+error SEM3080 testdata/golden/sema/invalid/concurrency/double_lock.sg:8:5 lock '' is not currently held
+error SEM3079 testdata/golden/sema/invalid/concurrency/double_lock.sg:18:9 lock 'lock' is already held (acquired at 0:325-341)
+error SEM3080 testdata/golden/sema/invalid/concurrency/double_lock.sg:20:9 lock 'lock' is not currently held

--- a/testdata/golden/sema/invalid/concurrency/double_lock.fmt
+++ b/testdata/golden/sema/invalid/concurrency/double_lock.fmt
@@ -1,0 +1,22 @@
+// Invalid: double lock acquisition
+
+pub fn test_double_lock() -> nothing {
+    let mut mtx: Mutex = Mutex.new();
+    mtx.lock();
+    mtx.lock();  // Error: already locked
+    mtx.unlock();
+    mtx.unlock();
+}
+
+type Data = {
+    lock: Mutex,
+}
+
+extern<Data> {
+    pub fn bad_double_lock(self: &mut Data) -> nothing {
+        self.lock.lock();
+        self.lock.lock();  // Error: already locked
+        self.lock.unlock();
+        self.lock.unlock();
+    }
+}

--- a/testdata/golden/sema/invalid/concurrency/double_lock.sg
+++ b/testdata/golden/sema/invalid/concurrency/double_lock.sg
@@ -1,0 +1,22 @@
+// Invalid: double lock acquisition
+
+pub fn test_double_lock() -> nothing {
+    let mut mtx: Mutex = Mutex.new();
+    mtx.lock();
+    mtx.lock();  // Error: already locked
+    mtx.unlock();
+    mtx.unlock();
+}
+
+type Data = {
+    lock: Mutex,
+}
+
+extern<Data> {
+    pub fn bad_double_lock(self: &mut Data) -> nothing {
+        self.lock.lock();
+        self.lock.lock();  // Error: already locked
+        self.lock.unlock();
+        self.lock.unlock();
+    }
+}

--- a/testdata/golden/sema/invalid/concurrency/double_lock.tokens
+++ b/testdata/golden/sema/invalid/concurrency/double_lock.tokens
@@ -1,0 +1,107 @@
+  1: KwPub           "pub" at 3:1-3:4 (leading: LineComment, Newline)
+  2: KwFn            "fn" at 3:5-3:7 (leading: Space)
+  3: Ident           "test_double_lock" at 3:8-3:24 (leading: Space)
+  4: LParen          "(" at 3:24-3:25
+  5: RParen          ")" at 3:25-3:26
+  6: Arrow           "->" at 3:27-3:29 (leading: Space)
+  7: NothingLit      "nothing" at 3:30-3:37 (leading: Space)
+  8: LBrace          "{" at 3:38-3:39 (leading: Space)
+  9: KwLet           "let" at 4:5-4:8 (leading: Newline, Space)
+ 10: KwMut           "mut" at 4:9-4:12 (leading: Space)
+ 11: Ident           "mtx" at 4:13-4:16 (leading: Space)
+ 12: Colon           ":" at 4:16-4:17
+ 13: Ident           "Mutex" at 4:18-4:23 (leading: Space)
+ 14: Assign          "=" at 4:24-4:25 (leading: Space)
+ 15: Ident           "Mutex" at 4:26-4:31 (leading: Space)
+ 16: Dot             "." at 4:31-4:32
+ 17: Ident           "new" at 4:32-4:35
+ 18: LParen          "(" at 4:35-4:36
+ 19: RParen          ")" at 4:36-4:37
+ 20: Semicolon       ";" at 4:37-4:38
+ 21: Ident           "mtx" at 5:5-5:8 (leading: Newline, Space)
+ 22: Dot             "." at 5:8-5:9
+ 23: Ident           "lock" at 5:9-5:13
+ 24: LParen          "(" at 5:13-5:14
+ 25: RParen          ")" at 5:14-5:15
+ 26: Semicolon       ";" at 5:15-5:16
+ 27: Ident           "mtx" at 6:5-6:8 (leading: Newline, Space)
+ 28: Dot             "." at 6:8-6:9
+ 29: Ident           "lock" at 6:9-6:13
+ 30: LParen          "(" at 6:13-6:14
+ 31: RParen          ")" at 6:14-6:15
+ 32: Semicolon       ";" at 6:15-6:16
+ 33: Ident           "mtx" at 7:5-7:8 (leading: Space, LineComment, Newline, Space)
+ 34: Dot             "." at 7:8-7:9
+ 35: Ident           "unlock" at 7:9-7:15
+ 36: LParen          "(" at 7:15-7:16
+ 37: RParen          ")" at 7:16-7:17
+ 38: Semicolon       ";" at 7:17-7:18
+ 39: Ident           "mtx" at 8:5-8:8 (leading: Newline, Space)
+ 40: Dot             "." at 8:8-8:9
+ 41: Ident           "unlock" at 8:9-8:15
+ 42: LParen          "(" at 8:15-8:16
+ 43: RParen          ")" at 8:16-8:17
+ 44: Semicolon       ";" at 8:17-8:18
+ 45: RBrace          "}" at 9:1-9:2 (leading: Newline)
+ 46: KwType          "type" at 11:1-11:5 (leading: Newline)
+ 47: Ident           "Data" at 11:6-11:10 (leading: Space)
+ 48: Assign          "=" at 11:11-11:12 (leading: Space)
+ 49: LBrace          "{" at 11:13-11:14 (leading: Space)
+ 50: Ident           "lock" at 12:5-12:9 (leading: Newline, Space)
+ 51: Colon           ":" at 12:9-12:10
+ 52: Ident           "Mutex" at 12:11-12:16 (leading: Space)
+ 53: Comma           "," at 12:16-12:17
+ 54: RBrace          "}" at 13:1-13:2 (leading: Newline)
+ 55: KwExtern        "extern" at 15:1-15:7 (leading: Newline)
+ 56: Lt              "<" at 15:7-15:8
+ 57: Ident           "Data" at 15:8-15:12
+ 58: Gt              ">" at 15:12-15:13
+ 59: LBrace          "{" at 15:14-15:15 (leading: Space)
+ 60: KwPub           "pub" at 16:5-16:8 (leading: Newline, Space)
+ 61: KwFn            "fn" at 16:9-16:11 (leading: Space)
+ 62: Ident           "bad_double_lock" at 16:12-16:27 (leading: Space)
+ 63: LParen          "(" at 16:27-16:28
+ 64: Ident           "self" at 16:28-16:32
+ 65: Colon           ":" at 16:32-16:33
+ 66: Amp             "&" at 16:34-16:35 (leading: Space)
+ 67: KwMut           "mut" at 16:35-16:38
+ 68: Ident           "Data" at 16:39-16:43 (leading: Space)
+ 69: RParen          ")" at 16:43-16:44
+ 70: Arrow           "->" at 16:45-16:47 (leading: Space)
+ 71: NothingLit      "nothing" at 16:48-16:55 (leading: Space)
+ 72: LBrace          "{" at 16:56-16:57 (leading: Space)
+ 73: Ident           "self" at 17:9-17:13 (leading: Newline, Space)
+ 74: Dot             "." at 17:13-17:14
+ 75: Ident           "lock" at 17:14-17:18
+ 76: Dot             "." at 17:18-17:19
+ 77: Ident           "lock" at 17:19-17:23
+ 78: LParen          "(" at 17:23-17:24
+ 79: RParen          ")" at 17:24-17:25
+ 80: Semicolon       ";" at 17:25-17:26
+ 81: Ident           "self" at 18:9-18:13 (leading: Newline, Space)
+ 82: Dot             "." at 18:13-18:14
+ 83: Ident           "lock" at 18:14-18:18
+ 84: Dot             "." at 18:18-18:19
+ 85: Ident           "lock" at 18:19-18:23
+ 86: LParen          "(" at 18:23-18:24
+ 87: RParen          ")" at 18:24-18:25
+ 88: Semicolon       ";" at 18:25-18:26
+ 89: Ident           "self" at 19:9-19:13 (leading: Space, LineComment, Newline, Space)
+ 90: Dot             "." at 19:13-19:14
+ 91: Ident           "lock" at 19:14-19:18
+ 92: Dot             "." at 19:18-19:19
+ 93: Ident           "unlock" at 19:19-19:25
+ 94: LParen          "(" at 19:25-19:26
+ 95: RParen          ")" at 19:26-19:27
+ 96: Semicolon       ";" at 19:27-19:28
+ 97: Ident           "self" at 20:9-20:13 (leading: Newline, Space)
+ 98: Dot             "." at 20:13-20:14
+ 99: Ident           "lock" at 20:14-20:18
+100: Dot             "." at 20:18-20:19
+101: Ident           "unlock" at 20:19-20:25
+102: LParen          "(" at 20:25-20:26
+103: RParen          ")" at 20:26-20:27
+104: Semicolon       ";" at 20:27-20:28
+105: RBrace          "}" at 21:5-21:6 (leading: Newline, Space)
+106: RBrace          "}" at 22:1-22:2 (leading: Newline)
+107: EOF             at 23:1-23:1

--- a/testdata/golden/sema/invalid/concurrency/guarded_by_not_lock.ast
+++ b/testdata/golden/sema/invalid/concurrency/guarded_by_not_lock.ast
@@ -1,0 +1,15 @@
+guarded_by_not_lock.sg (span: 3:1-12:1)
+├─ Item[0]: Type (span: 3:1-6:2)
+│  ├─ Name: BadGuard
+│  ├─ Kind: Struct
+│  ├─ Visibility: private
+│  └─ Struct:
+│     ├─ Field[0]: counter: int
+│     └─ Field[1]: value: int [@guarded_by("counter")]
+└─ Item[1]: Type (span: 8:1-11:2)
+   ├─ Name: BadGuard2
+   ├─ Kind: Struct
+   ├─ Visibility: private
+   └─ Struct:
+      ├─ Field[0]: name: string
+      └─ Field[1]: data: int [@guarded_by("name")]

--- a/testdata/golden/sema/invalid/concurrency/guarded_by_not_lock.diag
+++ b/testdata/golden/sema/invalid/concurrency/guarded_by_not_lock.diag
@@ -1,0 +1,2 @@
+error SEM3069 testdata/golden/sema/invalid/concurrency/guarded_by_not_lock.sg:5:17 @guarded_by field must be of type Mutex or RwLock, got 'int'
+error SEM3069 testdata/golden/sema/invalid/concurrency/guarded_by_not_lock.sg:10:17 @guarded_by field must be of type Mutex or RwLock, got 'string'

--- a/testdata/golden/sema/invalid/concurrency/guarded_by_not_lock.fmt
+++ b/testdata/golden/sema/invalid/concurrency/guarded_by_not_lock.fmt
@@ -1,0 +1,11 @@
+// Invalid @guarded_by usage - field is not Mutex or RwLock
+
+type BadGuard = {
+    counter: int,
+    @guarded_by("counter")value: int,
+}
+
+type BadGuard2 = {
+    name: string,
+    @guarded_by("name")data: int,
+}

--- a/testdata/golden/sema/invalid/concurrency/guarded_by_not_lock.sg
+++ b/testdata/golden/sema/invalid/concurrency/guarded_by_not_lock.sg
@@ -1,0 +1,11 @@
+// Invalid @guarded_by usage - field is not Mutex or RwLock
+
+type BadGuard = {
+    counter: int,
+    @guarded_by("counter") value: int,
+}
+
+type BadGuard2 = {
+    name: string,
+    @guarded_by("name") data: int,
+}

--- a/testdata/golden/sema/invalid/concurrency/guarded_by_not_lock.tokens
+++ b/testdata/golden/sema/invalid/concurrency/guarded_by_not_lock.tokens
@@ -1,0 +1,37 @@
+  1: KwType          "type" at 3:1-3:5 (leading: LineComment, Newline)
+  2: Ident           "BadGuard" at 3:6-3:14 (leading: Space)
+  3: Assign          "=" at 3:15-3:16 (leading: Space)
+  4: LBrace          "{" at 3:17-3:18 (leading: Space)
+  5: Ident           "counter" at 4:5-4:12 (leading: Newline, Space)
+  6: Colon           ":" at 4:12-4:13
+  7: Ident           "int" at 4:14-4:17 (leading: Space)
+  8: Comma           "," at 4:17-4:18
+  9: At              "@" at 5:5-5:6 (leading: Newline, Space)
+ 10: Ident           "guarded_by" at 5:6-5:16
+ 11: LParen          "(" at 5:16-5:17
+ 12: StringLit       "\"counter\"" at 5:17-5:26
+ 13: RParen          ")" at 5:26-5:27
+ 14: Ident           "value" at 5:28-5:33 (leading: Space)
+ 15: Colon           ":" at 5:33-5:34
+ 16: Ident           "int" at 5:35-5:38 (leading: Space)
+ 17: Comma           "," at 5:38-5:39
+ 18: RBrace          "}" at 6:1-6:2 (leading: Newline)
+ 19: KwType          "type" at 8:1-8:5 (leading: Newline)
+ 20: Ident           "BadGuard2" at 8:6-8:15 (leading: Space)
+ 21: Assign          "=" at 8:16-8:17 (leading: Space)
+ 22: LBrace          "{" at 8:18-8:19 (leading: Space)
+ 23: Ident           "name" at 9:5-9:9 (leading: Newline, Space)
+ 24: Colon           ":" at 9:9-9:10
+ 25: Ident           "string" at 9:11-9:17 (leading: Space)
+ 26: Comma           "," at 9:17-9:18
+ 27: At              "@" at 10:5-10:6 (leading: Newline, Space)
+ 28: Ident           "guarded_by" at 10:6-10:16
+ 29: LParen          "(" at 10:16-10:17
+ 30: StringLit       "\"name\"" at 10:17-10:23
+ 31: RParen          ")" at 10:23-10:24
+ 32: Ident           "data" at 10:25-10:29 (leading: Space)
+ 33: Colon           ":" at 10:29-10:30
+ 34: Ident           "int" at 10:31-10:34 (leading: Space)
+ 35: Comma           "," at 10:34-10:35
+ 36: RBrace          "}" at 11:1-11:2 (leading: Newline)
+ 37: EOF             at 12:1-12:1

--- a/testdata/golden/sema/invalid/concurrency/lock_not_released.ast
+++ b/testdata/golden/sema/invalid/concurrency/lock_not_released.ast
@@ -1,0 +1,52 @@
+lock_not_released.sg (span: 3:1-29:1)
+├─ Item[0]: Fn (span: 3:1-7:2)
+│  ├─ Name: test_lock_not_released
+│  ├─ Params: ()
+│  ├─ Return: nothing
+│  └─ Body:
+│     └─ Stmt[0]: Block (span: 3:44-7:2)
+│        ├─ Stmt[0]: Let (span: 4:5-4:38)
+│        │  ├─ Name: mtx
+│        │  ├─ Mutable: true
+│        │  ├─ Type: Mutex
+│        │  └─ Value: expr#3: Mutex.new()
+│        └─ Stmt[1]: Expr (span: 5:5-5:16)
+│           └─ Expr: expr#6: mtx.lock()
+├─ Item[1]: Fn (span: 9:1-17:2)
+│  ├─ Name: test_partial_release
+│  ├─ Params: ()
+│  ├─ Return: nothing
+│  └─ Body:
+│     └─ Stmt[0]: Block (span: 9:42-17:2)
+│        ├─ Stmt[0]: Let (span: 10:5-10:37)
+│        │  ├─ Name: m1
+│        │  ├─ Mutable: true
+│        │  ├─ Type: Mutex
+│        │  └─ Value: expr#9: Mutex.new()
+│        ├─ Stmt[1]: Let (span: 11:5-11:37)
+│        │  ├─ Name: m2
+│        │  ├─ Mutable: true
+│        │  ├─ Type: Mutex
+│        │  └─ Value: expr#12: Mutex.new()
+│        ├─ Stmt[2]: Expr (span: 13:5-13:15)
+│        │  └─ Expr: expr#15: m1.lock()
+│        ├─ Stmt[3]: Expr (span: 14:5-14:15)
+│        │  └─ Expr: expr#18: m2.lock()
+│        └─ Stmt[4]: Expr (span: 15:5-15:17)
+│           └─ Expr: expr#21: m2.unlock()
+├─ Item[2]: Type (span: 19:1-21:2)
+│  ├─ Name: Resource
+│  ├─ Kind: Struct
+│  ├─ Visibility: private
+│  └─ Struct:
+│     └─ Field[0]: lock: Mutex
+└─ Item[3]: Extern (span: 23:1-28:2)
+   ├─ Target: Resource
+   ├─ Members:
+   │  └─ Fn[0]: bad_no_release
+   │     ├─ Params: (self: &mut Resource)
+   │     ├─ Return: nothing
+   │     └─ Body:
+   │        Stmt[0]: Block (span: 24:59-27:6)
+   │        └─ Stmt[0]: Expr (span: 25:9-25:26)
+   │           └─ Expr: expr#25: self.lock.lock()

--- a/testdata/golden/sema/invalid/concurrency/lock_not_released.diag
+++ b/testdata/golden/sema/invalid/concurrency/lock_not_released.diag
@@ -1,0 +1,3 @@
+error SEM3081 testdata/golden/sema/invalid/concurrency/lock_not_released.sg:5:5 lock '' acquired here but not released before function exit
+error SEM3081 testdata/golden/sema/invalid/concurrency/lock_not_released.sg:13:5 lock '' acquired here but not released before function exit
+error SEM3081 testdata/golden/sema/invalid/concurrency/lock_not_released.sg:25:9 lock 'lock' acquired here but not released before function exit

--- a/testdata/golden/sema/invalid/concurrency/lock_not_released.fmt
+++ b/testdata/golden/sema/invalid/concurrency/lock_not_released.fmt
@@ -1,0 +1,28 @@
+// Invalid: lock acquired but not released before function exit
+
+pub fn test_lock_not_released() -> nothing {
+    let mut mtx: Mutex = Mutex.new();
+    mtx.lock();
+    // Error: lock not released before function exit
+}
+
+pub fn test_partial_release() -> nothing {
+    let mut m1: Mutex = Mutex.new();
+    let mut m2: Mutex = Mutex.new();
+
+    m1.lock();
+    m2.lock();
+    m2.unlock();
+    // Error: m1 not released before function exit
+}
+
+type Resource = {
+    lock: Mutex,
+}
+
+extern<Resource> {
+    pub fn bad_no_release(self: &mut Resource) -> nothing {
+        self.lock.lock();
+        // Error: lock not released before function exit
+    }
+}

--- a/testdata/golden/sema/invalid/concurrency/lock_not_released.sg
+++ b/testdata/golden/sema/invalid/concurrency/lock_not_released.sg
@@ -1,0 +1,28 @@
+// Invalid: lock acquired but not released before function exit
+
+pub fn test_lock_not_released() -> nothing {
+    let mut mtx: Mutex = Mutex.new();
+    mtx.lock();
+    // Error: lock not released before function exit
+}
+
+pub fn test_partial_release() -> nothing {
+    let mut m1: Mutex = Mutex.new();
+    let mut m2: Mutex = Mutex.new();
+
+    m1.lock();
+    m2.lock();
+    m2.unlock();
+    // Error: m1 not released before function exit
+}
+
+type Resource = {
+    lock: Mutex,
+}
+
+extern<Resource> {
+    pub fn bad_no_release(self: &mut Resource) -> nothing {
+        self.lock.lock();
+        // Error: lock not released before function exit
+    }
+}

--- a/testdata/golden/sema/invalid/concurrency/lock_not_released.tokens
+++ b/testdata/golden/sema/invalid/concurrency/lock_not_released.tokens
@@ -1,0 +1,116 @@
+  1: KwPub           "pub" at 3:1-3:4 (leading: LineComment, Newline)
+  2: KwFn            "fn" at 3:5-3:7 (leading: Space)
+  3: Ident           "test_lock_not_released" at 3:8-3:30 (leading: Space)
+  4: LParen          "(" at 3:30-3:31
+  5: RParen          ")" at 3:31-3:32
+  6: Arrow           "->" at 3:33-3:35 (leading: Space)
+  7: NothingLit      "nothing" at 3:36-3:43 (leading: Space)
+  8: LBrace          "{" at 3:44-3:45 (leading: Space)
+  9: KwLet           "let" at 4:5-4:8 (leading: Newline, Space)
+ 10: KwMut           "mut" at 4:9-4:12 (leading: Space)
+ 11: Ident           "mtx" at 4:13-4:16 (leading: Space)
+ 12: Colon           ":" at 4:16-4:17
+ 13: Ident           "Mutex" at 4:18-4:23 (leading: Space)
+ 14: Assign          "=" at 4:24-4:25 (leading: Space)
+ 15: Ident           "Mutex" at 4:26-4:31 (leading: Space)
+ 16: Dot             "." at 4:31-4:32
+ 17: Ident           "new" at 4:32-4:35
+ 18: LParen          "(" at 4:35-4:36
+ 19: RParen          ")" at 4:36-4:37
+ 20: Semicolon       ";" at 4:37-4:38
+ 21: Ident           "mtx" at 5:5-5:8 (leading: Newline, Space)
+ 22: Dot             "." at 5:8-5:9
+ 23: Ident           "lock" at 5:9-5:13
+ 24: LParen          "(" at 5:13-5:14
+ 25: RParen          ")" at 5:14-5:15
+ 26: Semicolon       ";" at 5:15-5:16
+ 27: RBrace          "}" at 7:1-7:2 (leading: Newline, Space, LineComment, Newline)
+ 28: KwPub           "pub" at 9:1-9:4 (leading: Newline)
+ 29: KwFn            "fn" at 9:5-9:7 (leading: Space)
+ 30: Ident           "test_partial_release" at 9:8-9:28 (leading: Space)
+ 31: LParen          "(" at 9:28-9:29
+ 32: RParen          ")" at 9:29-9:30
+ 33: Arrow           "->" at 9:31-9:33 (leading: Space)
+ 34: NothingLit      "nothing" at 9:34-9:41 (leading: Space)
+ 35: LBrace          "{" at 9:42-9:43 (leading: Space)
+ 36: KwLet           "let" at 10:5-10:8 (leading: Newline, Space)
+ 37: KwMut           "mut" at 10:9-10:12 (leading: Space)
+ 38: Ident           "m1" at 10:13-10:15 (leading: Space)
+ 39: Colon           ":" at 10:15-10:16
+ 40: Ident           "Mutex" at 10:17-10:22 (leading: Space)
+ 41: Assign          "=" at 10:23-10:24 (leading: Space)
+ 42: Ident           "Mutex" at 10:25-10:30 (leading: Space)
+ 43: Dot             "." at 10:30-10:31
+ 44: Ident           "new" at 10:31-10:34
+ 45: LParen          "(" at 10:34-10:35
+ 46: RParen          ")" at 10:35-10:36
+ 47: Semicolon       ";" at 10:36-10:37
+ 48: KwLet           "let" at 11:5-11:8 (leading: Newline, Space)
+ 49: KwMut           "mut" at 11:9-11:12 (leading: Space)
+ 50: Ident           "m2" at 11:13-11:15 (leading: Space)
+ 51: Colon           ":" at 11:15-11:16
+ 52: Ident           "Mutex" at 11:17-11:22 (leading: Space)
+ 53: Assign          "=" at 11:23-11:24 (leading: Space)
+ 54: Ident           "Mutex" at 11:25-11:30 (leading: Space)
+ 55: Dot             "." at 11:30-11:31
+ 56: Ident           "new" at 11:31-11:34
+ 57: LParen          "(" at 11:34-11:35
+ 58: RParen          ")" at 11:35-11:36
+ 59: Semicolon       ";" at 11:36-11:37
+ 60: Ident           "m1" at 13:5-13:7 (leading: Newline, Space)
+ 61: Dot             "." at 13:7-13:8
+ 62: Ident           "lock" at 13:8-13:12
+ 63: LParen          "(" at 13:12-13:13
+ 64: RParen          ")" at 13:13-13:14
+ 65: Semicolon       ";" at 13:14-13:15
+ 66: Ident           "m2" at 14:5-14:7 (leading: Newline, Space)
+ 67: Dot             "." at 14:7-14:8
+ 68: Ident           "lock" at 14:8-14:12
+ 69: LParen          "(" at 14:12-14:13
+ 70: RParen          ")" at 14:13-14:14
+ 71: Semicolon       ";" at 14:14-14:15
+ 72: Ident           "m2" at 15:5-15:7 (leading: Newline, Space)
+ 73: Dot             "." at 15:7-15:8
+ 74: Ident           "unlock" at 15:8-15:14
+ 75: LParen          "(" at 15:14-15:15
+ 76: RParen          ")" at 15:15-15:16
+ 77: Semicolon       ";" at 15:16-15:17
+ 78: RBrace          "}" at 17:1-17:2 (leading: Newline, Space, LineComment, Newline)
+ 79: KwType          "type" at 19:1-19:5 (leading: Newline)
+ 80: Ident           "Resource" at 19:6-19:14 (leading: Space)
+ 81: Assign          "=" at 19:15-19:16 (leading: Space)
+ 82: LBrace          "{" at 19:17-19:18 (leading: Space)
+ 83: Ident           "lock" at 20:5-20:9 (leading: Newline, Space)
+ 84: Colon           ":" at 20:9-20:10
+ 85: Ident           "Mutex" at 20:11-20:16 (leading: Space)
+ 86: Comma           "," at 20:16-20:17
+ 87: RBrace          "}" at 21:1-21:2 (leading: Newline)
+ 88: KwExtern        "extern" at 23:1-23:7 (leading: Newline)
+ 89: Lt              "<" at 23:7-23:8
+ 90: Ident           "Resource" at 23:8-23:16
+ 91: Gt              ">" at 23:16-23:17
+ 92: LBrace          "{" at 23:18-23:19 (leading: Space)
+ 93: KwPub           "pub" at 24:5-24:8 (leading: Newline, Space)
+ 94: KwFn            "fn" at 24:9-24:11 (leading: Space)
+ 95: Ident           "bad_no_release" at 24:12-24:26 (leading: Space)
+ 96: LParen          "(" at 24:26-24:27
+ 97: Ident           "self" at 24:27-24:31
+ 98: Colon           ":" at 24:31-24:32
+ 99: Amp             "&" at 24:33-24:34 (leading: Space)
+100: KwMut           "mut" at 24:34-24:37
+101: Ident           "Resource" at 24:38-24:46 (leading: Space)
+102: RParen          ")" at 24:46-24:47
+103: Arrow           "->" at 24:48-24:50 (leading: Space)
+104: NothingLit      "nothing" at 24:51-24:58 (leading: Space)
+105: LBrace          "{" at 24:59-24:60 (leading: Space)
+106: Ident           "self" at 25:9-25:13 (leading: Newline, Space)
+107: Dot             "." at 25:13-25:14
+108: Ident           "lock" at 25:14-25:18
+109: Dot             "." at 25:18-25:19
+110: Ident           "lock" at 25:19-25:23
+111: LParen          "(" at 25:23-25:24
+112: RParen          ")" at 25:24-25:25
+113: Semicolon       ";" at 25:25-25:26
+114: RBrace          "}" at 27:5-27:6 (leading: Newline, Space, LineComment, Newline, Space)
+115: RBrace          "}" at 28:1-28:2 (leading: Newline)
+116: EOF             at 29:1-29:1

--- a/testdata/golden/sema/invalid/concurrency/requires_lock_not_lock.ast
+++ b/testdata/golden/sema/invalid/concurrency/requires_lock_not_lock.ast
@@ -1,0 +1,29 @@
+requires_lock_not_lock.sg (span: 3:1-24:1)
+├─ Item[0]: Type (span: 3:1-6:2)
+│  ├─ Name: BadLocking
+│  ├─ Kind: Struct
+│  ├─ Visibility: private
+│  └─ Struct:
+│     ├─ Field[0]: counter: int
+│     └─ Field[1]: cond: Condition
+└─ Item[1]: Extern (span: 8:1-23:2)
+   ├─ Target: BadLocking
+   ├─ Members:
+   │  ├─ Fn[0]: bad_requires
+   │  │  ├─ Params: (self: &BadLocking)
+   │  │  ├─ Return: nothing
+   │  │  ├─ Attributes: @requires_lock("counter")
+   │  │  └─ Body:
+   │  │     Stmt[0]: Block (span: 10:55-12:6)
+   │  ├─ Fn[1]: bad_acquires
+   │  │  ├─ Params: (self: &mut BadLocking)
+   │  │  ├─ Return: nothing
+   │  │  ├─ Attributes: @acquires_lock("cond")
+   │  │  └─ Body:
+   │  │     Stmt[0]: Block (span: 15:59-17:6)
+   │  └─ Fn[2]: bad_releases
+   │     ├─ Params: (self: &mut BadLocking)
+   │     ├─ Return: nothing
+   │     ├─ Attributes: @releases_lock("counter")
+   │     └─ Body:
+   │        Stmt[0]: Block (span: 20:59-22:6)

--- a/testdata/golden/sema/invalid/concurrency/requires_lock_not_lock.diag
+++ b/testdata/golden/sema/invalid/concurrency/requires_lock_not_lock.diag
@@ -1,0 +1,3 @@
+error SEM3085 testdata/golden/sema/invalid/concurrency/requires_lock_not_lock.sg:9:20 @requires_lock field must be of type Mutex or RwLock, got 'int'
+error SEM3085 testdata/golden/sema/invalid/concurrency/requires_lock_not_lock.sg:14:20 @acquires_lock field must be of type Mutex or RwLock, got 'Condition'
+error SEM3085 testdata/golden/sema/invalid/concurrency/requires_lock_not_lock.sg:19:20 @releases_lock field must be of type Mutex or RwLock, got 'int'

--- a/testdata/golden/sema/invalid/concurrency/requires_lock_not_lock.diag
+++ b/testdata/golden/sema/invalid/concurrency/requires_lock_not_lock.diag
@@ -1,3 +1,4 @@
 error SEM3085 testdata/golden/sema/invalid/concurrency/requires_lock_not_lock.sg:9:20 @requires_lock field must be of type Mutex or RwLock, got 'int'
 error SEM3085 testdata/golden/sema/invalid/concurrency/requires_lock_not_lock.sg:14:20 @acquires_lock field must be of type Mutex or RwLock, got 'Condition'
+error SEM3081 testdata/golden/sema/invalid/concurrency/requires_lock_not_lock.sg:19:5 lock 'counter' acquired here but not released before function exit
 error SEM3085 testdata/golden/sema/invalid/concurrency/requires_lock_not_lock.sg:19:20 @releases_lock field must be of type Mutex or RwLock, got 'int'

--- a/testdata/golden/sema/invalid/concurrency/requires_lock_not_lock.diag
+++ b/testdata/golden/sema/invalid/concurrency/requires_lock_not_lock.diag
@@ -1,4 +1,3 @@
 error SEM3085 testdata/golden/sema/invalid/concurrency/requires_lock_not_lock.sg:9:20 @requires_lock field must be of type Mutex or RwLock, got 'int'
 error SEM3085 testdata/golden/sema/invalid/concurrency/requires_lock_not_lock.sg:14:20 @acquires_lock field must be of type Mutex or RwLock, got 'Condition'
-error SEM3081 testdata/golden/sema/invalid/concurrency/requires_lock_not_lock.sg:19:5 lock 'counter' acquired here but not released before function exit
 error SEM3085 testdata/golden/sema/invalid/concurrency/requires_lock_not_lock.sg:19:20 @releases_lock field must be of type Mutex or RwLock, got 'int'

--- a/testdata/golden/sema/invalid/concurrency/requires_lock_not_lock.fmt
+++ b/testdata/golden/sema/invalid/concurrency/requires_lock_not_lock.fmt
@@ -1,0 +1,23 @@
+// Invalid @requires_lock/@acquires_lock/@releases_lock - field is not Mutex or RwLock
+
+type BadLocking = {
+    counter: int,
+    cond: Condition,
+}
+
+extern<BadLocking> {
+    @requires_lock("counter")
+    pub fn bad_requires(self: &BadLocking) -> nothing {
+        // Error: counter is int, not Mutex/RwLock
+    }
+
+    @acquires_lock("cond")
+    pub fn bad_acquires(self: &mut BadLocking) -> nothing {
+        // Error: cond is Condition, not Mutex/RwLock
+    }
+
+    @releases_lock("counter")
+    pub fn bad_releases(self: &mut BadLocking) -> nothing {
+        // Error: counter is int, not Mutex/RwLock
+    }
+}

--- a/testdata/golden/sema/invalid/concurrency/requires_lock_not_lock.sg
+++ b/testdata/golden/sema/invalid/concurrency/requires_lock_not_lock.sg
@@ -1,0 +1,23 @@
+// Invalid @requires_lock/@acquires_lock/@releases_lock - field is not Mutex or RwLock
+
+type BadLocking = {
+    counter: int,
+    cond: Condition,
+}
+
+extern<BadLocking> {
+    @requires_lock("counter")
+    pub fn bad_requires(self: &BadLocking) -> nothing {
+        // Error: counter is int, not Mutex/RwLock
+    }
+
+    @acquires_lock("cond")
+    pub fn bad_acquires(self: &mut BadLocking) -> nothing {
+        // Error: cond is Condition, not Mutex/RwLock
+    }
+
+    @releases_lock("counter")
+    pub fn bad_releases(self: &mut BadLocking) -> nothing {
+        // Error: counter is int, not Mutex/RwLock
+    }
+}

--- a/testdata/golden/sema/invalid/concurrency/requires_lock_not_lock.tokens
+++ b/testdata/golden/sema/invalid/concurrency/requires_lock_not_lock.tokens
@@ -1,0 +1,76 @@
+  1: KwType          "type" at 3:1-3:5 (leading: LineComment, Newline)
+  2: Ident           "BadLocking" at 3:6-3:16 (leading: Space)
+  3: Assign          "=" at 3:17-3:18 (leading: Space)
+  4: LBrace          "{" at 3:19-3:20 (leading: Space)
+  5: Ident           "counter" at 4:5-4:12 (leading: Newline, Space)
+  6: Colon           ":" at 4:12-4:13
+  7: Ident           "int" at 4:14-4:17 (leading: Space)
+  8: Comma           "," at 4:17-4:18
+  9: Ident           "cond" at 5:5-5:9 (leading: Newline, Space)
+ 10: Colon           ":" at 5:9-5:10
+ 11: Ident           "Condition" at 5:11-5:20 (leading: Space)
+ 12: Comma           "," at 5:20-5:21
+ 13: RBrace          "}" at 6:1-6:2 (leading: Newline)
+ 14: KwExtern        "extern" at 8:1-8:7 (leading: Newline)
+ 15: Lt              "<" at 8:7-8:8
+ 16: Ident           "BadLocking" at 8:8-8:18
+ 17: Gt              ">" at 8:18-8:19
+ 18: LBrace          "{" at 8:20-8:21 (leading: Space)
+ 19: At              "@" at 9:5-9:6 (leading: Newline, Space)
+ 20: Ident           "requires_lock" at 9:6-9:19
+ 21: LParen          "(" at 9:19-9:20
+ 22: StringLit       "\"counter\"" at 9:20-9:29
+ 23: RParen          ")" at 9:29-9:30
+ 24: KwPub           "pub" at 10:5-10:8 (leading: Newline, Space)
+ 25: KwFn            "fn" at 10:9-10:11 (leading: Space)
+ 26: Ident           "bad_requires" at 10:12-10:24 (leading: Space)
+ 27: LParen          "(" at 10:24-10:25
+ 28: Ident           "self" at 10:25-10:29
+ 29: Colon           ":" at 10:29-10:30
+ 30: Amp             "&" at 10:31-10:32 (leading: Space)
+ 31: Ident           "BadLocking" at 10:32-10:42
+ 32: RParen          ")" at 10:42-10:43
+ 33: Arrow           "->" at 10:44-10:46 (leading: Space)
+ 34: NothingLit      "nothing" at 10:47-10:54 (leading: Space)
+ 35: LBrace          "{" at 10:55-10:56 (leading: Space)
+ 36: RBrace          "}" at 12:5-12:6 (leading: Newline, Space, LineComment, Newline, Space)
+ 37: At              "@" at 14:5-14:6 (leading: Newline, Space)
+ 38: Ident           "acquires_lock" at 14:6-14:19
+ 39: LParen          "(" at 14:19-14:20
+ 40: StringLit       "\"cond\"" at 14:20-14:26
+ 41: RParen          ")" at 14:26-14:27
+ 42: KwPub           "pub" at 15:5-15:8 (leading: Newline, Space)
+ 43: KwFn            "fn" at 15:9-15:11 (leading: Space)
+ 44: Ident           "bad_acquires" at 15:12-15:24 (leading: Space)
+ 45: LParen          "(" at 15:24-15:25
+ 46: Ident           "self" at 15:25-15:29
+ 47: Colon           ":" at 15:29-15:30
+ 48: Amp             "&" at 15:31-15:32 (leading: Space)
+ 49: KwMut           "mut" at 15:32-15:35
+ 50: Ident           "BadLocking" at 15:36-15:46 (leading: Space)
+ 51: RParen          ")" at 15:46-15:47
+ 52: Arrow           "->" at 15:48-15:50 (leading: Space)
+ 53: NothingLit      "nothing" at 15:51-15:58 (leading: Space)
+ 54: LBrace          "{" at 15:59-15:60 (leading: Space)
+ 55: RBrace          "}" at 17:5-17:6 (leading: Newline, Space, LineComment, Newline, Space)
+ 56: At              "@" at 19:5-19:6 (leading: Newline, Space)
+ 57: Ident           "releases_lock" at 19:6-19:19
+ 58: LParen          "(" at 19:19-19:20
+ 59: StringLit       "\"counter\"" at 19:20-19:29
+ 60: RParen          ")" at 19:29-19:30
+ 61: KwPub           "pub" at 20:5-20:8 (leading: Newline, Space)
+ 62: KwFn            "fn" at 20:9-20:11 (leading: Space)
+ 63: Ident           "bad_releases" at 20:12-20:24 (leading: Space)
+ 64: LParen          "(" at 20:24-20:25
+ 65: Ident           "self" at 20:25-20:29
+ 66: Colon           ":" at 20:29-20:30
+ 67: Amp             "&" at 20:31-20:32 (leading: Space)
+ 68: KwMut           "mut" at 20:32-20:35
+ 69: Ident           "BadLocking" at 20:36-20:46 (leading: Space)
+ 70: RParen          ")" at 20:46-20:47
+ 71: Arrow           "->" at 20:48-20:50 (leading: Space)
+ 72: NothingLit      "nothing" at 20:51-20:58 (leading: Space)
+ 73: LBrace          "{" at 20:59-20:60 (leading: Space)
+ 74: RBrace          "}" at 22:5-22:6 (leading: Newline, Space, LineComment, Newline, Space)
+ 75: RBrace          "}" at 23:1-23:2 (leading: Newline)
+ 76: EOF             at 24:1-24:1

--- a/testdata/golden/sema/invalid/concurrency/requires_lock_other_leak.ast
+++ b/testdata/golden/sema/invalid/concurrency/requires_lock_other_leak.ast
@@ -1,0 +1,20 @@
+requires_lock_other_leak.sg (span: 3:1-18:1)
+├─ Item[0]: Type (span: 3:1-7:2)
+│  ├─ Name: MultiLock
+│  ├─ Kind: Struct
+│  ├─ Visibility: private
+│  └─ Struct:
+│     ├─ Field[0]: required_lock: Mutex
+│     ├─ Field[1]: other_lock: Mutex
+│     └─ Field[2]: value: int
+└─ Item[1]: Extern (span: 9:1-17:2)
+   ├─ Target: MultiLock
+   ├─ Members:
+   │  └─ Fn[0]: leaks_other_lock
+   │     ├─ Params: (self: &mut MultiLock)
+   │     ├─ Return: nothing
+   │     ├─ Attributes: @requires_lock("required_lock")
+   │     └─ Body:
+   │        Stmt[0]: Block (span: 13:62-16:6)
+   │        └─ Stmt[0]: Expr (span: 14:9-14:32)
+   │           └─ Expr: expr#5: self.other_lock.lock()

--- a/testdata/golden/sema/invalid/concurrency/requires_lock_other_leak.diag
+++ b/testdata/golden/sema/invalid/concurrency/requires_lock_other_leak.diag
@@ -1,0 +1,1 @@
+error SEM3081 testdata/golden/sema/invalid/concurrency/requires_lock_other_leak.sg:14:9 lock 'other_lock' acquired here but not released before function exit

--- a/testdata/golden/sema/invalid/concurrency/requires_lock_other_leak.fmt
+++ b/testdata/golden/sema/invalid/concurrency/requires_lock_other_leak.fmt
@@ -1,0 +1,17 @@
+// Test: @requires_lock should NOT exempt other locks from leak check
+
+type MultiLock = {
+    required_lock: Mutex,
+    other_lock: Mutex,
+    value: int,
+}
+
+extern<MultiLock> {
+    // This function requires 'required_lock' to be held
+    // But it acquires 'other_lock' and forgets to release it
+    @requires_lock("required_lock")
+    pub fn leaks_other_lock(self: &mut MultiLock) -> nothing {
+        self.other_lock.lock();
+        // Error: other_lock not released (should NOT be exempted by @requires_lock)
+    }
+}

--- a/testdata/golden/sema/invalid/concurrency/requires_lock_other_leak.sg
+++ b/testdata/golden/sema/invalid/concurrency/requires_lock_other_leak.sg
@@ -1,0 +1,17 @@
+// Test: @requires_lock should NOT exempt other locks from leak check
+
+type MultiLock = {
+    required_lock: Mutex,
+    other_lock: Mutex,
+    value: int,
+}
+
+extern<MultiLock> {
+    // This function requires 'required_lock' to be held
+    // But it acquires 'other_lock' and forgets to release it
+    @requires_lock("required_lock")
+    pub fn leaks_other_lock(self: &mut MultiLock) -> nothing {
+        self.other_lock.lock();
+        // Error: other_lock not released (should NOT be exempted by @requires_lock)
+    }
+}

--- a/testdata/golden/sema/invalid/concurrency/requires_lock_other_leak.tokens
+++ b/testdata/golden/sema/invalid/concurrency/requires_lock_other_leak.tokens
@@ -1,0 +1,51 @@
+  1: KwType          "type" at 3:1-3:5 (leading: LineComment, Newline)
+  2: Ident           "MultiLock" at 3:6-3:15 (leading: Space)
+  3: Assign          "=" at 3:16-3:17 (leading: Space)
+  4: LBrace          "{" at 3:18-3:19 (leading: Space)
+  5: Ident           "required_lock" at 4:5-4:18 (leading: Newline, Space)
+  6: Colon           ":" at 4:18-4:19
+  7: Ident           "Mutex" at 4:20-4:25 (leading: Space)
+  8: Comma           "," at 4:25-4:26
+  9: Ident           "other_lock" at 5:5-5:15 (leading: Newline, Space)
+ 10: Colon           ":" at 5:15-5:16
+ 11: Ident           "Mutex" at 5:17-5:22 (leading: Space)
+ 12: Comma           "," at 5:22-5:23
+ 13: Ident           "value" at 6:5-6:10 (leading: Newline, Space)
+ 14: Colon           ":" at 6:10-6:11
+ 15: Ident           "int" at 6:12-6:15 (leading: Space)
+ 16: Comma           "," at 6:15-6:16
+ 17: RBrace          "}" at 7:1-7:2 (leading: Newline)
+ 18: KwExtern        "extern" at 9:1-9:7 (leading: Newline)
+ 19: Lt              "<" at 9:7-9:8
+ 20: Ident           "MultiLock" at 9:8-9:17
+ 21: Gt              ">" at 9:17-9:18
+ 22: LBrace          "{" at 9:19-9:20 (leading: Space)
+ 23: At              "@" at 12:5-12:6 (leading: Newline, Space, LineComment, Newline, Space, LineComment, Newline, Space)
+ 24: Ident           "requires_lock" at 12:6-12:19
+ 25: LParen          "(" at 12:19-12:20
+ 26: StringLit       "\"required_lock\"" at 12:20-12:35
+ 27: RParen          ")" at 12:35-12:36
+ 28: KwPub           "pub" at 13:5-13:8 (leading: Newline, Space)
+ 29: KwFn            "fn" at 13:9-13:11 (leading: Space)
+ 30: Ident           "leaks_other_lock" at 13:12-13:28 (leading: Space)
+ 31: LParen          "(" at 13:28-13:29
+ 32: Ident           "self" at 13:29-13:33
+ 33: Colon           ":" at 13:33-13:34
+ 34: Amp             "&" at 13:35-13:36 (leading: Space)
+ 35: KwMut           "mut" at 13:36-13:39
+ 36: Ident           "MultiLock" at 13:40-13:49 (leading: Space)
+ 37: RParen          ")" at 13:49-13:50
+ 38: Arrow           "->" at 13:51-13:53 (leading: Space)
+ 39: NothingLit      "nothing" at 13:54-13:61 (leading: Space)
+ 40: LBrace          "{" at 13:62-13:63 (leading: Space)
+ 41: Ident           "self" at 14:9-14:13 (leading: Newline, Space)
+ 42: Dot             "." at 14:13-14:14
+ 43: Ident           "other_lock" at 14:14-14:24
+ 44: Dot             "." at 14:24-14:25
+ 45: Ident           "lock" at 14:25-14:29
+ 46: LParen          "(" at 14:29-14:30
+ 47: RParen          ")" at 14:30-14:31
+ 48: Semicolon       ";" at 14:31-14:32
+ 49: RBrace          "}" at 16:5-16:6 (leading: Newline, Space, LineComment, Newline, Space)
+ 50: RBrace          "}" at 17:1-17:2 (leading: Newline)
+ 51: EOF             at 18:1-18:1

--- a/testdata/golden/sema/invalid/concurrency/unlock_not_held.ast
+++ b/testdata/golden/sema/invalid/concurrency/unlock_not_held.ast
@@ -1,0 +1,47 @@
+unlock_not_held.sg (span: 3:1-24:1)
+├─ Item[0]: Fn (span: 3:1-6:2)
+│  ├─ Name: test_unlock_not_held
+│  ├─ Params: ()
+│  ├─ Return: nothing
+│  └─ Body:
+│     └─ Stmt[0]: Block (span: 3:42-6:2)
+│        ├─ Stmt[0]: Let (span: 4:5-4:38)
+│        │  ├─ Name: mtx
+│        │  ├─ Mutable: true
+│        │  ├─ Type: Mutex
+│        │  └─ Value: expr#3: Mutex.new()
+│        └─ Stmt[1]: Expr (span: 5:5-5:18)
+│           └─ Expr: expr#6: mtx.unlock()
+├─ Item[1]: Fn (span: 8:1-13:2)
+│  ├─ Name: test_double_unlock
+│  ├─ Params: ()
+│  ├─ Return: nothing
+│  └─ Body:
+│     └─ Stmt[0]: Block (span: 8:40-13:2)
+│        ├─ Stmt[0]: Let (span: 9:5-9:38)
+│        │  ├─ Name: mtx
+│        │  ├─ Mutable: true
+│        │  ├─ Type: Mutex
+│        │  └─ Value: expr#9: Mutex.new()
+│        ├─ Stmt[1]: Expr (span: 10:5-10:16)
+│        │  └─ Expr: expr#12: mtx.lock()
+│        ├─ Stmt[2]: Expr (span: 11:5-11:18)
+│        │  └─ Expr: expr#15: mtx.unlock()
+│        └─ Stmt[3]: Expr (span: 12:5-12:18)
+│           └─ Expr: expr#18: mtx.unlock()
+├─ Item[2]: Type (span: 15:1-17:2)
+│  ├─ Name: Container
+│  ├─ Kind: Struct
+│  ├─ Visibility: private
+│  └─ Struct:
+│     └─ Field[0]: lock: Mutex
+└─ Item[3]: Extern (span: 19:1-23:2)
+   ├─ Target: Container
+   ├─ Members:
+   │  └─ Fn[0]: bad_unlock
+   │     ├─ Params: (self: &mut Container)
+   │     ├─ Return: nothing
+   │     └─ Body:
+   │        Stmt[0]: Block (span: 20:56-22:6)
+   │        └─ Stmt[0]: Expr (span: 21:9-21:28)
+   │           └─ Expr: expr#22: self.lock.unlock()

--- a/testdata/golden/sema/invalid/concurrency/unlock_not_held.diag
+++ b/testdata/golden/sema/invalid/concurrency/unlock_not_held.diag
@@ -1,0 +1,3 @@
+error SEM3080 testdata/golden/sema/invalid/concurrency/unlock_not_held.sg:5:5 lock '' is not currently held
+error SEM3080 testdata/golden/sema/invalid/concurrency/unlock_not_held.sg:12:5 lock '' is not currently held
+error SEM3080 testdata/golden/sema/invalid/concurrency/unlock_not_held.sg:21:9 lock 'lock' is not currently held

--- a/testdata/golden/sema/invalid/concurrency/unlock_not_held.fmt
+++ b/testdata/golden/sema/invalid/concurrency/unlock_not_held.fmt
@@ -1,0 +1,23 @@
+// Invalid: unlock without prior lock
+
+pub fn test_unlock_not_held() -> nothing {
+    let mut mtx: Mutex = Mutex.new();
+    mtx.unlock();  // Error: lock not held
+}
+
+pub fn test_double_unlock() -> nothing {
+    let mut mtx: Mutex = Mutex.new();
+    mtx.lock();
+    mtx.unlock();
+    mtx.unlock();  // Error: lock not held (already unlocked)
+}
+
+type Container = {
+    lock: Mutex,
+}
+
+extern<Container> {
+    pub fn bad_unlock(self: &mut Container) -> nothing {
+        self.lock.unlock();  // Error: lock not held
+    }
+}

--- a/testdata/golden/sema/invalid/concurrency/unlock_not_held.sg
+++ b/testdata/golden/sema/invalid/concurrency/unlock_not_held.sg
@@ -1,0 +1,23 @@
+// Invalid: unlock without prior lock
+
+pub fn test_unlock_not_held() -> nothing {
+    let mut mtx: Mutex = Mutex.new();
+    mtx.unlock();  // Error: lock not held
+}
+
+pub fn test_double_unlock() -> nothing {
+    let mut mtx: Mutex = Mutex.new();
+    mtx.lock();
+    mtx.unlock();
+    mtx.unlock();  // Error: lock not held (already unlocked)
+}
+
+type Container = {
+    lock: Mutex,
+}
+
+extern<Container> {
+    pub fn bad_unlock(self: &mut Container) -> nothing {
+        self.lock.unlock();  // Error: lock not held
+    }
+}

--- a/testdata/golden/sema/invalid/concurrency/unlock_not_held.tokens
+++ b/testdata/golden/sema/invalid/concurrency/unlock_not_held.tokens
@@ -1,0 +1,104 @@
+  1: KwPub           "pub" at 3:1-3:4 (leading: LineComment, Newline)
+  2: KwFn            "fn" at 3:5-3:7 (leading: Space)
+  3: Ident           "test_unlock_not_held" at 3:8-3:28 (leading: Space)
+  4: LParen          "(" at 3:28-3:29
+  5: RParen          ")" at 3:29-3:30
+  6: Arrow           "->" at 3:31-3:33 (leading: Space)
+  7: NothingLit      "nothing" at 3:34-3:41 (leading: Space)
+  8: LBrace          "{" at 3:42-3:43 (leading: Space)
+  9: KwLet           "let" at 4:5-4:8 (leading: Newline, Space)
+ 10: KwMut           "mut" at 4:9-4:12 (leading: Space)
+ 11: Ident           "mtx" at 4:13-4:16 (leading: Space)
+ 12: Colon           ":" at 4:16-4:17
+ 13: Ident           "Mutex" at 4:18-4:23 (leading: Space)
+ 14: Assign          "=" at 4:24-4:25 (leading: Space)
+ 15: Ident           "Mutex" at 4:26-4:31 (leading: Space)
+ 16: Dot             "." at 4:31-4:32
+ 17: Ident           "new" at 4:32-4:35
+ 18: LParen          "(" at 4:35-4:36
+ 19: RParen          ")" at 4:36-4:37
+ 20: Semicolon       ";" at 4:37-4:38
+ 21: Ident           "mtx" at 5:5-5:8 (leading: Newline, Space)
+ 22: Dot             "." at 5:8-5:9
+ 23: Ident           "unlock" at 5:9-5:15
+ 24: LParen          "(" at 5:15-5:16
+ 25: RParen          ")" at 5:16-5:17
+ 26: Semicolon       ";" at 5:17-5:18
+ 27: RBrace          "}" at 6:1-6:2 (leading: Space, LineComment, Newline)
+ 28: KwPub           "pub" at 8:1-8:4 (leading: Newline)
+ 29: KwFn            "fn" at 8:5-8:7 (leading: Space)
+ 30: Ident           "test_double_unlock" at 8:8-8:26 (leading: Space)
+ 31: LParen          "(" at 8:26-8:27
+ 32: RParen          ")" at 8:27-8:28
+ 33: Arrow           "->" at 8:29-8:31 (leading: Space)
+ 34: NothingLit      "nothing" at 8:32-8:39 (leading: Space)
+ 35: LBrace          "{" at 8:40-8:41 (leading: Space)
+ 36: KwLet           "let" at 9:5-9:8 (leading: Newline, Space)
+ 37: KwMut           "mut" at 9:9-9:12 (leading: Space)
+ 38: Ident           "mtx" at 9:13-9:16 (leading: Space)
+ 39: Colon           ":" at 9:16-9:17
+ 40: Ident           "Mutex" at 9:18-9:23 (leading: Space)
+ 41: Assign          "=" at 9:24-9:25 (leading: Space)
+ 42: Ident           "Mutex" at 9:26-9:31 (leading: Space)
+ 43: Dot             "." at 9:31-9:32
+ 44: Ident           "new" at 9:32-9:35
+ 45: LParen          "(" at 9:35-9:36
+ 46: RParen          ")" at 9:36-9:37
+ 47: Semicolon       ";" at 9:37-9:38
+ 48: Ident           "mtx" at 10:5-10:8 (leading: Newline, Space)
+ 49: Dot             "." at 10:8-10:9
+ 50: Ident           "lock" at 10:9-10:13
+ 51: LParen          "(" at 10:13-10:14
+ 52: RParen          ")" at 10:14-10:15
+ 53: Semicolon       ";" at 10:15-10:16
+ 54: Ident           "mtx" at 11:5-11:8 (leading: Newline, Space)
+ 55: Dot             "." at 11:8-11:9
+ 56: Ident           "unlock" at 11:9-11:15
+ 57: LParen          "(" at 11:15-11:16
+ 58: RParen          ")" at 11:16-11:17
+ 59: Semicolon       ";" at 11:17-11:18
+ 60: Ident           "mtx" at 12:5-12:8 (leading: Newline, Space)
+ 61: Dot             "." at 12:8-12:9
+ 62: Ident           "unlock" at 12:9-12:15
+ 63: LParen          "(" at 12:15-12:16
+ 64: RParen          ")" at 12:16-12:17
+ 65: Semicolon       ";" at 12:17-12:18
+ 66: RBrace          "}" at 13:1-13:2 (leading: Space, LineComment, Newline)
+ 67: KwType          "type" at 15:1-15:5 (leading: Newline)
+ 68: Ident           "Container" at 15:6-15:15 (leading: Space)
+ 69: Assign          "=" at 15:16-15:17 (leading: Space)
+ 70: LBrace          "{" at 15:18-15:19 (leading: Space)
+ 71: Ident           "lock" at 16:5-16:9 (leading: Newline, Space)
+ 72: Colon           ":" at 16:9-16:10
+ 73: Ident           "Mutex" at 16:11-16:16 (leading: Space)
+ 74: Comma           "," at 16:16-16:17
+ 75: RBrace          "}" at 17:1-17:2 (leading: Newline)
+ 76: KwExtern        "extern" at 19:1-19:7 (leading: Newline)
+ 77: Lt              "<" at 19:7-19:8
+ 78: Ident           "Container" at 19:8-19:17
+ 79: Gt              ">" at 19:17-19:18
+ 80: LBrace          "{" at 19:19-19:20 (leading: Space)
+ 81: KwPub           "pub" at 20:5-20:8 (leading: Newline, Space)
+ 82: KwFn            "fn" at 20:9-20:11 (leading: Space)
+ 83: Ident           "bad_unlock" at 20:12-20:22 (leading: Space)
+ 84: LParen          "(" at 20:22-20:23
+ 85: Ident           "self" at 20:23-20:27
+ 86: Colon           ":" at 20:27-20:28
+ 87: Amp             "&" at 20:29-20:30 (leading: Space)
+ 88: KwMut           "mut" at 20:30-20:33
+ 89: Ident           "Container" at 20:34-20:43 (leading: Space)
+ 90: RParen          ")" at 20:43-20:44
+ 91: Arrow           "->" at 20:45-20:47 (leading: Space)
+ 92: NothingLit      "nothing" at 20:48-20:55 (leading: Space)
+ 93: LBrace          "{" at 20:56-20:57 (leading: Space)
+ 94: Ident           "self" at 21:9-21:13 (leading: Newline, Space)
+ 95: Dot             "." at 21:13-21:14
+ 96: Ident           "lock" at 21:14-21:18
+ 97: Dot             "." at 21:18-21:19
+ 98: Ident           "unlock" at 21:19-21:25
+ 99: LParen          "(" at 21:25-21:26
+100: RParen          ")" at 21:26-21:27
+101: Semicolon       ";" at 21:27-21:28
+102: RBrace          "}" at 22:5-22:6 (leading: Space, LineComment, Newline, Space)
+103: RBrace          "}" at 23:1-23:2 (leading: Newline)
+104: EOF             at 24:1-24:1

--- a/testdata/golden/sema/invalid/concurrency/waits_on_not_condition.ast
+++ b/testdata/golden/sema/invalid/concurrency/waits_on_not_condition.ast
@@ -1,0 +1,23 @@
+waits_on_not_condition.sg (span: 3:1-19:1)
+├─ Item[0]: Type (span: 3:1-6:2)
+│  ├─ Name: BadMonitor
+│  ├─ Kind: Struct
+│  ├─ Visibility: private
+│  └─ Struct:
+│     ├─ Field[0]: lock: Mutex
+│     └─ Field[1]: counter: int
+└─ Item[1]: Extern (span: 8:1-18:2)
+   ├─ Target: BadMonitor
+   ├─ Members:
+   │  ├─ Fn[0]: wait_on_mutex
+   │  │  ├─ Params: (self: &mut BadMonitor)
+   │  │  ├─ Return: nothing
+   │  │  ├─ Attributes: @waits_on("lock")
+   │  │  └─ Body:
+   │  │     Stmt[0]: Block (span: 10:60-12:6)
+   │  └─ Fn[1]: wait_on_int
+   │     ├─ Params: (self: &mut BadMonitor)
+   │     ├─ Return: nothing
+   │     ├─ Attributes: @waits_on("counter")
+   │     └─ Body:
+   │        Stmt[0]: Block (span: 15:58-17:6)

--- a/testdata/golden/sema/invalid/concurrency/waits_on_not_condition.diag
+++ b/testdata/golden/sema/invalid/concurrency/waits_on_not_condition.diag
@@ -1,0 +1,2 @@
+error SEM3100 testdata/golden/sema/invalid/concurrency/waits_on_not_condition.sg:9:15 @waits_on field must be of type Condition or Semaphore, got 'Mutex'
+error SEM3100 testdata/golden/sema/invalid/concurrency/waits_on_not_condition.sg:14:15 @waits_on field must be of type Condition or Semaphore, got 'int'

--- a/testdata/golden/sema/invalid/concurrency/waits_on_not_condition.fmt
+++ b/testdata/golden/sema/invalid/concurrency/waits_on_not_condition.fmt
@@ -1,0 +1,18 @@
+// Invalid @waits_on - field is not Condition or Semaphore
+
+type BadMonitor = {
+    lock: Mutex,
+    counter: int,
+}
+
+extern<BadMonitor> {
+    @waits_on("lock")
+    pub fn wait_on_mutex(self: &mut BadMonitor) -> nothing {
+        // Error: lock is Mutex, not Condition/Semaphore
+    }
+
+    @waits_on("counter")
+    pub fn wait_on_int(self: &mut BadMonitor) -> nothing {
+        // Error: counter is int, not Condition/Semaphore
+    }
+}

--- a/testdata/golden/sema/invalid/concurrency/waits_on_not_condition.sg
+++ b/testdata/golden/sema/invalid/concurrency/waits_on_not_condition.sg
@@ -1,0 +1,18 @@
+// Invalid @waits_on - field is not Condition or Semaphore
+
+type BadMonitor = {
+    lock: Mutex,
+    counter: int,
+}
+
+extern<BadMonitor> {
+    @waits_on("lock")
+    pub fn wait_on_mutex(self: &mut BadMonitor) -> nothing {
+        // Error: lock is Mutex, not Condition/Semaphore
+    }
+
+    @waits_on("counter")
+    pub fn wait_on_int(self: &mut BadMonitor) -> nothing {
+        // Error: counter is int, not Condition/Semaphore
+    }
+}

--- a/testdata/golden/sema/invalid/concurrency/waits_on_not_condition.tokens
+++ b/testdata/golden/sema/invalid/concurrency/waits_on_not_condition.tokens
@@ -1,0 +1,58 @@
+  1: KwType          "type" at 3:1-3:5 (leading: LineComment, Newline)
+  2: Ident           "BadMonitor" at 3:6-3:16 (leading: Space)
+  3: Assign          "=" at 3:17-3:18 (leading: Space)
+  4: LBrace          "{" at 3:19-3:20 (leading: Space)
+  5: Ident           "lock" at 4:5-4:9 (leading: Newline, Space)
+  6: Colon           ":" at 4:9-4:10
+  7: Ident           "Mutex" at 4:11-4:16 (leading: Space)
+  8: Comma           "," at 4:16-4:17
+  9: Ident           "counter" at 5:5-5:12 (leading: Newline, Space)
+ 10: Colon           ":" at 5:12-5:13
+ 11: Ident           "int" at 5:14-5:17 (leading: Space)
+ 12: Comma           "," at 5:17-5:18
+ 13: RBrace          "}" at 6:1-6:2 (leading: Newline)
+ 14: KwExtern        "extern" at 8:1-8:7 (leading: Newline)
+ 15: Lt              "<" at 8:7-8:8
+ 16: Ident           "BadMonitor" at 8:8-8:18
+ 17: Gt              ">" at 8:18-8:19
+ 18: LBrace          "{" at 8:20-8:21 (leading: Space)
+ 19: At              "@" at 9:5-9:6 (leading: Newline, Space)
+ 20: Ident           "waits_on" at 9:6-9:14
+ 21: LParen          "(" at 9:14-9:15
+ 22: StringLit       "\"lock\"" at 9:15-9:21
+ 23: RParen          ")" at 9:21-9:22
+ 24: KwPub           "pub" at 10:5-10:8 (leading: Newline, Space)
+ 25: KwFn            "fn" at 10:9-10:11 (leading: Space)
+ 26: Ident           "wait_on_mutex" at 10:12-10:25 (leading: Space)
+ 27: LParen          "(" at 10:25-10:26
+ 28: Ident           "self" at 10:26-10:30
+ 29: Colon           ":" at 10:30-10:31
+ 30: Amp             "&" at 10:32-10:33 (leading: Space)
+ 31: KwMut           "mut" at 10:33-10:36
+ 32: Ident           "BadMonitor" at 10:37-10:47 (leading: Space)
+ 33: RParen          ")" at 10:47-10:48
+ 34: Arrow           "->" at 10:49-10:51 (leading: Space)
+ 35: NothingLit      "nothing" at 10:52-10:59 (leading: Space)
+ 36: LBrace          "{" at 10:60-10:61 (leading: Space)
+ 37: RBrace          "}" at 12:5-12:6 (leading: Newline, Space, LineComment, Newline, Space)
+ 38: At              "@" at 14:5-14:6 (leading: Newline, Space)
+ 39: Ident           "waits_on" at 14:6-14:14
+ 40: LParen          "(" at 14:14-14:15
+ 41: StringLit       "\"counter\"" at 14:15-14:24
+ 42: RParen          ")" at 14:24-14:25
+ 43: KwPub           "pub" at 15:5-15:8 (leading: Newline, Space)
+ 44: KwFn            "fn" at 15:9-15:11 (leading: Space)
+ 45: Ident           "wait_on_int" at 15:12-15:23 (leading: Space)
+ 46: LParen          "(" at 15:23-15:24
+ 47: Ident           "self" at 15:24-15:28
+ 48: Colon           ":" at 15:28-15:29
+ 49: Amp             "&" at 15:30-15:31 (leading: Space)
+ 50: KwMut           "mut" at 15:31-15:34
+ 51: Ident           "BadMonitor" at 15:35-15:45 (leading: Space)
+ 52: RParen          ")" at 15:45-15:46
+ 53: Arrow           "->" at 15:47-15:49 (leading: Space)
+ 54: NothingLit      "nothing" at 15:50-15:57 (leading: Space)
+ 55: LBrace          "{" at 15:58-15:59 (leading: Space)
+ 56: RBrace          "}" at 17:5-17:6 (leading: Newline, Space, LineComment, Newline, Space)
+ 57: RBrace          "}" at 18:1-18:2 (leading: Newline)
+ 58: EOF             at 19:1-19:1

--- a/testdata/golden/sema/valid/concurrency/atomic_valid.ast
+++ b/testdata/golden/sema/valid/concurrency/atomic_valid.ast
@@ -1,0 +1,32 @@
+atomic_valid.sg (span: 3:1-19:1)
+├─ Item[0]: Type (span: 3:1-7:2)
+│  ├─ Name: AtomicCounter
+│  ├─ Kind: Struct
+│  ├─ Visibility: private
+│  └─ Struct:
+│     ├─ Field[0]: count: int [@atomic]
+│     ├─ Field[1]: flags: uint [@atomic]
+│     └─ Field[2]: active: bool [@atomic]
+├─ Item[1]: Type (span: 9:1-11:2)
+│  ├─ Name: AtomicPointer
+│  ├─ Kind: Struct
+│  ├─ Visibility: private
+│  └─ Struct:
+│     └─ Field[0]: ptr: *int [@atomic]
+└─ Item[2]: Fn (span: 13:1-18:2)
+   ├─ Name: test_atomic_int
+   ├─ Params: ()
+   ├─ Return: nothing
+   └─ Body:
+      └─ Stmt[0]: Block (span: 13:37-18:2)
+         ├─ Stmt[0]: Let (span: 14:5-14:84)
+         │  ├─ Name: a
+         │  ├─ Mutable: true
+         │  ├─ Type: AtomicCounter
+         │  └─ Value: expr#7: <ExprKind(18)>
+         ├─ Stmt[1]: Expr (span: 15:5-15:17)
+         │  └─ Expr: expr#11: (a.count = 1)
+         ├─ Stmt[2]: Expr (span: 16:5-16:19)
+         │  └─ Expr: expr#15: (a.flags = 255)
+         └─ Stmt[3]: Expr (span: 17:5-17:21)
+            └─ Expr: expr#19: (a.active = true)

--- a/testdata/golden/sema/valid/concurrency/atomic_valid.fmt
+++ b/testdata/golden/sema/valid/concurrency/atomic_valid.fmt
@@ -1,0 +1,18 @@
+// Valid @atomic field usage with int, uint, bool, and pointer types
+
+type AtomicCounter = {
+    @atomiccount: int,
+    @atomicflags: uint,
+    @atomicactive: bool,
+}
+
+type AtomicPointer = {
+    @atomicptr: *int,
+}
+
+pub fn test_atomic_int() -> nothing {
+    let mut a: AtomicCounter = AtomicCounter { count: 0, flags: 0, active: false };
+    a.count = 1;
+    a.flags = 255;
+    a.active = true;
+}

--- a/testdata/golden/sema/valid/concurrency/atomic_valid.sg
+++ b/testdata/golden/sema/valid/concurrency/atomic_valid.sg
@@ -1,0 +1,18 @@
+// Valid @atomic field usage with int, uint, bool, and pointer types
+
+type AtomicCounter = {
+    @atomic count: int,
+    @atomic flags: uint,
+    @atomic active: bool,
+}
+
+type AtomicPointer = {
+    @atomic ptr: *int,
+}
+
+pub fn test_atomic_int() -> nothing {
+    let mut a: AtomicCounter = AtomicCounter { count: 0, flags: 0, active: false };
+    a.count = 1;
+    a.flags = 255;
+    a.active = true;
+}

--- a/testdata/golden/sema/valid/concurrency/atomic_valid.tokens
+++ b/testdata/golden/sema/valid/concurrency/atomic_valid.tokens
@@ -1,0 +1,84 @@
+  1: KwType          "type" at 3:1-3:5 (leading: LineComment, Newline)
+  2: Ident           "AtomicCounter" at 3:6-3:19 (leading: Space)
+  3: Assign          "=" at 3:20-3:21 (leading: Space)
+  4: LBrace          "{" at 3:22-3:23 (leading: Space)
+  5: At              "@" at 4:5-4:6 (leading: Newline, Space)
+  6: Ident           "atomic" at 4:6-4:12
+  7: Ident           "count" at 4:13-4:18 (leading: Space)
+  8: Colon           ":" at 4:18-4:19
+  9: Ident           "int" at 4:20-4:23 (leading: Space)
+ 10: Comma           "," at 4:23-4:24
+ 11: At              "@" at 5:5-5:6 (leading: Newline, Space)
+ 12: Ident           "atomic" at 5:6-5:12
+ 13: Ident           "flags" at 5:13-5:18 (leading: Space)
+ 14: Colon           ":" at 5:18-5:19
+ 15: Ident           "uint" at 5:20-5:24 (leading: Space)
+ 16: Comma           "," at 5:24-5:25
+ 17: At              "@" at 6:5-6:6 (leading: Newline, Space)
+ 18: Ident           "atomic" at 6:6-6:12
+ 19: Ident           "active" at 6:13-6:19 (leading: Space)
+ 20: Colon           ":" at 6:19-6:20
+ 21: Ident           "bool" at 6:21-6:25 (leading: Space)
+ 22: Comma           "," at 6:25-6:26
+ 23: RBrace          "}" at 7:1-7:2 (leading: Newline)
+ 24: KwType          "type" at 9:1-9:5 (leading: Newline)
+ 25: Ident           "AtomicPointer" at 9:6-9:19 (leading: Space)
+ 26: Assign          "=" at 9:20-9:21 (leading: Space)
+ 27: LBrace          "{" at 9:22-9:23 (leading: Space)
+ 28: At              "@" at 10:5-10:6 (leading: Newline, Space)
+ 29: Ident           "atomic" at 10:6-10:12
+ 30: Ident           "ptr" at 10:13-10:16 (leading: Space)
+ 31: Colon           ":" at 10:16-10:17
+ 32: Star            "*" at 10:18-10:19 (leading: Space)
+ 33: Ident           "int" at 10:19-10:22
+ 34: Comma           "," at 10:22-10:23
+ 35: RBrace          "}" at 11:1-11:2 (leading: Newline)
+ 36: KwPub           "pub" at 13:1-13:4 (leading: Newline)
+ 37: KwFn            "fn" at 13:5-13:7 (leading: Space)
+ 38: Ident           "test_atomic_int" at 13:8-13:23 (leading: Space)
+ 39: LParen          "(" at 13:23-13:24
+ 40: RParen          ")" at 13:24-13:25
+ 41: Arrow           "->" at 13:26-13:28 (leading: Space)
+ 42: NothingLit      "nothing" at 13:29-13:36 (leading: Space)
+ 43: LBrace          "{" at 13:37-13:38 (leading: Space)
+ 44: KwLet           "let" at 14:5-14:8 (leading: Newline, Space)
+ 45: KwMut           "mut" at 14:9-14:12 (leading: Space)
+ 46: Ident           "a" at 14:13-14:14 (leading: Space)
+ 47: Colon           ":" at 14:14-14:15
+ 48: Ident           "AtomicCounter" at 14:16-14:29 (leading: Space)
+ 49: Assign          "=" at 14:30-14:31 (leading: Space)
+ 50: Ident           "AtomicCounter" at 14:32-14:45 (leading: Space)
+ 51: LBrace          "{" at 14:46-14:47 (leading: Space)
+ 52: Ident           "count" at 14:48-14:53 (leading: Space)
+ 53: Colon           ":" at 14:53-14:54
+ 54: IntLit          "0" at 14:55-14:56 (leading: Space)
+ 55: Comma           "," at 14:56-14:57
+ 56: Ident           "flags" at 14:58-14:63 (leading: Space)
+ 57: Colon           ":" at 14:63-14:64
+ 58: IntLit          "0" at 14:65-14:66 (leading: Space)
+ 59: Comma           "," at 14:66-14:67
+ 60: Ident           "active" at 14:68-14:74 (leading: Space)
+ 61: Colon           ":" at 14:74-14:75
+ 62: KwFalse         "false" at 14:76-14:81 (leading: Space)
+ 63: RBrace          "}" at 14:82-14:83 (leading: Space)
+ 64: Semicolon       ";" at 14:83-14:84
+ 65: Ident           "a" at 15:5-15:6 (leading: Newline, Space)
+ 66: Dot             "." at 15:6-15:7
+ 67: Ident           "count" at 15:7-15:12
+ 68: Assign          "=" at 15:13-15:14 (leading: Space)
+ 69: IntLit          "1" at 15:15-15:16 (leading: Space)
+ 70: Semicolon       ";" at 15:16-15:17
+ 71: Ident           "a" at 16:5-16:6 (leading: Newline, Space)
+ 72: Dot             "." at 16:6-16:7
+ 73: Ident           "flags" at 16:7-16:12
+ 74: Assign          "=" at 16:13-16:14 (leading: Space)
+ 75: IntLit          "255" at 16:15-16:18 (leading: Space)
+ 76: Semicolon       ";" at 16:18-16:19
+ 77: Ident           "a" at 17:5-17:6 (leading: Newline, Space)
+ 78: Dot             "." at 17:6-17:7
+ 79: Ident           "active" at 17:7-17:13
+ 80: Assign          "=" at 17:14-17:15 (leading: Space)
+ 81: KwTrue          "true" at 17:16-17:20 (leading: Space)
+ 82: Semicolon       ";" at 17:20-17:21
+ 83: RBrace          "}" at 18:1-18:2 (leading: Newline)
+ 84: EOF             at 19:1-19:1

--- a/testdata/golden/sema/valid/concurrency/guarded_by_valid.ast
+++ b/testdata/golden/sema/valid/concurrency/guarded_by_valid.ast
@@ -1,0 +1,32 @@
+guarded_by_valid.sg (span: 3:1-19:1)
+├─ Item[0]: Type (span: 3:1-6:2)
+│  ├─ Name: Counter
+│  ├─ Kind: Struct
+│  ├─ Visibility: private
+│  └─ Struct:
+│     ├─ Field[0]: lock: Mutex
+│     └─ Field[1]: value: int [@guarded_by("lock")]
+├─ Item[1]: Type (span: 8:1-11:2)
+│  ├─ Name: SharedData
+│  ├─ Kind: Struct
+│  ├─ Visibility: private
+│  └─ Struct:
+│     ├─ Field[0]: rw: RwLock
+│     └─ Field[1]: data: string [@guarded_by("rw")]
+└─ Item[2]: Fn (span: 13:1-18:2)
+   ├─ Name: test_counter
+   ├─ Params: ()
+   ├─ Return: nothing
+   └─ Body:
+      └─ Stmt[0]: Block (span: 13:34-18:2)
+         ├─ Stmt[0]: Let (span: 14:5-14:66)
+         │  ├─ Name: c
+         │  ├─ Mutable: true
+         │  ├─ Type: Counter
+         │  └─ Value: expr#9: <ExprKind(18)>
+         ├─ Stmt[1]: Expr (span: 15:5-15:19)
+         │  └─ Expr: expr#13: c.lock.lock()
+         ├─ Stmt[2]: Expr (span: 16:5-16:27)
+         │  └─ Expr: expr#20: (c.value = ((c.value + 1)))
+         └─ Stmt[3]: Expr (span: 17:5-17:21)
+            └─ Expr: expr#24: c.lock.unlock()

--- a/testdata/golden/sema/valid/concurrency/guarded_by_valid.fmt
+++ b/testdata/golden/sema/valid/concurrency/guarded_by_valid.fmt
@@ -1,0 +1,18 @@
+// Valid @guarded_by usage with Mutex and RwLock
+
+type Counter = {
+    lock: Mutex,
+    @guarded_by("lock")value: int,
+}
+
+type SharedData = {
+    rw: RwLock,
+    @guarded_by("rw")data: string,
+}
+
+pub fn test_counter() -> nothing {
+    let mut c: Counter = Counter { lock: Mutex.new(), value: 0 };
+    c.lock.lock();
+    c.value = c.value + 1;
+    c.lock.unlock();
+}

--- a/testdata/golden/sema/valid/concurrency/guarded_by_valid.sg
+++ b/testdata/golden/sema/valid/concurrency/guarded_by_valid.sg
@@ -1,0 +1,18 @@
+// Valid @guarded_by usage with Mutex and RwLock
+
+type Counter = {
+    lock: Mutex,
+    @guarded_by("lock") value: int,
+}
+
+type SharedData = {
+    rw: RwLock,
+    @guarded_by("rw") data: string,
+}
+
+pub fn test_counter() -> nothing {
+    let mut c: Counter = Counter { lock: Mutex.new(), value: 0 };
+    c.lock.lock();
+    c.value = c.value + 1;
+    c.lock.unlock();
+}

--- a/testdata/golden/sema/valid/concurrency/guarded_by_valid.tokens
+++ b/testdata/golden/sema/valid/concurrency/guarded_by_valid.tokens
@@ -1,0 +1,93 @@
+  1: KwType          "type" at 3:1-3:5 (leading: LineComment, Newline)
+  2: Ident           "Counter" at 3:6-3:13 (leading: Space)
+  3: Assign          "=" at 3:14-3:15 (leading: Space)
+  4: LBrace          "{" at 3:16-3:17 (leading: Space)
+  5: Ident           "lock" at 4:5-4:9 (leading: Newline, Space)
+  6: Colon           ":" at 4:9-4:10
+  7: Ident           "Mutex" at 4:11-4:16 (leading: Space)
+  8: Comma           "," at 4:16-4:17
+  9: At              "@" at 5:5-5:6 (leading: Newline, Space)
+ 10: Ident           "guarded_by" at 5:6-5:16
+ 11: LParen          "(" at 5:16-5:17
+ 12: StringLit       "\"lock\"" at 5:17-5:23
+ 13: RParen          ")" at 5:23-5:24
+ 14: Ident           "value" at 5:25-5:30 (leading: Space)
+ 15: Colon           ":" at 5:30-5:31
+ 16: Ident           "int" at 5:32-5:35 (leading: Space)
+ 17: Comma           "," at 5:35-5:36
+ 18: RBrace          "}" at 6:1-6:2 (leading: Newline)
+ 19: KwType          "type" at 8:1-8:5 (leading: Newline)
+ 20: Ident           "SharedData" at 8:6-8:16 (leading: Space)
+ 21: Assign          "=" at 8:17-8:18 (leading: Space)
+ 22: LBrace          "{" at 8:19-8:20 (leading: Space)
+ 23: Ident           "rw" at 9:5-9:7 (leading: Newline, Space)
+ 24: Colon           ":" at 9:7-9:8
+ 25: Ident           "RwLock" at 9:9-9:15 (leading: Space)
+ 26: Comma           "," at 9:15-9:16
+ 27: At              "@" at 10:5-10:6 (leading: Newline, Space)
+ 28: Ident           "guarded_by" at 10:6-10:16
+ 29: LParen          "(" at 10:16-10:17
+ 30: StringLit       "\"rw\"" at 10:17-10:21
+ 31: RParen          ")" at 10:21-10:22
+ 32: Ident           "data" at 10:23-10:27 (leading: Space)
+ 33: Colon           ":" at 10:27-10:28
+ 34: Ident           "string" at 10:29-10:35 (leading: Space)
+ 35: Comma           "," at 10:35-10:36
+ 36: RBrace          "}" at 11:1-11:2 (leading: Newline)
+ 37: KwPub           "pub" at 13:1-13:4 (leading: Newline)
+ 38: KwFn            "fn" at 13:5-13:7 (leading: Space)
+ 39: Ident           "test_counter" at 13:8-13:20 (leading: Space)
+ 40: LParen          "(" at 13:20-13:21
+ 41: RParen          ")" at 13:21-13:22
+ 42: Arrow           "->" at 13:23-13:25 (leading: Space)
+ 43: NothingLit      "nothing" at 13:26-13:33 (leading: Space)
+ 44: LBrace          "{" at 13:34-13:35 (leading: Space)
+ 45: KwLet           "let" at 14:5-14:8 (leading: Newline, Space)
+ 46: KwMut           "mut" at 14:9-14:12 (leading: Space)
+ 47: Ident           "c" at 14:13-14:14 (leading: Space)
+ 48: Colon           ":" at 14:14-14:15
+ 49: Ident           "Counter" at 14:16-14:23 (leading: Space)
+ 50: Assign          "=" at 14:24-14:25 (leading: Space)
+ 51: Ident           "Counter" at 14:26-14:33 (leading: Space)
+ 52: LBrace          "{" at 14:34-14:35 (leading: Space)
+ 53: Ident           "lock" at 14:36-14:40 (leading: Space)
+ 54: Colon           ":" at 14:40-14:41
+ 55: Ident           "Mutex" at 14:42-14:47 (leading: Space)
+ 56: Dot             "." at 14:47-14:48
+ 57: Ident           "new" at 14:48-14:51
+ 58: LParen          "(" at 14:51-14:52
+ 59: RParen          ")" at 14:52-14:53
+ 60: Comma           "," at 14:53-14:54
+ 61: Ident           "value" at 14:55-14:60 (leading: Space)
+ 62: Colon           ":" at 14:60-14:61
+ 63: IntLit          "0" at 14:62-14:63 (leading: Space)
+ 64: RBrace          "}" at 14:64-14:65 (leading: Space)
+ 65: Semicolon       ";" at 14:65-14:66
+ 66: Ident           "c" at 15:5-15:6 (leading: Newline, Space)
+ 67: Dot             "." at 15:6-15:7
+ 68: Ident           "lock" at 15:7-15:11
+ 69: Dot             "." at 15:11-15:12
+ 70: Ident           "lock" at 15:12-15:16
+ 71: LParen          "(" at 15:16-15:17
+ 72: RParen          ")" at 15:17-15:18
+ 73: Semicolon       ";" at 15:18-15:19
+ 74: Ident           "c" at 16:5-16:6 (leading: Newline, Space)
+ 75: Dot             "." at 16:6-16:7
+ 76: Ident           "value" at 16:7-16:12
+ 77: Assign          "=" at 16:13-16:14 (leading: Space)
+ 78: Ident           "c" at 16:15-16:16 (leading: Space)
+ 79: Dot             "." at 16:16-16:17
+ 80: Ident           "value" at 16:17-16:22
+ 81: Plus            "+" at 16:23-16:24 (leading: Space)
+ 82: IntLit          "1" at 16:25-16:26 (leading: Space)
+ 83: Semicolon       ";" at 16:26-16:27
+ 84: Ident           "c" at 17:5-17:6 (leading: Newline, Space)
+ 85: Dot             "." at 17:6-17:7
+ 86: Ident           "lock" at 17:7-17:11
+ 87: Dot             "." at 17:11-17:12
+ 88: Ident           "unlock" at 17:12-17:18
+ 89: LParen          "(" at 17:18-17:19
+ 90: RParen          ")" at 17:19-17:20
+ 91: Semicolon       ";" at 17:20-17:21
+ 92: RBrace          "}" at 18:1-18:2 (leading: Newline)
+ 93: EOF             at 19:1-19:1

--- a/testdata/golden/sema/valid/concurrency/lock_annotations_valid.ast
+++ b/testdata/golden/sema/valid/concurrency/lock_annotations_valid.ast
@@ -1,0 +1,69 @@
+lock_annotations_valid.sg (span: 3:1-46:1)
+├─ Item[0]: Type (span: 3:1-6:2)
+│  ├─ Name: SafeCounter
+│  ├─ Kind: Struct
+│  ├─ Visibility: private
+│  └─ Struct:
+│     ├─ Field[0]: lock: Mutex
+│     └─ Field[1]: value: int
+├─ Item[1]: Extern (span: 8:1-23:2)
+│  ├─ Target: SafeCounter
+│  ├─ Members:
+│  │  ├─ Fn[0]: get_value
+│  │  │  ├─ Params: (self: &SafeCounter)
+│  │  │  ├─ Return: int
+│  │  │  ├─ Attributes: @requires_lock("lock")
+│  │  │  └─ Body:
+│  │  │     Stmt[0]: Block (span: 10:49-12:6)
+│  │  │     └─ Stmt[0]: Return (span: 11:9-11:27)
+│  │  │        └─ Expr: expr#3: self.value
+│  │  ├─ Fn[1]: acquire
+│  │  │  ├─ Params: (self: &mut SafeCounter)
+│  │  │  ├─ Return: nothing
+│  │  │  ├─ Attributes: @acquires_lock("lock")
+│  │  │  └─ Body:
+│  │  │     Stmt[0]: Block (span: 15:55-17:6)
+│  │  │     └─ Stmt[0]: Expr (span: 16:9-16:26)
+│  │  │        └─ Expr: expr#8: self.lock.lock()
+│  │  └─ Fn[2]: release
+│  │     ├─ Params: (self: &mut SafeCounter)
+│  │     ├─ Return: nothing
+│  │     ├─ Attributes: @releases_lock("lock")
+│  │     └─ Body:
+│  │        Stmt[0]: Block (span: 20:55-22:6)
+│  │        └─ Stmt[0]: Expr (span: 21:9-21:28)
+│  │           └─ Expr: expr#13: self.lock.unlock()
+├─ Item[2]: Type (span: 25:1-28:2)
+│  ├─ Name: RwCounter
+│  ├─ Kind: Struct
+│  ├─ Visibility: private
+│  └─ Struct:
+│     ├─ Field[0]: rw: RwLock
+│     └─ Field[1]: data: string
+└─ Item[3]: Extern (span: 30:1-45:2)
+   ├─ Target: RwCounter
+   ├─ Members:
+   │  ├─ Fn[0]: read_data
+   │  │  ├─ Params: (self: &RwCounter)
+   │  │  ├─ Return: string
+   │  │  ├─ Attributes: @requires_lock("rw")
+   │  │  └─ Body:
+   │  │     Stmt[0]: Block (span: 32:50-34:6)
+   │  │     └─ Stmt[0]: Return (span: 33:9-33:26)
+   │  │        └─ Expr: expr#16: self.data
+   │  ├─ Fn[1]: acquire_read
+   │  │  ├─ Params: (self: &mut RwCounter)
+   │  │  ├─ Return: nothing
+   │  │  ├─ Attributes: @acquires_lock("rw")
+   │  │  └─ Body:
+   │  │     Stmt[0]: Block (span: 37:58-39:6)
+   │  │     └─ Stmt[0]: Expr (span: 38:9-38:29)
+   │  │        └─ Expr: expr#21: self.rw.read_lock()
+   │  └─ Fn[2]: release_read
+   │     ├─ Params: (self: &mut RwCounter)
+   │     ├─ Return: nothing
+   │     ├─ Attributes: @releases_lock("rw")
+   │     └─ Body:
+   │        Stmt[0]: Block (span: 42:58-44:6)
+   │        └─ Stmt[0]: Expr (span: 43:9-43:31)
+   │           └─ Expr: expr#26: self.rw.read_unlock()

--- a/testdata/golden/sema/valid/concurrency/lock_annotations_valid.fmt
+++ b/testdata/golden/sema/valid/concurrency/lock_annotations_valid.fmt
@@ -1,0 +1,45 @@
+// Valid lock annotation attributes on methods
+
+type SafeCounter = {
+    lock: Mutex,
+    value: int,
+}
+
+extern<SafeCounter> {
+    @requires_lock("lock")
+    pub fn get_value(self: &SafeCounter) -> int {
+        return self.value;
+    }
+
+    @acquires_lock("lock")
+    pub fn acquire(self: &mut SafeCounter) -> nothing {
+        self.lock.lock();
+    }
+
+    @releases_lock("lock")
+    pub fn release(self: &mut SafeCounter) -> nothing {
+        self.lock.unlock();
+    }
+}
+
+type RwCounter = {
+    rw: RwLock,
+    data: string,
+}
+
+extern<RwCounter> {
+    @requires_lock("rw")
+    pub fn read_data(self: &RwCounter) -> string {
+        return self.data;
+    }
+
+    @acquires_lock("rw")
+    pub fn acquire_read(self: &mut RwCounter) -> nothing {
+        self.rw.read_lock();
+    }
+
+    @releases_lock("rw")
+    pub fn release_read(self: &mut RwCounter) -> nothing {
+        self.rw.read_unlock();
+    }
+}

--- a/testdata/golden/sema/valid/concurrency/lock_annotations_valid.sg
+++ b/testdata/golden/sema/valid/concurrency/lock_annotations_valid.sg
@@ -1,0 +1,45 @@
+// Valid lock annotation attributes on methods
+
+type SafeCounter = {
+    lock: Mutex,
+    value: int,
+}
+
+extern<SafeCounter> {
+    @requires_lock("lock")
+    pub fn get_value(self: &SafeCounter) -> int {
+        return self.value;
+    }
+
+    @acquires_lock("lock")
+    pub fn acquire(self: &mut SafeCounter) -> nothing {
+        self.lock.lock();
+    }
+
+    @releases_lock("lock")
+    pub fn release(self: &mut SafeCounter) -> nothing {
+        self.lock.unlock();
+    }
+}
+
+type RwCounter = {
+    rw: RwLock,
+    data: string,
+}
+
+extern<RwCounter> {
+    @requires_lock("rw")
+    pub fn read_data(self: &RwCounter) -> string {
+        return self.data;
+    }
+
+    @acquires_lock("rw")
+    pub fn acquire_read(self: &mut RwCounter) -> nothing {
+        self.rw.read_lock();
+    }
+
+    @releases_lock("rw")
+    pub fn release_read(self: &mut RwCounter) -> nothing {
+        self.rw.read_unlock();
+    }
+}

--- a/testdata/golden/sema/valid/concurrency/lock_annotations_valid.tokens
+++ b/testdata/golden/sema/valid/concurrency/lock_annotations_valid.tokens
@@ -1,0 +1,193 @@
+  1: KwType          "type" at 3:1-3:5 (leading: LineComment, Newline)
+  2: Ident           "SafeCounter" at 3:6-3:17 (leading: Space)
+  3: Assign          "=" at 3:18-3:19 (leading: Space)
+  4: LBrace          "{" at 3:20-3:21 (leading: Space)
+  5: Ident           "lock" at 4:5-4:9 (leading: Newline, Space)
+  6: Colon           ":" at 4:9-4:10
+  7: Ident           "Mutex" at 4:11-4:16 (leading: Space)
+  8: Comma           "," at 4:16-4:17
+  9: Ident           "value" at 5:5-5:10 (leading: Newline, Space)
+ 10: Colon           ":" at 5:10-5:11
+ 11: Ident           "int" at 5:12-5:15 (leading: Space)
+ 12: Comma           "," at 5:15-5:16
+ 13: RBrace          "}" at 6:1-6:2 (leading: Newline)
+ 14: KwExtern        "extern" at 8:1-8:7 (leading: Newline)
+ 15: Lt              "<" at 8:7-8:8
+ 16: Ident           "SafeCounter" at 8:8-8:19
+ 17: Gt              ">" at 8:19-8:20
+ 18: LBrace          "{" at 8:21-8:22 (leading: Space)
+ 19: At              "@" at 9:5-9:6 (leading: Newline, Space)
+ 20: Ident           "requires_lock" at 9:6-9:19
+ 21: LParen          "(" at 9:19-9:20
+ 22: StringLit       "\"lock\"" at 9:20-9:26
+ 23: RParen          ")" at 9:26-9:27
+ 24: KwPub           "pub" at 10:5-10:8 (leading: Newline, Space)
+ 25: KwFn            "fn" at 10:9-10:11 (leading: Space)
+ 26: Ident           "get_value" at 10:12-10:21 (leading: Space)
+ 27: LParen          "(" at 10:21-10:22
+ 28: Ident           "self" at 10:22-10:26
+ 29: Colon           ":" at 10:26-10:27
+ 30: Amp             "&" at 10:28-10:29 (leading: Space)
+ 31: Ident           "SafeCounter" at 10:29-10:40
+ 32: RParen          ")" at 10:40-10:41
+ 33: Arrow           "->" at 10:42-10:44 (leading: Space)
+ 34: Ident           "int" at 10:45-10:48 (leading: Space)
+ 35: LBrace          "{" at 10:49-10:50 (leading: Space)
+ 36: KwReturn        "return" at 11:9-11:15 (leading: Newline, Space)
+ 37: Ident           "self" at 11:16-11:20 (leading: Space)
+ 38: Dot             "." at 11:20-11:21
+ 39: Ident           "value" at 11:21-11:26
+ 40: Semicolon       ";" at 11:26-11:27
+ 41: RBrace          "}" at 12:5-12:6 (leading: Newline, Space)
+ 42: At              "@" at 14:5-14:6 (leading: Newline, Space)
+ 43: Ident           "acquires_lock" at 14:6-14:19
+ 44: LParen          "(" at 14:19-14:20
+ 45: StringLit       "\"lock\"" at 14:20-14:26
+ 46: RParen          ")" at 14:26-14:27
+ 47: KwPub           "pub" at 15:5-15:8 (leading: Newline, Space)
+ 48: KwFn            "fn" at 15:9-15:11 (leading: Space)
+ 49: Ident           "acquire" at 15:12-15:19 (leading: Space)
+ 50: LParen          "(" at 15:19-15:20
+ 51: Ident           "self" at 15:20-15:24
+ 52: Colon           ":" at 15:24-15:25
+ 53: Amp             "&" at 15:26-15:27 (leading: Space)
+ 54: KwMut           "mut" at 15:27-15:30
+ 55: Ident           "SafeCounter" at 15:31-15:42 (leading: Space)
+ 56: RParen          ")" at 15:42-15:43
+ 57: Arrow           "->" at 15:44-15:46 (leading: Space)
+ 58: NothingLit      "nothing" at 15:47-15:54 (leading: Space)
+ 59: LBrace          "{" at 15:55-15:56 (leading: Space)
+ 60: Ident           "self" at 16:9-16:13 (leading: Newline, Space)
+ 61: Dot             "." at 16:13-16:14
+ 62: Ident           "lock" at 16:14-16:18
+ 63: Dot             "." at 16:18-16:19
+ 64: Ident           "lock" at 16:19-16:23
+ 65: LParen          "(" at 16:23-16:24
+ 66: RParen          ")" at 16:24-16:25
+ 67: Semicolon       ";" at 16:25-16:26
+ 68: RBrace          "}" at 17:5-17:6 (leading: Newline, Space)
+ 69: At              "@" at 19:5-19:6 (leading: Newline, Space)
+ 70: Ident           "releases_lock" at 19:6-19:19
+ 71: LParen          "(" at 19:19-19:20
+ 72: StringLit       "\"lock\"" at 19:20-19:26
+ 73: RParen          ")" at 19:26-19:27
+ 74: KwPub           "pub" at 20:5-20:8 (leading: Newline, Space)
+ 75: KwFn            "fn" at 20:9-20:11 (leading: Space)
+ 76: Ident           "release" at 20:12-20:19 (leading: Space)
+ 77: LParen          "(" at 20:19-20:20
+ 78: Ident           "self" at 20:20-20:24
+ 79: Colon           ":" at 20:24-20:25
+ 80: Amp             "&" at 20:26-20:27 (leading: Space)
+ 81: KwMut           "mut" at 20:27-20:30
+ 82: Ident           "SafeCounter" at 20:31-20:42 (leading: Space)
+ 83: RParen          ")" at 20:42-20:43
+ 84: Arrow           "->" at 20:44-20:46 (leading: Space)
+ 85: NothingLit      "nothing" at 20:47-20:54 (leading: Space)
+ 86: LBrace          "{" at 20:55-20:56 (leading: Space)
+ 87: Ident           "self" at 21:9-21:13 (leading: Newline, Space)
+ 88: Dot             "." at 21:13-21:14
+ 89: Ident           "lock" at 21:14-21:18
+ 90: Dot             "." at 21:18-21:19
+ 91: Ident           "unlock" at 21:19-21:25
+ 92: LParen          "(" at 21:25-21:26
+ 93: RParen          ")" at 21:26-21:27
+ 94: Semicolon       ";" at 21:27-21:28
+ 95: RBrace          "}" at 22:5-22:6 (leading: Newline, Space)
+ 96: RBrace          "}" at 23:1-23:2 (leading: Newline)
+ 97: KwType          "type" at 25:1-25:5 (leading: Newline)
+ 98: Ident           "RwCounter" at 25:6-25:15 (leading: Space)
+ 99: Assign          "=" at 25:16-25:17 (leading: Space)
+100: LBrace          "{" at 25:18-25:19 (leading: Space)
+101: Ident           "rw" at 26:5-26:7 (leading: Newline, Space)
+102: Colon           ":" at 26:7-26:8
+103: Ident           "RwLock" at 26:9-26:15 (leading: Space)
+104: Comma           "," at 26:15-26:16
+105: Ident           "data" at 27:5-27:9 (leading: Newline, Space)
+106: Colon           ":" at 27:9-27:10
+107: Ident           "string" at 27:11-27:17 (leading: Space)
+108: Comma           "," at 27:17-27:18
+109: RBrace          "}" at 28:1-28:2 (leading: Newline)
+110: KwExtern        "extern" at 30:1-30:7 (leading: Newline)
+111: Lt              "<" at 30:7-30:8
+112: Ident           "RwCounter" at 30:8-30:17
+113: Gt              ">" at 30:17-30:18
+114: LBrace          "{" at 30:19-30:20 (leading: Space)
+115: At              "@" at 31:5-31:6 (leading: Newline, Space)
+116: Ident           "requires_lock" at 31:6-31:19
+117: LParen          "(" at 31:19-31:20
+118: StringLit       "\"rw\"" at 31:20-31:24
+119: RParen          ")" at 31:24-31:25
+120: KwPub           "pub" at 32:5-32:8 (leading: Newline, Space)
+121: KwFn            "fn" at 32:9-32:11 (leading: Space)
+122: Ident           "read_data" at 32:12-32:21 (leading: Space)
+123: LParen          "(" at 32:21-32:22
+124: Ident           "self" at 32:22-32:26
+125: Colon           ":" at 32:26-32:27
+126: Amp             "&" at 32:28-32:29 (leading: Space)
+127: Ident           "RwCounter" at 32:29-32:38
+128: RParen          ")" at 32:38-32:39
+129: Arrow           "->" at 32:40-32:42 (leading: Space)
+130: Ident           "string" at 32:43-32:49 (leading: Space)
+131: LBrace          "{" at 32:50-32:51 (leading: Space)
+132: KwReturn        "return" at 33:9-33:15 (leading: Newline, Space)
+133: Ident           "self" at 33:16-33:20 (leading: Space)
+134: Dot             "." at 33:20-33:21
+135: Ident           "data" at 33:21-33:25
+136: Semicolon       ";" at 33:25-33:26
+137: RBrace          "}" at 34:5-34:6 (leading: Newline, Space)
+138: At              "@" at 36:5-36:6 (leading: Newline, Space)
+139: Ident           "acquires_lock" at 36:6-36:19
+140: LParen          "(" at 36:19-36:20
+141: StringLit       "\"rw\"" at 36:20-36:24
+142: RParen          ")" at 36:24-36:25
+143: KwPub           "pub" at 37:5-37:8 (leading: Newline, Space)
+144: KwFn            "fn" at 37:9-37:11 (leading: Space)
+145: Ident           "acquire_read" at 37:12-37:24 (leading: Space)
+146: LParen          "(" at 37:24-37:25
+147: Ident           "self" at 37:25-37:29
+148: Colon           ":" at 37:29-37:30
+149: Amp             "&" at 37:31-37:32 (leading: Space)
+150: KwMut           "mut" at 37:32-37:35
+151: Ident           "RwCounter" at 37:36-37:45 (leading: Space)
+152: RParen          ")" at 37:45-37:46
+153: Arrow           "->" at 37:47-37:49 (leading: Space)
+154: NothingLit      "nothing" at 37:50-37:57 (leading: Space)
+155: LBrace          "{" at 37:58-37:59 (leading: Space)
+156: Ident           "self" at 38:9-38:13 (leading: Newline, Space)
+157: Dot             "." at 38:13-38:14
+158: Ident           "rw" at 38:14-38:16
+159: Dot             "." at 38:16-38:17
+160: Ident           "read_lock" at 38:17-38:26
+161: LParen          "(" at 38:26-38:27
+162: RParen          ")" at 38:27-38:28
+163: Semicolon       ";" at 38:28-38:29
+164: RBrace          "}" at 39:5-39:6 (leading: Newline, Space)
+165: At              "@" at 41:5-41:6 (leading: Newline, Space)
+166: Ident           "releases_lock" at 41:6-41:19
+167: LParen          "(" at 41:19-41:20
+168: StringLit       "\"rw\"" at 41:20-41:24
+169: RParen          ")" at 41:24-41:25
+170: KwPub           "pub" at 42:5-42:8 (leading: Newline, Space)
+171: KwFn            "fn" at 42:9-42:11 (leading: Space)
+172: Ident           "release_read" at 42:12-42:24 (leading: Space)
+173: LParen          "(" at 42:24-42:25
+174: Ident           "self" at 42:25-42:29
+175: Colon           ":" at 42:29-42:30
+176: Amp             "&" at 42:31-42:32 (leading: Space)
+177: KwMut           "mut" at 42:32-42:35
+178: Ident           "RwCounter" at 42:36-42:45 (leading: Space)
+179: RParen          ")" at 42:45-42:46
+180: Arrow           "->" at 42:47-42:49 (leading: Space)
+181: NothingLit      "nothing" at 42:50-42:57 (leading: Space)
+182: LBrace          "{" at 42:58-42:59 (leading: Space)
+183: Ident           "self" at 43:9-43:13 (leading: Newline, Space)
+184: Dot             "." at 43:13-43:14
+185: Ident           "rw" at 43:14-43:16
+186: Dot             "." at 43:16-43:17
+187: Ident           "read_unlock" at 43:17-43:28
+188: LParen          "(" at 43:28-43:29
+189: RParen          ")" at 43:29-43:30
+190: Semicolon       ";" at 43:30-43:31
+191: RBrace          "}" at 44:5-44:6 (leading: Newline, Space)
+192: RBrace          "}" at 45:1-45:2 (leading: Newline)
+193: EOF             at 46:1-46:1

--- a/testdata/golden/sema/valid/concurrency/lock_balance_valid.ast
+++ b/testdata/golden/sema/valid/concurrency/lock_balance_valid.ast
@@ -1,0 +1,80 @@
+lock_balance_valid.sg (span: 4:1-47:1)
+├─ Item[0]: Fn (span: 4:1-9:2)
+│  ├─ Name: test_simple_lock
+│  ├─ Params: ()
+│  ├─ Return: nothing
+│  └─ Body:
+│     └─ Stmt[0]: Block (span: 4:38-9:2)
+│        ├─ Stmt[0]: Let (span: 5:5-5:38)
+│        │  ├─ Name: mtx
+│        │  ├─ Mutable: true
+│        │  ├─ Type: Mutex
+│        │  └─ Value: expr#3: Mutex.new()
+│        ├─ Stmt[1]: Expr (span: 6:5-6:16)
+│        │  └─ Expr: expr#6: mtx.lock()
+│        └─ Stmt[2]: Expr (span: 8:5-8:18)
+│           └─ Expr: expr#9: mtx.unlock()
+├─ Item[1]: Fn (span: 12:1-21:2)
+│  ├─ Name: test_multiple_locks
+│  ├─ Params: ()
+│  ├─ Return: nothing
+│  └─ Body:
+│     └─ Stmt[0]: Block (span: 12:41-21:2)
+│        ├─ Stmt[0]: Let (span: 13:5-13:37)
+│        │  ├─ Name: m1
+│        │  ├─ Mutable: true
+│        │  ├─ Type: Mutex
+│        │  └─ Value: expr#12: Mutex.new()
+│        ├─ Stmt[1]: Let (span: 14:5-14:37)
+│        │  ├─ Name: m2
+│        │  ├─ Mutable: true
+│        │  ├─ Type: Mutex
+│        │  └─ Value: expr#15: Mutex.new()
+│        ├─ Stmt[2]: Expr (span: 16:5-16:15)
+│        │  └─ Expr: expr#18: m1.lock()
+│        ├─ Stmt[3]: Expr (span: 17:5-17:15)
+│        │  └─ Expr: expr#21: m2.lock()
+│        ├─ Stmt[4]: Expr (span: 19:5-19:17)
+│        │  └─ Expr: expr#24: m2.unlock()
+│        └─ Stmt[5]: Expr (span: 20:5-20:17)
+│           └─ Expr: expr#27: m1.unlock()
+├─ Item[2]: Fn (span: 24:1-32:2)
+│  ├─ Name: test_rwlock_patterns
+│  ├─ Params: ()
+│  ├─ Return: nothing
+│  └─ Body:
+│     └─ Stmt[0]: Block (span: 24:42-32:2)
+│        ├─ Stmt[0]: Let (span: 25:5-25:39)
+│        │  ├─ Name: rw
+│        │  ├─ Mutable: true
+│        │  ├─ Type: RwLock
+│        │  └─ Value: expr#30: RwLock.new()
+│        ├─ Stmt[1]: Expr (span: 27:5-27:20)
+│        │  └─ Expr: expr#33: rw.read_lock()
+│        ├─ Stmt[2]: Expr (span: 28:5-28:22)
+│        │  └─ Expr: expr#36: rw.read_unlock()
+│        ├─ Stmt[3]: Expr (span: 30:5-30:21)
+│        │  └─ Expr: expr#39: rw.write_lock()
+│        └─ Stmt[4]: Expr (span: 31:5-31:23)
+│           └─ Expr: expr#42: rw.write_unlock()
+├─ Item[3]: Type (span: 35:1-38:2)
+│  ├─ Name: Counter
+│  ├─ Kind: Struct
+│  ├─ Visibility: private
+│  └─ Struct:
+│     ├─ Field[0]: lock: Mutex
+│     └─ Field[1]: value: int
+└─ Item[4]: Extern (span: 40:1-46:2)
+   ├─ Target: Counter
+   ├─ Members:
+   │  └─ Fn[0]: increment
+   │     ├─ Params: (self: &mut Counter)
+   │     ├─ Return: nothing
+   │     └─ Body:
+   │        Stmt[0]: Block (span: 41:53-45:6)
+   │        ├─ Stmt[0]: Expr (span: 42:9-42:26)
+   │        │  └─ Expr: expr#46: self.lock.lock()
+   │        ├─ Stmt[1]: Expr (span: 43:9-43:37)
+   │        │  └─ Expr: expr#53: (self.value = ((self.value + 1)))
+   │        └─ Stmt[2]: Expr (span: 44:9-44:28)
+   │           └─ Expr: expr#57: self.lock.unlock()

--- a/testdata/golden/sema/valid/concurrency/lock_balance_valid.fmt
+++ b/testdata/golden/sema/valid/concurrency/lock_balance_valid.fmt
@@ -1,0 +1,46 @@
+// Valid lock/unlock balance patterns
+
+// Simple lock/unlock on local variable
+pub fn test_simple_lock() -> nothing {
+    let mut mtx: Mutex = Mutex.new();
+    mtx.lock();
+    // critical section
+    mtx.unlock();
+}
+
+// Multiple locks acquired and released
+pub fn test_multiple_locks() -> nothing {
+    let mut m1: Mutex = Mutex.new();
+    let mut m2: Mutex = Mutex.new();
+
+    m1.lock();
+    m2.lock();
+    // critical section with both locks
+    m2.unlock();
+    m1.unlock();
+}
+
+// RwLock read/write patterns
+pub fn test_rwlock_patterns() -> nothing {
+    let mut rw: RwLock = RwLock.new();
+
+    rw.read_lock();
+    rw.read_unlock();
+
+    rw.write_lock();
+    rw.write_unlock();
+}
+
+// Lock in struct field
+type Counter = {
+    lock: Mutex,
+    value: int,
+}
+
+extern<Counter> {
+    pub fn increment(self: &mut Counter) -> nothing {
+        self.lock.lock();
+        self.value = self.value + 1;
+        self.lock.unlock();
+    }
+}

--- a/testdata/golden/sema/valid/concurrency/lock_balance_valid.sg
+++ b/testdata/golden/sema/valid/concurrency/lock_balance_valid.sg
@@ -1,0 +1,46 @@
+// Valid lock/unlock balance patterns
+
+// Simple lock/unlock on local variable
+pub fn test_simple_lock() -> nothing {
+    let mut mtx: Mutex = Mutex.new();
+    mtx.lock();
+    // critical section
+    mtx.unlock();
+}
+
+// Multiple locks acquired and released
+pub fn test_multiple_locks() -> nothing {
+    let mut m1: Mutex = Mutex.new();
+    let mut m2: Mutex = Mutex.new();
+
+    m1.lock();
+    m2.lock();
+    // critical section with both locks
+    m2.unlock();
+    m1.unlock();
+}
+
+// RwLock read/write patterns
+pub fn test_rwlock_patterns() -> nothing {
+    let mut rw: RwLock = RwLock.new();
+
+    rw.read_lock();
+    rw.read_unlock();
+
+    rw.write_lock();
+    rw.write_unlock();
+}
+
+// Lock in struct field
+type Counter = {
+    lock: Mutex,
+    value: int,
+}
+
+extern<Counter> {
+    pub fn increment(self: &mut Counter) -> nothing {
+        self.lock.lock();
+        self.value = self.value + 1;
+        self.lock.unlock();
+    }
+}

--- a/testdata/golden/sema/valid/concurrency/lock_balance_valid.tokens
+++ b/testdata/golden/sema/valid/concurrency/lock_balance_valid.tokens
@@ -1,0 +1,195 @@
+  1: KwPub           "pub" at 4:1-4:4 (leading: LineComment, Newline, LineComment, Newline)
+  2: KwFn            "fn" at 4:5-4:7 (leading: Space)
+  3: Ident           "test_simple_lock" at 4:8-4:24 (leading: Space)
+  4: LParen          "(" at 4:24-4:25
+  5: RParen          ")" at 4:25-4:26
+  6: Arrow           "->" at 4:27-4:29 (leading: Space)
+  7: NothingLit      "nothing" at 4:30-4:37 (leading: Space)
+  8: LBrace          "{" at 4:38-4:39 (leading: Space)
+  9: KwLet           "let" at 5:5-5:8 (leading: Newline, Space)
+ 10: KwMut           "mut" at 5:9-5:12 (leading: Space)
+ 11: Ident           "mtx" at 5:13-5:16 (leading: Space)
+ 12: Colon           ":" at 5:16-5:17
+ 13: Ident           "Mutex" at 5:18-5:23 (leading: Space)
+ 14: Assign          "=" at 5:24-5:25 (leading: Space)
+ 15: Ident           "Mutex" at 5:26-5:31 (leading: Space)
+ 16: Dot             "." at 5:31-5:32
+ 17: Ident           "new" at 5:32-5:35
+ 18: LParen          "(" at 5:35-5:36
+ 19: RParen          ")" at 5:36-5:37
+ 20: Semicolon       ";" at 5:37-5:38
+ 21: Ident           "mtx" at 6:5-6:8 (leading: Newline, Space)
+ 22: Dot             "." at 6:8-6:9
+ 23: Ident           "lock" at 6:9-6:13
+ 24: LParen          "(" at 6:13-6:14
+ 25: RParen          ")" at 6:14-6:15
+ 26: Semicolon       ";" at 6:15-6:16
+ 27: Ident           "mtx" at 8:5-8:8 (leading: Newline, Space, LineComment, Newline, Space)
+ 28: Dot             "." at 8:8-8:9
+ 29: Ident           "unlock" at 8:9-8:15
+ 30: LParen          "(" at 8:15-8:16
+ 31: RParen          ")" at 8:16-8:17
+ 32: Semicolon       ";" at 8:17-8:18
+ 33: RBrace          "}" at 9:1-9:2 (leading: Newline)
+ 34: KwPub           "pub" at 12:1-12:4 (leading: Newline, LineComment, Newline)
+ 35: KwFn            "fn" at 12:5-12:7 (leading: Space)
+ 36: Ident           "test_multiple_locks" at 12:8-12:27 (leading: Space)
+ 37: LParen          "(" at 12:27-12:28
+ 38: RParen          ")" at 12:28-12:29
+ 39: Arrow           "->" at 12:30-12:32 (leading: Space)
+ 40: NothingLit      "nothing" at 12:33-12:40 (leading: Space)
+ 41: LBrace          "{" at 12:41-12:42 (leading: Space)
+ 42: KwLet           "let" at 13:5-13:8 (leading: Newline, Space)
+ 43: KwMut           "mut" at 13:9-13:12 (leading: Space)
+ 44: Ident           "m1" at 13:13-13:15 (leading: Space)
+ 45: Colon           ":" at 13:15-13:16
+ 46: Ident           "Mutex" at 13:17-13:22 (leading: Space)
+ 47: Assign          "=" at 13:23-13:24 (leading: Space)
+ 48: Ident           "Mutex" at 13:25-13:30 (leading: Space)
+ 49: Dot             "." at 13:30-13:31
+ 50: Ident           "new" at 13:31-13:34
+ 51: LParen          "(" at 13:34-13:35
+ 52: RParen          ")" at 13:35-13:36
+ 53: Semicolon       ";" at 13:36-13:37
+ 54: KwLet           "let" at 14:5-14:8 (leading: Newline, Space)
+ 55: KwMut           "mut" at 14:9-14:12 (leading: Space)
+ 56: Ident           "m2" at 14:13-14:15 (leading: Space)
+ 57: Colon           ":" at 14:15-14:16
+ 58: Ident           "Mutex" at 14:17-14:22 (leading: Space)
+ 59: Assign          "=" at 14:23-14:24 (leading: Space)
+ 60: Ident           "Mutex" at 14:25-14:30 (leading: Space)
+ 61: Dot             "." at 14:30-14:31
+ 62: Ident           "new" at 14:31-14:34
+ 63: LParen          "(" at 14:34-14:35
+ 64: RParen          ")" at 14:35-14:36
+ 65: Semicolon       ";" at 14:36-14:37
+ 66: Ident           "m1" at 16:5-16:7 (leading: Newline, Space)
+ 67: Dot             "." at 16:7-16:8
+ 68: Ident           "lock" at 16:8-16:12
+ 69: LParen          "(" at 16:12-16:13
+ 70: RParen          ")" at 16:13-16:14
+ 71: Semicolon       ";" at 16:14-16:15
+ 72: Ident           "m2" at 17:5-17:7 (leading: Newline, Space)
+ 73: Dot             "." at 17:7-17:8
+ 74: Ident           "lock" at 17:8-17:12
+ 75: LParen          "(" at 17:12-17:13
+ 76: RParen          ")" at 17:13-17:14
+ 77: Semicolon       ";" at 17:14-17:15
+ 78: Ident           "m2" at 19:5-19:7 (leading: Newline, Space, LineComment, Newline, Space)
+ 79: Dot             "." at 19:7-19:8
+ 80: Ident           "unlock" at 19:8-19:14
+ 81: LParen          "(" at 19:14-19:15
+ 82: RParen          ")" at 19:15-19:16
+ 83: Semicolon       ";" at 19:16-19:17
+ 84: Ident           "m1" at 20:5-20:7 (leading: Newline, Space)
+ 85: Dot             "." at 20:7-20:8
+ 86: Ident           "unlock" at 20:8-20:14
+ 87: LParen          "(" at 20:14-20:15
+ 88: RParen          ")" at 20:15-20:16
+ 89: Semicolon       ";" at 20:16-20:17
+ 90: RBrace          "}" at 21:1-21:2 (leading: Newline)
+ 91: KwPub           "pub" at 24:1-24:4 (leading: Newline, LineComment, Newline)
+ 92: KwFn            "fn" at 24:5-24:7 (leading: Space)
+ 93: Ident           "test_rwlock_patterns" at 24:8-24:28 (leading: Space)
+ 94: LParen          "(" at 24:28-24:29
+ 95: RParen          ")" at 24:29-24:30
+ 96: Arrow           "->" at 24:31-24:33 (leading: Space)
+ 97: NothingLit      "nothing" at 24:34-24:41 (leading: Space)
+ 98: LBrace          "{" at 24:42-24:43 (leading: Space)
+ 99: KwLet           "let" at 25:5-25:8 (leading: Newline, Space)
+100: KwMut           "mut" at 25:9-25:12 (leading: Space)
+101: Ident           "rw" at 25:13-25:15 (leading: Space)
+102: Colon           ":" at 25:15-25:16
+103: Ident           "RwLock" at 25:17-25:23 (leading: Space)
+104: Assign          "=" at 25:24-25:25 (leading: Space)
+105: Ident           "RwLock" at 25:26-25:32 (leading: Space)
+106: Dot             "." at 25:32-25:33
+107: Ident           "new" at 25:33-25:36
+108: LParen          "(" at 25:36-25:37
+109: RParen          ")" at 25:37-25:38
+110: Semicolon       ";" at 25:38-25:39
+111: Ident           "rw" at 27:5-27:7 (leading: Newline, Space)
+112: Dot             "." at 27:7-27:8
+113: Ident           "read_lock" at 27:8-27:17
+114: LParen          "(" at 27:17-27:18
+115: RParen          ")" at 27:18-27:19
+116: Semicolon       ";" at 27:19-27:20
+117: Ident           "rw" at 28:5-28:7 (leading: Newline, Space)
+118: Dot             "." at 28:7-28:8
+119: Ident           "read_unlock" at 28:8-28:19
+120: LParen          "(" at 28:19-28:20
+121: RParen          ")" at 28:20-28:21
+122: Semicolon       ";" at 28:21-28:22
+123: Ident           "rw" at 30:5-30:7 (leading: Newline, Space)
+124: Dot             "." at 30:7-30:8
+125: Ident           "write_lock" at 30:8-30:18
+126: LParen          "(" at 30:18-30:19
+127: RParen          ")" at 30:19-30:20
+128: Semicolon       ";" at 30:20-30:21
+129: Ident           "rw" at 31:5-31:7 (leading: Newline, Space)
+130: Dot             "." at 31:7-31:8
+131: Ident           "write_unlock" at 31:8-31:20
+132: LParen          "(" at 31:20-31:21
+133: RParen          ")" at 31:21-31:22
+134: Semicolon       ";" at 31:22-31:23
+135: RBrace          "}" at 32:1-32:2 (leading: Newline)
+136: KwType          "type" at 35:1-35:5 (leading: Newline, LineComment, Newline)
+137: Ident           "Counter" at 35:6-35:13 (leading: Space)
+138: Assign          "=" at 35:14-35:15 (leading: Space)
+139: LBrace          "{" at 35:16-35:17 (leading: Space)
+140: Ident           "lock" at 36:5-36:9 (leading: Newline, Space)
+141: Colon           ":" at 36:9-36:10
+142: Ident           "Mutex" at 36:11-36:16 (leading: Space)
+143: Comma           "," at 36:16-36:17
+144: Ident           "value" at 37:5-37:10 (leading: Newline, Space)
+145: Colon           ":" at 37:10-37:11
+146: Ident           "int" at 37:12-37:15 (leading: Space)
+147: Comma           "," at 37:15-37:16
+148: RBrace          "}" at 38:1-38:2 (leading: Newline)
+149: KwExtern        "extern" at 40:1-40:7 (leading: Newline)
+150: Lt              "<" at 40:7-40:8
+151: Ident           "Counter" at 40:8-40:15
+152: Gt              ">" at 40:15-40:16
+153: LBrace          "{" at 40:17-40:18 (leading: Space)
+154: KwPub           "pub" at 41:5-41:8 (leading: Newline, Space)
+155: KwFn            "fn" at 41:9-41:11 (leading: Space)
+156: Ident           "increment" at 41:12-41:21 (leading: Space)
+157: LParen          "(" at 41:21-41:22
+158: Ident           "self" at 41:22-41:26
+159: Colon           ":" at 41:26-41:27
+160: Amp             "&" at 41:28-41:29 (leading: Space)
+161: KwMut           "mut" at 41:29-41:32
+162: Ident           "Counter" at 41:33-41:40 (leading: Space)
+163: RParen          ")" at 41:40-41:41
+164: Arrow           "->" at 41:42-41:44 (leading: Space)
+165: NothingLit      "nothing" at 41:45-41:52 (leading: Space)
+166: LBrace          "{" at 41:53-41:54 (leading: Space)
+167: Ident           "self" at 42:9-42:13 (leading: Newline, Space)
+168: Dot             "." at 42:13-42:14
+169: Ident           "lock" at 42:14-42:18
+170: Dot             "." at 42:18-42:19
+171: Ident           "lock" at 42:19-42:23
+172: LParen          "(" at 42:23-42:24
+173: RParen          ")" at 42:24-42:25
+174: Semicolon       ";" at 42:25-42:26
+175: Ident           "self" at 43:9-43:13 (leading: Newline, Space)
+176: Dot             "." at 43:13-43:14
+177: Ident           "value" at 43:14-43:19
+178: Assign          "=" at 43:20-43:21 (leading: Space)
+179: Ident           "self" at 43:22-43:26 (leading: Space)
+180: Dot             "." at 43:26-43:27
+181: Ident           "value" at 43:27-43:32
+182: Plus            "+" at 43:33-43:34 (leading: Space)
+183: IntLit          "1" at 43:35-43:36 (leading: Space)
+184: Semicolon       ";" at 43:36-43:37
+185: Ident           "self" at 44:9-44:13 (leading: Newline, Space)
+186: Dot             "." at 44:13-44:14
+187: Ident           "lock" at 44:14-44:18
+188: Dot             "." at 44:18-44:19
+189: Ident           "unlock" at 44:19-44:25
+190: LParen          "(" at 44:25-44:26
+191: RParen          ")" at 44:26-44:27
+192: Semicolon       ";" at 44:27-44:28
+193: RBrace          "}" at 45:5-45:6 (leading: Newline, Space)
+194: RBrace          "}" at 46:1-46:2 (leading: Newline)
+195: EOF             at 47:1-47:1

--- a/testdata/golden/sema/valid/concurrency/waits_on_valid.ast
+++ b/testdata/golden/sema/valid/concurrency/waits_on_valid.ast
@@ -1,0 +1,23 @@
+waits_on_valid.sg (span: 3:1-19:1)
+├─ Item[0]: Type (span: 3:1-6:2)
+│  ├─ Name: Monitor
+│  ├─ Kind: Struct
+│  ├─ Visibility: private
+│  └─ Struct:
+│     ├─ Field[0]: cond: Condition
+│     └─ Field[1]: sem: Semaphore
+└─ Item[1]: Extern (span: 8:1-18:2)
+   ├─ Target: Monitor
+   ├─ Members:
+   │  ├─ Fn[0]: wait_for_condition
+   │  │  ├─ Params: (self: &mut Monitor)
+   │  │  ├─ Return: nothing
+   │  │  ├─ Attributes: @waits_on("cond")
+   │  │  └─ Body:
+   │  │     Stmt[0]: Block (span: 10:62-12:6)
+   │  └─ Fn[1]: wait_for_semaphore
+   │     ├─ Params: (self: &mut Monitor)
+   │     ├─ Return: nothing
+   │     ├─ Attributes: @waits_on("sem")
+   │     └─ Body:
+   │        Stmt[0]: Block (span: 15:62-17:6)

--- a/testdata/golden/sema/valid/concurrency/waits_on_valid.fmt
+++ b/testdata/golden/sema/valid/concurrency/waits_on_valid.fmt
@@ -1,0 +1,18 @@
+// Valid @waits_on usage with Condition and Semaphore
+
+type Monitor = {
+    cond: Condition,
+    sem: Semaphore,
+}
+
+extern<Monitor> {
+    @waits_on("cond")
+    pub fn wait_for_condition(self: &mut Monitor) -> nothing {
+        // Attribute validation: cond is Condition type - valid
+    }
+
+    @waits_on("sem")
+    pub fn wait_for_semaphore(self: &mut Monitor) -> nothing {
+        // Attribute validation: sem is Semaphore type - valid
+    }
+}

--- a/testdata/golden/sema/valid/concurrency/waits_on_valid.sg
+++ b/testdata/golden/sema/valid/concurrency/waits_on_valid.sg
@@ -1,0 +1,18 @@
+// Valid @waits_on usage with Condition and Semaphore
+
+type Monitor = {
+    cond: Condition,
+    sem: Semaphore,
+}
+
+extern<Monitor> {
+    @waits_on("cond")
+    pub fn wait_for_condition(self: &mut Monitor) -> nothing {
+        // Attribute validation: cond is Condition type - valid
+    }
+
+    @waits_on("sem")
+    pub fn wait_for_semaphore(self: &mut Monitor) -> nothing {
+        // Attribute validation: sem is Semaphore type - valid
+    }
+}

--- a/testdata/golden/sema/valid/concurrency/waits_on_valid.tokens
+++ b/testdata/golden/sema/valid/concurrency/waits_on_valid.tokens
@@ -1,0 +1,58 @@
+  1: KwType          "type" at 3:1-3:5 (leading: LineComment, Newline)
+  2: Ident           "Monitor" at 3:6-3:13 (leading: Space)
+  3: Assign          "=" at 3:14-3:15 (leading: Space)
+  4: LBrace          "{" at 3:16-3:17 (leading: Space)
+  5: Ident           "cond" at 4:5-4:9 (leading: Newline, Space)
+  6: Colon           ":" at 4:9-4:10
+  7: Ident           "Condition" at 4:11-4:20 (leading: Space)
+  8: Comma           "," at 4:20-4:21
+  9: Ident           "sem" at 5:5-5:8 (leading: Newline, Space)
+ 10: Colon           ":" at 5:8-5:9
+ 11: Ident           "Semaphore" at 5:10-5:19 (leading: Space)
+ 12: Comma           "," at 5:19-5:20
+ 13: RBrace          "}" at 6:1-6:2 (leading: Newline)
+ 14: KwExtern        "extern" at 8:1-8:7 (leading: Newline)
+ 15: Lt              "<" at 8:7-8:8
+ 16: Ident           "Monitor" at 8:8-8:15
+ 17: Gt              ">" at 8:15-8:16
+ 18: LBrace          "{" at 8:17-8:18 (leading: Space)
+ 19: At              "@" at 9:5-9:6 (leading: Newline, Space)
+ 20: Ident           "waits_on" at 9:6-9:14
+ 21: LParen          "(" at 9:14-9:15
+ 22: StringLit       "\"cond\"" at 9:15-9:21
+ 23: RParen          ")" at 9:21-9:22
+ 24: KwPub           "pub" at 10:5-10:8 (leading: Newline, Space)
+ 25: KwFn            "fn" at 10:9-10:11 (leading: Space)
+ 26: Ident           "wait_for_condition" at 10:12-10:30 (leading: Space)
+ 27: LParen          "(" at 10:30-10:31
+ 28: Ident           "self" at 10:31-10:35
+ 29: Colon           ":" at 10:35-10:36
+ 30: Amp             "&" at 10:37-10:38 (leading: Space)
+ 31: KwMut           "mut" at 10:38-10:41
+ 32: Ident           "Monitor" at 10:42-10:49 (leading: Space)
+ 33: RParen          ")" at 10:49-10:50
+ 34: Arrow           "->" at 10:51-10:53 (leading: Space)
+ 35: NothingLit      "nothing" at 10:54-10:61 (leading: Space)
+ 36: LBrace          "{" at 10:62-10:63 (leading: Space)
+ 37: RBrace          "}" at 12:5-12:6 (leading: Newline, Space, LineComment, Newline, Space)
+ 38: At              "@" at 14:5-14:6 (leading: Newline, Space)
+ 39: Ident           "waits_on" at 14:6-14:14
+ 40: LParen          "(" at 14:14-14:15
+ 41: StringLit       "\"sem\"" at 14:15-14:20
+ 42: RParen          ")" at 14:20-14:21
+ 43: KwPub           "pub" at 15:5-15:8 (leading: Newline, Space)
+ 44: KwFn            "fn" at 15:9-15:11 (leading: Space)
+ 45: Ident           "wait_for_semaphore" at 15:12-15:30 (leading: Space)
+ 46: LParen          "(" at 15:30-15:31
+ 47: Ident           "self" at 15:31-15:35
+ 48: Colon           ":" at 15:35-15:36
+ 49: Amp             "&" at 15:37-15:38 (leading: Space)
+ 50: KwMut           "mut" at 15:38-15:41
+ 51: Ident           "Monitor" at 15:42-15:49 (leading: Space)
+ 52: RParen          ")" at 15:49-15:50
+ 53: Arrow           "->" at 15:51-15:53 (leading: Space)
+ 54: NothingLit      "nothing" at 15:54-15:61 (leading: Space)
+ 55: LBrace          "{" at 15:62-15:63 (leading: Space)
+ 56: RBrace          "}" at 17:5-17:6 (leading: Newline, Space, LineComment, Newline, Space)
+ 57: RBrace          "}" at 18:1-18:2 (leading: Newline)
+ 58: EOF             at 19:1-19:1


### PR DESCRIPTION
## 1. Шаг: базовые правила на уровне типов и синтаксиса

Здесь мы **ничего ещё не анализируем по потоку управления**, только требования «по месту использования».

### 1.1. Async/Task/Checkpoint

**Правила:**

* `.await()`:

  * Только в `async fn` или `async { ... }`.
  * Тип слева — `Task<T>`.
* `spawn`:

  * Принимает только `Task<T>` (никакого «spawn любого выражения»).
  * Результат — `Task<T>` или `Task<nothing>` (в зависимости от дизайна).
* `checkpoint()`:

  * Можно вызывать откуда угодно.
  * `Task<nothing>` от `checkpoint()` можно только `.await()` или проигнорировать; нельзя, например, `spawn(checkpoint())`.

**Что делать в семантике:**

* Жёстко проверять типы `Task<T>` и контекст `await`.
* Диагностировать неправильный `spawn`/`.await()` (это уже почти есть, но привести к «железному» состоянию и покрыть тестами).

---

### 1.2. Граница между задачами: ownership vs borrows, @send/@nosend

**Правила:**

* Всё, что «пересекает» границу задачи:

  * Параметры `async fn`.
  * Значение, возвращаемое `async fn`.
  * Захваты в `async { ... }` / в лямбдах, из которых получается `Task<T>` (когда они появятся).
  * Сообщения в каналах.
* должно быть **либо**:

  * `own T` (по твоей модели владения),
  * **либо** тип с атрибутом `@send`.
* Типы с `@nosend` запрещены к передаче в задачи/каналы.

**Что реально проверять:**

* При формировании `Task<T>`:

  * Берём все захваченные значения / параметры и прогоняем через «sendability»:

    * Примитивы, строки, `Array<T>` (если `T` sendable) помечаем явно как `@send` в stdlib.
    * Любой тип с `@nosend` → ошибка.
* При отправке в канал: `Channel<T>`:

  * `T` должен быть sendable по тем же правилам.

Это уже «подготовка почвы» под v2 (потоки), но полезно и в однопоточной модели — не позволим случайно швырять, например, `Mutex` между задачами.

---

### 1.3. Атрибуты конкурентности на декларациях

Здесь мы просто **валидируем декларации**, не заглядываем в тело.

**Атрибуты:**

* `@guarded_by("lock_name")` — на полях.
* `@requires_lock("lock_name")` / `@acquires_lock("lock_name")` / `@releases_lock("lock_name")` / `@waits_on("cond_name")` — на функциях/методах.
* `@nonblocking` — на функциях/методах.
* `@send` / `@nosend` — на типах.
* `@atomic` — на полях.

**Правила:**

* `@guarded_by("L")`:

  * Владеющий тип должен иметь поле `L`.
  * Тип поля `L` → `Mutex` или `RwLock` (можно сначала грубо: «какой-то тип с именем Mutex/RwLock», потом уточнить).
* `@requires_lock/@acquires_lock/@releases_lock/@waits_on`:

  * Указанное поле должно существовать и быть `Mutex`/`RwLock`.
* `@waits_on("cond")`:

  * Поле `cond` должно иметь тип `Condition`.
* `@nonblocking`:

  * Нельзя вместе с `@waits_on` (у тебя уже есть такой конфликт как минимум на уровне атрибутов).
* `@send/@nosend`:

  * Взаимоисключающие.
* `@atomic`:

  * Тип поля из списка разрешённых атомарных: `int`, `uint`, `*T`, возможно `bool`.

**Что делать в семантике:**

* На этом шаге просто **строим и валидируем мета-информацию**:

  * Для типов — карта `field_name → { is_lock, is_cond, is_atomic, guarded_by(...) }`.
  * Для функций — «аннотация» `FnConcurrencyInfo` с полями:

    * `requires: [lock_id...]`
    * `acquires: [lock_id...]`
    * `releases: [lock_id...]`
    * `waits_on: [cond_id...]`
    * флаг `nonblocking`.
    * флаг `blocking` (заполним позже).

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added lock analysis to detect double-locks and unreleased locks; runs after function body checks.
  * Enhanced attribute validation: stricter type checks for @atomic, @waits_on, @guarded_by, @requires_lock/@acquires_lock/@releases_lock.
  * New diagnostics for invalid @waits_on and @atomic targets.

* **Tests**
  * Added many golden tests covering valid/invalid concurrency patterns: atomic, guarded_by, waits_on, double-locks, unlock/not-held, and lock-balance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->