### PR TITLE
feat(stdlib): add safe random helpers

### DIFF
--- a/STATS.md
+++ b/STATS.md
@@ -5,26 +5,26 @@
 ## 📊 Main code (without tests)
 
 - **Files:** 673 (Go: 644, C: 29)
-- **Lines of code:** 152825 (Go: 139666, C: 13159)
+- **Lines of code:** 152992 (Go: 139833, C: 13159)
 
 ## 📁 Directory breakdown
 
 | Directory | Files | Lines |
 |------------|--------|-------|
 | `cmd/` | 27 | 4635 |
-| `internal/` | 616 | 135016 |
+| `internal/` | 616 | 135183 |
 | `runtime/native/` (C code) | 29 | 13159 |
 
 ## 🏆 Top 10 packages by size
 
 | # | Package | Lines |
 |---|-------|-------|
-| 1 | `internal/sema` | 28111 |
+| 1 | `internal/sema` | 28232 |
 | 2 | `internal/vm` | 22496 |
 | 3 | `internal/backend/llvm` | 11554 |
 | 4 | `internal/mir` | 10023 |
 | 5 | `internal/parser` | 8960 |
-| 6 | `internal/hir` | 7070 |
+| 6 | `internal/hir` | 7094 |
 | 7 | `internal/driver` | 6009 |
 | 8 | `internal/mono` | 5120 |
 | 9 | `internal/lsp` | 5082 |
@@ -32,13 +32,13 @@
 
 ## 🧪 Test files
 
-- **Files:** 161
-- **Lines of code:** 33460
+- **Files:** 162
+- **Lines of code:** 33561
 
 ## 📈 Total volume (code + tests)
 
-- **Files:** 834
-- **Lines of code:** 186285
+- **Files:** 835
+- **Lines of code:** 186553
 
 ## 📊 Percentage breakdown
 

--- a/docs/STDLIB.md
+++ b/docs/STDLIB.md
@@ -103,23 +103,36 @@ import stdlib/random as random;
 Public API:
 
 - `contract RandomSource<T>`
+- `RANDOM_ERR_ZERO_LIMIT`
+- `RANDOM_ERR_EMPTY_RANGE`
 - `type SystemRng`
 - `type Pcg32`
 - `system() -> SystemRng`
 - `bytes(n: uint) -> Erring<byte[], Error>`
 - `fill(out: &mut byte[]) -> Erring<nothing, Error>`
+- `next_bool() -> Erring<bool, Error>`
 - `next_u32() -> Erring<uint32, Error>`
 - `next_u64() -> Erring<uint64, Error>`
+- `below_u32(limit: uint32) -> Erring<uint32, Error>`
+- `below_u64(limit: uint64) -> Erring<uint64, Error>`
+- `range_u32(start: uint32, end_exclusive: uint32) -> Erring<uint32, Error>`
+- `range_u64(start: uint64, end_exclusive: uint64) -> Erring<uint64, Error>`
 - `pcg32(seed: uint64) -> Pcg32`
 - `pcg32_stream(seed: uint64, stream: uint64) -> Pcg32`
-- `SystemRng.fill(...)`, `SystemRng.next_u32()`, `SystemRng.next_u64()`
-- `Pcg32.fill(...)`, `Pcg32.next_u32()`, `Pcg32.next_u64()`
+- `SystemRng.fill(...)`, `SystemRng.next_bool()`, `SystemRng.next_u32()`, `SystemRng.next_u64()`
+- `SystemRng.below_u32(...)`, `SystemRng.below_u64(...)`, `SystemRng.range_u32(...)`, `SystemRng.range_u64(...)`
+- `Pcg32.fill(...)`, `Pcg32.next_bool()`, `Pcg32.next_u32()`, `Pcg32.next_u64()`
+- `Pcg32.below_u32(...)`, `Pcg32.below_u64(...)`, `Pcg32.range_u32(...)`, `Pcg32.range_u64(...)`
 
 Design split:
 
 - `SystemRng` is host-backed and uses `stdlib/entropy`.
 - `Pcg32` is deterministic and suitable for tests and fixtures.
 - `Pcg32` is not cryptographically secure.
+- `RandomSource<T>` remains the minimal primitive contract: `fill`, `next_u32`, `next_u64`.
+- Range helpers use half-open ranges: `[start, end_exclusive)`.
+- `below_*` returns `RANDOM_ERR_ZERO_LIMIT` for a zero limit; `range_*` returns `RANDOM_ERR_EMPTY_RANGE` when `start >= end_exclusive`.
+- Entropy/backend errors from the source are passed through unchanged.
 
 Example: secure random bytes
 
