### PR TITLE
fix(mir): preserve typed default arg lowering

### DIFF
--- a/STATS.md
+++ b/STATS.md
@@ -5,14 +5,14 @@
 ## 📊 Main code (without tests)
 
 - **Files:** 673 (Go: 644, C: 29)
-- **Lines of code:** 152992 (Go: 139833, C: 13159)
+- **Lines of code:** 152999 (Go: 139840, C: 13159)
 
 ## 📁 Directory breakdown
 
 | Directory | Files | Lines |
 |------------|--------|-------|
 | `cmd/` | 27 | 4635 |
-| `internal/` | 616 | 135183 |
+| `internal/` | 616 | 135190 |
 | `runtime/native/` (C code) | 29 | 13159 |
 
 ## 🏆 Top 10 packages by size
@@ -22,7 +22,7 @@
 | 1 | `internal/sema` | 28232 |
 | 2 | `internal/vm` | 22496 |
 | 3 | `internal/backend/llvm` | 11554 |
-| 4 | `internal/mir` | 10023 |
+| 4 | `internal/mir` | 10030 |
 | 5 | `internal/parser` | 8960 |
 | 6 | `internal/hir` | 7094 |
 | 7 | `internal/driver` | 6009 |
@@ -33,15 +33,15 @@
 ## 🧪 Test files
 
 - **Files:** 162
-- **Lines of code:** 33561
+- **Lines of code:** 33594
 
 ## 📈 Total volume (code + tests)
 
 - **Files:** 835
-- **Lines of code:** 186553
+- **Lines of code:** 186593
 
 ## 📊 Percentage breakdown
 
-- **Main code (Go + C):** 82% (Go: 74%, C: 7%)
-- **Tests:** 17%
+- **Main code (Go + C):** 81% (Go: 74%, C: 7%)
+- **Tests:** 18%
 

--- a/internal/mir/entrypoint_args.go
+++ b/internal/mir/entrypoint_args.go
@@ -22,7 +22,7 @@ func (b *surgeStartBuilder) prepareArgsNone() []Operand {
 			b.emitExitWithMessage(fmt.Sprintf("missing default for parameter %q", param.Name), 1)
 			break
 		}
