### PR TITLE
Vm async exit poll

### DIFF
--- a/STATS.md
+++ b/STATS.md
@@ -5,14 +5,14 @@
 ## 📊 Main code (without tests)
 
 - **Files:** 673 (Go: 644, C: 29)
-- **Lines of code:** 152739 (Go: 139580, C: 13159)
+- **Lines of code:** 152759 (Go: 139600, C: 13159)
 
 ## 📁 Directory breakdown
 
 | Directory | Files | Lines |
 |------------|--------|-------|
 | `cmd/` | 27 | 4635 |
-| `internal/` | 616 | 134930 |
+| `internal/` | 616 | 134950 |
 | `runtime/native/` (C code) | 29 | 13159 |
 
 ## 🏆 Top 10 packages by size
@@ -20,7 +20,7 @@
 | # | Package | Lines |
 |---|-------|-------|
 | 1 | `internal/sema` | 28111 |
-| 2 | `internal/vm` | 22469 |
+| 2 | `internal/vm` | 22473 |
 | 3 | `internal/backend/llvm` | 11554 |
 | 4 | `internal/mir` | 10023 |
 | 5 | `internal/parser` | 8960 |
@@ -32,13 +32,13 @@
 
 ## 🧪 Test files
 
-- **Files:** 159
-- **Lines of code:** 33241
+- **Files:** 160
+- **Lines of code:** 33320
 
 ## 📈 Total volume (code + tests)
 
-- **Files:** 832
-- **Lines of code:** 185980
+- **Files:** 833
+- **Lines of code:** 186079
 
 ## 📊 Percentage breakdown
 

--- a/STATS.md
+++ b/STATS.md
@@ -4,15 +4,15 @@
 
 ## 📊 Main code (without tests)
 
-- **Files:** 672 (Go: 643, C: 29)
-- **Lines of code:** 152631 (Go: 139472, C: 13159)
+- **Files:** 673 (Go: 644, C: 29)
+- **Lines of code:** 152697 (Go: 139538, C: 13159)
 
 ## 📁 Directory breakdown
 
 | Directory | Files | Lines |
 |------------|--------|-------|
 | `cmd/` | 27 | 4635 |
-| `internal/` | 615 | 134822 |
+| `internal/` | 616 | 134888 |
 | `runtime/native/` (C code) | 29 | 13159 |
 
 ## 🏆 Top 10 packages by size
@@ -20,7 +20,7 @@
 | # | Package | Lines |
 |---|-------|-------|
 | 1 | `internal/sema` | 28111 |
-| 2 | `internal/vm` | 22403 |
+| 2 | `internal/vm` | 22469 |
 | 3 | `internal/backend/llvm` | 11554 |
 | 4 | `internal/mir` | 10023 |
 | 5 | `internal/parser` | 8960 |
@@ -32,13 +32,13 @@
 
 ## 🧪 Test files
 
-- **Files:** 158
-- **Lines of code:** 33105
+- **Files:** 159
+- **Lines of code:** 33158
 
 ## 📈 Total volume (code + tests)
 
-- **Files:** 830
-- **Lines of code:** 185736
+- **Files:** 832
+- **Lines of code:** 185855
 
 ## 📊 Percentage breakdown
 

--- a/STATS.md
+++ b/STATS.md
@@ -5,14 +5,14 @@
 ## 📊 Main code (without tests)
 
 - **Files:** 673 (Go: 644, C: 29)
-- **Lines of code:** 152697 (Go: 139538, C: 13159)
+- **Lines of code:** 152739 (Go: 139580, C: 13159)
 
 ## 📁 Directory breakdown
 
 | Directory | Files | Lines |
 |------------|--------|-------|
 | `cmd/` | 27 | 4635 |
-| `internal/` | 616 | 134888 |
+| `internal/` | 616 | 134930 |
 | `runtime/native/` (C code) | 29 | 13159 |
 
 ## 🏆 Top 10 packages by size
@@ -33,12 +33,12 @@
 ## 🧪 Test files
 
 - **Files:** 159
-- **Lines of code:** 33158
+- **Lines of code:** 33241
 
 ## 📈 Total volume (code + tests)
 
 - **Files:** 832
-- **Lines of code:** 185855
+- **Lines of code:** 185980
 
 ## 📊 Percentage breakdown
 

--- a/STATS.md
+++ b/STATS.md
@@ -5,14 +5,14 @@
 ## 📊 Main code (without tests)
 
 - **Files:** 673 (Go: 644, C: 29)
-- **Lines of code:** 152815 (Go: 139656, C: 13159)
+- **Lines of code:** 152825 (Go: 139666, C: 13159)
 
 ## 📁 Directory breakdown
 
 | Directory | Files | Lines |
 |------------|--------|-------|
 | `cmd/` | 27 | 4635 |
-| `internal/` | 616 | 135006 |
+| `internal/` | 616 | 135016 |
 | `runtime/native/` (C code) | 29 | 13159 |
 
 ## 🏆 Top 10 packages by size
@@ -20,7 +20,7 @@
 | # | Package | Lines |
 |---|-------|-------|
 | 1 | `internal/sema` | 28111 |
-| 2 | `internal/vm` | 22486 |
+| 2 | `internal/vm` | 22496 |
 | 3 | `internal/backend/llvm` | 11554 |
 | 4 | `internal/mir` | 10023 |
 | 5 | `internal/parser` | 8960 |
@@ -33,12 +33,12 @@
 ## 🧪 Test files
 
 - **Files:** 161
-- **Lines of code:** 33403
+- **Lines of code:** 33460
 
 ## 📈 Total volume (code + tests)
 
 - **Files:** 834
-- **Lines of code:** 186218
+- **Lines of code:** 186285
 
 ## 📊 Percentage breakdown
 

--- a/STATS.md
+++ b/STATS.md
@@ -5,14 +5,14 @@
 ## 📊 Main code (without tests)
 
 - **Files:** 673 (Go: 644, C: 29)
-- **Lines of code:** 152759 (Go: 139600, C: 13159)
+- **Lines of code:** 152815 (Go: 139656, C: 13159)
 
 ## 📁 Directory breakdown
 
 | Directory | Files | Lines |
 |------------|--------|-------|
 | `cmd/` | 27 | 4635 |
-| `internal/` | 616 | 134950 |
+| `internal/` | 616 | 135006 |
 | `runtime/native/` (C code) | 29 | 13159 |
 
 ## 🏆 Top 10 packages by size
@@ -20,7 +20,7 @@
 | # | Package | Lines |
 |---|-------|-------|
 | 1 | `internal/sema` | 28111 |
-| 2 | `internal/vm` | 22473 |
+| 2 | `internal/vm` | 22486 |
 | 3 | `internal/backend/llvm` | 11554 |
 | 4 | `internal/mir` | 10023 |
 | 5 | `internal/parser` | 8960 |
@@ -32,16 +32,16 @@
 
 ## 🧪 Test files
 