@@ -139,6 +152,17 @@ import stdlib/random as random;
 fn fixture_word() -> Erring<uint64, Error> {
     let mut rng: random.Pcg32 = random.pcg32_stream(42:uint64, 54:uint64);
     return rng.next_u64();
+}
+```
+
+Example: deterministic bounded value
+
+```sg
+import stdlib/random as random;
+
+fn fixture_index() -> Erring<uint32, Error> {
+    let mut rng: random.Pcg32 = random.pcg32(123:uint64);
+    return rng.range_u32(10:uint32, 20:uint32);
 }
 ```
 

--- a/docs/STDLIB.ru.md
+++ b/docs/STDLIB.ru.md
@@ -103,23 +103,36 @@ import stdlib/random as random;
 Публичный API:
 
 - `contract RandomSource<T>`
+- `RANDOM_ERR_ZERO_LIMIT`
+- `RANDOM_ERR_EMPTY_RANGE`
 - `type SystemRng`
 - `type Pcg32`
 - `system() -> SystemRng`
 - `bytes(n: uint) -> Erring<byte[], Error>`
 - `fill(out: &mut byte[]) -> Erring<nothing, Error>`
+- `next_bool() -> Erring<bool, Error>`
 - `next_u32() -> Erring<uint32, Error>`
 - `next_u64() -> Erring<uint64, Error>`
+- `below_u32(limit: uint32) -> Erring<uint32, Error>`
+- `below_u64(limit: uint64) -> Erring<uint64, Error>`
+- `range_u32(start: uint32, end_exclusive: uint32) -> Erring<uint32, Error>`
+- `range_u64(start: uint64, end_exclusive: uint64) -> Erring<uint64, Error>`
 - `pcg32(seed: uint64) -> Pcg32`
 - `pcg32_stream(seed: uint64, stream: uint64) -> Pcg32`
-- `SystemRng.fill(...)`, `SystemRng.next_u32()`, `SystemRng.next_u64()`
-- `Pcg32.fill(...)`, `Pcg32.next_u32()`, `Pcg32.next_u64()`
+- `SystemRng.fill(...)`, `SystemRng.next_bool()`, `SystemRng.next_u32()`, `SystemRng.next_u64()`
+- `SystemRng.below_u32(...)`, `SystemRng.below_u64(...)`, `SystemRng.range_u32(...)`, `SystemRng.range_u64(...)`
+- `Pcg32.fill(...)`, `Pcg32.next_bool()`, `Pcg32.next_u32()`, `Pcg32.next_u64()`
+- `Pcg32.below_u32(...)`, `Pcg32.below_u64(...)`, `Pcg32.range_u32(...)`, `Pcg32.range_u64(...)`
 
 Разделение ролей:
 
 - `SystemRng` использует `stdlib/entropy`.
 - `Pcg32` детерминирован и подходит для тестов и фикстур.
 - `Pcg32` не является криптографически стойким.
+- `RandomSource<T>` остается минимальным primitive contract: `fill`, `next_u32`, `next_u64`.
+- Range helpers используют полуоткрытые диапазоны: `[start, end_exclusive)`.
+- `below_*` возвращает `RANDOM_ERR_ZERO_LIMIT` для нулевого limit; `range_*` возвращает `RANDOM_ERR_EMPTY_RANGE`, если `start >= end_exclusive`.
+- Ошибки entropy/backend от источника проходят наружу без оборачивания.
 
 Пример: secure random bytes
 
@@ -139,6 +152,17 @@ import stdlib/random as random;
 fn fixture_word() -> Erring<uint64, Error> {
     let mut rng: random.Pcg32 = random.pcg32_stream(42:uint64, 54:uint64);
     return rng.next_u64();
+}
+```
+
+Пример: deterministic bounded value
+
+```sg
+import stdlib/random as random;
+
+fn fixture_index() -> Erring<uint32, Error> {
+    let mut rng: random.Pcg32 = random.pcg32(123:uint64);
+    return rng.range_u32(10:uint32, 20:uint32);
 }
 ```
 

