### PR TITLE
Handle resync before closing brace when recovering statements

### DIFF
--- a/internal/parser/helpers.go
+++ b/internal/parser/helpers.go
@@ -246,9 +246,6 @@ func (p *Parser) resyncStatement() {
 				break
 			}
 			if parenDepth == 0 && bracketDepth == 0 {
-				if !p.at(token.EOF) {
-					p.advance()
-				}
 				return
 			}
 		case token.LParen:

--- a/internal/parser/stmt_parser_test.go
+++ b/internal/parser/stmt_parser_test.go
@@ -440,6 +440,28 @@ func TestParseBlockStatements_Diagnostics(t *testing.T) {
 	}
 }
 
+func TestParseBlock_MissingSemicolonBeforeClosingBrace(t *testing.T) {
+	input := `
+fn foo() {
+    let x = 1
+}
+
+@inline
+fn bar() {}
+`
+	_, _, bag := parseSource(t, input)
+	if !bag.HasErrors() {
+		t.Fatalf("expected diagnostics, got none")
+	}
+	codes := make(map[diag.Code]int)
+	for _, d := range bag.Items() {
+		codes[d.Code]++
+	}
+	if len(codes) != 1 || codes[diag.SynExpectSemicolon] == 0 {
+		t.Fatalf("expected only SynExpectSemicolon diagnostic, got %+v", bag.Items())
+	}
+}
+
 // Additional comprehensive tests for statement parsing
 
 func TestParseReturnStatement(t *testing.T) {


### PR DESCRIPTION
## Summary
- stop statement resync from consuming a closing brace when recovery reaches the end of a block
- add a parser regression test for a missing semicolon before a closing brace to ensure only SYN2012 is reported

## Testing
- go test ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952da519a048321bb1bf2b416f02f91)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parser error detection and recovery for block statement edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->