### PR TITLE
fix(llvm): support time.monotonic_now

### DIFF
--- a/internal/backend/llvm/builtins.go
+++ b/internal/backend/llvm/builtins.go
@@ -60,6 +60,7 @@ func runtimeDecls() []builtinDecl {
 		{name: "rt_panic", ret: "void", params: []string{"ptr", "i64"}},
 		{name: "rt_panic_numeric", ret: "void", params: []string{"ptr", "i64"}},
 		{name: "rt_panic_bounds", ret: "void", params: []string{"i64", "i64", "i64"}},
+		{name: "rt_monotonic_now", ret: "i64", params: nil},
 		{name: "rt_worker_count", ret: "i64", params: nil},
 		{name: "rt_string_from_bytes", ret: "ptr", params: []string{"ptr", "i64"}},
 		{name: "rt_string_from_utf16", ret: "ptr", params: []string{"ptr", "i64"}},

--- a/internal/backend/llvm/emit_intrinsics_runtime.go
+++ b/internal/backend/llvm/emit_intrinsics_runtime.go
@@ -74,6 +74,8 @@ func (fe *funcEmitter) emitRuntimeIntrinsic(call *mir.CallInstr) (bool, error) {
 		return true, fe.emitRtPanic(call)
 	case "rt_panic_bounds":
 		return true, fe.emitRtPanicBounds(call)
+	case "monotonic_now":
+		return true, fe.emitRtMonotonicNow(call)
 	case "rt_worker_count":
 		return true, fe.emitRtWorkerCount(call)
 	case "rt_exit":
@@ -85,6 +87,68 @@ func (fe *funcEmitter) emitRuntimeIntrinsic(call *mir.CallInstr) (bool, error) {
 	default:
 		return false, nil
 	}
+}
+
+func (fe *funcEmitter) emitRtMonotonicNow(call *mir.CallInstr) error {
+	if call == nil {
+		return nil
+	}
+	if len(call.Args) != 0 {
+		return fmt.Errorf("monotonic_now requires 0 arguments")
+	}
+	if !call.HasDst {
+		return nil
+	}
+	dstType, err := fe.placeBaseType(call.Dst)
+	if err != nil {
+		return err
+	}
+	layoutInfo, err := fe.emitter.layoutOf(dstType)
+	if err != nil {
+		return err
+	}
+	fieldIdx, fieldType, err := fe.structFieldInfo(dstType, mir.PlaceProj{
+		Kind:      mir.PlaceProjField,
+		FieldName: "__opaque",
+		FieldIdx:  -1,
+	})
+	if err != nil {
+		return err
+	}
+	if fieldIdx < 0 || fieldIdx >= len(layoutInfo.FieldOffsets) {
+		return fmt.Errorf("duration field index %d out of range", fieldIdx)
+	}
+	fieldLLVM, err := llvmValueType(fe.emitter.types, fieldType)
+	if err != nil {
+		return err
+	}
+	if fieldLLVM != "i64" {
+		return fmt.Errorf("monotonic_now requires int64 __opaque field, got %s", fieldLLVM)
+	}
+	size := layoutInfo.Size
+	align := layoutInfo.Align
+	if size <= 0 {
+		size = 1
+	}
+	if align <= 0 {
+		align = 1
+	}
+	mem := fe.nextTemp()
+	fmt.Fprintf(&fe.emitter.buf, "  %s = call ptr @rt_alloc(i64 %d, i64 %d)\n", mem, size, align)
+	now := fe.nextTemp()
+	fmt.Fprintf(&fe.emitter.buf, "  %s = call i64 @rt_monotonic_now()\n", now)
+	fieldPtr := fe.nextTemp()
+	fmt.Fprintf(&fe.emitter.buf, "  %s = getelementptr inbounds i8, ptr %s, i64 %d\n", fieldPtr, mem, layoutInfo.FieldOffsets[fieldIdx])
+	fmt.Fprintf(&fe.emitter.buf, "  store i64 %s, ptr %s\n", now, fieldPtr)
+	ptr, dstTy, err := fe.emitPlacePtr(call.Dst)
+	if err != nil {
+		return err
+	}
+	if dstTy != "ptr" {
+		dstTy = "ptr"
+	}
+	fmt.Fprintf(&fe.emitter.buf, "  store %s %s, ptr %s\n", dstTy, mem, ptr)
+	return nil
 }
 
 func (fe *funcEmitter) emitRtSleep(call *mir.CallInstr) error {

--- a/internal/backend/llvm/emit_intrinsics_runtime.go
+++ b/internal/backend/llvm/emit_intrinsics_runtime.go
@@ -99,47 +99,17 @@ func (fe *funcEmitter) emitRtMonotonicNow(call *mir.CallInstr) error {
 	if !call.HasDst {
 		return nil
 	}
-	dstType, err := fe.placeBaseType(call.Dst)
+	size, align, opaqueOffset, err := fe.monotonicDurationLayout(call.Dst)
 	if err != nil {
 		return err
-	}
-	layoutInfo, err := fe.emitter.layoutOf(dstType)
-	if err != nil {
-		return err
-	}
-	fieldIdx, fieldType, err := fe.structFieldInfo(dstType, mir.PlaceProj{
-		Kind:      mir.PlaceProjField,
-		FieldName: "__opaque",
-		FieldIdx:  -1,
-	})
-	if err != nil {
-		return err
-	}
-	if fieldIdx < 0 || fieldIdx >= len(layoutInfo.FieldOffsets) {
-		return fmt.Errorf("duration field index %d out of range", fieldIdx)
-	}
-	fieldLLVM, err := llvmValueType(fe.emitter.types, fieldType)
-	if err != nil {
-		return err
-	}
-	if fieldLLVM != "i64" {
-		return fmt.Errorf("monotonic_now requires int64 __opaque field, got %s", fieldLLVM)
-	}
-	size := layoutInfo.Size
-	align := layoutInfo.Align
-	if size <= 0 {
-		size = 1
-	}
-	if align <= 0 {
-		align = 1
 	}
 	mem := fe.nextTemp()
 	fmt.Fprintf(&fe.emitter.buf, "  %s = call ptr @rt_alloc(i64 %d, i64 %d)\n", mem, size, align)
-	now := fe.nextTemp()
-	fmt.Fprintf(&fe.emitter.buf, "  %s = call i64 @rt_monotonic_now()\n", now)
-	fieldPtr := fe.nextTemp()
-	fmt.Fprintf(&fe.emitter.buf, "  %s = getelementptr inbounds i8, ptr %s, i64 %d\n", fieldPtr, mem, layoutInfo.FieldOffsets[fieldIdx])
-	fmt.Fprintf(&fe.emitter.buf, "  store i64 %s, ptr %s\n", now, fieldPtr)
+	elapsedNs := fe.nextTemp()
+	fmt.Fprintf(&fe.emitter.buf, "  %s = call i64 @rt_monotonic_now()\n", elapsedNs)
+	opaquePtr := fe.nextTemp()
+	fmt.Fprintf(&fe.emitter.buf, "  %s = getelementptr inbounds i8, ptr %s, i64 %d\n", opaquePtr, mem, opaqueOffset)
+	fmt.Fprintf(&fe.emitter.buf, "  store i64 %s, ptr %s\n", elapsedNs, opaquePtr)
 	ptr, dstTy, err := fe.emitPlacePtr(call.Dst)
 	if err != nil {
 		return err
@@ -149,6 +119,44 @@ func (fe *funcEmitter) emitRtMonotonicNow(call *mir.CallInstr) error {
 	}
 	fmt.Fprintf(&fe.emitter.buf, "  store %s %s, ptr %s\n", dstTy, mem, ptr)
 	return nil
+}
+
+func (fe *funcEmitter) monotonicDurationLayout(dst mir.Place) (size, align, opaqueOffset int, err error) {
+	dstType, err := fe.placeBaseType(dst)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	layoutInfo, err := fe.emitter.layoutOf(dstType)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	fieldIdx, fieldType, err := fe.structFieldInfo(dstType, mir.PlaceProj{
+		Kind:      mir.PlaceProjField,
+		FieldName: "__opaque",
+		FieldIdx:  -1,
+	})
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	if fieldIdx < 0 || fieldIdx >= len(layoutInfo.FieldOffsets) {
+		return 0, 0, 0, fmt.Errorf("duration field index %d out of range", fieldIdx)
+	}
+	fieldLLVM, err := llvmValueType(fe.emitter.types, fieldType)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	if fieldLLVM != "i64" {
+		return 0, 0, 0, fmt.Errorf("monotonic_now requires int64 __opaque field, got %s", fieldLLVM)
+	}
+	size = layoutInfo.Size
+	align = layoutInfo.Align
+	if size <= 0 {
+		size = 1
+	}
+	if align <= 0 {
+		align = 1
+	}
+	return size, align, layoutInfo.FieldOffsets[fieldIdx], nil
 }
 
 func (fe *funcEmitter) emitRtSleep(call *mir.CallInstr) error {

--- a/internal/vm/llvm_smoke_test.go
+++ b/internal/vm/llvm_smoke_test.go
@@ -27,6 +27,7 @@ func TestLLVMSmoke(t *testing.T) {
 		file string
 	}{
 		{name: "hello_print", file: "hello_print.sg"},
+		{name: "time_monotonic_now", file: "time_monotonic_now.sg"},
 		{name: "unicode_print", file: "unicode_print.sg"},
 		{name: "exit_code", file: "exit_code.sg"},
 	}

--- a/runtime/native/rt.h
+++ b/runtime/native/rt.h
@@ -34,6 +34,7 @@ void rt_exit(int64_t code);
 void rt_panic(const uint8_t* ptr, uint64_t length);
 void rt_panic_numeric(const uint8_t* ptr, uint64_t length);
 void rt_panic_bounds(uint64_t kind, int64_t index, int64_t length);
+int64_t rt_monotonic_now(void);
 uint64_t rt_worker_count(void);
 void rt_sched_trace_dump(void);
 

--- a/runtime/native/rt_time.c
+++ b/runtime/native/rt_time.c
@@ -1,0 +1,37 @@
+#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L // NOLINT(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp)
+#endif
+
+#include "rt.h"
+
+#include <pthread.h>
+#include <stdint.h>
+#include <time.h>
+
+static pthread_once_t monotonic_once = PTHREAD_ONCE_INIT;
+static struct timespec monotonic_start;
+
+static void monotonic_init(void) {
+    if (clock_gettime(CLOCK_MONOTONIC, &monotonic_start) != 0) {
+        monotonic_start.tv_sec = 0;
+        monotonic_start.tv_nsec = 0;
+    }
+}
+
+int64_t rt_monotonic_now(void) {
+    struct timespec now = {0};
+    if (pthread_once(&monotonic_once, monotonic_init) != 0) {
+        return 0;
+    }
+    if (clock_gettime(CLOCK_MONOTONIC, &now) != 0) {
+        return 0;
+    }
+
+    int64_t sec = (int64_t)now.tv_sec - (int64_t)monotonic_start.tv_sec;
+    int64_t nsec = (int64_t)now.tv_nsec - (int64_t)monotonic_start.tv_nsec;
+    if (nsec < 0) {
+        sec -= 1;
+        nsec += 1000000000LL;
+    }
+    return sec * 1000000000LL + nsec;
+}

--- a/runtime/native/rt_time.c
+++ b/runtime/native/rt_time.c
@@ -5,30 +5,32 @@
 #include "rt.h"
 
 #include <pthread.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include <time.h>
 
 static pthread_once_t monotonic_once = PTHREAD_ONCE_INIT;
-static struct timespec monotonic_start;
+static struct timespec monotonic_baseline;
+static bool monotonic_initialized_ok = false;
 
 static void monotonic_init(void) {
-    if (clock_gettime(CLOCK_MONOTONIC, &monotonic_start) != 0) {
-        monotonic_start.tv_sec = 0;
-        monotonic_start.tv_nsec = 0;
-    }
+    // The native runtime does not have a dedicated startup hook yet, so we
+    // sample the baseline once on first use and fail closed if that sample is
+    // unavailable. Later calls must not silently re-anchor against boot time.
+    monotonic_initialized_ok = clock_gettime(CLOCK_MONOTONIC, &monotonic_baseline) == 0;
 }
 
 int64_t rt_monotonic_now(void) {
     struct timespec now = {0};
-    if (pthread_once(&monotonic_once, monotonic_init) != 0) {
+    if (pthread_once(&monotonic_once, monotonic_init) != 0 || !monotonic_initialized_ok) {
         return 0;
     }
     if (clock_gettime(CLOCK_MONOTONIC, &now) != 0) {
         return 0;
     }
 
-    int64_t sec = (int64_t)now.tv_sec - (int64_t)monotonic_start.tv_sec;
-    int64_t nsec = (int64_t)now.tv_nsec - (int64_t)monotonic_start.tv_nsec;
+    int64_t sec = (int64_t)now.tv_sec - (int64_t)monotonic_baseline.tv_sec;
+    int64_t nsec = (int64_t)now.tv_nsec - (int64_t)monotonic_baseline.tv_nsec;
     if (nsec < 0) {
         sec -= 1;
         nsec += 1000000000LL;

--- a/testdata/llvm_smoke/time_monotonic_now.sg
+++ b/testdata/llvm_smoke/time_monotonic_now.sg
@@ -1,0 +1,7 @@
+import stdlib/time;
+
+@entrypoint
+fn main() -> int {
+    let started = time.monotonic_now();
+    return 0;
+}

--- a/testdata/llvm_smoke/time_monotonic_now.sg
+++ b/testdata/llvm_smoke/time_monotonic_now.sg
@@ -3,5 +3,9 @@ import stdlib/time;
 @entrypoint
 fn main() -> int {
     let started = time.monotonic_now();
+    let later = time.monotonic_now();
+    if later.__opaque < started.__opaque {
+        return 1;
+    }
     return 0;
 }


### PR DESCRIPTION
## Summary
- add native runtime support for monotonic timestamps in nanoseconds
- lower `stdlib/time.monotonic_now()` in the LLVM backend by materializing a `time.Duration` value
- add an observable LLVM smoke test that fails if monotonic time goes backwards
- tighten the native runtime init path to fail closed if the monotonic baseline cannot be sampled

## Testing
- `go run ./cmd/surge build testdata/llvm_smoke/time_monotonic_now.sg`
- `go test ./internal/backend/llvm -count=1`
- `go test ./internal/vm -run 'TestLLVMSmoke/time_monotonic_now' -count=1`
- `make check`

Closes #75