--- a/internal/hir/lower_expr.go
+++ b/internal/hir/lower_expr.go
@@ -76,7 +76,7 @@ func (l *lowerer) lowerExprCore(exprID ast.ExprID) *Expr {
 		return l.lowerCallExpr(exprID, expr, ty)
 
 	case ast.ExprMember:
-		return l.lowerMemberExpr(expr, ty)
+		return l.lowerMemberExpr(exprID, expr, ty)
 
 	case ast.ExprIndex:
 		return l.lowerIndexExpr(exprID, expr, ty)
@@ -345,10 +345,20 @@ func (l *lowerer) lowerUnaryExpr(exprID ast.ExprID, expr *ast.Expr, ty types.Typ
 }
 
 // lowerMemberExpr lowers a member access expression.
-func (l *lowerer) lowerMemberExpr(expr *ast.Expr, ty types.TypeID) *Expr {
+func (l *lowerer) lowerMemberExpr(exprID ast.ExprID, expr *ast.Expr, ty types.TypeID) *Expr {
 	memberData := l.builder.Exprs.Members.Get(uint32(expr.Payload))
 	if memberData == nil {
 		return nil
+	}
+
+	if l.isModuleExpr(memberData.Target) && l.symRes != nil {
+		if symID := l.symRes.ExprSymbols[exprID]; symID.IsValid() {
+			ref := l.varRefForSymbol(symID, expr.Span)
+			if ref != nil {
+				ref.Type = ty
+				return ref
+			}
+		}
 	}
 
 	if lit := l.enumVariantLiteral(memberData, ty, expr.Span); lit != nil {

--- a/internal/hir/lower_expr_calls.go
+++ b/internal/hir/lower_expr_calls.go
@@ -48,6 +48,18 @@ func (l *lowerer) packVariadicArgs(symID symbols.SymbolID, args []*Expr, span so
 	return packed
 }
 
+func (l *lowerer) isModuleExpr(id ast.ExprID) bool {
+	if l == nil || l.symRes == nil || l.symRes.Table == nil || l.symRes.Table.Symbols == nil {
+		return false
+	}
+	symID := l.symRes.ExprSymbols[id]
+	if !symID.IsValid() {
+		return false
+	}
+	sym := l.symRes.Table.Symbols.Get(symID)
+	return sym != nil && sym.Kind == symbols.SymbolModule
+}
+
 // lowerCallExpr lowers a function call expression.
 func (l *lowerer) lowerCallExpr(exprID ast.ExprID, expr *ast.Expr, ty types.TypeID) *Expr {
 	callData := l.builder.Exprs.Calls.Get(uint32(expr.Payload))
@@ -112,10 +124,12 @@ func (l *lowerer) lowerCallExpr(exprID ast.ExprID, expr *ast.Expr, ty types.Type
 
 	if isMember && member != nil {
 		if symID.IsValid() {
-			recv := l.lowerExpr(member.Target)
-			if recv != nil && recv.Type != types.NoTypeID {
-				recv = l.applySelfBorrow(symID, recv)
-				args = append([]*Expr{recv}, args...)
+			if !l.isModuleExpr(member.Target) {
+				recv := l.lowerExpr(member.Target)
+				if recv != nil && recv.Type != types.NoTypeID {
+					recv = l.applySelfBorrow(symID, recv)
+					args = append([]*Expr{recv}, args...)
+				}
 			}
 			args = l.packVariadicArgs(symID, args, expr.Span)
 			args = l.applyParamBorrow(symID, args)

--- a/internal/sema/module_imports.go
+++ b/internal/sema/module_imports.go
@@ -49,18 +49,12 @@ func (tc *typeChecker) resolveImportedValueSymbol(sym *symbols.Symbol, name sour
 		tc.report(diag.SemaModuleMemberNotFound, span, "module %q has no member %q", sym.ModulePath, nameStr)
 		return sym
 	}
-	var candidate *symbols.ExportedSymbol
-	for i := range exported {
-		if exported[i].Flags&symbols.SymbolFlagPublic != 0 {
-			candidate = &exported[i]
-			break
-		}
-	}
-	if candidate == nil {
+	candidates := tc.publicModuleValueExports(exported)
+	if len(candidates) == 0 {
 		tc.report(diag.SemaModuleMemberNotPublic, span, "member %q of module %q is not public", nameStr, sym.ModulePath)
 		return sym
 	}
-	tc.applyExportToSymbol(sym, candidate, sym.ModulePath)
+	tc.applyExportToSymbol(sym, candidates[0], sym.ModulePath)
 	return sym
 }
 
@@ -78,20 +72,29 @@ func (tc *typeChecker) typeOfModuleMember(module *symbols.Symbol, field source.S
 	}
 }
 
-func (tc *typeChecker) moduleFunctionResult(module *symbols.Symbol, name source.StringID, args []callArg, typeArgs []types.TypeID, span source.Span) types.TypeID {
+func (tc *typeChecker) moduleFunctionResult(callID ast.ExprID, module *symbols.Symbol, name source.StringID, args []callArg, typeArgs []types.TypeID, span source.Span) types.TypeID {
 	exported := tc.moduleExportsByName(module, name, span)
 	if len(exported) == 0 {
 		return types.NoTypeID
 	}
-	candidates := make([]*symbols.Symbol, 0, len(exported))
-	for i := range exported {
-		if exported[i].Flags&symbols.SymbolFlagPublic == 0 {
+	type moduleCandidate struct {
+		id  symbols.SymbolID
+		sym *symbols.Symbol
+	}
+	candidates := make([]moduleCandidate, 0, len(exported))
+	for _, exp := range tc.publicModuleValueExports(exported) {
+		if exp == nil || (exp.Kind != symbols.SymbolFunction && exp.Kind != symbols.SymbolTag) {
 			continue
 		}
-		if exported[i].Kind != symbols.SymbolFunction && exported[i].Kind != symbols.SymbolTag {
+		if tc.receiverBoundModuleExport(exp) {
 			continue
 		}
-		candidates = append(candidates, tc.exportedSymbolToSymbol(&exported[i], module.ModulePath))
+		symID := tc.ensureImportedModuleExportSymbol(module.ModulePath, name, exp, span)
+		sym := tc.symbolFromID(symID)
+		if sym == nil {
+			sym = tc.exportedSymbolToSymbol(exp, module.ModulePath)
+		}
+		candidates = append(candidates, moduleCandidate{id: symID, sym: sym})
 	}
 	if len(candidates) == 0 {
 		tc.report(diag.SemaModuleMemberNotPublic, span, "member %q of module %q is not public or not a function", tc.lookupName(name), module.ModulePath)
@@ -100,6 +103,7 @@ func (tc *typeChecker) moduleFunctionResult(module *symbols.Symbol, name source.
 	bestCost := -1
 	bestType := types.NoTypeID
 	var bestSym *symbols.Symbol
+	var bestSymID symbols.SymbolID
 	var bestArgs []types.TypeID
 	bestName := tc.lookupName(name)
 	if bestName == "" {
@@ -107,14 +111,15 @@ func (tc *typeChecker) moduleFunctionResult(module *symbols.Symbol, name source.
 	}
 	var borrowInfo borrowMatchInfo
 	for _, cand := range candidates {
-		cost, result, concreteArgs, ok := tc.evaluateFunctionCandidate(cand, args, typeArgs, &borrowInfo)
+		cost, result, concreteArgs, ok := tc.evaluateFunctionCandidate(cand.sym, args, typeArgs, &borrowInfo)
 		if !ok {
 			continue
 		}
 		if bestCost == -1 || cost < bestCost {
 			bestCost = cost
 			bestType = result
-			bestSym = cand
+			bestSym = cand.sym
+			bestSymID = cand.id
 			bestArgs = concreteArgs
 		} else if cost == bestCost {
 			tc.report(diag.SemaAmbiguousOverload, span, "ambiguous overload for %s", bestName)
@@ -131,13 +136,22 @@ func (tc *typeChecker) moduleFunctionResult(module *symbols.Symbol, name source.
 				tc.checkArrayViewResizeCall(bestName, args, span)
 			}
 		}
+		if bestSymID.IsValid() {
+			tc.checkDeprecatedSymbol(bestSymID, "function", span)
+			note := "call"
+			if bestSym != nil && bestSym.Kind == symbols.SymbolTag {
+				note = "tag"
+			}
+			tc.rememberFunctionInstantiation(bestSymID, bestArgs, span, note)
+			tc.recordCallSymbol(callID, bestSymID)
+		}
 		return bestType
 	}
 	if borrowInfo.expr.IsValid() {
 		tc.reportBorrowFailure(&borrowInfo)
 		return types.NoTypeID
 	}
-	if len(candidates) == 1 && tc.reportCallArgumentMismatch(candidates[0], args, typeArgs) {
+	if len(candidates) == 1 && tc.reportCallArgumentMismatch(candidates[0].sym, args, typeArgs) {
 		return types.NoTypeID
 	}
 	tc.report(diag.SemaNoOverload, span, "no matching overload for %s", bestName)
@@ -170,10 +184,9 @@ func (tc *typeChecker) lookupModuleExport(module *symbols.Symbol, field source.S
 	if len(exported) == 0 {
 		return nil
 	}
-	for i := range exported {
-		if exported[i].Flags&symbols.SymbolFlagPublic != 0 {
-			return &exported[i]
-		}
+	candidates := tc.publicModuleValueExports(exported)
+	if len(candidates) > 0 {
+		return candidates[0]
 	}
 	nameStr := tc.lookupName(field)
 	if nameStr == "" {
@@ -181,6 +194,114 @@ func (tc *typeChecker) lookupModuleExport(module *symbols.Symbol, field source.S
 	}
 	tc.report(diag.SemaModuleMemberNotPublic, span, "member %q of module %q is not public", nameStr, module.ModulePath)
 	return nil
+}
+
+func (tc *typeChecker) receiverBoundModuleExport(exp *symbols.ExportedSymbol) bool {
+	return exp != nil && exp.Kind == symbols.SymbolFunction && (exp.ReceiverKey != "" || exp.Flags&symbols.SymbolFlagMethod != 0)
+}
+
+func (tc *typeChecker) publicModuleValueExports(exported []symbols.ExportedSymbol) []*symbols.ExportedSymbol {
+	values := make([]*symbols.ExportedSymbol, 0, len(exported))
+	methods := make([]*symbols.ExportedSymbol, 0, len(exported))
+	for i := range exported {
+		if exported[i].Flags&symbols.SymbolFlagPublic == 0 {
+			continue
+		}
+		if tc.receiverBoundModuleExport(&exported[i]) {
+			methods = append(methods, &exported[i])
+			continue
+		}
+		values = append(values, &exported[i])
+	}
+	if len(values) > 0 {
+		return values
+	}
+	return methods
+}
+
+func (tc *typeChecker) ensureImportedModuleExportSymbol(modulePath string, name source.StringID, exp *symbols.ExportedSymbol, fallback source.Span) symbols.SymbolID {
+	if exp == nil || tc.symbols == nil || tc.symbols.Table == nil || tc.symbols.Table.Symbols == nil {
+		return symbols.NoSymbolID
+	}
+	nameID := exp.NameID
+	if nameID == source.NoStringID {
+		nameID = name
+	}
+	if nameID == source.NoStringID && exp.Name != "" && tc.builder != nil && tc.builder.StringsInterner != nil {
+		nameID = tc.builder.StringsInterner.Intern(exp.Name)
+	}
+	if nameID == source.NoStringID {
+		return symbols.NoSymbolID
+	}
+
+	scope := tc.fileScope()
+	if scope.IsValid() && tc.symbols.Table.Scopes != nil {
+		if scopeData := tc.symbols.Table.Scopes.Get(scope); scopeData != nil {
+			for _, id := range scopeData.NameIndex[nameID] {
+				sym := tc.symbolFromID(id)
+				if tc.moduleExportMatchesSymbol(sym, modulePath, nameID, exp) {
+					return id
+				}
+			}
+		}
+	}
+
+	sym := tc.exportedSymbolToSymbol(exp, modulePath)
+	if sym == nil {
+		return symbols.NoSymbolID
+	}
+	sym.Name = nameID
+	sym.ImportName = nameID
+	sym.Scope = scope
+	if sym.Span == (source.Span{}) {
+		sym.Span = fallback
+	}
+	id := tc.symbols.Table.Symbols.New(sym)
+	if scope.IsValid() && tc.symbols.Table.Scopes != nil {
+		if scopeData := tc.symbols.Table.Scopes.Get(scope); scopeData != nil {
+			scopeData.Symbols = append(scopeData.Symbols, id)
+			if scopeData.NameIndex == nil {
+				scopeData.NameIndex = make(map[source.StringID][]symbols.SymbolID)
+			}
+			scopeData.NameIndex[nameID] = append(scopeData.NameIndex[nameID], id)
+		}
+	}
+	return id
+}
+
+func (tc *typeChecker) moduleExportMatchesSymbol(sym *symbols.Symbol, modulePath string, name source.StringID, exp *symbols.ExportedSymbol) bool {
+	if sym == nil || exp == nil {
+		return false
+	}
+	if sym.ModulePath != modulePath || sym.Name != name || sym.Kind != exp.Kind {
+		return false
+	}
+	if !typeKeyEqual(sym.ReceiverKey, exp.ReceiverKey) {
+		return false
+	}
+	return moduleFunctionSignaturesEqual(sym.Signature, exp.Signature)
+}
+
+func moduleFunctionSignaturesEqual(a, b *symbols.FunctionSignature) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	if !typeKeyEqual(a.Result, b.Result) || len(a.Params) != len(b.Params) || a.HasSelf != b.HasSelf {
+		return false
+	}
+	for i := range a.Params {
+		if !typeKeyEqual(a.Params[i], b.Params[i]) ||
+			boolAt(a.Variadic, i) != boolAt(b.Variadic, i) ||
+			boolAt(a.Defaults, i) != boolAt(b.Defaults, i) ||
+			boolAt(a.AllowTo, i) != boolAt(b.AllowTo, i) {
+			return false
+		}
+	}
+	return true
+}
+
+func boolAt(values []bool, index int) bool {
+	return index >= 0 && index < len(values) && values[index]
 }
 
 func (tc *typeChecker) applyExportToSymbol(target *symbols.Symbol, exp *symbols.ExportedSymbol, modulePath string) {

--- a/internal/sema/module_imports_test.go
+++ b/internal/sema/module_imports_test.go
@@ -1,0 +1,34 @@
+package sema
+
+import (
+	"testing"
+
+	"surge/internal/symbols"
+)
+
+func TestModuleFunctionSignaturesEqualTreatsMissingBoolMetadataAsFalse(t *testing.T) {
+	withoutMetadata := &symbols.FunctionSignature{
+		Params: []symbols.TypeKey{"string"},
+		Result: "JsonString",
+	}
+	withFalseMetadata := &symbols.FunctionSignature{
+		Params:   []symbols.TypeKey{"string"},
+		Variadic: []bool{false},
+		Defaults: []bool{false},
+		AllowTo:  []bool{false},
+		Result:   "JsonString",
+	}
+
+	if !moduleFunctionSignaturesEqual(withoutMetadata, withFalseMetadata) {
+		t.Fatalf("expected missing boolean metadata to match explicit false metadata")
+	}
+
+	withVariadic := &symbols.FunctionSignature{
+		Params:   []symbols.TypeKey{"string"},
+		Variadic: []bool{true},
+		Result:   "JsonString",
+	}
+	if moduleFunctionSignaturesEqual(withoutMetadata, withVariadic) {
+		t.Fatalf("expected true variadic metadata to differ from missing metadata")
+	}
+}

--- a/internal/sema/type_expr_calls.go
+++ b/internal/sema/type_expr_calls.go
@@ -49,7 +49,7 @@ func (tc *typeChecker) callResultType(callID ast.ExprID, call *ast.ExprCallData,
 	if member, ok := tc.builder.Exprs.Member(call.Target); ok && member != nil {
 		if module := tc.moduleSymbolForExpr(member.Target); module != nil {
 			typeArgs := tc.resolveCallTypeArgs(call.TypeArgs)
-			return tc.moduleFunctionResult(module, member.Field, args, typeArgs, span)
+			return tc.moduleFunctionResult(callID, module, member.Field, args, typeArgs, span)
 		}
 	}
 	ident, ok := tc.builder.Exprs.Ident(call.Target)

--- a/internal/symbols/resolve_module_members.go
+++ b/internal/symbols/resolve_module_members.go
@@ -53,22 +53,49 @@ func (fr *fileResolver) resolveModuleMember(exprID ast.ExprID, member *ast.ExprM
 		fr.reportModuleMemberNotFound(modulePath, member.Field, useSpan)
 		return
 	}
-	var candidate *ExportedSymbol
-	for i := range exported {
-		if exported[i].Flags&SymbolFlagPublic != 0 {
-			candidate = &exported[i]
-			break
-		}
-	}
-	if candidate == nil {
+	candidates := publicModuleValueExports(exported)
+	if len(candidates) == 0 {
 		refSpan := exported[0].Span
 		fr.reportModuleMemberNotPublic(modulePath, member.Field, useSpan, refSpan)
 		return
 	}
-	symID := fr.syntheticSymbolForExport(modulePath, memberName, candidate, useSpan)
-	if symID.IsValid() {
-		fr.result.ExprSymbols[exprID] = symID
+
+	var first SymbolID
+	for _, candidate := range candidates {
+		if candidate == nil {
+			continue
+		}
+		symID := fr.syntheticSymbolForExport(modulePath, memberName, candidate, useSpan)
+		if symID.IsValid() && !first.IsValid() {
+			first = symID
+		}
 	}
+	if first.IsValid() {
+		fr.result.ExprSymbols[exprID] = first
+	}
+}
+
+func receiverBoundExport(exp *ExportedSymbol) bool {
+	return exp != nil && exp.Kind == SymbolFunction && (exp.ReceiverKey != "" || exp.Flags&SymbolFlagMethod != 0)
+}
+
+func publicModuleValueExports(exported []ExportedSymbol) []*ExportedSymbol {
+	values := make([]*ExportedSymbol, 0, len(exported))
+	methods := make([]*ExportedSymbol, 0, len(exported))
+	for i := range exported {
+		if exported[i].Flags&SymbolFlagPublic == 0 {
+			continue
+		}
+		if receiverBoundExport(&exported[i]) {
+			methods = append(methods, &exported[i])
+			continue
+		}
+		values = append(values, &exported[i])
+	}
+	if len(values) > 0 {
+		return values
+	}
+	return methods
 }
 
 func signatureKey(sig *FunctionSignature) string {

--- a/internal/symbols/resolve_test.go
+++ b/internal/symbols/resolve_test.go
@@ -771,8 +771,8 @@ func TestResolveModuleAndItemImportDoesNotConflict(t *testing.T) {
 
 func TestResolveModuleMemberUsesExports(t *testing.T) {
 	src := `
-        import foo;
-        fn run() {
+	        import foo;
+	        fn run() {
             foo.bar();
         }
     `
@@ -802,9 +802,76 @@ func TestResolveModuleMemberUsesExports(t *testing.T) {
 	}
 }
 
+func TestResolveModuleMemberPrefersFreeFunctionOverMethod(t *testing.T) {
+	src := `
+	        import foo;
+	        fn run() {
+	            foo.next();
+	        }
+	    `
+	builder, fileID, parseBag := parseSnippet(t, src)
+	if parseBag.Len() != 0 {
+		t.Fatalf("unexpected parse diagnostics: %d", parseBag.Len())
+	}
+
+	exports := NewModuleExports("foo")
+	exports.Add(&ExportedSymbol{
+		Name:        "next",
+		Kind:        SymbolFunction,
+		Flags:       SymbolFlagPublic | SymbolFlagMethod,
+		Signature:   &FunctionSignature{Params: []TypeKey{"&mut Rng"}, Variadic: []bool{false}, Result: "uint32", HasSelf: true},
+		ReceiverKey: "Rng",
+	})
+	exports.Add(&ExportedSymbol{
+		Name:      "next",
+		Kind:      SymbolFunction,
+		Flags:     SymbolFlagPublic,
+		Signature: &FunctionSignature{Result: "uint32"},
+	})
+
+	bag := diag.NewBag(8)
+	res := ResolveFile(builder, fileID, &ResolveOptions{
+		Reporter: &diag.BagReporter{Bag: bag},
+		Validate: true,
+		ModuleExports: map[string]*ModuleExports{
+			"foo": exports,
+		},
+	})
+
+	if bag.Len() != 0 {
+		t.Fatalf("expected no diagnostics, got %d", bag.Len())
+	}
+
+	nextID := builder.StringsInterner.Intern("next")
+	var memberID ast.ExprID
+	for i := uint32(1); i <= builder.Exprs.Arena.Len(); i++ {
+		id := ast.ExprID(i)
+		member, ok := builder.Exprs.Member(id)
+		if ok && member != nil && member.Field == nextID {
+			memberID = id
+			break
+		}
+	}
+	if !memberID.IsValid() {
+		t.Fatalf("expected foo.next member expression")
+	}
+
+	symID := res.ExprSymbols[memberID]
+	sym := res.Table.Symbols.Get(symID)
+	if sym == nil {
+		t.Fatalf("expected resolved module member symbol")
+	}
+	if sym.ReceiverKey != "" {
+		t.Fatalf("expected free function export, got receiver %q", sym.ReceiverKey)
+	}
+	if sym.Signature == nil || len(sym.Signature.Params) != 0 {
+		t.Fatalf("expected zero-arg free function signature, got %#v", sym.Signature)
+	}
+}
+
 func TestResolveModuleMemberMissing(t *testing.T) {
 	src := `
-        import foo;
+	        import foo;
         fn run() {
             foo.missing();
         }

--- a/internal/symbols/resolve_walk_helpers.go
+++ b/internal/symbols/resolve_walk_helpers.go
@@ -258,12 +258,7 @@ func (fr *fileResolver) tryResolveImportSymbol(exprID ast.ExprID, span source.Sp
 		fr.reportModuleMemberNotFound(modulePath, name, span)
 		return true
 	}
-	publics := make([]*ExportedSymbol, 0, len(exported))
-	for i := range exported {
-		if exported[i].Flags&SymbolFlagPublic != 0 {
-			publics = append(publics, &exported[i])
-		}
-	}
+	publics := publicModuleValueExports(exported)
 	if len(publics) == 0 {
 		refSpan := exported[0].Span
 		fr.reportModuleMemberNotPublic(modulePath, name, span, refSpan)

--- a/stdlib/random/random.sg
+++ b/stdlib/random/random.sg
@@ -3,6 +3,9 @@
 
 import stdlib/entropy as entropy;
 
+pub const RANDOM_ERR_ZERO_LIMIT: uint = 1;
+pub const RANDOM_ERR_EMPTY_RANGE: uint = 2;
+
 const U32_MOD: uint = 4_294_967_296;
 const U64_MOD: uint = 18_446_744_073_709_551_616;
 
@@ -52,6 +55,8 @@ fn decode_le_u64(data: &byte[]) -> uint64 {
         | (b7 << 56:uint64);
 }
 
+// PCG needs modulo wraparound, while fixed-width numeric operations are checked.
+// Use dynamic uint for the intermediate and cast back only after reducing.
 fn wrap_u64_mul_add(a: uint64, b: uint64, c: uint64) -> uint64 {
     let wide_a: uint = a to uint;
     let wide_b: uint = b to uint;
@@ -67,10 +72,9 @@ fn wrap_u64_add(a: uint64, b: uint64) -> uint64 {
     return wide to uint64;
 }
 
-fn wrap_u64_shift_left(value: uint64, shift: uint64) -> uint64 {
+fn wrap_u64_shift_left(value: uint64, shift: uint) -> uint64 {
     let wide_value: uint = value to uint;
-    let wide_shift: uint = shift to uint;
-    let wide: uint = (wide_value << wide_shift) % U64_MOD;
+    let wide: uint = (wide_value << shift) % U64_MOD;
     return wide to uint64;
 }
 
@@ -99,6 +103,22 @@ fn pcg32_step(self: &mut Pcg32) -> uint32 {
     return rotate_right_u32(xorshifted, rot);
 }
 
+fn zero_limit_u32() -> Erring<uint32, Error> {
+    return Error { message: "random: limit must be greater than zero", code: RANDOM_ERR_ZERO_LIMIT };
+}
+
+fn zero_limit_u64() -> Erring<uint64, Error> {
+    return Error { message: "random: limit must be greater than zero", code: RANDOM_ERR_ZERO_LIMIT };
+}
+
+fn empty_range_u32() -> Erring<uint32, Error> {
+    return Error { message: "random: empty range", code: RANDOM_ERR_EMPTY_RANGE };
+}
+
+fn empty_range_u64() -> Erring<uint64, Error> {
+    return Error { message: "random: empty range", code: RANDOM_ERR_EMPTY_RANGE };
+}
+
 extern<SystemRng> {
     pub fn new() -> SystemRng {
         return { _private = 0:uint8 };
@@ -114,6 +134,97 @@ extern<SystemRng> {
         compare entropy.bytes(4:uint) {
             Success(data) => {
                 return Success(decode_le_u32(&data));
+            }
+            err => {
+                return err;
+            }
+        };
+    }
+
+    pub fn next_bool(self: &mut SystemRng) -> Erring<bool, Error> {
+        compare self.next_u32() {
+            Success(value) => {
+                return Success((value & 1:uint32) == 1:uint32);
+            }
+            err => {
+                return err;
+            }
+        };
+    }
+
+    pub fn below_u32(self: &mut SystemRng, limit: uint32) -> Erring<uint32, Error> {
+        if limit == 0:uint32 {
+            return zero_limit_u32();
+        }
+
+        let wide_limit: uint = limit to uint;
+        let threshold: uint = (U32_MOD - wide_limit) % wide_limit;
+        while true {
+            compare self.next_u32() {
+                Success(candidate) => {
+                    let wide: uint = candidate to uint;
+                    if wide >= threshold {
+                        return Success((wide % wide_limit) to uint32);
+                    }
+                }
+                err => {
+                    return err;
+                }
+            };
+        }
+        // Unreachable; satisfies current return analysis for infinite rejection loops.
+        return zero_limit_u32();
+    }
+
+    pub fn below_u64(self: &mut SystemRng, limit: uint64) -> Erring<uint64, Error> {
+        if limit == 0:uint64 {
+            return zero_limit_u64();
+        }
+
+        let wide_limit: uint = limit to uint;
+        let threshold: uint = (U64_MOD - wide_limit) % wide_limit;
+        while true {
+            compare self.next_u64() {
+                Success(candidate) => {
+                    let wide: uint = candidate to uint;
+                    if wide >= threshold {
+                        return Success((wide % wide_limit) to uint64);
+                    }
+                }
+                err => {
+                    return err;
+                }
+            };
+        }
+        // Unreachable; satisfies current return analysis for infinite rejection loops.
+        return zero_limit_u64();
+    }
+
+    pub fn range_u32(self: &mut SystemRng, start: uint32, end_exclusive: uint32) -> Erring<uint32, Error> {
+        if start >= end_exclusive {
+            return empty_range_u32();
+        }
+
+        let span: uint32 = end_exclusive - start;
+        compare self.below_u32(span) {
+            Success(offset) => {
+                return Success(start + offset);
+            }
+            err => {
+                return err;
+            }
+        };
+    }
+
+    pub fn range_u64(self: &mut SystemRng, start: uint64, end_exclusive: uint64) -> Erring<uint64, Error> {
+        if start >= end_exclusive {
+            return empty_range_u64();
+        }
+
+        let span: uint64 = end_exclusive - start;
+        compare self.below_u64(span) {
+            Success(offset) => {
+                return Success(start + offset);
             }
             err => {
                 return err;
@@ -159,10 +270,101 @@ extern<Pcg32> {
         return Success(pcg32_step(self));
     }
 
+    pub fn next_bool(self: &mut Pcg32) -> Erring<bool, Error> {
+        compare self.next_u32() {
+            Success(value) => {
+                return Success((value & 1:uint32) == 1:uint32);
+            }
+            err => {
+                return err;
+            }
+        };
+    }
+
     pub fn next_u64(self: &mut Pcg32) -> Erring<uint64, Error> {
         let lo: uint64 = pcg32_step(self) to uint64;
         let hi: uint64 = pcg32_step(self) to uint64;
         return Success(lo | (hi << 32:uint64));
+    }
+
+    pub fn below_u32(self: &mut Pcg32, limit: uint32) -> Erring<uint32, Error> {
+        if limit == 0:uint32 {
+            return zero_limit_u32();
+        }
+
+        let wide_limit: uint = limit to uint;
+        let threshold: uint = (U32_MOD - wide_limit) % wide_limit;
+        while true {
+            compare self.next_u32() {
+                Success(candidate) => {
+                    let wide: uint = candidate to uint;
+                    if wide >= threshold {
+                        return Success((wide % wide_limit) to uint32);
+                    }
+                }
+                err => {
+                    return err;
+                }
+            };
+        }
+        // Unreachable; satisfies current return analysis for infinite rejection loops.
+        return zero_limit_u32();
+    }
+
+    pub fn below_u64(self: &mut Pcg32, limit: uint64) -> Erring<uint64, Error> {
+        if limit == 0:uint64 {
+            return zero_limit_u64();
+        }
+
+        let wide_limit: uint = limit to uint;
+        let threshold: uint = (U64_MOD - wide_limit) % wide_limit;
+        while true {
+            compare self.next_u64() {
+                Success(candidate) => {
+                    let wide: uint = candidate to uint;
+                    if wide >= threshold {
+                        return Success((wide % wide_limit) to uint64);
+                    }
+                }
+                err => {
+                    return err;
+                }
+            };
+        }
+        // Unreachable; satisfies current return analysis for infinite rejection loops.
+        return zero_limit_u64();
+    }
+
+    pub fn range_u32(self: &mut Pcg32, start: uint32, end_exclusive: uint32) -> Erring<uint32, Error> {
+        if start >= end_exclusive {
+            return empty_range_u32();
+        }
+
+        let span: uint32 = end_exclusive - start;
+        compare self.below_u32(span) {
+            Success(offset) => {
+                return Success(start + offset);
+            }
+            err => {
+                return err;
+            }
+        };
+    }
+
+    pub fn range_u64(self: &mut Pcg32, start: uint64, end_exclusive: uint64) -> Erring<uint64, Error> {
+        if start >= end_exclusive {
+            return empty_range_u64();
+        }
+
+        let span: uint64 = end_exclusive - start;
+        compare self.below_u64(span) {
+            Success(offset) => {
+                return Success(start + offset);
+            }
+            err => {
+                return err;
+            }
+        };
     }
 }
 
@@ -193,6 +395,36 @@ pub fn next_u64() -> Erring<uint64, Error> {
     return rng.next_u64();
 }
 
+// Read one random boolean from SystemRng.
+pub fn next_bool() -> Erring<bool, Error> {
+    let mut rng: SystemRng = system();
+    return rng.next_bool();
+}
+
+// Return a uniform uint32 in [0, limit).
+pub fn below_u32(limit: uint32) -> Erring<uint32, Error> {
+    let mut rng: SystemRng = system();
+    return rng.below_u32(limit);
+}
+
+// Return a uniform uint64 in [0, limit).
+pub fn below_u64(limit: uint64) -> Erring<uint64, Error> {
+    let mut rng: SystemRng = system();
+    return rng.below_u64(limit);
+}
+
+// Return a uniform uint32 in [start, end_exclusive).
+pub fn range_u32(start: uint32, end_exclusive: uint32) -> Erring<uint32, Error> {
+    let mut rng: SystemRng = system();
+    return rng.range_u32(start, end_exclusive);
+}
+
+// Return a uniform uint64 in [start, end_exclusive).
+pub fn range_u64(start: uint64, end_exclusive: uint64) -> Erring<uint64, Error> {
+    let mut rng: SystemRng = system();
+    return rng.range_u64(start, end_exclusive);
+}
+
 // Construct a deterministic PCG32 stream with the default stream selector.
 pub fn pcg32(seed: uint64) -> Pcg32 {
     return pcg32_stream(seed, 54:uint64);
@@ -202,7 +434,7 @@ pub fn pcg32(seed: uint64) -> Pcg32 {
 pub fn pcg32_stream(seed: uint64, stream: uint64) -> Pcg32 {
     let mut rng: Pcg32 = {
         state = 0:uint64,
-        inc = wrap_u64_shift_left(stream, 1:uint64) | 1:uint64
+        inc = wrap_u64_shift_left(stream, 1:uint) | 1:uint64
     };
     let _ = pcg32_step(&mut rng);
     rng.state = wrap_u64_add(rng.state, seed);

--- a/testdata/llvm_parity/random_pcg32.sg
+++ b/testdata/llvm_parity/random_pcg32.sg
@@ -62,5 +62,105 @@ fn main() -> int {
         }
     };
 
+    let mut helpers: random.Pcg32 = random.pcg32_stream(42:uint64, 54:uint64);
+    compare helpers.next_bool() {
+        Success(flag) => {
+            if !flag {
+                return 7;
+            }
+        }
+        err => {
+            return err.code to int;
+        }
+    };
+    compare helpers.below_u32(10:uint32) {
+        Success(v) => {
+            if v != 7:uint32 {
+                return 8;
+            }
+        }
+        err => {
+            return err.code to int;
+        }
+    };
+    compare helpers.range_u32(20:uint32, 30:uint32) {
+        Success(v) => {
+            if v != 24:uint32 {
+                return 9;
+            }
+        }
+        err => {
+            return err.code to int;
+        }
+    };
+    compare helpers.below_u64(1000:uint64) {
+        Success(v) => {
+            if v != 635:uint64 {
+                return 10;
+            }
+        }
+        err => {
+            return err.code to int;
+        }
+    };
+    compare helpers.range_u64(1000:uint64, 2000:uint64) {
+        Success(v) => {
+            if v != 1926:uint64 {
+                return 11;
+            }
+        }
+        err => {
+            return err.code to int;
+        }
+    };
+
+    compare helpers.below_u32(0:uint32) {
+        Success(_) => {
+            return 12;
+        }
+        err => {
+            if err.code != random.RANDOM_ERR_ZERO_LIMIT {
+                return 13;
+            }
+        }
+    };
+    compare helpers.range_u64(5:uint64, 5:uint64) {
+        Success(_) => {
+            return 14;
+        }
+        err => {
+            if err.code != random.RANDOM_ERR_EMPTY_RANGE {
+                return 15;
+            }
+        }
+    };
+
+    compare random.next_bool() {
+        Success(_) => {}
+        err => {
+            return err.code to int;
+        }
+    };
+    compare random.below_u32(10:uint32) {
+        Success(v) => {
+            if v >= 10:uint32 {
+                return 16;
+            }
+        }
+        err => {
+            return err.code to int;
+        }
+    };
+    compare random.range_u64(1000:uint64, 2000:uint64) {
+        Success(v) => {
+            if v < 1000:uint64 || v >= 2000:uint64 {
+                return 17;
+            }
+        }
+        err => {
+            return err.code to int;
+        }
+    };
+
     return 0;
 }


### PR DESCRIPTION
## Summary

- extend `stdlib/random` with safe boolean, bounded integer, and half-open range helpers for `SystemRng` and deterministic `Pcg32`
- add explicit random error codes for zero limits and empty ranges, with docs in English and Russian
- fix module-qualified export resolution/lowering so imported free functions and tag constructors are not treated as receiver calls
- add regression coverage for module export selection/signature metadata and LLVM parity coverage for the new random helpers

## Root Cause / Notes

Adding public constants and top-level wrappers in `stdlib/random` exposed gaps in module-qualified member handling: exported free functions could be confused with receiver-bound methods during resolution/lowering, and imported tag constructor signatures could have missing boolean metadata slices. The compiler now prefers value/free-function exports for module members and treats missing bool signature metadata as explicit `false`.

`STATS.md` was updated by the pre-commit `make check` hook.

## Validation

- `make golden-update`
- `make check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added boolean random number generation to the standard library.
  * Added bounded and range-based random number helpers with validation.
  * Introduced new error constants for invalid bounds conditions.

* **Documentation**
  * Updated random module API documentation with new function descriptions and usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->