-		op, err := b.lowerDefaultExpr(param.Default)
+		op, err := b.lowerDefaultExpr(param.Default, param.Type)
 		if err != nil {
 			b.emitExitWithMessage(fmt.Sprintf("failed to lower default for parameter %q", param.Name), 1)
 			break
@@ -129,7 +129,7 @@ func (b *surgeStartBuilder) prepareArgsArgv() []Operand {
 
 		b.startBlock(noArgBB)
 		if param.HasDefault && param.Default != nil {
-			op, err := b.lowerDefaultExpr(param.Default)
+			op, err := b.lowerDefaultExpr(param.Default, param.Type)
 			if err != nil {
 				b.emitExitWithMessage(fmt.Sprintf("failed to lower default for parameter %q", param.Name), 1)
 			} else {

--- a/internal/mir/entrypoint_emit.go
+++ b/internal/mir/entrypoint_emit.go
@@ -231,12 +231,13 @@ func (b *surgeStartBuilder) emitExitCall(codeLocal LocalID) {
 	})
 }
 
-func (b *surgeStartBuilder) lowerDefaultExpr(expr *hir.Expr) (Operand, error) {
+func (b *surgeStartBuilder) lowerDefaultExpr(expr *hir.Expr, expected types.TypeID) (Operand, error) {
 	if expr == nil {
 		return Operand{}, fmt.Errorf("nil default expression")
 	}
 	lowerer := &funcLowerer{
 		f:                   b.f,
+		sema:                b.sema,
 		types:               b.typesIn,
 		symToLocal:          make(map[symbols.SymbolID]LocalID, len(b.paramLocals)),
 		nextTemp:            1,
@@ -249,7 +250,7 @@ func (b *surgeStartBuilder) lowerDefaultExpr(expr *hir.Expr) (Operand, error) {
 	for sym, local := range b.paramLocals {
 		lowerer.symToLocal[sym] = local
 	}
-	op, err := lowerer.lowerExpr(expr, true)
+	op, err := lowerer.lowerExprForType(expr, expected)
 	if err != nil {
 		return Operand{}, err
 	}

--- a/internal/mir/lower_expr_calls.go
+++ b/internal/mir/lower_expr_calls.go
@@ -121,7 +121,7 @@ func (l *funcLowerer) lowerCallArgsWithDefaults(e *hir.Expr, data hir.CallData, 
 			}
 			return nil, fmt.Errorf("mir: call: missing default for parameter %q", name)
 		}
-		op, err := l.lowerExpr(param.Default, true)
+		op, err := l.lowerExprForType(param.Default, param.Type)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/mir/lower_expr_ops.go
+++ b/internal/mir/lower_expr_ops.go
@@ -211,10 +211,6 @@ func (l *funcLowerer) lowerCastExpr(e *hir.Expr, consume bool) (Operand, error) 
 	if !ok {
 		return Operand{}, fmt.Errorf("mir: cast: unexpected payload %T", e.Data)
 	}
-	value, err := l.lowerValueExpr(data.Value, false)
-	if err != nil {
-		return Operand{}, err
-	}
 	resultTy := e.Type
 	if resultTy == types.NoTypeID {
 		resultTy = data.TargetTy
@@ -222,6 +218,16 @@ func (l *funcLowerer) lowerCastExpr(e *hir.Expr, consume bool) (Operand, error) 
 	targetTy := data.TargetTy
 	if targetTy == types.NoTypeID {
 		targetTy = resultTy
+	}
+	valueExpr := data.Value
+	if valueExpr != nil && valueExpr.Type == types.NoTypeID && targetTy != types.NoTypeID && valueExpr.Kind == hir.ExprLiteral {
+		clone := *valueExpr
+		clone.Type = targetTy
+		valueExpr = &clone
+	}
+	value, err := l.lowerValueExpr(valueExpr, false)
+	if err != nil {
+		return Operand{}, err
 	}
 	tmp := l.newTemp(resultTy, "cast", e.Span)
 	l.emit(&Instr{

--- a/internal/vm/vm_test.go
+++ b/internal/vm/vm_test.go
@@ -200,6 +200,39 @@ func TestVMEntrypointArgvInt(t *testing.T) {
 	}
 }
 
+func TestVMEntrypointArgvDefault(t *testing.T) {
+	sourceCode := `@entrypoint("argv") fn main(port: uint = 7379:uint) -> int {
+    if port == 7379:uint {
+        return 0;
+    }
+    return 1;
+}
+`
+	result := runProgramFromSource(t, sourceCode, runOptions{})
+	if result.exitCode != 0 {
+		t.Errorf("expected exit code 0, got %d", result.exitCode)
+	}
+}
+
+func TestVMCallDefaultUintCast(t *testing.T) {
+	sourceCode := `fn port(value: uint = 7379:uint) -> int {
+    if value == 7379:uint {
+        return 0;
+    }
+    return 1;
+}
+
+@entrypoint
+fn main() -> int {
+    return port();
+}
+`
+	result := runProgramFromSource(t, sourceCode, runOptions{})
+	if result.exitCode != 0 {
+		t.Errorf("expected exit code 0, got %d", result.exitCode)
+	}
+}
+
 func TestVMEntrypointStdinInt(t *testing.T) {
 	sourceCode := `@entrypoint("stdin") fn main(x: int) -> int { return x; }
 `


### PR DESCRIPTION
## Summary

- lower omitted default arguments with the parameter's expected type in MIR
- fix synthetic `__surge_start` handling for `@entrypoint("argv")` defaults that use typed casts such as `7379:uint`
- add VM regressions for both entrypoint defaults and regular call-site defaults

## Root Cause

Default expressions were being lowered without an expected target type on certain MIR-only paths. For typed casts inside defaults, this let the cast source stay effectively untyped, which first produced `unknown type` in MIR validation and then an LLVM cast failure once MIR typing was tightened.

The fix applies the parameter type when lowering defaults and adds a small cast-lowering fallback for untyped literals when the cast target is already known.

## Validation

- `go test ./internal/vm -run 'TestVMEntrypointArgvDefault|TestVMCallDefaultUintCast'`
- `make check`

## Notes

- `STATS.md` was updated automatically by the pre-commit `make check` hook.

Closes #72

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed type-aware processing of default arguments in function calls.
  * Enhanced cast expression handling to properly infer types for literal values.

* **Tests**
  * Added test coverage for default argument scenarios involving type casting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->