### PR TITLE
fix(vm): preserve borrowed async frame locals

### DIFF
--- a/STATS.md
+++ b/STATS.md
@@ -5,14 +5,14 @@
 ## 📊 Main code (without tests)
 
 - **Files:** 674 (Go: 645, C: 29)
-- **Lines of code:** 153361 (Go: 140202, C: 13159)
+- **Lines of code:** 153384 (Go: 140225, C: 13159)
 
 ## 📁 Directory breakdown
 
 | Directory | Files | Lines |
 |------------|--------|-------|
 | `cmd/` | 27 | 4669 |
-| `internal/` | 617 | 135518 |
+| `internal/` | 617 | 135541 |
 | `runtime/native/` (C code) | 29 | 13159 |
 
 ## 🏆 Top 10 packages by size
@@ -20,7 +20,7 @@
 | # | Package | Lines |
 |---|-------|-------|
 | 1 | `internal/sema` | 28232 |
-| 2 | `internal/vm` | 22824 |
+| 2 | `internal/vm` | 22847 |
 | 3 | `internal/backend/llvm` | 11554 |
 | 4 | `internal/mir` | 10030 |
 | 5 | `internal/parser` | 8960 |
@@ -33,12 +33,12 @@
 ## 🧪 Test files
 
 - **Files:** 165
-- **Lines of code:** 33858
+- **Lines of code:** 33902
 
 ## 📈 Total volume (code + tests)
 
 - **Files:** 839
-- **Lines of code:** 187219
+- **Lines of code:** 187286
 
 ## 📊 Percentage breakdown
 

--- a/STATS.md
+++ b/STATS.md
@@ -4,15 +4,15 @@
 
 ## 📊 Main code (without tests)
 
-- **Files:** 673 (Go: 644, C: 29)
-- **Lines of code:** 152999 (Go: 139840, C: 13159)
+- **Files:** 674 (Go: 645, C: 29)
+- **Lines of code:** 153358 (Go: 140199, C: 13159)
 
 ## 📁 Directory breakdown
 
 | Directory | Files | Lines |
 |------------|--------|-------|
-| `cmd/` | 27 | 4635 |
-| `internal/` | 616 | 135190 |
+| `cmd/` | 27 | 4669 |
+| `internal/` | 617 | 135515 |
 | `runtime/native/` (C code) | 29 | 13159 |
 
 ## 🏆 Top 10 packages by size
@@ -20,7 +20,7 @@
 | # | Package | Lines |
 |---|-------|-------|
 | 1 | `internal/sema` | 28232 |
-| 2 | `internal/vm` | 22496 |
+| 2 | `internal/vm` | 22821 |
 | 3 | `internal/backend/llvm` | 11554 |
 | 4 | `internal/mir` | 10030 |
 | 5 | `internal/parser` | 8960 |
@@ -28,17 +28,17 @@
 | 7 | `internal/driver` | 6009 |
 | 8 | `internal/mono` | 5120 |
 | 9 | `internal/lsp` | 5082 |
-| 10 | `cmd/surge` | 4635 |
+| 10 | `cmd/surge` | 4669 |
 
 ## 🧪 Test files
 
-- **Files:** 162
-- **Lines of code:** 33594
+- **Files:** 163
+- **Lines of code:** 33732
 
 ## 📈 Total volume (code + tests)
 
-- **Files:** 835
-- **Lines of code:** 186593
+- **Files:** 837
+- **Lines of code:** 187090
 
 ## 📊 Percentage breakdown
 

--- a/STATS.md
+++ b/STATS.md
@@ -5,14 +5,14 @@
 ## 📊 Main code (without tests)
 
 - **Files:** 674 (Go: 645, C: 29)
-- **Lines of code:** 153358 (Go: 140199, C: 13159)
+- **Lines of code:** 153359 (Go: 140200, C: 13159)
 
 ## 📁 Directory breakdown
 
 | Directory | Files | Lines |
 |------------|--------|-------|
 | `cmd/` | 27 | 4669 |
-| `internal/` | 617 | 135515 |
+| `internal/` | 617 | 135516 |
 | `runtime/native/` (C code) | 29 | 13159 |
 
 ## 🏆 Top 10 packages by size
@@ -20,7 +20,7 @@
 | # | Package | Lines |
 |---|-------|-------|
 | 1 | `internal/sema` | 28232 |
-| 2 | `internal/vm` | 22821 |
+| 2 | `internal/vm` | 22822 |
 | 3 | `internal/backend/llvm` | 11554 |
 | 4 | `internal/mir` | 10030 |
 | 5 | `internal/parser` | 8960 |
@@ -32,13 +32,13 @@
 
 ## 🧪 Test files
 
-- **Files:** 163
-- **Lines of code:** 33732
+- **Files:** 164
+- **Lines of code:** 33801
 
 ## 📈 Total volume (code + tests)
 
-- **Files:** 837
-- **Lines of code:** 187090
+- **Files:** 838
+- **Lines of code:** 187160
 
 ## 📊 Percentage breakdown
 

--- a/STATS.md
+++ b/STATS.md
@@ -5,14 +5,14 @@
 ## 📊 Main code (without tests)
 
 - **Files:** 674 (Go: 645, C: 29)
-- **Lines of code:** 153359 (Go: 140200, C: 13159)
+- **Lines of code:** 153361 (Go: 140202, C: 13159)
 
 ## 📁 Directory breakdown
 
 | Directory | Files | Lines |
 |------------|--------|-------|
 | `cmd/` | 27 | 4669 |
-| `internal/` | 617 | 135516 |
+| `internal/` | 617 | 135518 |
 | `runtime/native/` (C code) | 29 | 13159 |
 
 ## 🏆 Top 10 packages by size
@@ -20,7 +20,7 @@
 | # | Package | Lines |
 |---|-------|-------|
 | 1 | `internal/sema` | 28232 |
-| 2 | `internal/vm` | 22822 |
+| 2 | `internal/vm` | 22824 |
 | 3 | `internal/backend/llvm` | 11554 |
 | 4 | `internal/mir` | 10030 |
 | 5 | `internal/parser` | 8960 |
@@ -32,13 +32,13 @@
 
 ## 🧪 Test files
 
-- **Files:** 164
-- **Lines of code:** 33801
+- **Files:** 165
+- **Lines of code:** 33858
 
 ## 📈 Total volume (code + tests)
 
-- **Files:** 838
-- **Lines of code:** 187160
+- **Files:** 839
+- **Lines of code:** 187219
 
 ## 📊 Percentage breakdown
 

--- a/cmd/surge/module_git.go
+++ b/cmd/surge/module_git.go
@@ -10,6 +10,23 @@ import (
 	"strings"
 )
 
