### PR TITLE
Refactor project file collection and introduce progress file handling

### DIFF
--- a/STATS.md
+++ b/STATS.md
@@ -4,27 +4,27 @@
 
 ## 📊 Main code (without tests)
 
-- **Files:** 556
-- **Lines of code:** 118054
+- **Files:** 557
+- **Lines of code:** 118359
 
 ## 📁 Directory breakdown
 
 | Directory | Files | Lines |
 |------------|--------|-------|
-| `cmd/` | 20 | 3596 |
-| `internal/` | 535 | 114443 |
+| `cmd/` | 20 | 3566 |
+| `internal/` | 536 | 114778 |
 
 ## 🏆 Top 10 packages by size
 
 | # | Package | Lines |
 |---|-------|-------|
-| 1 | `internal/sema` | 25090 |
+| 1 | `internal/sema` | 25125 |
 | 2 | `internal/vm` | 17615 |
 | 3 | `internal/backend/llvm` | 9229 |
 | 4 | `internal/mir` | 8940 |
 | 5 | `internal/parser` | 8671 |
-| 6 | `internal/hir` | 6693 |
-| 7 | `internal/driver` | 5274 |
+| 6 | `internal/hir` | 6810 |
+| 7 | `internal/driver` | 5300 |
 | 8 | `internal/mono` | 4566 |
 | 9 | `internal/ast` | 4389 |
 | 10 | `internal/diagfmt` | 4387 |
@@ -36,8 +36,8 @@
 
 ## 📈 Total volume (code + tests)
 
-- **Files:** 671
-- **Lines of code:** 142632
+- **Files:** 672
+- **Lines of code:** 142937
 
 ## 📊 Percentage breakdown
 

--- a/cmd/surge/project_files.go
+++ b/cmd/surge/project_files.go
@@ -14,27 +14,7 @@ func collectProjectFiles(targetPath string, dirInfo *runDirInfo) ([]string, erro
 	if targetPath == "" {
 		return nil, nil
 	}
-	dir := filepath.Dir(targetPath)
-	files, err := listSGFiles(dir)
-	if err != nil {
-		return nil, err
-	}
-	if len(files) == 0 {
-		return []string{targetPath}, nil
-	}
-	targetPath = filepath.Clean(targetPath)
-	found := false
-	for _, file := range files {
-		if filepath.Clean(file) == targetPath {
-			found = true
-			break
-		}
-	}
-	if !found {
-		files = append(files, targetPath)
-		sort.Strings(files)
-	}
-	return files, nil
+	return []string{targetPath}, nil
 }
 
 func displayFileList(files []string, baseDir string) []string {
@@ -76,29 +56,19 @@ func displayFileList(files []string, baseDir string) []string {
 }
 
 func listSGFiles(dir string) ([]string, error) {
-	var files []string
-	err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if d.IsDir() {
-			name := d.Name()
-			// Skip hidden directories and common build folders
-			if len(name) > 1 && strings.HasPrefix(name, ".") {
-				return filepath.SkipDir
-			}
-			if name == "target" || name == "build" || name == "node_modules" {
-				return filepath.SkipDir
-			}
-			return nil
-		}
-		if filepath.Ext(path) == ".sg" {
-			files = append(files, path)
-		}
-		return nil
-	})
+	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, err
+	}
+	files := make([]string, 0, len(entries))
+	for _, ent := range entries {
+		if ent.IsDir() {
+			continue
+		}
+		if filepath.Ext(ent.Name()) != ".sg" {
+			continue
+		}
+		files = append(files, filepath.Join(dir, ent.Name()))
 	}
 	sort.Strings(files)
 	return files, nil

--- a/internal/buildpipeline/compile.go
+++ b/internal/buildpipeline/compile.go
@@ -79,6 +79,7 @@ func Compile(ctx context.Context, req *CompileRequest) (CompileResult, error) {
 	}
 	result.Diagnose = diagRes
 	recordDiagnoseTimings(&result, diagRes.TimingReport)
