### PR TITLE
fix(vm): reborrow shared calls from map mut refs

### DIFF
--- a/internal/mir/lower_expr_calls.go
+++ b/internal/mir/lower_expr_calls.go
@@ -9,6 +9,36 @@ import (
 	"surge/internal/types"
 )
 
+func (l *funcLowerer) lowerCallArgExpr(argExpr *hir.Expr, paramType types.TypeID) (Operand, error) {
+	if op, ok := l.lowerSharedRefReborrowArg(argExpr, paramType); ok {
+		return op, nil
+	}
+	return l.lowerExpr(argExpr, true)
+}
+
+func (l *funcLowerer) lowerSharedRefReborrowArg(argExpr *hir.Expr, paramType types.TypeID) (Operand, bool) {
+	if l == nil || l.types == nil || argExpr == nil || argExpr.Type == types.NoTypeID || paramType == types.NoTypeID {
+		return Operand{}, false
+	}
+
+	paramInfo, ok := l.types.Lookup(resolveAlias(l.types, paramType))
+	if !ok || paramInfo.Kind != types.KindReference || paramInfo.Mutable {
+		return Operand{}, false
+	}
+
+	argInfo, ok := l.types.Lookup(resolveAlias(l.types, argExpr.Type))
+	if !ok || argInfo.Kind != types.KindReference || !argInfo.Mutable {
+		return Operand{}, false
+	}
+
+	place, err := l.lowerPlace(argExpr)
+	if err != nil {
+		return Operand{}, false
+	}
+	place.Proj = append(place.Proj, PlaceProj{Kind: PlaceProjDeref})
+	return Operand{Kind: OperandAddrOf, Type: paramType, Place: place}, true
+}
+
 func (l *funcLowerer) calleeFunc(symID symbols.SymbolID) *hir.Func {
 	if l == nil || !symID.IsValid() || l.mono == nil || l.mono.FuncBySym == nil {
 		return nil
@@ -25,7 +55,11 @@ func (l *funcLowerer) lowerCallArgs(e *hir.Expr, data hir.CallData) ([]Operand, 
 	if fn == nil || fn.IsIntrinsic() || len(data.Args) >= len(fn.Params) {
 		args := make([]Operand, 0, len(data.Args))
 		for i, a := range data.Args {
-			op, err := l.lowerExpr(a, true)
+			paramType := types.NoTypeID
+			if fn != nil && i < len(fn.Params) {
+				paramType = fn.Params[i].Type
+			}
+			op, err := l.lowerCallArgExpr(a, paramType)
 			if err != nil {
 				return nil, err
 			}
@@ -87,7 +121,7 @@ func (l *funcLowerer) lowerCallArgsWithDefaults(e *hir.Expr, data hir.CallData, 
 
 	args := make([]Operand, 0, len(params))
 	for i, argExpr := range data.Args {
-		op, err := l.lowerExpr(argExpr, true)
+		op, err := l.lowerCallArgExpr(argExpr, params[i].Type)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/vm/vm_refs_test.go
+++ b/internal/vm/vm_refs_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"surge/internal/mir"
 	"surge/internal/vm"
 )
 
@@ -135,5 +136,103 @@ fn main() -> int {
 	}
 	if !strings.Contains(out, "backtrace:") || !strings.Contains(out, "main") {
 		t.Fatalf("expected backtrace with main frame, got:\n%s", out)
+	}
+}
+
+func TestVMRefsMapGetMutReadonlyHelperKeepsMutRefLive(t *testing.T) {
+	sourceCode := `type Entry = { value: string, owner: string? };
+
+fn inspect(entry: &Entry) -> nothing {
+    let _ = entry;
+    return nothing;
+}
+
+@entrypoint
+fn main() -> int {
+    let mut entries = { "k" => Entry { value = "seed", owner = nothing } };
+    compare entries.get_mut(&"k") {
+        Some(entry) => {
+            inspect(entry);
+            entry.owner = Some("client-a");
+            return 7;
+        }
+        nothing => return 1;
+    }
+    return 2;
+}
+`
+	result := runProgramFromSource(t, sourceCode, runOptions{})
+	if result.exitCode != 7 {
+		t.Fatalf("expected exit code 7, got %d\nstderr:\n%s", result.exitCode, result.stderr)
+	}
+	if result.stderr != "" {
+		t.Fatalf("expected empty stderr, got:\n%s", result.stderr)
+	}
+}
+
+func TestVMRefsMapGetMutReadonlyHelperUsesSharedReborrowInMIR(t *testing.T) {
+	sourceCode := `type Entry = { value: string, owner: string? };
+
+fn inspect(entry: &Entry) -> nothing {
+    let _ = entry;
+    return nothing;
+}
+
+@entrypoint
+fn main() -> nothing {
+    let mut entries = { "k" => Entry { value = "seed", owner = nothing } };
+    compare entries.get_mut(&"k") {
+        Some(entry) => {
+            inspect(entry);
+            entry.owner = Some("client-a");
+        }
+        nothing => {}
+    }
+    return nothing;
+}
+`
+
+	mirMod, _, _ := compileToMIRFromSource(t, sourceCode)
+
+	var inspectCall *mir.CallInstr
+	for _, fn := range mirMod.Funcs {
+		if fn == nil || fn.Name != "main" {
+			continue
+		}
+		for _, bb := range fn.Blocks {
+			for _, instr := range bb.Instrs {
+				if instr.Kind != mir.InstrCall {
+					continue
+				}
+				if instr.Call.Callee.Name != "inspect" {
+					continue
+				}
+				call := instr.Call
+				inspectCall = &call
+				break
+			}
+			if inspectCall != nil {
+				break
+			}
+		}
+	}
+
+	if inspectCall == nil {
+		t.Fatal("expected inspect call in MIR")
+	}
+	if len(inspectCall.Args) != 1 {
+		t.Fatalf("expected 1 inspect arg, got %d", len(inspectCall.Args))
+	}
+
+	arg := inspectCall.Args[0]
+	if arg.Kind != mir.OperandAddrOf {
+		t.Fatalf("expected inspect arg to be addr_of reborrow, got %s", arg.Kind.String())
+	}
+	if len(arg.Place.Proj) == 0 {
+		t.Fatalf("expected inspect arg place to deref the mutable ref local")
+	}
+	lastProj := arg.Place.Proj[len(arg.Place.Proj)-1]
+	if lastProj.Kind != mir.PlaceProjDeref {
+		t.Fatalf("expected final projection to be deref, got %v", lastProj.Kind)
 	}
 }


### PR DESCRIPTION
## Summary
- lower `&mut T` -> `&T` call arguments as shared reborrows instead of consuming moves
- add VM regression coverage for `Map.get_mut` mutable refs passed through readonly helpers
- assert the MIR call shape to prevent this ownership mismatch from regressing

Closes #74

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed handling of mutable references when passed as arguments to functions expecting immutable references, ensuring correct borrow semantics across function calls.
  * Improved validation of mutable borrow operations during reference handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->