+var gitLocalEnvVars = map[string]struct{}{
+	"GIT_ALTERNATE_OBJECT_DIRECTORIES": {},
+	"GIT_COMMON_DIR":                   {},
+	"GIT_DIR":                          {},
+	"GIT_GRAFT_FILE":                   {},
+	"GIT_IMPLICIT_WORK_TREE":           {},
+	"GIT_INDEX_FILE":                   {},
+	"GIT_INTERNAL_SUPER_PREFIX":        {},
+	"GIT_NO_REPLACE_OBJECTS":           {},
+	"GIT_OBJECT_DIRECTORY":             {},
+	"GIT_PREFIX":                       {},
+	"GIT_QUARANTINE_PATH":              {},
+	"GIT_REPLACE_REF_BASE":             {},
+	"GIT_SHALLOW_FILE":                 {},
+	"GIT_WORK_TREE":                    {},
+}
+
 type moduleSyncState string
 
 const (
@@ -176,6 +193,7 @@ func gitRun(dir string, args ...string) (string, error) {
 	// #nosec G204 -- exec.Command does not invoke a shell; argv entries are passed directly.
 	cmd := exec.Command("git", args...)
 	cmd.Dir = dir
+	cmd.Env = gitRunEnv()
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -188,4 +206,20 @@ func gitRun(dir string, args ...string) (string, error) {
 		return "", errors.New(msg)
 	}
 	return stdout.String(), nil
+}
+
+func gitRunEnv() []string {
+	env := os.Environ()
+	filtered := make([]string, 0, len(env))
+	for _, item := range env {
+		name := item
+		if idx := strings.IndexByte(item, '='); idx >= 0 {
+			name = item[:idx]
+		}
+		if _, ok := gitLocalEnvVars[name]; ok {
+			continue
+		}
+		filtered = append(filtered, item)
+	}
+	return filtered
 }

--- a/cmd/surge/module_update_test.go
+++ b/cmd/surge/module_update_test.go
@@ -154,7 +154,7 @@ func pushModuleCommit(t *testing.T, remote, source string) string {
 func mustGit(t *testing.T, dir string, args ...string) string {
 	t.Helper()
 	if len(args) > 0 && args[0] == "commit" {
-		args = append([]string{"-c", "core.hooksPath=/dev/null"}, args...)
+		args = append([]string{"-c", "core.hooksPath=" + os.DevNull}, args...)
 	}
 	out, err := gitRun(dir, args...)
 	if err != nil {

--- a/cmd/surge/module_update_test.go
+++ b/cmd/surge/module_update_test.go
@@ -82,6 +82,26 @@ func TestSyncGitModuleRejectsTrackedLocalChanges(t *testing.T) {
 	}
 }
 
+func TestSyncGitModuleIgnoresParentGitEnv(t *testing.T) {
+	requireGit(t)
+
+	t.Setenv("GIT_DIR", filepath.Join(t.TempDir(), "not-a-repo"))
+	t.Setenv("GIT_WORK_TREE", t.TempDir())
+	t.Setenv("GIT_INDEX_FILE", filepath.Join(t.TempDir(), "index"))
+
+	projectRoot := t.TempDir()
+	remote := createModuleRemote(t)
+	dest := filepath.Join(projectRoot, "deps", "sigil")
+
+	got, err := syncGitModule(projectRoot, "sigil", remote, dest)
+	if err != nil {
+		t.Fatalf("syncGitModule with parent git env: %v", err)
+	}
+	if got.State != moduleSyncInstalled {
+		t.Fatalf("state = %q, want %q", got.State, moduleSyncInstalled)
+	}
+}
+
 func requireGit(t *testing.T) {
 	t.Helper()
 	if _, err := exec.LookPath("git"); err != nil {
@@ -100,7 +120,7 @@ func createModuleRemote(t *testing.T) string {
 	mustGit(t, root, "clone", remote, worktree)
 	mustGit(t, worktree, "config", "user.email", "test@example.com")
 	mustGit(t, worktree, "config", "user.name", "Test User")
-	mustGit(t, worktree, "checkout", "-b", "main")
+	mustGit(t, worktree, "checkout", "-B", "main")
 
 	writeFile(t, filepath.Join(worktree, "surge.toml"), `[package]
 name = "sigil"
@@ -133,6 +153,9 @@ func pushModuleCommit(t *testing.T, remote, source string) string {
 
 func mustGit(t *testing.T, dir string, args ...string) string {
 	t.Helper()
+	if len(args) > 0 && args[0] == "commit" {
+		args = append([]string{"-c", "core.hooksPath=/dev/null"}, args...)
+	}
 	out, err := gitRun(dir, args...)
 	if err != nil {
 		t.Fatalf("git %v failed: %v", args, err)

--- a/internal/vm/async_runtime.go
+++ b/internal/vm/async_runtime.go
@@ -13,12 +13,13 @@ type asyncExit struct {
 	kind    asyncrt.PollOutcomeKind
 	parkKey asyncrt.WakerKey
 	state   Value
+	pins    taskStatePins
 	value   Value
 }
 
 type userTaskState struct {
-	state       Value
-	pinnedFrame []*Frame
+	state Value
+	pins  taskStatePins
 }
 
 func (vm *VM) ensureExecutor() *asyncrt.Executor {
@@ -47,30 +48,12 @@ func (vm *VM) ensureUserTaskState(task *asyncrt.Task) *userTaskState {
 	}
 	state := &userTaskState{}
 	if val, ok := task.State.(Value); ok {
-		state.state = val
+		if vmErr := vm.setUserTaskState(state, val); vmErr != nil {
+			vm.panic(vmErr.Code, vmErr.Message)
+		}
 	}
 	task.State = state
 	return state
-}
-
-func (vm *VM) pinAsyncFrame(frame *Frame) {
-	if vm == nil || frame == nil {
-		return
-	}
-	exec := vm.ensureExecutor()
-	if exec == nil {
-		return
-	}
-	task := exec.Task(exec.Current())
-	if task == nil || task.Kind != asyncrt.TaskKindUser {
-		return
-	}
-	state := vm.ensureUserTaskState(task)
-	if state == nil {
-		return
-	}
-	frame.BorrowOnly = true
-	state.pinnedFrame = append(state.pinnedFrame, frame)
 }
 
 func (vm *VM) currentTaskCancelled() bool {
@@ -480,15 +463,14 @@ func (vm *VM) pollUserTask(task *asyncrt.Task) (outcome asyncrt.PollOutcome, vmE
 		return asyncrt.PollOutcome{}, vm.eb.makeError(PanicUnimplemented, fmt.Sprintf("missing poll function %d", task.PollFuncID))
 	}
 	state := vm.ensureUserTaskState(task)
-	outcome, stateOut, vmErr := vm.runPoll(fn)
+	outcome, stateOut, statePins, vmErr := vm.runPoll(fn)
 	if vmErr != nil {
 		return asyncrt.PollOutcome{}, vmErr
 	}
-	if stateOut.Kind != VKInvalid {
-		state.state = stateOut
-	} else {
-		state.state = Value{}
+	if stateOut.Kind == VKInvalid {
+		stateOut = Value{}
 	}
+	vm.setUserTaskStateWithPins(state, stateOut, statePins)
 	task.State = state
 	return outcome, nil
 }
@@ -581,9 +563,9 @@ func (vm *VM) releaseTaskState(task *asyncrt.Task) {
 		if state.state.Kind != VKInvalid {
 			vm.dropValue(state.state)
 		}
-		vm.releasePinnedFrames(state.pinnedFrame)
+		vm.releaseTaskStatePins(state.pins)
 		state.state = Value{}
-		state.pinnedFrame = nil
+		state.pins = taskStatePins{}
 		task.State = nil
 		return
 	}
@@ -593,12 +575,12 @@ func (vm *VM) releaseTaskState(task *asyncrt.Task) {
 	task.State = nil
 }
 
-func (vm *VM) runPoll(fn *mir.Func) (outcome asyncrt.PollOutcome, stateOut Value, vmErr *VMError) {
+func (vm *VM) runPoll(fn *mir.Func) (outcome asyncrt.PollOutcome, stateOut Value, statePins taskStatePins, vmErr *VMError) {
 	if vm == nil {
-		return asyncrt.PollOutcome{}, Value{}, nil
+		return asyncrt.PollOutcome{}, Value{}, taskStatePins{}, nil
 	}
 	if fn == nil {
-		return asyncrt.PollOutcome{}, Value{}, vm.eb.makeError(PanicUnimplemented, "missing poll function")
+		return asyncrt.PollOutcome{}, Value{}, taskStatePins{}, vm.eb.makeError(PanicUnimplemented, "missing poll function")
 	}
 	savedStack := vm.Stack
 	savedHalted := vm.Halted
@@ -632,7 +614,7 @@ func (vm *VM) runPoll(fn *mir.Func) (outcome asyncrt.PollOutcome, stateOut Value
 			vm.asyncCapture = savedAsync
 			vm.asyncPendingParkKey = savedPendingParkKey
 			vm.deferredShutdown = savedDeferredShutdown
-			return asyncrt.PollOutcome{}, Value{}, vmErr
+			return asyncrt.PollOutcome{}, Value{}, taskStatePins{}, vmErr
 		}
 		if exit.set {
 			break
@@ -654,16 +636,16 @@ func (vm *VM) runPoll(fn *mir.Func) (outcome asyncrt.PollOutcome, stateOut Value
 			vm.Halted = true
 			vm.deferredShutdown.active = true
 			vm.deferredShutdown.checkLeaks = checkLeaks
-			return asyncrt.PollOutcome{}, Value{}, nil
+			return asyncrt.PollOutcome{}, Value{}, taskStatePins{}, nil
 		}
 		vm.finishShutdown(checkLeaks)
-		return asyncrt.PollOutcome{}, Value{}, nil
+		return asyncrt.PollOutcome{}, Value{}, taskStatePins{}, nil
 	}
 
 	if !exit.set {
-		return asyncrt.PollOutcome{}, Value{}, vm.eb.makeError(PanicUnimplemented, "poll function exited without async terminator")
+		return asyncrt.PollOutcome{}, Value{}, taskStatePins{}, vm.eb.makeError(PanicUnimplemented, "poll function exited without async terminator")
 	}
 
 	outcome = asyncrt.PollOutcome{Kind: exit.kind, Value: exit.value, ParkKey: exit.parkKey}
-	return outcome, exit.state, nil
+	return outcome, exit.state, exit.pins, nil
 }

--- a/internal/vm/async_runtime.go
+++ b/internal/vm/async_runtime.go
@@ -16,6 +16,11 @@ type asyncExit struct {
 	value   Value
 }
 
+type userTaskState struct {
+	state       Value
+	pinnedFrame []*Frame
+}
+
 func (vm *VM) ensureExecutor() *asyncrt.Executor {
 	if vm == nil {
 		return nil
@@ -31,6 +36,41 @@ func (vm *VM) ensureExecutor() *asyncrt.Executor {
 		vm.Async = asyncrt.NewExecutor(cfg)
 	}
 	return vm.Async
+}
+
+func (vm *VM) ensureUserTaskState(task *asyncrt.Task) *userTaskState {
+	if task == nil {
+		return nil
+	}
+	if state, ok := task.State.(*userTaskState); ok && state != nil {
+		return state
+	}
+	state := &userTaskState{}
+	if val, ok := task.State.(Value); ok {
+		state.state = val
+	}
+	task.State = state
+	return state
+}
+
+func (vm *VM) pinAsyncFrame(frame *Frame) {
+	if vm == nil || frame == nil {
+		return
+	}
+	exec := vm.ensureExecutor()
+	if exec == nil {
+		return
+	}
+	task := exec.Task(exec.Current())
+	if task == nil || task.Kind != asyncrt.TaskKindUser {
+		return
+	}
+	state := vm.ensureUserTaskState(task)
+	if state == nil {
+		return
+	}
+	frame.BorrowOnly = true
+	state.pinnedFrame = append(state.pinnedFrame, frame)
 }
 
 func (vm *VM) currentTaskCancelled() bool {
@@ -414,14 +454,9 @@ func (vm *VM) pollTask(task *asyncrt.Task) (asyncrt.PollOutcome, *VMError) {
 	case asyncrt.TaskKindNetAccept, asyncrt.TaskKindNetRead, asyncrt.TaskKindNetWrite:
 		return vm.pollNetWaitTask(task)
 	default:
-		outcome, stateOut, vmErr := vm.pollUserTask(task)
+		outcome, vmErr := vm.pollUserTask(task)
 		if vmErr != nil {
 			return asyncrt.PollOutcome{}, vmErr
-		}
-		if stateOut.Kind != VKInvalid {
-			task.State = stateOut
-		} else {
-			task.State = nil
 		}
 		if outcome.Kind == asyncrt.PollDoneSuccess || outcome.Kind == asyncrt.PollDoneCancelled {
 			vm.releaseTaskState(task)
@@ -430,25 +465,32 @@ func (vm *VM) pollTask(task *asyncrt.Task) (asyncrt.PollOutcome, *VMError) {
 	}
 }
 
-func (vm *VM) pollUserTask(task *asyncrt.Task) (outcome asyncrt.PollOutcome, stateOut Value, vmErr *VMError) {
+func (vm *VM) pollUserTask(task *asyncrt.Task) (outcome asyncrt.PollOutcome, vmErr *VMError) {
 	if vm == nil {
-		return asyncrt.PollOutcome{}, Value{}, nil
+		return asyncrt.PollOutcome{}, nil
 	}
 	if task == nil {
-		return asyncrt.PollOutcome{}, Value{}, vm.eb.makeError(PanicUnimplemented, "missing task")
+		return asyncrt.PollOutcome{}, vm.eb.makeError(PanicUnimplemented, "missing task")
 	}
 	if vm.M == nil {
-		return asyncrt.PollOutcome{}, Value{}, vm.eb.makeError(PanicUnimplemented, "missing module")
+		return asyncrt.PollOutcome{}, vm.eb.makeError(PanicUnimplemented, "missing module")
 	}
 	fn := vm.M.Funcs[mir.FuncID(task.PollFuncID)] //nolint:gosec // PollFuncID is bounded by module
 	if fn == nil {
-		return asyncrt.PollOutcome{}, Value{}, vm.eb.makeError(PanicUnimplemented, fmt.Sprintf("missing poll function %d", task.PollFuncID))
+		return asyncrt.PollOutcome{}, vm.eb.makeError(PanicUnimplemented, fmt.Sprintf("missing poll function %d", task.PollFuncID))
 	}
-	outcome, stateOut, vmErr = vm.runPoll(fn)
+	state := vm.ensureUserTaskState(task)
+	outcome, stateOut, vmErr := vm.runPoll(fn)
 	if vmErr != nil {
-		return asyncrt.PollOutcome{}, Value{}, vmErr
+		return asyncrt.PollOutcome{}, vmErr
 	}
-	return outcome, stateOut, nil
+	if stateOut.Kind != VKInvalid {
+		state.state = stateOut
+	} else {
+		state.state = Value{}
+	}
+	task.State = state
+	return outcome, nil
 }
 
 func (vm *VM) runReadyOne() (bool, *VMError) {
@@ -535,6 +577,16 @@ func (vm *VM) releaseTaskState(task *asyncrt.Task) {
 	if vm == nil || task == nil {
 		return
 	}
+	if state, ok := task.State.(*userTaskState); ok && state != nil {
+		if state.state.Kind != VKInvalid {
+			vm.dropValue(state.state)
+		}
+		vm.releasePinnedFrames(state.pinnedFrame)
+		state.state = Value{}
+		state.pinnedFrame = nil
+		task.State = nil
+		return
+	}
 	if v, ok := task.State.(Value); ok {
 		vm.dropValue(v)
 	}
@@ -569,7 +621,7 @@ func (vm *VM) runPoll(fn *mir.Func) (outcome asyncrt.PollOutcome, stateOut Value
 	vm.started = true
 
 	frame := NewFrame(fn)
-	vm.Stack = []Frame{*frame}
+	vm.Stack = []*Frame{frame}
 
 	for len(vm.Stack) > 0 && !vm.Halted {
 		if vmErr := vm.Step(); vmErr != nil {

--- a/internal/vm/breakpoints.go
+++ b/internal/vm/breakpoints.go
@@ -150,7 +150,7 @@ func (bps *Breakpoints) Match(vm *VM, sp StopPoint) (*Breakpoint, bool) {
 	}
 
 	if vm != nil && len(vm.Stack) > 0 {
-		f := &vm.Stack[len(vm.Stack)-1]
+		f := vm.Stack[len(vm.Stack)-1]
 		isEntry = f.Func != nil && f.BB == f.Func.Entry && f.IP == 0
 	}
 

--- a/internal/vm/debugger.go
+++ b/internal/vm/debugger.go
@@ -235,7 +235,7 @@ func (d *Debugger) cmdNext() (DebuggerResult, *VMError) {
 	}
 
 	origDepth := len(d.vm.Stack)
-	caller := &d.vm.Stack[origDepth-1]
+	caller := d.vm.Stack[origDepth-1]
 	callerFunc := caller.Func
 	callerBB := caller.BB
 	callerIP := caller.IP
@@ -257,7 +257,7 @@ func (d *Debugger) cmdNext() (DebuggerResult, *VMError) {
 		}
 
 		if len(d.vm.Stack) == origDepth {
-			top := &d.vm.Stack[origDepth-1]
+			top := d.vm.Stack[origDepth-1]
 			if top.Func == callerFunc && top.BB == callerBB && top.IP == targetIP {
 				d.printStepLine(sp)
 				return DebuggerResult{}, nil

--- a/internal/vm/drop.go
+++ b/internal/vm/drop.go
@@ -52,41 +52,19 @@ func (vm *VM) dropFrameLocals(frame *Frame) {
 	if frame == nil || frame.Func == nil {
 		return
 	}
-	if frame.BorrowOnly {
-		return
-	}
 	// Contract: implicit drops run in strictly reverse local order.
 	for id := len(frame.Locals) - 1; id >= 0; id-- {
 		slot := &frame.Locals[id]
-		if !slot.IsInit || slot.IsMoved || slot.IsDropped {
+		if !slot.IsInit || slot.PinCount != 0 {
 			continue
 		}
-		vm.dropValue(slot.V)
+		if !slot.IsMoved && !slot.IsDropped {
+			vm.dropValue(slot.V)
+		}
 		slot.V = Value{}
 		slot.IsInit = false
 		slot.IsMoved = false
 		slot.IsDropped = false
-	}
-}
-
-func (vm *VM) releasePinnedFrames(frames []*Frame) {
-	for _, frame := range frames {
-		if frame == nil {
-			continue
-		}
-		for id := len(frame.Locals) - 1; id >= 0; id-- {
-			slot := &frame.Locals[id]
-			if !slot.IsInit || slot.IsDropped {
-				continue
-			}
-			if !slot.IsMoved {
-				vm.dropValue(slot.V)
-			}
-			slot.V = Value{}
-			slot.IsInit = false
-			slot.IsMoved = false
-			slot.IsDropped = false
-		}
 	}
 }
 
@@ -123,10 +101,11 @@ func (vm *VM) dropAsyncTasks() {
 			if state.state.Kind != VKInvalid {
 				vm.dropValue(state.state)
 			}
-			vm.releasePinnedFrames(state.pinnedFrame)
+			vm.releaseTaskStatePins(state.pins)
 			state.state = Value{}
-			state.pinnedFrame = nil
+			state.pins = taskStatePins{}
 			task.State = nil
+			continue
 		}
 		if v, ok := task.State.(Value); ok {
 			vm.dropValue(v)

--- a/internal/vm/drop.go
+++ b/internal/vm/drop.go
@@ -105,9 +105,7 @@ func (vm *VM) dropAsyncTasks() {
 			state.state = Value{}
 			state.pins = taskStatePins{}
 			task.State = nil
-			continue
-		}
-		if v, ok := task.State.(Value); ok {
+		} else if v, ok := task.State.(Value); ok {
 			vm.dropValue(v)
 		}
 		if v, ok := task.ResultValue.(Value); ok {

--- a/internal/vm/drop.go
+++ b/internal/vm/drop.go
@@ -52,6 +52,9 @@ func (vm *VM) dropFrameLocals(frame *Frame) {
 	if frame == nil || frame.Func == nil {
 		return
 	}
+	if frame.BorrowOnly {
+		return
+	}
 	// Contract: implicit drops run in strictly reverse local order.
 	for id := len(frame.Locals) - 1; id >= 0; id-- {
 		slot := &frame.Locals[id]
@@ -66,9 +69,30 @@ func (vm *VM) dropFrameLocals(frame *Frame) {
 	}
 }
 
+func (vm *VM) releasePinnedFrames(frames []*Frame) {
+	for _, frame := range frames {
+		if frame == nil {
+			continue
+		}
+		for id := len(frame.Locals) - 1; id >= 0; id-- {
+			slot := &frame.Locals[id]
+			if !slot.IsInit || slot.IsDropped {
+				continue
+			}
+			if !slot.IsMoved {
+				vm.dropValue(slot.V)
+			}
+			slot.V = Value{}
+			slot.IsInit = false
+			slot.IsMoved = false
+			slot.IsDropped = false
+		}
+	}
+}
+
 func (vm *VM) dropAllFrames() {
 	for i := len(vm.Stack) - 1; i >= 0; i-- {
-		vm.dropFrameLocals(&vm.Stack[i])
+		vm.dropFrameLocals(vm.Stack[i])
 	}
 }
 
@@ -94,6 +118,15 @@ func (vm *VM) dropAsyncTasks() {
 	for _, task := range drained.Tasks {
 		if task == nil {
 			continue
+		}
+		if state, ok := task.State.(*userTaskState); ok && state != nil {
+			if state.state.Kind != VKInvalid {
+				vm.dropValue(state.state)
+			}
+			vm.releasePinnedFrames(state.pinnedFrame)
+			state.state = Value{}
+			state.pinnedFrame = nil
+			task.State = nil
 		}
 		if v, ok := task.State.(Value); ok {
 			vm.dropValue(v)

--- a/internal/vm/frame.go
+++ b/internal/vm/frame.go
@@ -12,18 +12,18 @@ type LocalSlot struct {
 	IsInit    bool         // True if initialized (assigned at least once)
 	IsMoved   bool         // True if value has been moved out
 	IsDropped bool         // True if value has been dropped (@drop)
+	PinCount  uint32       // Async task states borrowing this slot as backing storage
 	Name      string       // Debug name from MIR
 	TypeID    types.TypeID // Static type from MIR
 }
 
 // Frame represents a function activation record on the call stack.
 type Frame struct {
-	Func       *mir.Func   // The function being executed
-	BB         mir.BlockID // Current basic block
-	IP         int         // Instruction pointer within BB.Instrs
-	Locals     []LocalSlot // Local variable slots
-	Span       source.Span // Current instruction span for error reporting
-	BorrowOnly bool        // Suspended async frame retained only as borrow backing storage
+	Func   *mir.Func   // The function being executed
+	BB     mir.BlockID // Current basic block
+	IP     int         // Instruction pointer within BB.Instrs
+	Locals []LocalSlot // Local variable slots
+	Span   source.Span // Current instruction span for error reporting
 }
 
 // NewFrame creates a new frame for executing the given function.

--- a/internal/vm/frame.go
+++ b/internal/vm/frame.go
@@ -18,11 +18,12 @@ type LocalSlot struct {
 
 // Frame represents a function activation record on the call stack.
 type Frame struct {
-	Func   *mir.Func   // The function being executed
-	BB     mir.BlockID // Current basic block
-	IP     int         // Instruction pointer within BB.Instrs
-	Locals []LocalSlot // Local variable slots
-	Span   source.Span // Current instruction span for error reporting
+	Func       *mir.Func   // The function being executed
+	BB         mir.BlockID // Current basic block
+	IP         int         // Instruction pointer within BB.Instrs
+	Locals     []LocalSlot // Local variable slots
+	Span       source.Span // Current instruction span for error reporting
+	BorrowOnly bool        // Suspended async frame retained only as borrow backing storage
 }
 
 // NewFrame creates a new frame for executing the given function.

--- a/internal/vm/heap.go
+++ b/internal/vm/heap.go
@@ -385,9 +385,9 @@ func (h *Heap) Free(handle Handle) {
 		obj.ArrSliceLen = 0
 		obj.ArrSliceCap = 0
 	case OKMap:
-		for _, entry := range obj.MapEntries {
-			h.releaseContainedValue(entry.Key)
-			h.releaseContainedValue(entry.Value)
+		for i := range obj.MapEntries {
+			h.releaseContainedValue(obj.MapEntries[i].Key)
+			h.releaseContainedValue(obj.MapEntries[i].Value)
 		}
 		obj.MapEntries = nil
 		obj.MapIndex = nil

--- a/internal/vm/heap_debug.go
+++ b/internal/vm/heap_debug.go
@@ -193,11 +193,11 @@ func (vm *VM) objectRefCount(obj *Object) int {
 			count++
 		}
 	case OKMap:
-		for _, entry := range obj.MapEntries {
-			if entry.Key.IsHeap() && entry.Key.H != 0 {
+		for i := range obj.MapEntries {
+			if obj.MapEntries[i].Key.IsHeap() && obj.MapEntries[i].Key.H != 0 {
 				count++
 			}
-			if entry.Value.IsHeap() && entry.Value.H != 0 {
+			if obj.MapEntries[i].Value.IsHeap() && obj.MapEntries[i].Value.H != 0 {
 				count++
 			}
 		}

--- a/internal/vm/inspect.go
+++ b/internal/vm/inspect.go
@@ -61,7 +61,7 @@ func (i *Inspector) PrintLocal(spec string) bool {
 		return false
 	}
 
-	frame := &i.vm.Stack[len(i.vm.Stack)-1]
+	frame := i.vm.Stack[len(i.vm.Stack)-1]
 	slot, label, ok := i.findLocal(frame, spec)
 	if !ok {
 		_, printErr = fmt.Fprintf(i.out, "error: unknown local '%s'\n", spec)

--- a/internal/vm/intrinsic_async.go
+++ b/internal/vm/intrinsic_async.go
@@ -31,7 +31,11 @@ func (vm *VM) handleTaskCreate(frame *Frame, call *mir.CallInstr, writes *[]Loca
 	if exec == nil {
 		return vm.eb.makeError(PanicUnimplemented, "async executor missing")
 	}
-	id := exec.Spawn(pollFnID, &userTaskState{state: stateVal})
+	state := &userTaskState{}
+	if stateErr := vm.setUserTaskState(state, stateVal); stateErr != nil {
+		return stateErr
+	}
+	id := exec.Spawn(pollFnID, state)
 	taskVal, vmErr := vm.taskValue(id, frame.Locals[call.Dst.Local].TypeID)
 	if vmErr != nil {
 		return vmErr

--- a/internal/vm/intrinsic_async.go
+++ b/internal/vm/intrinsic_async.go
@@ -31,7 +31,7 @@ func (vm *VM) handleTaskCreate(frame *Frame, call *mir.CallInstr, writes *[]Loca
 	if exec == nil {
 		return vm.eb.makeError(PanicUnimplemented, "async executor missing")
 	}
-	id := exec.Spawn(pollFnID, stateVal)
+	id := exec.Spawn(pollFnID, &userTaskState{state: stateVal})
 	taskVal, vmErr := vm.taskValue(id, frame.Locals[call.Dst.Local].TypeID)
 	if vmErr != nil {
 		return vmErr
@@ -304,11 +304,12 @@ func (vm *VM) handleTaskState(frame *Frame, call *mir.CallInstr, writes *[]Local
 	if task == nil {
 		return vm.eb.makeError(PanicInvalidHandle, fmt.Sprintf("invalid task id %d", current))
 	}
-	stateVal, ok := task.State.(Value)
-	if !ok {
+	state := vm.ensureUserTaskState(task)
+	if state == nil || state.state.Kind == VKInvalid {
 		return vm.eb.makeError(PanicUnimplemented, "__task_state missing state")
 	}
-	task.State = nil
+	stateVal := state.state
+	state.state = Value{}
 	if vmErr := vm.writeLocal(frame, call.Dst.Local, stateVal); vmErr != nil {
 		return vmErr
 	}

--- a/internal/vm/intrinsic_map.go
+++ b/internal/vm/intrinsic_map.go
@@ -465,8 +465,8 @@ func (vm *VM) handleMapKeys(frame *Frame, call *mir.CallInstr, writes *[]LocalWr
 	dstLocal := call.Dst.Local
 	dstType := frame.Locals[dstLocal].TypeID
 	elems := make([]Value, len(obj.MapEntries))
-	for i, entry := range obj.MapEntries {
-		cloned, cloneErr := vm.cloneForShare(entry.Key)
+	for i := range obj.MapEntries {
+		cloned, cloneErr := vm.cloneForShare(obj.MapEntries[i].Key)
 		if cloneErr != nil {
 			for j := range i {
 				vm.dropValue(elems[j])

--- a/internal/vm/panic.go
+++ b/internal/vm/panic.go
@@ -134,14 +134,14 @@ func (eb *errorBuilder) makeError(code PanicCode, msg string) *VMError {
 
 	// Get current span from top frame
 	if len(eb.vm.Stack) > 0 {
-		frame := &eb.vm.Stack[len(eb.vm.Stack)-1]
+		frame := eb.vm.Stack[len(eb.vm.Stack)-1]
 		e.Span = frame.Span
 	}
 
 	// Build backtrace from stack (top to bottom)
 	e.Backtrace = make([]BacktraceFrame, len(eb.vm.Stack))
 	for i := len(eb.vm.Stack) - 1; i >= 0; i-- {
-		frame := &eb.vm.Stack[i]
+		frame := eb.vm.Stack[i]
 		e.Backtrace[len(eb.vm.Stack)-1-i] = BacktraceFrame{
 			FuncName: frame.Func.Name,
 			Span:     frame.Span,

--- a/internal/vm/panic.go
+++ b/internal/vm/panic.go
@@ -135,16 +135,26 @@ func (eb *errorBuilder) makeError(code PanicCode, msg string) *VMError {
 	// Get current span from top frame
 	if len(eb.vm.Stack) > 0 {
 		frame := eb.vm.Stack[len(eb.vm.Stack)-1]
-		e.Span = frame.Span
+		if frame != nil {
+			e.Span = frame.Span
+		}
 	}
 
 	// Build backtrace from stack (top to bottom)
 	e.Backtrace = make([]BacktraceFrame, len(eb.vm.Stack))
 	for i := len(eb.vm.Stack) - 1; i >= 0; i-- {
 		frame := eb.vm.Stack[i]
+		funcName := "<nil>"
+		var span source.Span
+		if frame != nil {
+			span = frame.Span
+			if frame.Func != nil {
+				funcName = frame.Func.Name
+			}
+		}
 		e.Backtrace[len(eb.vm.Stack)-1-i] = BacktraceFrame{
-			FuncName: frame.Func.Name,
-			Span:     frame.Span,
+			FuncName: funcName,
+			Span:     span,
 		}
 	}
 

--- a/internal/vm/place.go
+++ b/internal/vm/place.go
@@ -30,13 +30,9 @@ func (vm *VM) EvalPlace(frame *Frame, p mir.Place) (Location, *VMError) {
 			IsMut:      true,
 		}
 	} else {
-		frameIdx, err := safecast.Conv[int32](len(vm.Stack) - 1)
-		if err != nil {
-			return Location{}, vm.eb.invalidLocation("invalid place: stack too deep")
-		}
 		loc = Location{
 			Kind:       LKLocal,
-			Frame:      frameIdx,
+			FrameRef:   frame,
 			Local:      int32(p.Local),
 			ByteOffset: 0,
 			IsMut:      true,
@@ -233,11 +229,10 @@ func maxIntValue(a, b int) int {
 func (vm *VM) loadLocationRaw(loc Location) (Value, *VMError) {
 	switch loc.Kind {
 	case LKLocal:
-		frameIdx := int(loc.Frame)
-		if loc.Frame < 0 || frameIdx < 0 || frameIdx >= len(vm.Stack) {
-			return Value{}, vm.eb.invalidLocation(fmt.Sprintf("invalid local frame %d", loc.Frame))
+		frame := loc.FrameRef
+		if frame == nil {
+			return Value{}, vm.eb.invalidLocation("invalid local frame <nil>")
 		}
-		frame := &vm.Stack[frameIdx]
 		localID, err := safecast.Conv[mir.LocalID](loc.Local)
 		if err != nil {
 			return Value{}, vm.eb.invalidLocation(fmt.Sprintf("invalid local id %d", loc.Local))
@@ -339,11 +334,10 @@ func (vm *VM) storeLocation(loc Location, val Value) *VMError {
 
 	switch loc.Kind {
 	case LKLocal:
-		frameIdx := int(loc.Frame)
-		if loc.Frame < 0 || frameIdx < 0 || frameIdx >= len(vm.Stack) {
-			return vm.eb.invalidLocation(fmt.Sprintf("invalid local frame %d", loc.Frame))
+		frame := loc.FrameRef
+		if frame == nil {
+			return vm.eb.invalidLocation("invalid local frame <nil>")
 		}
-		frame := &vm.Stack[frameIdx]
 		localID, err := safecast.Conv[mir.LocalID](loc.Local)
 		if err != nil {
 			return vm.eb.invalidLocation(fmt.Sprintf("invalid local id %d", loc.Local))

--- a/internal/vm/place.go
+++ b/internal/vm/place.go
@@ -237,6 +237,10 @@ func (vm *VM) loadLocationRaw(loc Location) (Value, *VMError) {
 		if err != nil {
 			return Value{}, vm.eb.invalidLocation(fmt.Sprintf("invalid local id %d", loc.Local))
 		}
+		slot := &frame.Locals[localID]
+		if slot.IsInit && !slot.IsDropped && slot.IsMoved && slot.PinCount != 0 {
+			return slot.V, nil
+		}
 		return vm.readLocal(frame, localID)
 
 	case LKGlobal:

--- a/internal/vm/ref.go
+++ b/internal/vm/ref.go
@@ -26,11 +26,10 @@ const (
 
 // Location represents a memory location in the VM.
 type Location struct {
-	Frame int32
-
-	Local  int32
-	Global int32
-	Index  int32
+	FrameRef *Frame
+	Local    int32
+	Global   int32
+	Index    int32
 	// ByteOffset is the ABI byte offset of the projected location within its base object.
 	// It is used for layout-consistent addressing (even if the VM stores values differently).
 	ByteOffset int32

--- a/internal/vm/shutdown.go
+++ b/internal/vm/shutdown.go
@@ -15,8 +15,8 @@ func (vm *VM) requestShutdown(checkLeaks bool) {
 		// runPoll restores the parent stack.
 		vm.dropAllFrames()
 		vm.Stack = nil
-		vm.dropAsyncTasks()
 		vm.Halted = true
+		vm.dropAsyncTasks()
 		vm.deferredShutdown.active = true
 		vm.deferredShutdown.checkLeaks = vm.deferredShutdown.checkLeaks || checkLeaks
 		return

--- a/internal/vm/shutdown.go
+++ b/internal/vm/shutdown.go
@@ -11,9 +11,11 @@ func (vm *VM) requestShutdown(checkLeaks bool) {
 	}
 	if vm.pollDepth > 0 {
 		// Poll frames are isolated from the outer caller stack, so drop them now
-		// and defer full-program cleanup until runPoll restores the parent stack.
+		// and drain async task payloads before deferring full-program cleanup until
+		// runPoll restores the parent stack.
 		vm.dropAllFrames()
 		vm.Stack = nil
+		vm.dropAsyncTasks()
 		vm.Halted = true
 		vm.deferredShutdown.active = true
 		vm.deferredShutdown.checkLeaks = vm.deferredShutdown.checkLeaks || checkLeaks

--- a/internal/vm/task_state_pins.go
+++ b/internal/vm/task_state_pins.go
@@ -163,6 +163,8 @@ func (c *taskStatePinCollector) pinLocal(frame *Frame, local int32) *VMError {
 	if !slot.IsInit {
 		return c.vm.eb.useBeforeInit(slot.Name)
 	}
+	// Pinned task state may extend backing storage lifetime, but it must not
+	// resurrect locals whose ownership has already moved elsewhere.
 	if slot.IsMoved {
 		return c.vm.eb.useAfterMove(slot.Name)
 	}

--- a/internal/vm/task_state_pins.go
+++ b/internal/vm/task_state_pins.go
@@ -1,0 +1,263 @@
+package vm
+
+import "fmt"
+
+type pinnedLocal struct {
+	frame *Frame
+	local int32
+}
+
+type taskStatePins struct {
+	locals  []pinnedLocal
+	handles []Handle
+}
+
+type taskStatePinCollector struct {
+	vm              *VM
+	pins            taskStatePins
+	visitedLocals   map[pinnedLocal]struct{}
+	visitedHandles  map[Handle]struct{}
+	retainedHandles map[Handle]struct{}
+}
+
+func (vm *VM) collectTaskStatePins(state Value) (taskStatePins, *VMError) {
+	if vm == nil || state.Kind == VKInvalid {
+		return taskStatePins{}, nil
+	}
+	collector := taskStatePinCollector{
+		vm:              vm,
+		visitedLocals:   make(map[pinnedLocal]struct{}),
+		visitedHandles:  make(map[Handle]struct{}),
+		retainedHandles: make(map[Handle]struct{}),
+	}
+	if vmErr := collector.visitValue(state); vmErr != nil {
+		vm.releaseTaskStatePins(collector.pins)
+		return taskStatePins{}, vmErr
+	}
+	return collector.pins, nil
+}
+
+func (vm *VM) setUserTaskState(state *userTaskState, next Value) *VMError {
+	if state == nil {
+		return nil
+	}
+	pins, vmErr := vm.collectTaskStatePins(next)
+	if vmErr != nil {
+		return vmErr
+	}
+	vm.setUserTaskStateWithPins(state, next, pins)
+	return nil
+}
+
+func (vm *VM) setUserTaskStateWithPins(state *userTaskState, next Value, pins taskStatePins) {
+	if state == nil {
+		return
+	}
+	prevState := state.state
+	prevPins := state.pins
+	state.state = next
+	state.pins = pins
+	if prevState.Kind != VKInvalid {
+		vm.dropValue(prevState)
+	}
+	vm.releaseTaskStatePins(prevPins)
+}
+
+func (vm *VM) releaseTaskStatePins(pins taskStatePins) {
+	if vm == nil {
+		return
+	}
+	for i := len(pins.handles) - 1; i >= 0; i-- {
+		handle := pins.handles[i]
+		if handle != 0 {
+			vm.Heap.Release(handle)
+		}
+	}
+	for i := len(pins.locals) - 1; i >= 0; i-- {
+		pin := pins.locals[i]
+		if pin.frame == nil || pin.local < 0 || int(pin.local) >= len(pin.frame.Locals) {
+			continue
+		}
+		slot := &pin.frame.Locals[pin.local]
+		if slot.PinCount == 0 {
+			continue
+		}
+		slot.PinCount--
+		if slot.PinCount == 0 && !vm.frameOnStack(pin.frame) {
+			vm.releaseDetachedLocal(pin.frame, pin.local)
+		}
+	}
+}
+
+func (vm *VM) frameOnStack(frame *Frame) bool {
+	if vm == nil || frame == nil {
+		return false
+	}
+	for _, candidate := range vm.Stack {
+		if candidate == frame {
+			return true
+		}
+	}
+	return false
+}
+
+func (vm *VM) releaseDetachedLocal(frame *Frame, local int32) {
+	if frame == nil || local < 0 || int(local) >= len(frame.Locals) {
+		return
+	}
+	slot := &frame.Locals[local]
+	if !slot.IsInit {
+		return
+	}
+	if !slot.IsMoved && !slot.IsDropped {
+		vm.dropValue(slot.V)
+	}
+	slot.V = Value{}
+	slot.IsInit = false
+	slot.IsMoved = false
+	slot.IsDropped = false
+}
+
+func (c *taskStatePinCollector) visitValue(v Value) *VMError {
+	switch v.Kind {
+	case VKRef, VKRefMut, VKPtr:
+		if vmErr := c.visitLocation(v.Loc); vmErr != nil {
+			return vmErr
+		}
+	}
+	if v.IsHeap() && v.H != 0 {
+		return c.visitHandle(v.H)
+	}
+	return nil
+}
+
+func (c *taskStatePinCollector) visitLocation(loc Location) *VMError {
+	switch loc.Kind {
+	case LKLocal:
+		return c.pinLocal(loc.FrameRef, loc.Local)
+	case LKStructField, LKArrayElem, LKMapElem, LKStringBytes, LKRawBytes, LKTagField:
+		if vmErr := c.retainHandle(loc.Handle); vmErr != nil {
+			return vmErr
+		}
+		return c.visitHandle(loc.Handle)
+	case LKGlobal:
+		return nil
+	default:
+		return c.vm.eb.invalidLocation(fmt.Sprintf("unsupported task-state location kind %d", loc.Kind))
+	}
+}
+
+func (c *taskStatePinCollector) pinLocal(frame *Frame, local int32) *VMError {
+	if frame == nil {
+		return c.vm.eb.invalidLocation("invalid local frame <nil>")
+	}
+	if local < 0 || int(local) >= len(frame.Locals) {
+		return c.vm.eb.invalidLocation(fmt.Sprintf("invalid local id %d", local))
+	}
+	key := pinnedLocal{frame: frame, local: local}
+	if _, ok := c.visitedLocals[key]; ok {
+		return nil
+	}
+	c.visitedLocals[key] = struct{}{}
+	slot := &frame.Locals[local]
+	if !slot.IsInit {
+		return c.vm.eb.useBeforeInit(slot.Name)
+	}
+	if slot.IsDropped {
+		return c.vm.eb.makeError(PanicRCUseAfterFree, fmt.Sprintf("use-after-free: local %q used after drop", slot.Name))
+	}
+	slot.PinCount++
+	c.pins.locals = append(c.pins.locals, key)
+	return c.visitValue(slot.V)
+}
+
+func (c *taskStatePinCollector) retainHandle(handle Handle) *VMError {
+	if handle == 0 {
+		return c.vm.eb.makeError(PanicInvalidHandle, "invalid handle 0")
+	}
+	if _, ok := c.retainedHandles[handle]; ok {
+		return nil
+	}
+	obj, ok := c.vm.Heap.lookup(handle)
+	if !ok || obj == nil {
+		return c.vm.eb.makeError(PanicInvalidHandle, fmt.Sprintf("invalid handle %d", handle))
+	}
+	if obj.Freed || obj.RefCount == 0 {
+		return c.vm.eb.makeError(PanicRCUseAfterFree, fmt.Sprintf("use-after-free: handle %d (alloc=%d)", handle, obj.AllocID))
+	}
+	c.vm.Heap.Retain(handle)
+	c.retainedHandles[handle] = struct{}{}
+	c.pins.handles = append(c.pins.handles, handle)
+	return nil
+}
+
+func (c *taskStatePinCollector) visitHandle(handle Handle) *VMError {
+	if handle == 0 {
+		return nil
+	}
+	if _, ok := c.visitedHandles[handle]; ok {
+		return nil
+	}
+	obj, ok := c.vm.Heap.lookup(handle)
+	if !ok || obj == nil {
+		return c.vm.eb.makeError(PanicInvalidHandle, fmt.Sprintf("invalid handle %d", handle))
+	}
+	if obj.Freed || obj.RefCount == 0 {
+		return c.vm.eb.makeError(PanicRCUseAfterFree, fmt.Sprintf("use-after-free: handle %d (alloc=%d)", handle, obj.AllocID))
+	}
+	c.visitedHandles[handle] = struct{}{}
+	switch obj.Kind {
+	case OKString:
+		if vmErr := c.visitHandle(obj.StrLeft); vmErr != nil {
+			return vmErr
+		}
+		if vmErr := c.visitHandle(obj.StrRight); vmErr != nil {
+			return vmErr
+		}
+		return c.visitHandle(obj.StrSliceBase)
+	case OKArray:
+		for _, elem := range obj.Arr {
+			if vmErr := c.visitValue(elem); vmErr != nil {
+				return vmErr
+			}
+		}
+	case OKArraySlice:
+		return c.visitHandle(obj.ArrSliceBase)
+	case OKMap:
+		for i := range obj.MapEntries {
+			if vmErr := c.visitValue(obj.MapEntries[i].Key); vmErr != nil {
+				return vmErr
+			}
+			if vmErr := c.visitValue(obj.MapEntries[i].Value); vmErr != nil {
+				return vmErr
+			}
+		}
+	case OKStruct:
+		for _, field := range obj.Fields {
+			if vmErr := c.visitValue(field); vmErr != nil {
+				return vmErr
+			}
+		}
+	case OKTag:
+		for _, field := range obj.Tag.Fields {
+			if vmErr := c.visitValue(field); vmErr != nil {
+				return vmErr
+			}
+		}
+	case OKRange:
+		if obj.Range.Kind == RangeArrayIter {
+			return c.visitHandle(obj.Range.ArrayBase)
+		}
+		if obj.Range.HasStart {
+			if vmErr := c.visitValue(obj.Range.Start); vmErr != nil {
+				return vmErr
+			}
+		}
+		if obj.Range.HasEnd {
+			if vmErr := c.visitValue(obj.Range.End); vmErr != nil {
+				return vmErr
+			}
+		}
+	}
+	return nil
+}

--- a/internal/vm/task_state_pins.go
+++ b/internal/vm/task_state_pins.go
@@ -31,10 +31,33 @@ func (vm *VM) collectTaskStatePins(state Value) (taskStatePins, *VMError) {
 		retainedHandles: make(map[Handle]struct{}),
 	}
 	if vmErr := collector.visitValue(state); vmErr != nil {
-		vm.releaseTaskStatePins(collector.pins)
+		collector.rollbackPins()
 		return taskStatePins{}, vmErr
 	}
 	return collector.pins, nil
+}
+
+func (c *taskStatePinCollector) rollbackPins() {
+	if c == nil || c.vm == nil {
+		return
+	}
+	for i := len(c.pins.handles) - 1; i >= 0; i-- {
+		handle := c.pins.handles[i]
+		if handle != 0 {
+			c.vm.Heap.Release(handle)
+		}
+	}
+	for i := len(c.pins.locals) - 1; i >= 0; i-- {
+		pin := c.pins.locals[i]
+		if pin.frame == nil || pin.local < 0 || int(pin.local) >= len(pin.frame.Locals) {
+			continue
+		}
+		slot := &pin.frame.Locals[pin.local]
+		if slot.PinCount == 0 {
+			continue
+		}
+		slot.PinCount--
+	}
 }
 
 func (vm *VM) setUserTaskState(state *userTaskState, next Value) *VMError {

--- a/internal/vm/task_state_pins.go
+++ b/internal/vm/task_state_pins.go
@@ -163,6 +163,9 @@ func (c *taskStatePinCollector) pinLocal(frame *Frame, local int32) *VMError {
 	if !slot.IsInit {
 		return c.vm.eb.useBeforeInit(slot.Name)
 	}
+	if slot.IsMoved {
+		return c.vm.eb.useAfterMove(slot.Name)
+	}
 	if slot.IsDropped {
 		return c.vm.eb.makeError(PanicRCUseAfterFree, fmt.Sprintf("use-after-free: local %q used after drop", slot.Name))
 	}

--- a/internal/vm/task_state_pins_internal_test.go
+++ b/internal/vm/task_state_pins_internal_test.go
@@ -1,0 +1,69 @@
+package vm
+
+import (
+	"testing"
+
+	"surge/internal/asyncrt"
+	"surge/internal/types"
+)
+
+func TestCollectTaskStatePinsRejectsMovedLocal(t *testing.T) {
+	vm := New(nil, nil, nil, nil, nil)
+	frame := &Frame{
+		Locals: []LocalSlot{{
+			Name:    "value",
+			V:       MakeInt(7, types.NoTypeID),
+			IsInit:  true,
+			IsMoved: true,
+		}},
+	}
+
+	_, vmErr := vm.collectTaskStatePins(MakeRef(Location{
+		Kind:     LKLocal,
+		FrameRef: frame,
+		Local:    0,
+	}, types.NoTypeID))
+	if vmErr == nil {
+		t.Fatal("expected moved local error")
+	}
+	if vmErr.Code != PanicUseAfterMove {
+		t.Fatalf("expected %v, got %v", PanicUseAfterMove, vmErr.Code)
+	}
+	if got := frame.Locals[0].PinCount; got != 0 {
+		t.Fatalf("expected pin count 0, got %d", got)
+	}
+}
+
+func TestDropAsyncTasksDropsWrappedUserTaskPayloads(t *testing.T) {
+	vm := New(nil, nil, nil, nil, nil)
+	vm.Async = asyncrt.NewExecutor(asyncrt.Config{Deterministic: true})
+
+	stateHandle := vm.Heap.AllocString(types.NoTypeID, "state")
+	resultHandle := vm.Heap.AllocString(types.NoTypeID, "result")
+	resumeHandle := vm.Heap.AllocString(types.NoTypeID, "resume")
+
+	taskID := vm.Async.Spawn(1, &userTaskState{state: MakeHandleString(stateHandle, types.NoTypeID)})
+	task := vm.Async.Task(taskID)
+	if task == nil {
+		t.Fatal("expected task")
+	}
+	task.ResultValue = MakeHandleString(resultHandle, types.NoTypeID)
+	task.ResumeValue = MakeHandleString(resumeHandle, types.NoTypeID)
+
+	vm.dropAsyncTasks()
+
+	assertFreed := func(handle Handle, label string) {
+		t.Helper()
+		obj, ok := vm.Heap.lookup(handle)
+		if !ok || obj == nil {
+			t.Fatalf("expected %s handle %d in heap", label, handle)
+		}
+		if !obj.Freed || obj.RefCount != 0 {
+			t.Fatalf("expected %s handle %d freed, freed=%v rc=%d", label, handle, obj.Freed, obj.RefCount)
+		}
+	}
+
+	assertFreed(stateHandle, "state")
+	assertFreed(resultHandle, "result")
+	assertFreed(resumeHandle, "resume")
+}

--- a/internal/vm/task_state_pins_internal_test.go
+++ b/internal/vm/task_state_pins_internal_test.go
@@ -34,6 +34,50 @@ func TestCollectTaskStatePinsRejectsMovedLocal(t *testing.T) {
 	}
 }
 
+func TestCollectTaskStatePinsRollbackKeepsDetachedLocalAlive(t *testing.T) {
+	vm := New(nil, nil, nil, nil, nil)
+	frame := &Frame{
+		Locals: []LocalSlot{
+			{
+				Name:   "keep",
+				V:      MakeHandleString(vm.Heap.AllocString(types.NoTypeID, "keep"), types.NoTypeID),
+				IsInit: true,
+			},
+			{
+				Name:    "moved",
+				V:       MakeInt(7, types.NoTypeID),
+				IsInit:  true,
+				IsMoved: true,
+			},
+		},
+	}
+	stateHandle := vm.Heap.AllocArray(types.NoTypeID, []Value{
+		MakeRef(Location{Kind: LKLocal, FrameRef: frame, Local: 0}, types.NoTypeID),
+		MakeRef(Location{Kind: LKLocal, FrameRef: frame, Local: 1}, types.NoTypeID),
+	})
+
+	_, vmErr := vm.collectTaskStatePins(MakeHandleArray(stateHandle, types.NoTypeID))
+	if vmErr == nil {
+		t.Fatal("expected moved local error")
+	}
+	if vmErr.Code != PanicUseAfterMove {
+		t.Fatalf("expected %v, got %v", PanicUseAfterMove, vmErr.Code)
+	}
+	if got := frame.Locals[0].PinCount; got != 0 {
+		t.Fatalf("expected keep pin count 0, got %d", got)
+	}
+	if !frame.Locals[0].IsInit {
+		t.Fatal("expected keep local to remain initialized after rollback")
+	}
+	if frame.Locals[0].V.Kind != VKHandleString {
+		t.Fatalf("expected keep local string handle, got %v", frame.Locals[0].V.Kind)
+	}
+	obj := vm.Heap.Get(frame.Locals[0].V.H)
+	if obj == nil || obj.Freed || obj.RefCount == 0 {
+		t.Fatalf("expected keep local backing object alive, got %#v", obj)
+	}
+}
+
 func TestDropAsyncTasksDropsWrappedUserTaskPayloads(t *testing.T) {
 	vm := New(nil, nil, nil, nil, nil)
 	vm.Async = asyncrt.NewExecutor(asyncrt.Config{Deterministic: true})

--- a/internal/vm/trace.go
+++ b/internal/vm/trace.go
@@ -536,14 +536,10 @@ func (t *Tracer) formatLocation(loc Location) string {
 	switch loc.Kind {
 	case LKLocal:
 		name := "?"
-		if t.vm != nil {
-			stackIdx := int(loc.Frame)
-			if loc.Frame >= 0 && stackIdx >= 0 && stackIdx < len(t.vm.Stack) {
-				frame := &t.vm.Stack[stackIdx]
-				localIdx := int(loc.Local)
-				if loc.Local >= 0 && localIdx >= 0 && localIdx < len(frame.Locals) && frame.Locals[localIdx].Name != "" {
-					name = frame.Locals[localIdx].Name
-				}
+		if frame := loc.FrameRef; frame != nil {
+			localIdx := int(loc.Local)
+			if loc.Local >= 0 && localIdx >= 0 && localIdx < len(frame.Locals) && frame.Locals[localIdx].Name != "" {
+				name = frame.Locals[localIdx].Name
 			}
 		}
 		return fmt.Sprintf("L%d(%s)", loc.Local, name)

--- a/internal/vm/vm.go
+++ b/internal/vm/vm.go
@@ -18,7 +18,7 @@ type Options struct {
 // VM is a direct MIR interpreter.
 type VM struct {
 	M             *mir.Module
-	Stack         []Frame
+	Stack         []*Frame
 	Globals       []LocalSlot
 	RT            Runtime
 	Recorder      *Recorder
@@ -159,7 +159,7 @@ func (vm *VM) Start() *VMError {
 		return nil
 	}
 
-	vm.Stack = append(vm.Stack, *NewFrame(startFn))
+	vm.Stack = append(vm.Stack, NewFrame(startFn))
 	vm.started = true
 
 	if vm.Replayer != nil {
@@ -193,7 +193,7 @@ func (vm *VM) Step() (vmErr *VMError) {
 
 	preDepth := len(vm.Stack)
 	frameIdx := preDepth - 1
-	frame := &vm.Stack[frameIdx]
+	frame := vm.Stack[frameIdx]
 	block := frame.CurrentBlock()
 	if block == nil {
 		return vm.eb.makeError(PanicUnimplemented, fmt.Sprintf("invalid block id: %d", frame.BB))
@@ -214,7 +214,7 @@ func (vm *VM) Step() (vmErr *VMError) {
 		return vmErr
 	}
 	if pushFrame != nil {
-		vm.Stack = append(vm.Stack, *pushFrame)
+		vm.Stack = append(vm.Stack, pushFrame)
 		return nil
 	}
 	if advanceIP && !vm.Halted && len(vm.Stack) == preDepth {
@@ -230,7 +230,7 @@ func (vm *VM) StopPoint() (sp StopPoint, ok bool) {
 		return StopPoint{}, false
 	}
 
-	frame := &vm.Stack[len(vm.Stack)-1]
+	frame := vm.Stack[len(vm.Stack)-1]
 	block := frame.CurrentBlock()
 	if block == nil {
 		return StopPoint{}, false

--- a/internal/vm/vm_access.go
+++ b/internal/vm/vm_access.go
@@ -24,9 +24,6 @@ func (vm *VM) readLocal(frame *Frame, id mir.LocalID) (Value, *VMError) {
 	}
 
 	if slot.IsMoved {
-		if frame.BorrowOnly {
-			return slot.V, nil
-		}
 		return Value{}, vm.eb.useAfterMove(slot.Name)
 	}
 

--- a/internal/vm/vm_access.go
+++ b/internal/vm/vm_access.go
@@ -24,6 +24,9 @@ func (vm *VM) readLocal(frame *Frame, id mir.LocalID) (Value, *VMError) {
 	}
 
 	if slot.IsMoved {
+		if frame.BorrowOnly {
+			return slot.V, nil
+		}
 		return Value{}, vm.eb.useAfterMove(slot.Name)
 	}
 

--- a/internal/vm/vm_async_borrow_diag_test.go
+++ b/internal/vm/vm_async_borrow_diag_test.go
@@ -1,0 +1,57 @@
+package vm_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBuildAndRunRejectBorrowCaptureAcrossAsyncSuspend(t *testing.T) {
+	root := repoRoot(t)
+	surge := buildSurgeBinary(t, root)
+
+	tmpDir := t.TempDir()
+	srcPath := filepath.Join(tmpDir, "main.sg")
+	source := `@entrypoint
+fn main() -> int {
+    let value: int = 2;
+    let refv = &value;
+    let task: Task<int> = spawn async {
+        checkpoint().await();
+        return *refv;
+    };
+    compare task.await() {
+        Success(out) => return out;
+        Cancelled() => return 9;
+    };
+}
+`
+	if err := os.WriteFile(srcPath, []byte(source), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	buildOut, buildErr, buildCode := runSurgeWithInput(t, root, surge, "", "build", "--ui", "off", srcPath)
+	if buildCode == 0 {
+		t.Fatalf("build unexpectedly succeeded\nstdout:\n%s\nstderr:\n%s", buildOut, buildErr)
+	}
+	buildCombined := buildOut + buildErr
+	if strings.Contains(buildCombined, "panic VM") || strings.Contains(buildCombined, "invalid local id") {
+		t.Fatalf("build should fail in diagnostics before VM execution\noutput:\n%s", buildCombined)
+	}
+	if !strings.Contains(buildCombined, "cannot send 'refv' to a task") {
+		t.Fatalf("missing async borrow capture diagnostic in build output:\n%s", buildCombined)
+	}
+
+	runOut, runErr, runCode := runSurgeWithInput(t, root, surge, "", "run", "--ui", "off", "--backend=vm", srcPath)
+	if runCode == 0 {
+		t.Fatalf("run unexpectedly succeeded\nstdout:\n%s\nstderr:\n%s", runOut, runErr)
+	}
+	runCombined := runOut + runErr
+	if strings.Contains(runCombined, "panic VM") || strings.Contains(runCombined, "invalid local id") {
+		t.Fatalf("run should fail in diagnostics before VM execution\noutput:\n%s", runCombined)
+	}
+	if !strings.Contains(runCombined, "cannot send 'refv' to a task") {
+		t.Fatalf("missing async borrow capture diagnostic in run output:\n%s", runCombined)
+	}
+}

--- a/internal/vm/vm_async_borrow_regression_test.go
+++ b/internal/vm/vm_async_borrow_regression_test.go
@@ -1,0 +1,112 @@
+package vm_test
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestBorrowedTcpConnAsyncHelperRunsWithoutVMPanic(t *testing.T) {
+	requireVMBackend(t)
+
+	port := pickFreePort(t)
+	res := runProgramFromSource(t, `import stdlib/net as net;
+
+fn pong_line() -> byte[] {
+    let mut out: byte[] = [];
+    let view = "PONG".bytes();
+    let mut i: int = 0;
+    while i < view.__len() to int {
+        out.push(view[i]);
+        i = i + 1;
+    }
+    out.push(10:byte);
+    return out;
+}
+
+async fn send_line(conn: &TcpConn, data: byte[]) -> nothing {
+    let _ = net.write_all(conn, data).await();
+}
+
+async fn server_once(listener: TcpListener) -> int {
+    let accept_res = net.accept(&listener).await();
+    let _ = net.close_listener(own listener);
+    compare accept_res {
+        Success(conn_res) => {
+            compare conn_res {
+                Success(conn) => {
+                    let data: byte[] = pong_line();
+                    let _ = send_line(&conn, data).await();
+                    let _ = net.close_conn(own conn);
+                    return 0;
+                }
+                _ => return 2;
+            };
+        }
+        Cancelled() => return 3;
+    };
+    return 4;
+}
+
+@entrypoint("argv")
+fn main(port: uint) -> int {
+    let listen_res = net.listen("127.0.0.1", port);
+    compare listen_res {
+        Success(listener) => {
+            let server_task: Task<int> = @local spawn server_once(listener);
+            let conn_res = net.connect("127.0.0.1", port);
+            compare conn_res {
+                Success(conn) => {
+                    let read_res = net.read_some(&conn, 5:uint).await();
+                    let _ = net.close_conn(own conn);
+                    let _ = server_task.await();
+                    compare read_res {
+                        Success(_) => return 0;
+                        Cancelled() => return 5;
+                    };
+                }
+                _ => {
+                    let _ = server_task.await();
+                    return 6;
+                }
+            };
+        }
+        _ => return 7;
+    };
+    return 8;
+}
+`, runOptions{argv: []string{strconv.Itoa(port)}})
+
+	if res.exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d\nstderr:\n%s", res.exitCode, res.stderr)
+	}
+	if strings.Contains(res.stderr, "invalid local id") || strings.Contains(res.stderr, "used after move") {
+		t.Fatalf("expected no async borrow VM panic, got:\n%s", res.stderr)
+	}
+}
+
+func TestBorrowedIntAsyncHelperRunsAfterSuspend(t *testing.T) {
+	requireVMBackend(t)
+
+	res := runProgramFromSource(t, `async fn read_after_wait(x: &int) -> int {
+    checkpoint().await();
+    return *x;
+}
+
+@entrypoint("argv")
+fn main() -> int {
+    let value: int = 2;
+    compare read_after_wait(&value).await() {
+        Success(out) => return out;
+        Cancelled() => return 9;
+    };
+}
+`, runOptions{})
+
+	if res.exitCode != 2 {
+		t.Fatalf("expected exit code 2, got %d\nstderr:\n%s", res.exitCode, res.stderr)
+	}
+	if strings.Contains(res.stderr, "invalid local id") || strings.Contains(res.stderr, "used after move") {
+		t.Fatalf("expected no async borrow VM panic, got:\n%s", res.stderr)
+	}
+}

--- a/internal/vm/vm_async_borrow_regression_test.go
+++ b/internal/vm/vm_async_borrow_regression_test.go
@@ -6,6 +6,13 @@ import (
 	"testing"
 )
 
+func requireNoAsyncBorrowPanic(t *testing.T, stderr string) {
+	t.Helper()
+	if strings.Contains(stderr, "invalid local id") || strings.Contains(stderr, "used after move") {
+		t.Fatalf("expected no async borrow VM panic, got:\n%s", stderr)
+	}
+}
+
 func TestBorrowedTcpConnAsyncHelperRunsWithoutVMPanic(t *testing.T) {
 	requireVMBackend(t)
 
@@ -80,9 +87,7 @@ fn main(port: uint) -> int {
 	if res.exitCode != 0 {
 		t.Fatalf("expected exit code 0, got %d\nstderr:\n%s", res.exitCode, res.stderr)
 	}
-	if strings.Contains(res.stderr, "invalid local id") || strings.Contains(res.stderr, "used after move") {
-		t.Fatalf("expected no async borrow VM panic, got:\n%s", res.stderr)
-	}
+	requireNoAsyncBorrowPanic(t, res.stderr)
 }
 
 func TestBorrowedIntAsyncHelperRunsAfterSuspend(t *testing.T) {
@@ -106,7 +111,5 @@ fn main() -> int {
 	if res.exitCode != 2 {
 		t.Fatalf("expected exit code 2, got %d\nstderr:\n%s", res.exitCode, res.stderr)
 	}
-	if strings.Contains(res.stderr, "invalid local id") || strings.Contains(res.stderr, "used after move") {
-		t.Fatalf("expected no async borrow VM panic, got:\n%s", res.stderr)
-	}
+	requireNoAsyncBorrowPanic(t, res.stderr)
 }

--- a/internal/vm/vm_scope_diag_test.go
+++ b/internal/vm/vm_scope_diag_test.go
@@ -40,7 +40,7 @@ func TestVMScopeExitInvariantBecomesVMError(t *testing.T) {
 	}
 
 	vmInstance := New(&mir.Module{}, NewTestRuntime(nil, ""), nil, typesIn, nil)
-	vmInstance.Stack = []Frame{*NewFrame(fn)}
+	vmInstance.Stack = []*Frame{NewFrame(fn)}
 	exec := vmInstance.ensureExecutor()
 	owner := exec.Spawn(1, nil)
 	actualScopeID := exec.EnterScope(owner, false)

--- a/internal/vm/vm_terminator.go
+++ b/internal/vm/vm_terminator.go
@@ -87,7 +87,11 @@ func (vm *VM) execTermAsyncYield(frame *Frame, term *mir.Terminator) *VMError {
 	if vmErr != nil {
 		return vmErr
 	}
-	vm.pinAsyncFrame(frame)
+	statePins, vmErr := vm.collectTaskStatePins(stateVal)
+	if vmErr != nil {
+		return vmErr
+	}
+	vm.dropFrameLocals(frame)
 	vm.Stack = vm.Stack[:len(vm.Stack)-1]
 	vm.asyncCapture.set = true
 	switch {
@@ -104,6 +108,7 @@ func (vm *VM) execTermAsyncYield(frame *Frame, term *mir.Terminator) *VMError {
 		vm.asyncCapture.parkKey = asyncrt.WakerKey{}
 	}
 	vm.asyncCapture.state = stateVal
+	vm.asyncCapture.pins = statePins
 	return nil
 }
 

--- a/internal/vm/vm_terminator.go
+++ b/internal/vm/vm_terminator.go
@@ -57,7 +57,7 @@ func (vm *VM) execTermReturn(frame *Frame, term *mir.Terminator) *VMError {
 
 	// If stack not empty, store return value in caller's destination
 	if len(vm.Stack) > 0 {
-		callerFrame := &vm.Stack[len(vm.Stack)-1]
+		callerFrame := vm.Stack[len(vm.Stack)-1]
 		// The caller's IP points to the call instruction that was just executed
 		// Find the call instruction and its destination
 		block := callerFrame.CurrentBlock()
@@ -87,7 +87,7 @@ func (vm *VM) execTermAsyncYield(frame *Frame, term *mir.Terminator) *VMError {
 	if vmErr != nil {
 		return vmErr
 	}
-	vm.dropFrameLocals(frame)
+	vm.pinAsyncFrame(frame)
 	vm.Stack = vm.Stack[:len(vm.Stack)-1]
 	vm.asyncCapture.set = true
 	switch {


### PR DESCRIPTION
## Summary
- keep suspended async frames alive as borrow backing storage for child tasks
- wrap user task state so async shutdown and task-state cleanup release pinned frames correctly
- add VM regressions for borrowed async helpers across suspend and nested async shutdown cleanup

## Testing
- go test ./internal/sema -count=1
- go test ./internal/vm -run 'TestBorrowedTcpConnAsyncHelperRunsWithoutVMPanic|TestBorrowedIntAsyncHelperRunsAfterSuspend|TestVMNestedAsyncChildRtExitHaltsProgram|TestVMScopeExitInvariantBecomesVMError' -count=1
- make check *(fails on existing non-change lint findings: gocritic rangeValCopy in internal/vm/heap.go, internal/vm/heap_debug.go, internal/vm/intrinsic_map.go)*

Closes #73

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved async task state handling and pinning to prevent panics, use-after-free, and resource leaks; safer async teardown and shutdown cleanup.

* **Tests**
  * Added regression and diagnostic tests covering async borrow, pinning, and suspend/capture scenarios to prevent regressions.

* **Improvements**
  * Git subprocesses run with a filtered environment for more reliable module operations.
  * Project statistics refreshed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->