-- **Files:** 160
-- **Lines of code:** 33320
+- **Files:** 161
+- **Lines of code:** 33403
 
 ## 📈 Total volume (code + tests)
 
-- **Files:** 833
-- **Lines of code:** 186079
+- **Files:** 834
+- **Lines of code:** 186218
 
 ## 📊 Percentage breakdown
 
-- **Main code (Go + C):** 82% (Go: 75%, C: 7%)
+- **Main code (Go + C):** 82% (Go: 74%, C: 7%)
 - **Tests:** 17%
 

--- a/docs/COMPILER_FOLLOWUPS.md
+++ b/docs/COMPILER_FOLLOWUPS.md
@@ -10,3 +10,22 @@ Short notes collected during stdlib work when something looked like a compiler o
 - `string -> byte[]` conversion currently accepts owned `string`, but rejects `&string` with `SEM3015: cannot cast &string to [byte]`.
   Observed while deduplicating local `string_to_bytes(...)` helpers in `stdlib/http` and `stdlib/json/parser`.
   Current workaround is `borrowed_string.__clone() to byte[]`.
+
+## 2026-04-20
+
+- VM async poll corrupts control flow around `rt_exit(...)` and `panic(...)` inside async tasks.
+  `internal/vm/async_runtime.go` runs poll functions against a shallow copy of `vm.Stack`, then restores `vm.Stack` and `vm.Halted` unconditionally.
+  If an async task exits or panics, the child poll can drop parent-frame locals and still return `VM1999: poll function exited without async terminator` instead of propagating program termination.
+
+- VM executor keeps completed child task ids in async scopes until scope exit.
+  `internal/asyncrt/scope.go` appends every child in `RegisterChild`, but `MarkDone` never prunes them.
+  This makes long-lived scopes grow monotonically and turns `join_all` / scope cancellation into scans over historical children.
+  Native runtime already has a dedicated fix and harness test for the same invariant (`bd2c2f9d`), so VM parity is currently behind.
+
+- Async scope invariant failures still panic the Go process directly.
+  `internal/asyncrt/scope.go` uses raw `panic(...)` on `ExitScope` with live children, while the VM only normalizes `*VMError` panics.
+  If lowering/runtime invariants drift, users get a host-process crash instead of a regular VM diagnostic.
+
+- VM async shutdown cleanup looks incomplete for buffered channels and parked senders.
+  `internal/vm/drop.go` only drops `task.State` and `task.ResultValue`, while `internal/asyncrt/channel.go` stores payloads in channel buffers and send queues.
+  `rt_exit` / `rt_panic` paths also skip `checkLeaksOrPanic`, unlike `exit(ErrorLike)`, so leak detection is weaker on normal program termination.

--- a/docs/COMPILER_FOLLOWUPS.md
+++ b/docs/COMPILER_FOLLOWUPS.md
@@ -1,6 +1,6 @@
 # Compiler And Runtime Follow-ups
 
-Short notes collected during stdlib work when something looked like a compiler or runtime sharp edge but did not block the current task.
+Open follow-up notes collected during stdlib work when something looked like a compiler or runtime sharp edge but did not block the current task.
 
 ## 2026-03-20
 
@@ -10,22 +10,3 @@ Short notes collected during stdlib work when something looked like a compiler o
 - `string -> byte[]` conversion currently accepts owned `string`, but rejects `&string` with `SEM3015: cannot cast &string to [byte]`.
   Observed while deduplicating local `string_to_bytes(...)` helpers in `stdlib/http` and `stdlib/json/parser`.
   Current workaround is `borrowed_string.__clone() to byte[]`.
-
-## 2026-04-20
-
-- VM async poll corrupts control flow around `rt_exit(...)` and `panic(...)` inside async tasks.
-  `internal/vm/async_runtime.go` runs poll functions against a shallow copy of `vm.Stack`, then restores `vm.Stack` and `vm.Halted` unconditionally.
-  If an async task exits or panics, the child poll can drop parent-frame locals and still return `VM1999: poll function exited without async terminator` instead of propagating program termination.
-
-- VM executor keeps completed child task ids in async scopes until scope exit.
-  `internal/asyncrt/scope.go` appends every child in `RegisterChild`, but `MarkDone` never prunes them.
-  This makes long-lived scopes grow monotonically and turns `join_all` / scope cancellation into scans over historical children.
-  Native runtime already has a dedicated fix and harness test for the same invariant (`bd2c2f9d`), so VM parity is currently behind.
-
-- Async scope invariant failures still panic the Go process directly.
-  `internal/asyncrt/scope.go` uses raw `panic(...)` on `ExitScope` with live children, while the VM only normalizes `*VMError` panics.
-  If lowering/runtime invariants drift, users get a host-process crash instead of a regular VM diagnostic.
-
-- VM async shutdown cleanup looks incomplete for buffered channels and parked senders.
-  `internal/vm/drop.go` only drops `task.State` and `task.ResultValue`, while `internal/asyncrt/channel.go` stores payloads in channel buffers and send queues.
-  `rt_exit` / `rt_panic` paths also skip `checkLeaksOrPanic`, unlike `exit(ErrorLike)`, so leak detection is weaker on normal program termination.

--- a/internal/asyncrt/asyncrt.go
+++ b/internal/asyncrt/asyncrt.go
@@ -112,6 +112,12 @@ type Task struct {
 	checkpointPolled bool
 }
 