+	expandProgressFiles(req, phaseProgress, diagRes)
 
 	if diagRes.Bag != nil && diagRes.Bag.HasErrors() {
 		for _, d := range diagRes.Bag.Items() {

--- a/internal/buildpipeline/progress_files.go
+++ b/internal/buildpipeline/progress_files.go
@@ -1,0 +1,133 @@
+package buildpipeline
+
+import (
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"surge/internal/driver"
+)
+
+func expandProgressFiles(req *CompileRequest, phase *phaseObserver, diagRes *driver.DiagnoseResult) {
+	if req == nil || req.Progress == nil || diagRes == nil || req.DirInfo == nil {
+		return
+	}
+	moduleFiles := diagRes.ModuleFiles()
+	if len(moduleFiles) == 0 {
+		return
+	}
+	rootDir := progressRootDir(req)
+	if rootDir != "" {
+		moduleFiles = filterFilesUnderRoot(moduleFiles, rootDir)
+	}
+	displayFiles := normalizeProgressFiles(moduleFiles, req.BaseDir)
+	if len(displayFiles) == 0 {
+		return
+	}
+	existing := make(map[string]struct{}, len(req.Files))
+	for _, file := range req.Files {
+		if file == "" {
+			continue
+		}
+		existing[file] = struct{}{}
+	}
+	newFiles := make([]string, 0, len(displayFiles))
+	for _, file := range displayFiles {
+		if _, ok := existing[file]; ok {
+			continue
+		}
+		newFiles = append(newFiles, file)
+	}
+	req.Files = displayFiles
+	if phase != nil {
+		phase.files = displayFiles
+	}
+	if len(newFiles) == 0 {
+		return
+	}
+	emitQueued(req.Progress, newFiles)
+	if phase != nil && phase.lowerStarted {
+		emitStage(req.Progress, newFiles, StageLower, StatusWorking, nil, 0)
+	}
+}
+
+func progressRootDir(req *CompileRequest) string {
+	if req == nil {
+		return ""
+	}
+	if req.BaseDir != "" {
+		return req.BaseDir
+	}
+	if req.DirInfo != nil && req.DirInfo.Path != "" {
+		return req.DirInfo.Path
+	}
+	if req.TargetPath != "" {
+		return filepath.Dir(req.TargetPath)
+	}
+	return ""
+}
+
+func filterFilesUnderRoot(files []string, root string) []string {
+	if len(files) == 0 || strings.TrimSpace(root) == "" {
+		return files
+	}
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return files
+	}
+	absRoot = filepath.Clean(absRoot)
+	prefix := absRoot + string(filepath.Separator)
+	filtered := make([]string, 0, len(files))
+	for _, file := range files {
+		if file == "" {
+			continue
+		}
+		absFile, err := filepath.Abs(file)
+		if err != nil {
+			continue
+		}
+		absFile = filepath.Clean(absFile)
+		if absFile == absRoot || strings.HasPrefix(absFile, prefix) {
+			filtered = append(filtered, file)
+		}
+	}
+	return filtered
+}
+
+func normalizeProgressFiles(files []string, baseDir string) []string {
+	if len(files) == 0 {
+		return files
+	}
+	normalized := make([]string, 0, len(files))
+	seen := make(map[string]struct{}, len(files))
+
+	base := strings.TrimSpace(baseDir)
+	if base != "" {
+		if abs, err := filepath.Abs(base); err == nil {
+			base = abs
+		}
+	}
+
+	for _, file := range files {
+		if file == "" {
+			continue
+		}
+		path := filepath.Clean(file)
+		if base != "" {
+			if abs, err := filepath.Abs(path); err == nil {
+				path = abs
+			}
+			if rel, err := filepath.Rel(base, path); err == nil && rel != "." && !strings.HasPrefix(rel, "..") {
+				path = rel
+			}
+		}
+		path = filepath.ToSlash(path)
+		if _, ok := seen[path]; ok {
+			continue
+		}
+		seen[path] = struct{}{}
+		normalized = append(normalized, path)
+	}
+	sort.Strings(normalized)
+	return normalized
+}

--- a/internal/driver/diagnose_result.go
+++ b/internal/driver/diagnose_result.go
@@ -26,6 +26,32 @@ func (r *DiagnoseResult) RootModuleMeta() *project.ModuleMeta {
 	return r.rootRecord.Meta
 }
 
+// ModuleFiles returns file paths for all modules resolved during diagnostics.
+func (r *DiagnoseResult) ModuleFiles() []string {
+	if r == nil || r.moduleRecords == nil {
+		return nil
+	}
+	seen := make(map[string]struct{})
+	files := make([]string, 0, len(r.moduleRecords))
+	for _, rec := range r.moduleRecords {
+		if rec == nil {
+			continue
+		}
+		for _, file := range rec.Files {
+			if file == nil || file.Path == "" {
+				continue
+			}
+			if _, ok := seen[file.Path]; ok {
+				continue
+			}
+			seen[file.Path] = struct{}{}
+			files = append(files, file.Path)
+		}
+	}
+	sort.Strings(files)
+	return files
+}
+
 // Entrypoints returns entrypoint metadata across all resolved modules.
 func (r *DiagnoseResult) Entrypoints() []EntrypointInfo {
 	if r == nil || r.moduleRecords == nil {


### PR DESCRIPTION
- Simplified the `collectProjectFiles` function to directly return the target path when provided, removing unnecessary file listing logic.
- Replaced the `listSGFiles` function with a more efficient implementation using `os.ReadDir` to gather `.sg` files from the specified directory.
- Added a new `progress_files.go` file to handle progress file management during the compilation process, including functions for filtering and normalizing file paths.
- Enhanced the `DiagnoseResult` struct with a new method `ModuleFiles` to retrieve file paths for all modules resolved during diagnostics.