+// DrainedTasks contains executor-owned payloads that must be released by the caller.
+type DrainedTasks struct {
+	Tasks           []*Task
+	ChannelPayloads []any
+}
+
 // Config configures executor scheduling behavior.
 type Config struct {
 	Deterministic bool
@@ -550,11 +556,12 @@ func (e *Executor) removeWaiter(key WakerKey, id TaskID) {
 	e.waiters[key] = waiters
 }
 
-// DrainTasks returns all tasks and resets executor queues.
-func (e *Executor) DrainTasks() []*Task {
+// DrainTasks returns all tasks plus pending channel payloads and resets executor queues.
+func (e *Executor) DrainTasks() DrainedTasks {
 	if e == nil {
-		return nil
+		return DrainedTasks{}
 	}
+	channelPayloads := e.drainChannelPayloads()
 	if len(e.tasks) == 0 {
 		e.ready = nil
 		if e.readySet != nil {
@@ -585,7 +592,7 @@ func (e *Executor) DrainTasks() []*Task {
 		e.nextSelectID = 1
 		e.nowMs = 0
 		e.current = 0
-		return nil
+		return DrainedTasks{ChannelPayloads: channelPayloads}
 	}
 	tasks := make([]*Task, 0, len(e.tasks))
 	for _, task := range e.tasks {
@@ -620,5 +627,41 @@ func (e *Executor) DrainTasks() []*Task {
 	e.nextTimerID = 1
 	e.nowMs = 0
 	e.current = 0
-	return tasks
+	return DrainedTasks{
+		Tasks:           tasks,
+		ChannelPayloads: channelPayloads,
+	}
+}
+
+func (e *Executor) drainChannelPayloads() []any {
+	if e == nil || len(e.channels) == 0 {
+		return nil
+	}
+	payloads := make([]any, 0)
+	for _, ch := range e.channels {
+		if ch == nil {
+			continue
+		}
+		payloads = append(payloads, ch.buf...)
+		clear(ch.buf)
+		ch.buf = nil
+		ch.head = 0
+
+		for i := range ch.sendq {
+			waiter := &ch.sendq[i]
+			if waiter.hasValue {
+				payloads = append(payloads, waiter.value)
+			}
+			waiter.value = nil
+			waiter.hasValue = false
+		}
+		ch.sendq = nil
+		ch.recvq = nil
+		ch.recvNotify = nil
+		ch.sendNotify = nil
+	}
+	if len(payloads) == 0 {
+		return nil
+	}
+	return payloads
 }

--- a/internal/asyncrt/asyncrt.go
+++ b/internal/asyncrt/asyncrt.go
@@ -105,6 +105,7 @@ type Task struct {
 	Cancelled        bool
 	ScopeID          ScopeID
 	ParentScopeID    ScopeID
+	ScopeRegistered  bool
 	Children         []TaskID
 	TimeoutTaskID    TaskID
 	SelectID         SelectID
@@ -451,6 +452,7 @@ func (e *Executor) MarkDone(id TaskID, kind TaskResultKind, result any) {
 			}
 		}
 	}
+	e.unregisterScopeChild(task)
 	e.WakeKeyAll(JoinKey(id))
 }
 

--- a/internal/asyncrt/drain_test.go
+++ b/internal/asyncrt/drain_test.go
@@ -1,0 +1,47 @@
+package asyncrt
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestDrainTasksCollectsPendingChannelPayloads(t *testing.T) {
+	exec := NewExecutor(Config{Deterministic: true})
+
+	bufferedID := exec.ChanNew(1)
+	if ok := exec.ChanTrySend(bufferedID, "buffered"); !ok {
+		t.Fatal("expected buffered send to succeed")
+	}
+	buffered := exec.channels[bufferedID]
+	if buffered == nil {
+		t.Fatal("expected buffered channel to exist")
+	}
+
+	taskID := exec.Spawn(1, nil)
+	parkedID := exec.ChanNew(0)
+	parked := exec.channels[parkedID]
+	if parked == nil {
+		t.Fatal("expected parked channel to exist")
+	}
+	exec.SetCurrent(taskID)
+	if ok := exec.ChanSendOrPark(parkedID, "parked"); ok {
+		t.Fatal("expected send to park on unbuffered channel")
+	}
+
+	drained := exec.DrainTasks()
+	if len(drained.Tasks) != 1 {
+		t.Fatalf("expected 1 drained task, got %d", len(drained.Tasks))
+	}
+	if !slices.Equal(drained.ChannelPayloads, []any{"buffered", "parked"}) {
+		t.Fatalf("unexpected drained payloads: %v", drained.ChannelPayloads)
+	}
+	if buffered.buf != nil || buffered.head != 0 {
+		t.Fatalf("expected buffered channel queue to be cleared, got buf=%v head=%d", buffered.buf, buffered.head)
+	}
+	if parked.sendq != nil {
+		t.Fatalf("expected parked send queue to be cleared, got %v", parked.sendq)
+	}
+	if len(exec.channels) != 0 {
+		t.Fatalf("expected executor channels to be reset, got %d", len(exec.channels))
+	}
+}

--- a/internal/asyncrt/drain_test.go
+++ b/internal/asyncrt/drain_test.go
@@ -32,7 +32,16 @@ func TestDrainTasksCollectsPendingChannelPayloads(t *testing.T) {
 	if len(drained.Tasks) != 1 {
 		t.Fatalf("expected 1 drained task, got %d", len(drained.Tasks))
 	}
-	if !slices.Equal(drained.ChannelPayloads, []any{"buffered", "parked"}) {
+	gotPayloads := make([]string, 0, len(drained.ChannelPayloads))
+	for _, payload := range drained.ChannelPayloads {
+		value, ok := payload.(string)
+		if !ok {
+			t.Fatalf("expected string payload, got %T", payload)
+		}
+		gotPayloads = append(gotPayloads, value)
+	}
+	slices.Sort(gotPayloads)
+	if !slices.Equal(gotPayloads, []string{"buffered", "parked"}) {
 		t.Fatalf("unexpected drained payloads: %v", drained.ChannelPayloads)
 	}
 	if buffered.buf != nil || buffered.head != 0 {

--- a/internal/asyncrt/scope.go
+++ b/internal/asyncrt/scope.go
@@ -1,6 +1,9 @@
 package asyncrt
 
-import "fmt"
+import (
+	"fmt"
+	"slices"
+)
 
 // ScopeID identifies an async scope.
 type ScopeID uint64
@@ -48,16 +51,9 @@ func (e *Executor) ExitScope(scopeID ScopeID) {
 	if scope == nil {
 		return
 	}
-	live := make([]TaskID, 0, len(scope.Children))
-	for _, child := range scope.Children {
-		task := e.tasks[child]
-		if task == nil || task.Status == TaskDone {
-			continue
-		}
-		live = append(live, child)
-	}
-	if len(live) > 0 {
-		panic(fmt.Sprintf("scope %d exited with live children: %v", scopeID, live))
+	e.compactScopeChildren(scope)
+	if len(scope.Children) > 0 {
+		panic(fmt.Sprintf("scope %d exited with live children: %v", scopeID, scope.Children))
 	}
 	delete(e.scopes, scopeID)
 	if task := e.tasks[scope.Owner]; task != nil && task.ScopeID == scopeID {
@@ -74,10 +70,23 @@ func (e *Executor) RegisterChild(scopeID ScopeID, child TaskID) {
 	if scope == nil {
 		return
 	}
-	scope.Children = append(scope.Children, child)
-	if task := e.tasks[child]; task != nil {
-		task.ParentScopeID = scopeID
+	task := e.tasks[child]
+	if task == nil || task.ScopeRegistered {
+		return
 	}
+	if task.Status == TaskDone {
+		if task.ResultKind == TaskResultCancelled && scope.Failfast && !scope.FailfastTriggered {
+			scope.FailfastTriggered = true
+			e.CancelAllChildren(scopeID)
+			if owner := e.tasks[scope.Owner]; owner != nil && owner.Status != TaskDone {
+				e.Wake(scope.Owner)
+			}
+		}
+		return
+	}
+	scope.Children = append(scope.Children, child)
+	task.ParentScopeID = scopeID
+	task.ScopeRegistered = true
 }
 
 // CancelAllChildren cancels all children in task order.
@@ -89,6 +98,7 @@ func (e *Executor) CancelAllChildren(scopeID ScopeID) {
 	if scope == nil {
 		return
 	}
+	e.compactScopeChildren(scope)
 	for _, child := range scope.Children {
 		e.Cancel(child)
 	}
@@ -105,12 +115,42 @@ func (e *Executor) JoinAllChildrenBlocking(scopeID ScopeID) (done bool, pending 
 	if scope == nil {
 		return true, 0, false
 	}
-	for _, child := range scope.Children {
-		task := e.tasks[child]
-		if task == nil || task.Status == TaskDone {
-			continue
-		}
-		return false, child, scope.FailfastTriggered
+	e.compactScopeChildren(scope)
+	if len(scope.Children) > 0 {
+		return false, scope.Children[0], scope.FailfastTriggered
 	}
 	return true, 0, scope.FailfastTriggered
+}
+
+func (e *Executor) compactScopeChildren(scope *Scope) {
+	if e == nil || scope == nil || len(scope.Children) == 0 {
+		return
+	}
+	scope.Children = slices.DeleteFunc(scope.Children, func(child TaskID) bool {
+		task := e.tasks[child]
+		if task == nil || task.Status == TaskDone {
+			if task != nil {
+				task.ParentScopeID = 0
+				task.ScopeRegistered = false
+			}
+			return true
+		}
+		return false
+	})
+}
+
+func (e *Executor) unregisterScopeChild(task *Task) {
+	if e == nil || task == nil {
+		return
+	}
+	scopeID := task.ParentScopeID
+	if scopeID != 0 {
+		if scope := e.scopes[scopeID]; scope != nil && len(scope.Children) > 0 {
+			if idx := slices.Index(scope.Children, task.ID); idx >= 0 {
+				scope.Children = slices.Delete(scope.Children, idx, idx+1)
+			}
+		}
+	}
+	task.ParentScopeID = 0
+	task.ScopeRegistered = false
 }

--- a/internal/asyncrt/scope.go
+++ b/internal/asyncrt/scope.go
@@ -5,6 +5,19 @@ import (
 	"slices"
 )
 
+// ScopeExitError reports that a scope was exited with live children still attached.
+type ScopeExitError struct {
+	ScopeID      ScopeID
+	LiveChildren []TaskID
+}
+
+func (e *ScopeExitError) Error() string {
+	if e == nil {
+		return "scope exited with live children"
+	}
+	return fmt.Sprintf("scope %d exited with live children: %v", e.ScopeID, e.LiveChildren)
+}
+
 // ScopeID identifies an async scope.
 type ScopeID uint64
 
@@ -53,7 +66,10 @@ func (e *Executor) ExitScope(scopeID ScopeID) {
 	}
 	e.compactScopeChildren(scope)
 	if len(scope.Children) > 0 {
-		panic(fmt.Sprintf("scope %d exited with live children: %v", scopeID, scope.Children))
+		panic(&ScopeExitError{
+			ScopeID:      scopeID,
+			LiveChildren: slices.Clone(scope.Children),
+		})
 	}
 	delete(e.scopes, scopeID)
 	if task := e.tasks[scope.Owner]; task != nil && task.ScopeID == scopeID {

--- a/internal/asyncrt/scope_test.go
+++ b/internal/asyncrt/scope_test.go
@@ -17,10 +17,20 @@ func TestScopeExitPanicsOnLiveChildren(t *testing.T) {
 		if r == nil {
 			t.Fatalf("expected panic on scope exit with live children")
 		}
-		msg := fmt.Sprint(r)
+		scopeErr, ok := r.(*ScopeExitError)
+		if !ok {
+			t.Fatalf("expected ScopeExitError, got %T", r)
+		}
+		msg := scopeErr.Error()
 		want := fmt.Sprintf("scope %d exited with live children: [%d]", scopeID, child)
 		if msg != want {
 			t.Fatalf("panic mismatch: want %q, got %q", want, msg)
+		}
+		if scopeErr.ScopeID != scopeID {
+			t.Fatalf("expected scope id %d, got %d", scopeID, scopeErr.ScopeID)
+		}
+		if len(scopeErr.LiveChildren) != 1 || scopeErr.LiveChildren[0] != child {
+			t.Fatalf("expected live children [%d], got %v", child, scopeErr.LiveChildren)
 		}
 	}()
 

--- a/internal/asyncrt/scope_test.go
+++ b/internal/asyncrt/scope_test.go
@@ -26,3 +26,86 @@ func TestScopeExitPanicsOnLiveChildren(t *testing.T) {
 
 	exec.ExitScope(scopeID)
 }
+
+func TestScopeDropsCompletedChildrenImmediately(t *testing.T) {
+	exec := NewExecutor(Config{Deterministic: true})
+	owner := exec.Spawn(1, nil)
+	scopeID := exec.EnterScope(owner, false)
+
+	scope := exec.scopes[scopeID]
+	if scope == nil {
+		t.Fatal("expected scope to exist")
+	}
+	ownerTask := exec.tasks[owner]
+	if ownerTask == nil || ownerTask.ScopeID != scopeID {
+		t.Fatalf("expected owner scope id %d, got %+v", scopeID, ownerTask)
+	}
+
+	active := exec.Spawn(2, nil)
+	exec.RegisterChild(scopeID, active)
+	activeTask := exec.tasks[active]
+	if activeTask == nil {
+		t.Fatal("expected active task to exist")
+	}
+	if len(scope.Children) != 1 || scope.Children[0] != active {
+		t.Fatalf("expected active child to be tracked, got %v", scope.Children)
+	}
+	if !activeTask.ScopeRegistered || activeTask.ParentScopeID != scopeID {
+		t.Fatalf("expected active child registration metadata, got %+v", activeTask)
+	}
+
+	exec.MarkDone(active, TaskResultSuccess, nil)
+	if len(scope.Children) != 0 {
+		t.Fatalf("expected completed child to be pruned, got %v", scope.Children)
+	}
+	if activeTask.ScopeRegistered || activeTask.ParentScopeID != 0 {
+		t.Fatalf("expected completed child metadata to be cleared, got %+v", activeTask)
+	}
+
+	completed := exec.Spawn(3, nil)
+	exec.MarkDone(completed, TaskResultSuccess, nil)
+	exec.RegisterChild(scopeID, completed)
+	completedTask := exec.tasks[completed]
+	if completedTask == nil {
+		t.Fatal("expected completed task to exist")
+	}
+	if len(scope.Children) != 0 {
+		t.Fatalf("expected already completed child to be ignored, got %v", scope.Children)
+	}
+	if completedTask.ScopeRegistered || completedTask.ParentScopeID != 0 {
+		t.Fatalf("expected completed child to remain unregistered, got %+v", completedTask)
+	}
+
+	exec.ExitScope(scopeID)
+	if ownerTask.ScopeID != 0 {
+		t.Fatalf("expected owner scope id to be cleared, got %d", ownerTask.ScopeID)
+	}
+}
+
+func TestScopeRegisterCancelledChildTriggersFailfast(t *testing.T) {
+	exec := NewExecutor(Config{Deterministic: true})
+	owner := exec.Spawn(1, nil)
+	scopeID := exec.EnterScope(owner, true)
+
+	active := exec.Spawn(2, nil)
+	exec.RegisterChild(scopeID, active)
+
+	cancelled := exec.Spawn(3, nil)
+	exec.MarkDone(cancelled, TaskResultCancelled, nil)
+	exec.RegisterChild(scopeID, cancelled)
+
+	scope := exec.scopes[scopeID]
+	if scope == nil {
+		t.Fatal("expected scope to exist")
+	}
+	if !scope.FailfastTriggered {
+		t.Fatal("expected failfast to trigger when registering a cancelled child")
+	}
+	activeTask := exec.tasks[active]
+	if activeTask == nil || !activeTask.Cancelled {
+		t.Fatalf("expected active child to be cancelled, got %+v", activeTask)
+	}
+	if len(scope.Children) != 1 || scope.Children[0] != active {
+		t.Fatalf("expected active child to remain the only registered child, got %v", scope.Children)
+	}
+}

--- a/internal/vm/async_runtime.go
+++ b/internal/vm/async_runtime.go
@@ -597,7 +597,14 @@ func (vm *VM) runPoll(fn *mir.Func) (outcome asyncrt.PollOutcome, stateOut Value
 	vm.deferredShutdown = savedDeferredShutdown
 
 	if deferredShutdown.active {
-		vm.finishShutdown(deferredShutdown.checkLeaks || savedDeferredShutdown.checkLeaks)
+		checkLeaks := deferredShutdown.checkLeaks || savedDeferredShutdown.checkLeaks
+		if savedAsync != nil {
+			vm.Halted = true
+			vm.deferredShutdown.active = true
+			vm.deferredShutdown.checkLeaks = checkLeaks
+			return asyncrt.PollOutcome{}, Value{}, nil
+		}
+		vm.finishShutdown(checkLeaks)
 		return asyncrt.PollOutcome{}, Value{}, nil
 	}
 

--- a/internal/vm/async_runtime.go
+++ b/internal/vm/async_runtime.go
@@ -471,6 +471,10 @@ func (vm *VM) runReadyOne() (bool, *VMError) {
 		exec.SetCurrent(0)
 		return true, vmErr
 	}
+	if vm.Halted {
+		exec.SetCurrent(0)
+		return true, nil
+	}
 	switch outcome.Kind {
 	case asyncrt.PollDoneSuccess:
 		exec.MarkDone(id, asyncrt.TaskResultSuccess, outcome.Value)
@@ -504,6 +508,9 @@ func (vm *VM) runUntilDone(id asyncrt.TaskID, resultType types.TypeID) (Value, *
 		exec.Wake(id)
 	}
 	for {
+		if vm.Halted {
+			return Value{}, nil
+		}
 		task := exec.Task(id)
 		if task == nil {
 			return Value{}, vm.eb.makeError(PanicInvalidHandle, fmt.Sprintf("invalid task id %d", id))
@@ -514,6 +521,9 @@ func (vm *VM) runUntilDone(id asyncrt.TaskID, resultType types.TypeID) (Value, *
 		ran, vmErr := vm.runReadyOne()
 		if vmErr != nil {
 			return Value{}, vmErr
+		}
+		if vm.Halted {
+			return Value{}, nil
 		}
 		if !ran {
 			return Value{}, vm.eb.makeError(PanicUnimplemented, "async deadlock")
@@ -544,17 +554,22 @@ func (vm *VM) runPoll(fn *mir.Func) (outcome asyncrt.PollOutcome, stateOut Value
 	savedCapture := vm.captureReturn
 	savedAsync := vm.asyncCapture
 	savedPendingParkKey := vm.asyncPendingParkKey
+	savedDeferredShutdown := vm.deferredShutdown
 
 	exit := asyncExit{}
+	vm.pollDepth++
+	defer func() {
+		vm.pollDepth--
+	}()
 	vm.asyncCapture = &exit
 	vm.asyncPendingParkKey = asyncrt.WakerKey{}
 	vm.captureReturn = nil
-	vm.Stack = append([]Frame(nil), vm.Stack...)
+	vm.deferredShutdown = shutdownState{}
 	vm.Halted = false
 	vm.started = true
 
 	frame := NewFrame(fn)
-	vm.Stack = append(vm.Stack, *frame)
+	vm.Stack = []Frame{*frame}
 
 	for len(vm.Stack) > 0 && !vm.Halted {
 		if vmErr := vm.Step(); vmErr != nil {
@@ -564,6 +579,7 @@ func (vm *VM) runPoll(fn *mir.Func) (outcome asyncrt.PollOutcome, stateOut Value
 			vm.captureReturn = savedCapture
 			vm.asyncCapture = savedAsync
 			vm.asyncPendingParkKey = savedPendingParkKey
+			vm.deferredShutdown = savedDeferredShutdown
 			return asyncrt.PollOutcome{}, Value{}, vmErr
 		}
 		if exit.set {
@@ -571,12 +587,19 @@ func (vm *VM) runPoll(fn *mir.Func) (outcome asyncrt.PollOutcome, stateOut Value
 		}
 	}
 
+	deferredShutdown := vm.deferredShutdown
 	vm.Stack = savedStack
 	vm.Halted = savedHalted
 	vm.started = savedStarted
 	vm.captureReturn = savedCapture
 	vm.asyncCapture = savedAsync
 	vm.asyncPendingParkKey = savedPendingParkKey
+	vm.deferredShutdown = savedDeferredShutdown
+
+	if deferredShutdown.active {
+		vm.finishShutdown(deferredShutdown.checkLeaks || savedDeferredShutdown.checkLeaks)
+		return asyncrt.PollOutcome{}, Value{}, nil
+	}
 
 	if !exit.set {
 		return asyncrt.PollOutcome{}, Value{}, vm.eb.makeError(PanicUnimplemented, "poll function exited without async terminator")

--- a/internal/vm/drop.go
+++ b/internal/vm/drop.go
@@ -90,8 +90,8 @@ func (vm *VM) dropAsyncTasks() {
 	if vm == nil || vm.Async == nil {
 		return
 	}
-	tasks := vm.Async.DrainTasks()
-	for _, task := range tasks {
+	drained := vm.Async.DrainTasks()
+	for _, task := range drained.Tasks {
 		if task == nil {
 			continue
 		}
@@ -101,8 +101,17 @@ func (vm *VM) dropAsyncTasks() {
 		if v, ok := task.ResultValue.(Value); ok {
 			vm.dropValue(v)
 		}
+		if v, ok := task.ResumeValue.(Value); ok {
+			vm.dropValue(v)
+		}
 		task.State = nil
 		task.ResultValue = nil
+		task.ResumeValue = nil
+	}
+	for _, payload := range drained.ChannelPayloads {
+		if v, ok := payload.(Value); ok {
+			vm.dropValue(v)
+		}
 	}
 }
 

--- a/internal/vm/intrinsic_async.go
+++ b/internal/vm/intrinsic_async.go
@@ -166,6 +166,9 @@ func (vm *VM) handleTimeout(frame *Frame, call *mir.CallInstr, writes *[]LocalWr
 	})
 
 	for {
+		if vm.Halted {
+			return nil
+		}
 		timeoutTask := exec.Task(timeoutID)
 		if timeoutTask == nil {
 			return vm.eb.makeError(PanicInvalidHandle, fmt.Sprintf("invalid task id %d", timeoutID))
@@ -206,6 +209,9 @@ func (vm *VM) handleTimeout(frame *Frame, call *mir.CallInstr, writes *[]LocalWr
 		ran, vmErr := vm.runReadyOne()
 		if vmErr != nil {
 			return vmErr
+		}
+		if vm.Halted {
+			return nil
 		}
 		if !ran {
 			return vm.eb.makeError(PanicUnimplemented, "async deadlock")

--- a/internal/vm/intrinsic_channel.go
+++ b/internal/vm/intrinsic_channel.go
@@ -81,6 +81,10 @@ func (vm *VM) handleChannelSend(frame *Frame, call *mir.CallInstr) *VMError {
 	}
 
 	for {
+		if vm.Halted {
+			vm.dropValue(val)
+			return nil
+		}
 		if exec.ChanSendOrPark(chID, val) {
 			return nil
 		}
@@ -92,6 +96,10 @@ func (vm *VM) handleChannelSend(frame *Frame, call *mir.CallInstr) *VMError {
 		if vmErr != nil {
 			vm.dropValue(val)
 			return vmErr
+		}
+		if vm.Halted {
+			vm.dropValue(val)
+			return nil
 		}
 		if !ran {
 			vm.dropValue(val)
@@ -129,6 +137,9 @@ func (vm *VM) handleChannelRecv(frame *Frame, call *mir.CallInstr, writes *[]Loc
 	dstType := frame.Locals[dstLocal].TypeID
 
 	for {
+		if vm.Halted {
+			return nil
+		}
 		valAny, ok := exec.ChanRecvOrPark(chID)
 		if ok {
 			v, ok := valAny.(Value)
@@ -174,6 +185,9 @@ func (vm *VM) handleChannelRecv(frame *Frame, call *mir.CallInstr, writes *[]Loc
 		ran, vmErr := vm.runReadyOne()
 		if vmErr != nil {
 			return vmErr
+		}
+		if vm.Halted {
+			return nil
 		}
 		if !ran {
 			return vm.eb.makeError(PanicUnimplemented, "async deadlock")

--- a/internal/vm/intrinsic_entrypoint.go
+++ b/internal/vm/intrinsic_entrypoint.go
@@ -48,14 +48,7 @@ func (vm *VM) handleExit(frame *Frame, call *mir.CallInstr) *VMError {
 
 	vm.ExitCode = code
 	vm.RT.Exit(code)
-
-	vm.dropAllFrames()
-	vm.dropGlobals()
-	vm.dropAsyncTasks()
-	vm.checkLeaksOrPanic()
-
-	vm.Halted = true
-	vm.Stack = nil
+	vm.requestShutdown(true)
 	return nil
 }
 

--- a/internal/vm/intrinsic_io.go
+++ b/internal/vm/intrinsic_io.go
@@ -318,7 +318,7 @@ func (vm *VM) handleRtExit(frame *Frame, call *mir.CallInstr) *VMError {
 	}
 	vm.ExitCode = code
 	vm.RT.Exit(code)
-	vm.requestShutdown(false)
+	vm.requestShutdown(true)
 	return nil
 }
 
@@ -331,21 +331,25 @@ func (vm *VM) handleRtPanic(frame *Frame, call *mir.CallInstr) *VMError {
 	if vmErr != nil {
 		return vmErr
 	}
-	defer vm.dropValue(ptrVal)
 	if ptrVal.Kind != VKPtr {
+		vm.dropValue(ptrVal)
 		return vm.eb.typeMismatch("*byte", ptrVal.Kind.String())
 	}
 	lenVal, vmErr := vm.evalOperand(frame, &call.Args[1])
 	if vmErr != nil {
+		vm.dropValue(ptrVal)
 		return vmErr
 	}
-	defer vm.dropValue(lenVal)
 
 	n, vmErr := vm.uintValueToInt(lenVal, "panic message length out of range")
 	if vmErr != nil {
+		vm.dropValue(lenVal)
+		vm.dropValue(ptrVal)
 		return vmErr
 	}
 	raw, vmErr := vm.readBytesFromPointer(ptrVal, n)
+	vm.dropValue(lenVal)
+	vm.dropValue(ptrVal)
 	if vmErr != nil {
 		return vmErr
 	}
@@ -361,7 +365,7 @@ func (vm *VM) handleRtPanic(frame *Frame, call *mir.CallInstr) *VMError {
 	code := 1
 	vm.ExitCode = code
 	vm.RT.Exit(code)
-	vm.requestShutdown(false)
+	vm.requestShutdown(true)
 	return nil
 }
 

--- a/internal/vm/intrinsic_io.go
+++ b/internal/vm/intrinsic_io.go
@@ -318,13 +318,7 @@ func (vm *VM) handleRtExit(frame *Frame, call *mir.CallInstr) *VMError {
 	}
 	vm.ExitCode = code
 	vm.RT.Exit(code)
-
-	vm.dropAllFrames()
-	vm.dropGlobals()
-	vm.dropAsyncTasks()
-
-	vm.Halted = true
-	vm.Stack = nil
+	vm.requestShutdown(false)
 	return nil
 }
 
@@ -367,13 +361,7 @@ func (vm *VM) handleRtPanic(frame *Frame, call *mir.CallInstr) *VMError {
 	code := 1
 	vm.ExitCode = code
 	vm.RT.Exit(code)
-
-	vm.dropAllFrames()
-	vm.dropGlobals()
-	vm.dropAsyncTasks()
-
-	vm.Halted = true
-	vm.Stack = nil
+	vm.requestShutdown(false)
 	return nil
 }
 

--- a/internal/vm/intrinsic_io.go
+++ b/internal/vm/intrinsic_io.go
@@ -348,12 +348,14 @@ func (vm *VM) handleRtPanic(frame *Frame, call *mir.CallInstr) *VMError {
 		return vmErr
 	}
 	raw, vmErr := vm.readBytesFromPointer(ptrVal, n)
-	vm.dropValue(lenVal)
-	vm.dropValue(ptrVal)
 	if vmErr != nil {
+		vm.dropValue(lenVal)
+		vm.dropValue(ptrVal)
 		return vmErr
 	}
 	msg := string(raw)
+	vm.dropValue(lenVal)
+	vm.dropValue(ptrVal)
 	if !strings.HasSuffix(msg, "\n") {
 		msg += "\n"
 	}

--- a/internal/vm/llvm_parity_test.go
+++ b/internal/vm/llvm_parity_test.go
@@ -36,6 +36,8 @@ func TestLLVMParity(t *testing.T) {
 		file  string
 		setup func(t *testing.T) []string
 	}{
+		{name: "async_rt_exit", file: "async_rt_exit.sg"},
+		{name: "async_panic", file: "async_panic.sg"},
 		{name: "exit_code", file: "exit_code.sg"},
 		{name: "panic", file: "panic.sg"},
 		{name: "string_concat", file: "string_concat.sg"},

--- a/internal/vm/shutdown.go
+++ b/internal/vm/shutdown.go
@@ -1,0 +1,37 @@
+package vm
+
+type shutdownState struct {
+	active     bool
+	checkLeaks bool
+}
+
+func (vm *VM) requestShutdown(checkLeaks bool) {
+	if vm == nil {
+		return
+	}
+	if vm.pollDepth > 0 {
+		// Poll frames are isolated from the outer caller stack, so drop them now
+		// and defer full-program cleanup until runPoll restores the parent stack.
+		vm.dropAllFrames()
+		vm.Stack = nil
+		vm.Halted = true
+		vm.deferredShutdown.active = true
+		vm.deferredShutdown.checkLeaks = vm.deferredShutdown.checkLeaks || checkLeaks
+		return
+	}
+	vm.finishShutdown(checkLeaks)
+}
+
+func (vm *VM) finishShutdown(checkLeaks bool) {
+	if vm == nil {
+		return
+	}
+	vm.dropAllFrames()
+	vm.dropGlobals()
+	vm.dropAsyncTasks()
+	if checkLeaks {
+		vm.checkLeaksOrPanic()
+	}
+	vm.Halted = true
+	vm.Stack = nil
+}

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -179,6 +179,10 @@ func (vm *VM) Step() (vmErr *VMError) {
 				vmErr = e
 				return
 			}
+			if e, ok := r.(*asyncrt.ScopeExitError); ok {
+				vmErr = vm.eb.makeError(PanicUnimplemented, "async scope invariant violated: "+e.Error())
+				return
+			}
 			panic(r)
 		}
 	}()

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -48,6 +48,8 @@ type VM struct {
 	captureReturn       *Value
 	asyncCapture        *asyncExit
 	asyncPendingParkKey asyncrt.WakerKey
+	pollDepth           int
+	deferredShutdown    shutdownState
 }
 
 // New creates a new VM for executing the given MIR module.

--- a/internal/vm/vm_async_shutdown_test.go
+++ b/internal/vm/vm_async_shutdown_test.go
@@ -49,3 +49,39 @@ fn main() -> int {
 		t.Fatalf("unexpected VM error:\n%s", result.stderr)
 	}
 }
+
+func TestVMRtExitDropsBufferedChannelPayloads(t *testing.T) {
+	sourceCode := `@entrypoint
+fn main() -> int {
+    let ch: own Channel<string> = make_channel::<string>(1);
+    ch.send(own "hello");
+    rt_exit(7);
+    return 0;
+}`
+
+	result := runProgramFromSource(t, sourceCode, runOptions{})
+	if result.exitCode != 7 {
+		t.Fatalf("expected exit code 7, got %d", result.exitCode)
+	}
+	if result.stderr != "" {
+		t.Fatalf("unexpected VM error:\n%s", result.stderr)
+	}
+}
+
+func TestVMPanicDropsBufferedChannelPayloads(t *testing.T) {
+	sourceCode := `@entrypoint
+fn main() -> int {
+    let ch: own Channel<string> = make_channel::<string>(1);
+    ch.send(own "boom");
+    panic("boom");
+    return 0;
+}`
+
+	result := runProgramFromSource(t, sourceCode, runOptions{})
+	if result.exitCode != 1 {
+		t.Fatalf("expected exit code 1, got %d", result.exitCode)
+	}
+	if result.stderr != "" {
+		t.Fatalf("unexpected VM error:\n%s", result.stderr)
+	}
+}

--- a/internal/vm/vm_async_shutdown_test.go
+++ b/internal/vm/vm_async_shutdown_test.go
@@ -51,12 +51,20 @@ fn main() -> int {
 }
 
 func TestVMRtExitDropsBufferedChannelPayloads(t *testing.T) {
-	sourceCode := `@entrypoint
+	sourceCode := `async fn child() -> nothing {
+    rt_exit(7);
+    return nothing;
+}
+
+@entrypoint
 fn main() -> int {
     let ch: own Channel<string> = make_channel::<string>(1);
     ch.send(own "hello");
-    rt_exit(7);
-    return 0;
+    let task: Task<nothing> = spawn child();
+    compare task.await() {
+        Success(_) => return 42;
+        Cancelled() => return 99;
+    }
 }`
 
 	result := runProgramFromSource(t, sourceCode, runOptions{})
@@ -69,17 +77,57 @@ fn main() -> int {
 }
 
 func TestVMPanicDropsBufferedChannelPayloads(t *testing.T) {
-	sourceCode := `@entrypoint
+	sourceCode := `async fn child() -> nothing {
+    panic("boom");
+    return nothing;
+}
+
+@entrypoint
 fn main() -> int {
     let ch: own Channel<string> = make_channel::<string>(1);
     ch.send(own "boom");
-    panic("boom");
-    return 0;
+    let task: Task<nothing> = spawn child();
+    compare task.await() {
+        Success(_) => return 42;
+        Cancelled() => return 99;
+    }
 }`
 
 	result := runProgramFromSource(t, sourceCode, runOptions{})
 	if result.exitCode != 1 {
 		t.Fatalf("expected exit code 1, got %d", result.exitCode)
+	}
+	if result.stderr != "" {
+		t.Fatalf("unexpected VM error:\n%s", result.stderr)
+	}
+}
+
+func TestVMNestedAsyncChildRtExitHaltsProgram(t *testing.T) {
+	sourceCode := `async fn child() -> nothing {
+    rt_exit(7);
+    return nothing;
+}
+
+async fn parent() -> nothing {
+    let task: Task<nothing> = spawn child();
+    compare task.await() {
+        Success(_) => return nothing;
+        Cancelled() => return nothing;
+    }
+}
+
+@entrypoint
+fn main() -> int {
+    let task: Task<nothing> = spawn parent();
+    compare task.await() {
+        Success(_) => return 42;
+        Cancelled() => return 99;
+    }
+}`
+
+	result := runProgramFromSource(t, sourceCode, runOptions{})
+	if result.exitCode != 7 {
+		t.Fatalf("expected exit code 7, got %d", result.exitCode)
 	}
 	if result.stderr != "" {
 		t.Fatalf("unexpected VM error:\n%s", result.stderr)

--- a/internal/vm/vm_async_shutdown_test.go
+++ b/internal/vm/vm_async_shutdown_test.go
@@ -1,0 +1,51 @@
+package vm_test
+
+import "testing"
+
+func TestVMAsyncChildRtExitHaltsProgram(t *testing.T) {
+	sourceCode := `async fn child() -> nothing {
+    rt_exit(7);
+    return nothing;
+}
+
+@entrypoint
+fn main() -> int {
+    let task: Task<nothing> = spawn child();
+    compare task.await() {
+        Success(_) => return 42;
+        Cancelled() => return 99;
+    }
+}`
+
+	result := runProgramFromSource(t, sourceCode, runOptions{})
+	if result.exitCode != 7 {
+		t.Fatalf("expected exit code 7, got %d", result.exitCode)
+	}
+	if result.stderr != "" {
+		t.Fatalf("unexpected VM error:\n%s", result.stderr)
+	}
+}
+
+func TestVMAsyncChildPanicHaltsProgram(t *testing.T) {
+	sourceCode := `async fn child() -> nothing {
+    panic("boom");
+    return nothing;
+}
+
+@entrypoint
+fn main() -> int {
+    let task: Task<nothing> = spawn child();
+    compare task.await() {
+        Success(_) => return 42;
+        Cancelled() => return 99;
+    }
+}`
+
+	result := runProgramFromSource(t, sourceCode, runOptions{})
+	if result.exitCode != 1 {
+		t.Fatalf("expected exit code 1, got %d", result.exitCode)
+	}
+	if result.stderr != "" {
+		t.Fatalf("unexpected VM error:\n%s", result.stderr)
+	}
+}

--- a/internal/vm/vm_dispatch_async_await.go
+++ b/internal/vm/vm_dispatch_async_await.go
@@ -22,6 +22,9 @@ func (vm *VM) execInstrAwait(frame *Frame, instr *mir.Instr, writes []LocalWrite
 	if vmErr != nil {
 		return false, Location{}, Value{}, writes, vmErr
 	}
+	if vm.Halted {
+		return false, Location{}, Value{}, writes, nil
+	}
 	dst := instr.Await.Dst
 	if len(dst.Proj) == 0 {
 		switch dst.Kind {

--- a/internal/vm/vm_dispatch_async_await.go
+++ b/internal/vm/vm_dispatch_async_await.go
@@ -23,6 +23,7 @@ func (vm *VM) execInstrAwait(frame *Frame, instr *mir.Instr, writes []LocalWrite
 		return false, Location{}, Value{}, writes, vmErr
 	}
 	if vm.Halted {
+		vm.dropValue(res)
 		return false, Location{}, Value{}, writes, nil
 	}
 	dst := instr.Await.Dst

--- a/internal/vm/vm_scope_diag_test.go
+++ b/internal/vm/vm_scope_diag_test.go
@@ -1,0 +1,69 @@
+package vm
+
+import (
+	"strings"
+	"testing"
+
+	"surge/internal/mir"
+	"surge/internal/source"
+	"surge/internal/symbols"
+	"surge/internal/types"
+)
+
+func TestVMScopeExitInvariantBecomesVMError(t *testing.T) {
+	typesIn := types.NewInterner()
+	intTy := typesIn.Builtins().Int
+	scopeID := int64(1)
+
+	fn := &mir.Func{
+		ID:     1,
+		Sym:    symbols.NoSymbolID,
+		Name:   "scope_exit_test",
+		Result: types.NoTypeID,
+		Entry:  0,
+		Blocks: []mir.Block{{
+			ID: 0,
+			Instrs: []mir.Instr{{
+				Kind: mir.InstrCall,
+				Call: mir.CallInstr{
+					Callee: mir.Callee{Kind: mir.CalleeSym, Sym: symbols.NoSymbolID, Name: "rt_scope_exit"},
+					Args: []mir.Operand{{
+						Kind:  mir.OperandConst,
+						Type:  intTy,
+						Const: mir.Const{Kind: mir.ConstInt, Type: intTy, IntValue: scopeID},
+					}},
+				},
+			}},
+			Term: mir.Terminator{Kind: mir.TermReturn},
+		}},
+		Span: source.Span{Start: 1, End: 1},
+	}
+
+	vmInstance := New(&mir.Module{}, NewTestRuntime(nil, ""), nil, typesIn, nil)
+	vmInstance.Stack = []Frame{*NewFrame(fn)}
+	exec := vmInstance.ensureExecutor()
+	owner := exec.Spawn(1, nil)
+	actualScopeID := exec.EnterScope(owner, false)
+	if actualScopeID != 1 {
+		t.Fatalf("expected scope id 1, got %d", actualScopeID)
+	}
+	child := exec.Spawn(2, nil)
+	exec.RegisterChild(actualScopeID, child)
+
+	vmErr := vmInstance.Step()
+	if vmErr == nil {
+		t.Fatal("expected VM error, got nil")
+	}
+	if vmErr.Code != PanicUnimplemented {
+		t.Fatalf("expected %v, got %v", PanicUnimplemented, vmErr.Code)
+	}
+	if !strings.Contains(vmErr.Message, "async scope invariant violated") {
+		t.Fatalf("expected invariant message, got %q", vmErr.Message)
+	}
+	if !strings.Contains(vmErr.Message, "scope 1 exited with live children: [2]") {
+		t.Fatalf("expected scope details in message, got %q", vmErr.Message)
+	}
+	if len(vmErr.Backtrace) == 0 || vmErr.Backtrace[0].FuncName != "scope_exit_test" {
+		t.Fatalf("expected backtrace for scope_exit_test, got %+v", vmErr.Backtrace)
+	}
+}

--- a/testdata/llvm_parity/async_panic.sg
+++ b/testdata/llvm_parity/async_panic.sg
@@ -1,0 +1,13 @@
+async fn child() -> nothing {
+    panic("boom");
+    return nothing;
+}
+
+@entrypoint
+fn main() -> int {
+    let task: Task<nothing> = spawn child();
+    compare task.await() {
+        Success(_) => return 42;
+        Cancelled() => return 99;
+    }
+}

--- a/testdata/llvm_parity/async_rt_exit.sg
+++ b/testdata/llvm_parity/async_rt_exit.sg
@@ -1,0 +1,13 @@
+async fn child() -> nothing {
+    rt_exit(7);
+    return nothing;
+}
+
+@entrypoint
+fn main() -> int {
+    let task: Task<nothing> = spawn child();
+    compare task.await() {
+        Success(_) => return 42;
+        Cancelled() => return 99;
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved async/runtime shutdown and VM halting so programs stop cleanly, drop pending channel payloads, and surface structured scope-exit errors instead of raw panics.
  * Better scope cleanup to prune completed children and avoid leaked registrations.

* **Tests**
  * Added integration and unit tests covering async shutdown, scope-exit diagnostics, and two LLVM parity async cases.

* **Documentation**
  * Updated project metrics and follow-up notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->