### PR TITLE
fix: lower duration intrinsics

### DIFF
--- a/docs/STDLIB.md
+++ b/docs/STDLIB.md
@@ -341,13 +341,15 @@ Public API:
 
 - `type Duration`
 - `monotonic_now() -> Duration`
+- `Duration.new(nanos) -> Duration`
+- `Duration.now() -> Duration`
 - `Duration.sub(other) -> Duration`
 - `Duration.as_seconds() -> int64`
 - `Duration.as_millis() -> int64`
 - `Duration.as_micros() -> int64`
 - `Duration.as_nanos() -> int64`
 
-`Duration` is copyable and stores whole nanoseconds. Unit conversion methods return whole units as `int64`.
+`Duration` is copyable and stores whole nanoseconds. `Duration.new` builds a duration from whole nanoseconds. `Duration.now` returns the current monotonic timestamp as a duration; use it with `sub` to measure elapsed time. Unit conversion methods return whole units as `int64`.
 
 `time` currently exposes a monotonic clock for measuring elapsed time. It is not a wall-clock calendar API.
 
@@ -357,7 +359,7 @@ Example:
 import stdlib/time as time;
 
 fn elapsed_ms(start: time.Duration) -> int64 {
-    let now: time.Duration = time.monotonic_now();
+    let now: time.Duration = time.Duration.now();
     return now.sub(start).as_millis();
 }
 ```

--- a/docs/STDLIB.md
+++ b/docs/STDLIB.md
@@ -341,11 +341,13 @@ Public API:
 
 - `type Duration`
 - `monotonic_now() -> Duration`
-- `Duration.sub(...)`
-- `Duration.as_seconds()`
-- `Duration.as_millis()`
-- `Duration.as_micros()`
-- `Duration.as_nanos()`
+- `Duration.sub(other) -> Duration`
+- `Duration.as_seconds() -> int64`
+- `Duration.as_millis() -> int64`
+- `Duration.as_micros() -> int64`
+- `Duration.as_nanos() -> int64`
+
+`Duration` is copyable and stores whole nanoseconds. Unit conversion methods return whole units as `int64`.
 
 `time` currently exposes a monotonic clock for measuring elapsed time. It is not a wall-clock calendar API.
 
@@ -354,7 +356,7 @@ Example:
 ```sg
 import stdlib/time as time;
 
-fn elapsed_ms(start: time.Duration) -> float {
+fn elapsed_ms(start: time.Duration) -> int64 {
     let now: time.Duration = time.monotonic_now();
     return now.sub(start).as_millis();
 }

--- a/docs/STDLIB.ru.md
+++ b/docs/STDLIB.ru.md
@@ -341,11 +341,13 @@ import stdlib/time as time;
 
 - `type Duration`
 - `monotonic_now() -> Duration`
-- `Duration.sub(...)`
-- `Duration.as_seconds()`
-- `Duration.as_millis()`
-- `Duration.as_micros()`
-- `Duration.as_nanos()`
+- `Duration.sub(other) -> Duration`
+- `Duration.as_seconds() -> int64`
+- `Duration.as_millis() -> int64`
+- `Duration.as_micros() -> int64`
+- `Duration.as_nanos() -> int64`
+
+`Duration` копируемый и хранит целые наносекунды. Методы конвертации единиц возвращают целые значения `int64`.
 
 `time` сейчас даёт монотонные часы для измерения elapsed time. Это не wall-clock calendar API.
 
@@ -354,7 +356,7 @@ import stdlib/time as time;
 ```sg
 import stdlib/time as time;
 
-fn elapsed_ms(start: time.Duration) -> float {
+fn elapsed_ms(start: time.Duration) -> int64 {
     let now: time.Duration = time.monotonic_now();
     return now.sub(start).as_millis();
 }

--- a/docs/STDLIB.ru.md
+++ b/docs/STDLIB.ru.md
@@ -341,13 +341,15 @@ import stdlib/time as time;
 
 - `type Duration`
 - `monotonic_now() -> Duration`
+- `Duration.new(nanos) -> Duration`
+- `Duration.now() -> Duration`
 - `Duration.sub(other) -> Duration`
 - `Duration.as_seconds() -> int64`
 - `Duration.as_millis() -> int64`
 - `Duration.as_micros() -> int64`
 - `Duration.as_nanos() -> int64`
 
-`Duration` копируемый и хранит целые наносекунды. Методы конвертации единиц возвращают целые значения `int64`.
+`Duration` копируемый и хранит целые наносекунды. `Duration.new` строит duration из целых наносекунд. `Duration.now` возвращает текущую монотонную отметку времени как duration; используйте её с `sub` для измерения elapsed time. Методы конвертации единиц возвращают целые значения `int64`.
 
 `time` сейчас даёт монотонные часы для измерения elapsed time. Это не wall-clock calendar API.
 
@@ -357,7 +359,7 @@ import stdlib/time as time;
 import stdlib/time as time;
 
 fn elapsed_ms(start: time.Duration) -> int64 {
-    let now: time.Duration = time.monotonic_now();
+    let now: time.Duration = time.Duration.now();
     return now.sub(start).as_millis();
 }
 ```

--- a/internal/backend/llvm/emit_intrinsics_runtime.go
+++ b/internal/backend/llvm/emit_intrinsics_runtime.go
@@ -27,6 +27,9 @@ func (fe *funcEmitter) emitRuntimeIntrinsic(call *mir.CallInstr) (bool, error) {
 	if handled, err := fe.emitNetIntrinsic(call); handled {
 		return true, err
 	}
+	if handled, err := fe.emitDurationMethodIntrinsic(name, call); handled {
+		return true, err
+	}
 	switch name {
 	case "rt_alloc":
 		return true, fe.emitRtAlloc(call)
@@ -87,76 +90,6 @@ func (fe *funcEmitter) emitRuntimeIntrinsic(call *mir.CallInstr) (bool, error) {
 	default:
 		return false, nil
 	}
-}
-
-func (fe *funcEmitter) emitRtMonotonicNow(call *mir.CallInstr) error {
-	if call == nil {
-		return nil
-	}
-	if len(call.Args) != 0 {
-		return fmt.Errorf("monotonic_now requires 0 arguments")
-	}
-	if !call.HasDst {
-		return nil
-	}
-	size, align, opaqueOffset, err := fe.monotonicDurationLayout(call.Dst)
-	if err != nil {
-		return err
-	}
-	mem := fe.nextTemp()
-	fmt.Fprintf(&fe.emitter.buf, "  %s = call ptr @rt_alloc(i64 %d, i64 %d)\n", mem, size, align)
-	elapsedNs := fe.nextTemp()
-	fmt.Fprintf(&fe.emitter.buf, "  %s = call i64 @rt_monotonic_now()\n", elapsedNs)
-	opaquePtr := fe.nextTemp()
-	fmt.Fprintf(&fe.emitter.buf, "  %s = getelementptr inbounds i8, ptr %s, i64 %d\n", opaquePtr, mem, opaqueOffset)
-	fmt.Fprintf(&fe.emitter.buf, "  store i64 %s, ptr %s\n", elapsedNs, opaquePtr)
-	ptr, dstTy, err := fe.emitPlacePtr(call.Dst)
-	if err != nil {
-		return err
-	}
-	if dstTy != "ptr" {
-		dstTy = "ptr"
-	}
-	fmt.Fprintf(&fe.emitter.buf, "  store %s %s, ptr %s\n", dstTy, mem, ptr)
-	return nil
-}
-
-func (fe *funcEmitter) monotonicDurationLayout(dst mir.Place) (size, align, opaqueOffset int, err error) {
-	dstType, err := fe.placeBaseType(dst)
-	if err != nil {
-		return 0, 0, 0, err
-	}
-	layoutInfo, err := fe.emitter.layoutOf(dstType)
-	if err != nil {
-		return 0, 0, 0, err
-	}
-	fieldIdx, fieldType, err := fe.structFieldInfo(dstType, mir.PlaceProj{
-		Kind:      mir.PlaceProjField,
-		FieldName: "__opaque",
-		FieldIdx:  -1,
-	})
-	if err != nil {
-		return 0, 0, 0, err
-	}
-	if fieldIdx < 0 || fieldIdx >= len(layoutInfo.FieldOffsets) {
-		return 0, 0, 0, fmt.Errorf("duration field index %d out of range", fieldIdx)
-	}
-	fieldLLVM, err := llvmValueType(fe.emitter.types, fieldType)
-	if err != nil {
-		return 0, 0, 0, err
-	}
-	if fieldLLVM != "i64" {
-		return 0, 0, 0, fmt.Errorf("monotonic_now requires int64 __opaque field, got %s", fieldLLVM)
-	}
-	size = layoutInfo.Size
-	align = layoutInfo.Align
-	if size <= 0 {
-		size = 1
-	}
-	if align <= 0 {
-		align = 1
-	}
-	return size, align, layoutInfo.FieldOffsets[fieldIdx], nil
 }
 
 func (fe *funcEmitter) emitRtSleep(call *mir.CallInstr) error {

--- a/internal/backend/llvm/emit_intrinsics_time.go
+++ b/internal/backend/llvm/emit_intrinsics_time.go
@@ -104,6 +104,11 @@ func (fe *funcEmitter) emitDurationNanosOperand(op *mir.Operand) (nanos string, 
 			return "", false, placeErr
 		}
 	}
+	if op != nil && isRefType(fe.emitter.types, op.Type) {
+		if elem, refOK := derefType(fe.emitter.types, op.Type); refOK {
+			typeID = elem
+		}
+	}
 	_, _, opaqueOffset, ok, err := fe.durationLayoutForType(typeID)
 	if err != nil || !ok {
 		return "", ok, err
@@ -145,7 +150,7 @@ func (fe *funcEmitter) emitDurationValue(dst mir.Place, nanos string) error {
 		return err
 	}
 	if dstTy != "ptr" {
-		dstTy = "ptr"
+		return fmt.Errorf("duration destination must lower to ptr, got %s", dstTy)
 	}
 	fmt.Fprintf(&fe.emitter.buf, "  store %s %s, ptr %s\n", dstTy, mem, ptr)
 	return nil

--- a/internal/backend/llvm/emit_intrinsics_time.go
+++ b/internal/backend/llvm/emit_intrinsics_time.go
@@ -1,0 +1,218 @@
+package llvm
+
+import (
+	"fmt"
+
+	"surge/internal/mir"
+	"surge/internal/types"
+)
+
+const (
+	durationOpaqueField = "__opaque"
+	nanosPerMicro       = int64(1_000)
+	nanosPerMilli       = int64(1_000_000)
+	nanosPerSecond      = int64(1_000_000_000)
+)
+
+func (fe *funcEmitter) emitRtMonotonicNow(call *mir.CallInstr) error {
+	if call == nil {
+		return nil
+	}
+	if len(call.Args) != 0 {
+		return fmt.Errorf("monotonic_now requires 0 arguments")
+	}
+	if !call.HasDst {
+		return nil
+	}
+	_, _, _, ok, err := fe.durationLayoutForPlace(call.Dst)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("monotonic_now requires Duration destination")
+	}
+	elapsedNs := fe.nextTemp()
+	fmt.Fprintf(&fe.emitter.buf, "  %s = call i64 @rt_monotonic_now()\n", elapsedNs)
+	return fe.emitDurationValue(call.Dst, elapsedNs)
+}
+
+func (fe *funcEmitter) emitDurationMethodIntrinsic(name string, call *mir.CallInstr) (bool, error) {
+	switch name {
+	case "sub":
+		return fe.emitDurationSub(call)
+	case "as_seconds":
+		return fe.emitDurationUnit(call, name, nanosPerSecond)
+	case "as_millis":
+		return fe.emitDurationUnit(call, name, nanosPerMilli)
+	case "as_micros":
+		return fe.emitDurationUnit(call, name, nanosPerMicro)
+	case "as_nanos":
+		return fe.emitDurationUnit(call, name, 1)
+	default:
+		return false, nil
+	}
+}
+
+func (fe *funcEmitter) emitDurationSub(call *mir.CallInstr) (bool, error) {
+	if call == nil || len(call.Args) != 2 {
+		return true, fmt.Errorf("duration.sub requires 2 arguments")
+	}
+	left, ok, err := fe.emitDurationNanosOperand(&call.Args[0])
+	if err != nil || !ok {
+		return ok, err
+	}
+	right, ok, err := fe.emitDurationNanosOperand(&call.Args[1])
+	if err != nil {
+		return true, err
+	}
+	if !ok {
+		return true, fmt.Errorf("duration.sub requires Duration argument")
+	}
+	if !call.HasDst {
+		return true, nil
+	}
+	diff := fe.nextTemp()
+	fmt.Fprintf(&fe.emitter.buf, "  %s = sub i64 %s, %s\n", diff, left, right)
+	return true, fe.emitDurationValue(call.Dst, diff)
+}
+
+func (fe *funcEmitter) emitDurationUnit(call *mir.CallInstr, name string, divisor int64) (bool, error) {
+	if call == nil || len(call.Args) != 1 {
+		return true, fmt.Errorf("%s requires 1 argument", name)
+	}
+	nanos, ok, err := fe.emitDurationNanosOperand(&call.Args[0])
+	if err != nil || !ok {
+		return ok, err
+	}
+	if !call.HasDst {
+		return true, nil
+	}
+	out := nanos
+	if divisor != 1 {
+		out = fe.nextTemp()
+		fmt.Fprintf(&fe.emitter.buf, "  %s = sdiv i64 %s, %d\n", out, nanos, divisor)
+	}
+	return true, fe.emitI64Result(call.Dst, out)
+}
+
+func (fe *funcEmitter) emitDurationNanosOperand(op *mir.Operand) (nanos string, ok bool, err error) {
+	typeID := operandValueType(fe.emitter.types, op)
+	if typeID == types.NoTypeID && op != nil && (op.Kind == mir.OperandCopy || op.Kind == mir.OperandMove) {
+		var placeErr error
+		typeID, placeErr = fe.placeBaseType(op.Place)
+		if placeErr != nil {
+			return "", false, placeErr
+		}
+	}
+	_, _, opaqueOffset, ok, err := fe.durationLayoutForType(typeID)
+	if err != nil || !ok {
+		return "", ok, err
+	}
+	value, ty, err := fe.emitValueOperand(op)
+	if err != nil {
+		return "", true, err
+	}
+	if ty != "ptr" {
+		return "", true, fmt.Errorf("duration value must be ptr, got %s", ty)
+	}
+	if isRefType(fe.emitter.types, op.Type) {
+		loaded := fe.nextTemp()
+		fmt.Fprintf(&fe.emitter.buf, "  %s = load ptr, ptr %s\n", loaded, value)
+		value = loaded
+	}
+	opaquePtr := fe.nextTemp()
+	fmt.Fprintf(&fe.emitter.buf, "  %s = getelementptr inbounds i8, ptr %s, i64 %d\n", opaquePtr, value, opaqueOffset)
+	nanos = fe.nextTemp()
+	fmt.Fprintf(&fe.emitter.buf, "  %s = load i64, ptr %s\n", nanos, opaquePtr)
+	return nanos, true, nil
+}
+
+func (fe *funcEmitter) emitDurationValue(dst mir.Place, nanos string) error {
+	size, align, opaqueOffset, ok, err := fe.durationLayoutForPlace(dst)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("duration destination must contain int64 __opaque field")
+	}
+	mem := fe.nextTemp()
+	fmt.Fprintf(&fe.emitter.buf, "  %s = call ptr @rt_alloc(i64 %d, i64 %d)\n", mem, size, align)
+	opaquePtr := fe.nextTemp()
+	fmt.Fprintf(&fe.emitter.buf, "  %s = getelementptr inbounds i8, ptr %s, i64 %d\n", opaquePtr, mem, opaqueOffset)
+	fmt.Fprintf(&fe.emitter.buf, "  store i64 %s, ptr %s\n", nanos, opaquePtr)
+	ptr, dstTy, err := fe.emitPlacePtr(dst)
+	if err != nil {
+		return err
+	}
+	if dstTy != "ptr" {
+		dstTy = "ptr"
+	}
+	fmt.Fprintf(&fe.emitter.buf, "  store %s %s, ptr %s\n", dstTy, mem, ptr)
+	return nil
+}
+
+func (fe *funcEmitter) emitI64Result(dst mir.Place, value string) error {
+	ptr, dstTy, err := fe.emitPlacePtr(dst)
+	if err != nil {
+		return err
+	}
+	out, outTy := value, "i64"
+	dstType, err := fe.placeBaseType(dst)
+	if err != nil {
+		return err
+	}
+	if dstTy != outTy {
+		out, outTy, err = fe.emitNumericCast(value, "i64", fe.emitter.types.Builtins().Int64, dstType)
+		if err != nil {
+			return err
+		}
+	}
+	fmt.Fprintf(&fe.emitter.buf, "  store %s %s, ptr %s\n", outTy, out, ptr)
+	return nil
+}
+
+func (fe *funcEmitter) durationLayoutForPlace(place mir.Place) (size, align, opaqueOffset int, ok bool, err error) {
+	typeID, err := fe.placeBaseType(place)
+	if err != nil {
+		return 0, 0, 0, false, err
+	}
+	return fe.durationLayoutForType(typeID)
+}
+
+func (fe *funcEmitter) durationLayoutForType(typeID types.TypeID) (size, align, opaqueOffset int, ok bool, err error) {
+	typeID = resolveAliasAndOwn(fe.emitter.types, typeID)
+	if _, ok := fe.emitter.types.StructInfo(typeID); !ok {
+		return 0, 0, 0, false, nil
+	}
+	layoutInfo, err := fe.emitter.layoutOf(typeID)
+	if err != nil {
+		return 0, 0, 0, false, err
+	}
+	fieldIdx, fieldType, err := fe.structFieldInfo(typeID, mir.PlaceProj{
+		Kind:      mir.PlaceProjField,
+		FieldName: durationOpaqueField,
+		FieldIdx:  -1,
+	})
+	if err != nil {
+		return 0, 0, 0, false, nil
+	}
+	if fieldIdx < 0 || fieldIdx >= len(layoutInfo.FieldOffsets) {
+		return 0, 0, 0, false, fmt.Errorf("duration field index %d out of range", fieldIdx)
+	}
+	fieldLLVM, err := llvmValueType(fe.emitter.types, fieldType)
+	if err != nil {
+		return 0, 0, 0, false, err
+	}
+	if fieldLLVM != "i64" {
+		return 0, 0, 0, false, nil
+	}
+	size = layoutInfo.Size
+	align = layoutInfo.Align
+	if size <= 0 {
+		size = 1
+	}
+	if align <= 0 {
+		align = 1
+	}
+	return size, align, layoutInfo.FieldOffsets[fieldIdx], true, nil
+}

--- a/internal/backend/llvm/emit_intrinsics_time_test.go
+++ b/internal/backend/llvm/emit_intrinsics_time_test.go
@@ -67,6 +67,9 @@ fn main() -> int {
 	if !regexp.MustCompile(`sdiv i64 [^,]+, 1000000000(?:\n|$)`).MatchString(ir) {
 		t.Fatalf("expected as_seconds to divide nanoseconds by 1_000_000_000:\n%s", ir)
 	}
+	if regexp.MustCompile(`sdiv i64 [^,]+, 1(?:\n|$)`).MatchString(ir) {
+		t.Fatalf("expected as_nanos to use raw nanoseconds without division:\n%s", ir)
+	}
 	if !regexp.MustCompile(`call i64 @rt_monotonic_now\(\)`).MatchString(ir) {
 		t.Fatalf("expected Duration.now to call rt_monotonic_now:\n%s", ir)
 	}

--- a/internal/backend/llvm/emit_intrinsics_time_test.go
+++ b/internal/backend/llvm/emit_intrinsics_time_test.go
@@ -1,0 +1,66 @@
+package llvm
+
+import (
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"testing"
+)
+
+func TestEmitDurationIntrinsicsLowered(t *testing.T) {
+	t.Setenv("SURGE_STDLIB", repoRootFromLLVMTest(t))
+
+	sourceCode := `import stdlib/time as time;
+
+fn duration(ns: int64) -> time.Duration {
+    return time.Duration { __opaque = ns };
+}
+
+@entrypoint
+fn main() -> int {
+    let d = duration(1_500_250_999:int64);
+    let later = duration(2_000_000_000:int64);
+    let diff = later.sub(d);
+    if diff.as_millis() != 499:int64 {
+        return 1;
+    }
+    if d.as_seconds() != 1:int64 {
+        return 2;
+    }
+    if d.as_micros() != 1_500_250:int64 {
+        return 3;
+    }
+    if d.as_nanos() != 1_500_250_999:int64 {
+        return 4;
+    }
+    return 0;
+}
+`
+
+	ir := emitLLVMFromSource(t, sourceCode)
+
+	for _, name := range []string{"sub", "as_seconds", "as_millis", "as_micros", "as_nanos"} {
+		pattern := regexp.MustCompile(`call [^(]+ @` + name + `\(`)
+		if pattern.MatchString(ir) {
+			t.Fatalf("duration intrinsic %s leaked as external call:\n%s", name, ir)
+		}
+	}
+	if !regexp.MustCompile(`sub i64`).MatchString(ir) {
+		t.Fatalf("expected Duration.sub to emit integer subtraction:\n%s", ir)
+	}
+	if !regexp.MustCompile(`sdiv i64 [^,]+, 1000000`).MatchString(ir) {
+		t.Fatalf("expected as_millis to divide nanoseconds by 1_000_000:\n%s", ir)
+	}
+	if !regexp.MustCompile(`sdiv i64 [^,]+, 1000000000`).MatchString(ir) {
+		t.Fatalf("expected as_seconds to divide nanoseconds by 1_000_000_000:\n%s", ir)
+	}
+}
+
+func repoRootFromLLVMTest(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", ".."))
+}

--- a/internal/backend/llvm/emit_intrinsics_time_test.go
+++ b/internal/backend/llvm/emit_intrinsics_time_test.go
@@ -12,14 +12,10 @@ func TestEmitDurationIntrinsicsLowered(t *testing.T) {
 
 	sourceCode := `import stdlib/time as time;
 
-fn duration(ns: int64) -> time.Duration {
-    return time.Duration { __opaque = ns };
-}
-
 @entrypoint
 fn main() -> int {
-    let d = duration(1_500_250_999:int64);
-    let later = duration(2_000_000_000:int64);
+    let d = time.Duration.new(1_500_250_999:int64);
+    let later = time.Duration.new(2_000_000_000:int64);
     let diff = later.sub(d);
     if diff.as_millis() != 499:int64 {
         return 1;
@@ -33,13 +29,16 @@ fn main() -> int {
     if d.as_nanos() != 1_500_250_999:int64 {
         return 4;
     }
+    let started = time.Duration.now();
+    let finished = time.Duration.now();
+    let _ = finished.sub(started).as_nanos();
     return 0;
 }
 `
 
 	ir := emitLLVMFromSource(t, sourceCode)
 
-	for _, name := range []string{"sub", "as_seconds", "as_millis", "as_micros", "as_nanos"} {
+	for _, name := range []string{"sub", "as_seconds", "as_millis", "as_micros", "as_nanos", "monotonic_now"} {
 		pattern := regexp.MustCompile(`call [^(]+ @` + name + `\(`)
 		if pattern.MatchString(ir) {
 			t.Fatalf("duration intrinsic %s leaked as external call:\n%s", name, ir)
@@ -53,6 +52,9 @@ fn main() -> int {
 	}
 	if !regexp.MustCompile(`sdiv i64 [^,]+, 1000000000`).MatchString(ir) {
 		t.Fatalf("expected as_seconds to divide nanoseconds by 1_000_000_000:\n%s", ir)
+	}
+	if !regexp.MustCompile(`call i64 @rt_monotonic_now\(\)`).MatchString(ir) {
+		t.Fatalf("expected Duration.now to call rt_monotonic_now:\n%s", ir)
 	}
 }
 

--- a/internal/backend/llvm/emit_intrinsics_time_test.go
+++ b/internal/backend/llvm/emit_intrinsics_time_test.go
@@ -12,9 +12,14 @@ func TestEmitDurationIntrinsicsLowered(t *testing.T) {
 
 	sourceCode := `import stdlib/time as time;
 
+fn seconds_ref(d: &time.Duration) -> int64 {
+    return d.as_seconds();
+}
+
 @entrypoint
 fn main() -> int {
     let d = time.Duration.new(1_500_250_999:int64);
+    let copied = d;
     let later = time.Duration.new(2_000_000_000:int64);
     let diff = later.sub(d);
     if diff.as_millis() != 499:int64 {
@@ -28,6 +33,12 @@ fn main() -> int {
     }
     if d.as_nanos() != 1_500_250_999:int64 {
         return 4;
+    }
+    if copied.as_millis() != 1_500:int64 {
+        return 5;
+    }
+    if seconds_ref(&d) != 1:int64 {
+        return 6;
     }
     let started = time.Duration.now();
     let finished = time.Duration.now();
@@ -47,10 +58,13 @@ fn main() -> int {
 	if !regexp.MustCompile(`sub i64`).MatchString(ir) {
 		t.Fatalf("expected Duration.sub to emit integer subtraction:\n%s", ir)
 	}
-	if !regexp.MustCompile(`sdiv i64 [^,]+, 1000000`).MatchString(ir) {
+	if !regexp.MustCompile(`sdiv i64 [^,]+, 1000000(?:\n|$)`).MatchString(ir) {
 		t.Fatalf("expected as_millis to divide nanoseconds by 1_000_000:\n%s", ir)
 	}
-	if !regexp.MustCompile(`sdiv i64 [^,]+, 1000000000`).MatchString(ir) {
+	if !regexp.MustCompile(`sdiv i64 [^,]+, 1000(?:\n|$)`).MatchString(ir) {
+		t.Fatalf("expected as_micros to divide nanoseconds by 1_000:\n%s", ir)
+	}
+	if !regexp.MustCompile(`sdiv i64 [^,]+, 1000000000(?:\n|$)`).MatchString(ir) {
 		t.Fatalf("expected as_seconds to divide nanoseconds by 1_000_000_000:\n%s", ir)
 	}
 	if !regexp.MustCompile(`call i64 @rt_monotonic_now\(\)`).MatchString(ir) {

--- a/internal/sema/module_imports.go
+++ b/internal/sema/module_imports.go
@@ -72,6 +72,47 @@ func (tc *typeChecker) typeOfModuleMember(module *symbols.Symbol, field source.S
 	}
 }
 
+func (tc *typeChecker) moduleTypeMember(module *symbols.Symbol, field source.StringID, span source.Span, report bool) types.TypeID {
+	if module == nil || module.ModulePath == "" || tc.exports == nil {
+		return types.NoTypeID
+	}
+	exports := tc.exports[module.ModulePath]
+	if exports == nil {
+		if report {
+			tc.report(diag.SemaModuleMemberNotFound, span, "module %q has no exports", module.ModulePath)
+		}
+		return types.NoTypeID
+	}
+	nameStr := tc.lookupName(field)
+	if nameStr == "" {
+		nameStr = "_"
+	}
+	exported := exports.Lookup(nameStr)
+	if len(exported) == 0 {
+		if report {
+			tc.report(diag.SemaModuleMemberNotFound, span, "module %q has no member %q", module.ModulePath, nameStr)
+		}
+		return types.NoTypeID
+	}
+	for i := range exported {
+		exp := &exported[i]
+		if exp.Kind != symbols.SymbolType {
+			continue
+		}
+		if exp.Flags&symbols.SymbolFlagPublic == 0 {
+			if report {
+				tc.report(diag.SemaModuleMemberNotPublic, span, "member %q of module %q is not public", nameStr, module.ModulePath)
+			}
+			return types.NoTypeID
+		}
+		return exp.Type
+	}
+	if report {
+		tc.report(diag.SemaModuleMemberNotPublic, span, "member %q of module %q is not a type", nameStr, module.ModulePath)
+	}
+	return types.NoTypeID
+}
+
 func (tc *typeChecker) moduleFunctionResult(callID ast.ExprID, module *symbols.Symbol, name source.StringID, args []callArg, typeArgs []types.TypeID, span source.Span) types.TypeID {
 	exported := tc.moduleExportsByName(module, name, span)
 	if len(exported) == 0 {

--- a/internal/sema/type_expr_type_operands.go
+++ b/internal/sema/type_expr_type_operands.go
@@ -69,6 +69,14 @@ func (tc *typeChecker) resolveTypeOperand(exprID ast.ExprID, opLabel string) (ty
 				return tc.symbolType(symID), true
 			}
 		}
+	case ast.ExprMember:
+		if member, ok := tc.builder.Exprs.Member(exprID); ok && member != nil {
+			if module := tc.moduleSymbolForExpr(member.Target); module != nil {
+				if ty := tc.moduleTypeMember(module, member.Field, expr.Span, true); ty != types.NoTypeID {
+					return ty, true
+				}
+			}
+		}
 	case ast.ExprLit:
 		// Handle 'nothing' literal as type operand
 		if lit, ok := tc.builder.Exprs.Literal(exprID); ok && lit != nil {
@@ -133,6 +141,12 @@ func (tc *typeChecker) tryResolveTypeOperand(exprID ast.ExprID) types.TypeID {
 			scope := tc.scopeOrFile(tc.currentScope())
 			if symID := tc.lookupTypeSymbol(ident.Name, scope); symID.IsValid() {
 				return tc.symbolType(symID)
+			}
+		}
+	case ast.ExprMember:
+		if member, ok := tc.builder.Exprs.Member(exprID); ok && member != nil {
+			if module := tc.moduleSymbolForExpr(member.Target); module != nil {
+				return tc.moduleTypeMember(module, member.Field, expr.Span, false)
 			}
 		}
 	case ast.ExprLit:

--- a/internal/sema/type_expr_type_operands.go
+++ b/internal/sema/type_expr_type_operands.go
@@ -75,6 +75,7 @@ func (tc *typeChecker) resolveTypeOperand(exprID ast.ExprID, opLabel string) (ty
 				if ty := tc.moduleTypeMember(module, member.Field, expr.Span, true); ty != types.NoTypeID {
 					return ty, true
 				}
+				return types.NoTypeID, false
 			}
 		}
 	case ast.ExprLit:

--- a/internal/vm/intrinsic.go
+++ b/internal/vm/intrinsic.go
@@ -24,6 +24,9 @@ func (vm *VM) callIntrinsic(frame *Frame, call *mir.CallInstr, writes *[]LocalWr
 	}
 
 	switch name {
+	case "sub", "as_seconds", "as_millis", "as_micros", "as_nanos":
+		return vm.handleDurationMethod(frame, call, writes, name)
+
 	case "size_of", "align_of":
 		return vm.handleSizeOfAlignOf(frame, call, writes, name)
 

--- a/internal/vm/intrinsic_time.go
+++ b/internal/vm/intrinsic_time.go
@@ -1,8 +1,17 @@
 package vm
 
 import (
+	"fmt"
+
 	"surge/internal/mir"
 	"surge/internal/types"
+)
+
+const (
+	durationOpaqueField = "__opaque"
+	nanosPerMicro       = int64(1_000)
+	nanosPerMilli       = int64(1_000_000)
+	nanosPerSecond      = int64(1_000_000_000)
 )
 
 func (vm *VM) handleMonotonicNow(frame *Frame, call *mir.CallInstr, writes *[]LocalWrite) *VMError {
@@ -34,6 +43,112 @@ func (vm *VM) handleMonotonicNow(frame *Frame, call *mir.CallInstr, writes *[]Lo
 	return nil
 }
 
+func (vm *VM) handleDurationMethod(frame *Frame, call *mir.CallInstr, writes *[]LocalWrite, name string) *VMError {
+	if call == nil || !call.HasDst {
+		return vm.eb.makeError(PanicTypeMismatch, name+" requires a destination")
+	}
+	switch name {
+	case "sub":
+		return vm.handleDurationSub(frame, call, writes)
+	case "as_seconds":
+		return vm.handleDurationUnit(frame, call, writes, name, nanosPerSecond)
+	case "as_millis":
+		return vm.handleDurationUnit(frame, call, writes, name, nanosPerMilli)
+	case "as_micros":
+		return vm.handleDurationUnit(frame, call, writes, name, nanosPerMicro)
+	case "as_nanos":
+		return vm.handleDurationUnit(frame, call, writes, name, 1)
+	default:
+		return vm.eb.unsupportedIntrinsic(name)
+	}
+}
+
+func (vm *VM) handleDurationSub(frame *Frame, call *mir.CallInstr, writes *[]LocalWrite) *VMError {
+	if len(call.Args) != 2 {
+		return vm.eb.makeError(PanicTypeMismatch, "Duration.sub requires 2 arguments")
+	}
+	left, vmErr := vm.evalOperand(frame, &call.Args[0])
+	if vmErr != nil {
+		return vmErr
+	}
+	defer vm.dropValue(left)
+	right, vmErr := vm.evalOperand(frame, &call.Args[1])
+	if vmErr != nil {
+		return vmErr
+	}
+	defer vm.dropValue(right)
+	leftNanos, vmErr := vm.durationNanos(left)
+	if vmErr != nil {
+		return vmErr
+	}
+	rightNanos, vmErr := vm.durationNanos(right)
+	if vmErr != nil {
+		return vmErr
+	}
+	res, vmErr := vm.durationValue(leftNanos-rightNanos, frame.Locals[call.Dst.Local].TypeID)
+	if vmErr != nil {
+		return vmErr
+	}
+	return vm.writeDurationResult(frame, call.Dst.Local, res, writes)
+}
+
+func (vm *VM) handleDurationUnit(frame *Frame, call *mir.CallInstr, writes *[]LocalWrite, name string, divisor int64) *VMError {
+	if len(call.Args) != 1 {
+		return vm.eb.makeError(PanicTypeMismatch, name+" requires 1 argument")
+	}
+	value, vmErr := vm.evalOperand(frame, &call.Args[0])
+	if vmErr != nil {
+		return vmErr
+	}
+	defer vm.dropValue(value)
+	nanos, vmErr := vm.durationNanos(value)
+	if vmErr != nil {
+		return vmErr
+	}
+	if divisor != 1 {
+		nanos /= divisor
+	}
+	dstLocal := call.Dst.Local
+	res := MakeInt(nanos, frame.Locals[dstLocal].TypeID)
+	return vm.writeDurationResult(frame, dstLocal, res, writes)
+}
+
+func (vm *VM) durationNanos(value Value) (int64, *VMError) {
+	if value.Kind == VKRef || value.Kind == VKRefMut {
+		loaded, vmErr := vm.loadLocationRaw(value.Loc)
+		if vmErr != nil {
+			return 0, vmErr
+		}
+		value = loaded
+	}
+	if value.Kind != VKHandleStruct {
+		return 0, vm.eb.typeMismatch("Duration", value.Kind.String())
+	}
+	obj := vm.Heap.Get(value.H)
+	if obj == nil {
+		return 0, vm.eb.typeMismatch("Duration", "invalid handle")
+	}
+	if obj.Kind != OKStruct {
+		return 0, vm.eb.typeMismatch("Duration", fmt.Sprintf("%v", obj.Kind))
+	}
+	layout, vmErr := vm.layouts.Struct(value.TypeID)
+	if vmErr != nil {
+		return 0, vmErr
+	}
+	idx, ok := layout.IndexByName[durationOpaqueField]
+	if !ok {
+		return 0, vm.eb.makeError(PanicTypeMismatch, "Duration missing __opaque field")
+	}
+	if idx < 0 || idx >= len(obj.Fields) {
+		return 0, vm.eb.makeError(PanicOutOfBounds, "Duration __opaque field out of range")
+	}
+	field := obj.Fields[idx]
+	if field.Kind != VKInt {
+		return 0, vm.eb.typeMismatch("int64", field.Kind.String())
+	}
+	return field.Int, nil
+}
+
 func (vm *VM) durationValue(nanos int64, typeID types.TypeID) (Value, *VMError) {
 	layout, vmErr := vm.layouts.Struct(typeID)
 	if vmErr != nil {
@@ -43,7 +158,7 @@ func (vm *VM) durationValue(nanos int64, typeID types.TypeID) (Value, *VMError) 
 	for i := range fields {
 		fields[i] = Value{Kind: VKInvalid}
 	}
-	idx, ok := layout.IndexByName["__opaque"]
+	idx, ok := layout.IndexByName[durationOpaqueField]
 	if !ok {
 		return Value{}, vm.eb.makeError(PanicTypeMismatch, "Duration missing __opaque field")
 	}
@@ -54,4 +169,21 @@ func (vm *VM) durationValue(nanos int64, typeID types.TypeID) (Value, *VMError) 
 	fields[idx] = MakeInt(nanos, fieldType)
 	h := vm.Heap.AllocStruct(typeID, fields)
 	return MakeHandleStruct(h, typeID), nil
+}
+
+func (vm *VM) writeDurationResult(frame *Frame, dst mir.LocalID, value Value, writes *[]LocalWrite) *VMError {
+	if vmErr := vm.writeLocal(frame, dst, value); vmErr != nil {
+		if value.IsHeap() {
+			vm.dropValue(value)
+		}
+		return vmErr
+	}
+	if writes != nil {
+		*writes = append(*writes, LocalWrite{
+			LocalID: dst,
+			Name:    frame.Locals[dst].Name,
+			Value:   value,
+		})
+	}
+	return nil
 }

--- a/internal/vm/intrinsic_time_test.go
+++ b/internal/vm/intrinsic_time_test.go
@@ -11,6 +11,7 @@ func TestVMDurationIntrinsicMethods(t *testing.T) {
 @entrypoint
 fn main() -> int {
     let d = time.Duration.new(1_500_250_999:int64);
+    let copied = d;
     if d.as_nanos() != 1_500_250_999:int64 {
         return 1;
     }
@@ -23,15 +24,18 @@ fn main() -> int {
     if d.as_seconds() != 1:int64 {
         return 4;
     }
+    if copied.as_millis() != 1_500:int64 {
+        return 5;
+    }
     let later = time.Duration.new(2_000_000_000:int64);
     let diff = later.sub(d);
     if diff.as_micros() != 499_749:int64 {
-        return 5;
+        return 6;
     }
     let started = time.Duration.now();
     let finished = time.Duration.now();
     if finished.sub(started).as_nanos() < 0:int64 {
-        return 6;
+        return 7;
     }
     return 0;
 }

--- a/internal/vm/intrinsic_time_test.go
+++ b/internal/vm/intrinsic_time_test.go
@@ -1,0 +1,46 @@
+package vm_test
+
+import "testing"
+
+func TestVMDurationIntrinsicMethods(t *testing.T) {
+	requireVMBackend(t)
+	t.Setenv("SURGE_STDLIB", repoRoot(t))
+
+	sourceCode := `import stdlib/time as time;
+
+fn duration(ns: int64) -> time.Duration {
+    return time.Duration { __opaque = ns };
+}
+
+@entrypoint
+fn main() -> int {
+    let d = duration(1_500_250_999:int64);
+    if d.as_nanos() != 1_500_250_999:int64 {
+        return 1;
+    }
+    if d.as_micros() != 1_500_250:int64 {
+        return 2;
+    }
+    if d.as_millis() != 1_500:int64 {
+        return 3;
+    }
+    if d.as_seconds() != 1:int64 {
+        return 4;
+    }
+    let later = duration(2_000_000_000:int64);
+    let diff = later.sub(d);
+    if diff.as_micros() != 499_749:int64 {
+        return 5;
+    }
+    return 0;
+}
+`
+
+	result := runProgramFromSource(t, sourceCode, runOptions{})
+	if result.exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d\nstderr:\n%s", result.exitCode, result.stderr)
+	}
+	if result.stderr != "" {
+		t.Fatalf("expected empty stderr, got:\n%s", result.stderr)
+	}
+}

--- a/internal/vm/intrinsic_time_test.go
+++ b/internal/vm/intrinsic_time_test.go
@@ -8,13 +8,9 @@ func TestVMDurationIntrinsicMethods(t *testing.T) {
 
 	sourceCode := `import stdlib/time as time;
 
-fn duration(ns: int64) -> time.Duration {
-    return time.Duration { __opaque = ns };
-}
-
 @entrypoint
 fn main() -> int {
-    let d = duration(1_500_250_999:int64);
+    let d = time.Duration.new(1_500_250_999:int64);
     if d.as_nanos() != 1_500_250_999:int64 {
         return 1;
     }
@@ -27,10 +23,15 @@ fn main() -> int {
     if d.as_seconds() != 1:int64 {
         return 4;
     }
-    let later = duration(2_000_000_000:int64);
+    let later = time.Duration.new(2_000_000_000:int64);
     let diff = later.sub(d);
     if diff.as_micros() != 499_749:int64 {
         return 5;
+    }
+    let started = time.Duration.now();
+    let finished = time.Duration.now();
+    if finished.sub(started).as_nanos() < 0:int64 {
+        return 6;
     }
     return 0;
 }

--- a/stdlib/time/time.sg
+++ b/stdlib/time/time.sg
@@ -3,6 +3,7 @@
 
 // Duration represents a time span with nanosecond precision.
 // Stored internally as nanoseconds in an int64.
+@copy
 @intrinsic
 pub type Duration = {
     __opaque: int64,
@@ -18,21 +19,21 @@ extern<Duration> {
     // Subtract another duration from this one.
     // Returns self - other.
     @intrinsic
-    pub fn sub(self: Duration, other: Duration) -> Duration;
+    pub fn sub(self: &Duration, other: Duration) -> Duration;
 
-    // Convert duration to floating-point seconds.
+    // Convert duration to whole seconds.
     @intrinsic
-    pub fn as_seconds(self: Duration) -> float;
+    pub fn as_seconds(self: &Duration) -> int64;
 
-    // Convert duration to floating-point milliseconds.
+    // Convert duration to whole milliseconds.
     @intrinsic
-    pub fn as_millis(self: Duration) -> float;
+    pub fn as_millis(self: &Duration) -> int64;
 
-    // Convert duration to floating-point microseconds.
+    // Convert duration to whole microseconds.
     @intrinsic
-    pub fn as_micros(self: Duration) -> float;
+    pub fn as_micros(self: &Duration) -> int64;
 
-    // Convert duration to floating-point nanoseconds.
+    // Convert duration to nanoseconds.
     @intrinsic
-    pub fn as_nanos(self: Duration) -> float;
+    pub fn as_nanos(self: &Duration) -> int64;
 }

--- a/stdlib/time/time.sg
+++ b/stdlib/time/time.sg
@@ -16,6 +16,17 @@ pub type Duration = {
 pub fn monotonic_now() -> Duration;
 
 extern<Duration> {
+    // Build a Duration from whole nanoseconds.
+    pub fn new(nanos: int64) -> Duration {
+        return Duration { __opaque = nanos };
+    }
+
+    // Return the current monotonic timestamp as a Duration.
+    // Use it with sub() to measure elapsed time; it is not wall-clock time.
+    pub fn now() -> Duration {
+        return monotonic_now();
+    }
+
     // Subtract another duration from this one.
     // Returns self - other.
     @intrinsic

--- a/testdata/golden/stdlib/time_duration_conversions.ast
+++ b/testdata/golden/stdlib/time_duration_conversions.ast
@@ -1,0 +1,35 @@
+time_duration_conversions.sg (span: 1:1-13:1)
+├─ Item[0]: Import (span: 1:1-1:28)
+│  ├─ Module: stdlib::time
+│  └─ Alias: time
+├─ Item[1]: Fn (span: 3:1-5:2)
+│  ├─ Name: duration
+│  ├─ Params: (ns: int64)
+│  ├─ Return: time.Duration
+│  └─ Body:
+│     └─ Stmt[0]: Block (span: 3:41-5:2)
+│        └─ Stmt[0]: Return (span: 4:5-4:44)
+│           └─ Expr: expr#5: <ExprKind(22)>
+└─ Item[2]: Fn (span: 7:1-12:2)
+   ├─ Name: duration_total
+   ├─ Params: ()
+   ├─ Return: int64
+   └─ Body:
+      └─ Stmt[0]: Block (span: 7:30-12:2)
+         ├─ Stmt[0]: Let (span: 8:5-8:43)
+         │  ├─ Name: d
+         │  ├─ Mutable: false
+         │  ├─ Type: <inferred>
+         │  └─ Value: expr#9: duration(1_234_567_890 to int64)
+         ├─ Stmt[1]: Let (span: 9:5-9:47)
+         │  ├─ Name: earlier
+         │  ├─ Mutable: false
+         │  ├─ Type: <inferred>
+         │  └─ Value: expr#13: duration(234_567_890 to int64)
+         ├─ Stmt[2]: Let (span: 10:5-10:31)
+         │  ├─ Name: diff
+         │  ├─ Mutable: false
+         │  ├─ Type: <inferred>
+         │  └─ Value: expr#17: d.sub(earlier)
+         └─ Stmt[3]: Return (span: 11:5-11:86)
+            └─ Expr: expr#32: (((((diff.as_seconds() + diff.as_millis())) + diff.as_micros())) + diff.as_nanos())

--- a/testdata/golden/stdlib/time_duration_conversions.ast
+++ b/testdata/golden/stdlib/time_duration_conversions.ast
@@ -1,35 +1,42 @@
-time_duration_conversions.sg (span: 1:1-13:1)
+time_duration_conversions.sg (span: 1:1-12:1)
 ├─ Item[0]: Import (span: 1:1-1:28)
 │  ├─ Module: stdlib::time
 │  └─ Alias: time
-├─ Item[1]: Fn (span: 3:1-5:2)
-│  ├─ Name: duration
-│  ├─ Params: (ns: int64)
-│  ├─ Return: time.Duration
-│  └─ Body:
-│     └─ Stmt[0]: Block (span: 3:41-5:2)
-│        └─ Stmt[0]: Return (span: 4:5-4:44)
-│           └─ Expr: expr#5: <ExprKind(22)>
-└─ Item[2]: Fn (span: 7:1-12:2)
+└─ Item[1]: Fn (span: 3:1-11:2)
    ├─ Name: duration_total
    ├─ Params: ()
    ├─ Return: int64
    └─ Body:
-      └─ Stmt[0]: Block (span: 7:30-12:2)
-         ├─ Stmt[0]: Let (span: 8:5-8:43)
+      └─ Stmt[0]: Block (span: 3:30-11:2)
+         ├─ Stmt[0]: Let (span: 4:5-4:52)
          │  ├─ Name: d
          │  ├─ Mutable: false
          │  ├─ Type: <inferred>
-         │  └─ Value: expr#9: duration(1_234_567_890 to int64)
-         ├─ Stmt[1]: Let (span: 9:5-9:47)
+         │  └─ Value: expr#6: time.Duration.new(1_234_567_890 to int64)
+         ├─ Stmt[1]: Let (span: 5:5-5:56)
          │  ├─ Name: earlier
          │  ├─ Mutable: false
          │  ├─ Type: <inferred>
-         │  └─ Value: expr#13: duration(234_567_890 to int64)
-         ├─ Stmt[2]: Let (span: 10:5-10:31)
+         │  └─ Value: expr#12: time.Duration.new(234_567_890 to int64)
+         ├─ Stmt[2]: Let (span: 6:5-6:31)
          │  ├─ Name: diff
          │  ├─ Mutable: false
          │  ├─ Type: <inferred>
-         │  └─ Value: expr#17: d.sub(earlier)
-         └─ Stmt[3]: Return (span: 11:5-11:86)
-            └─ Expr: expr#32: (((((diff.as_seconds() + diff.as_millis())) + diff.as_micros())) + diff.as_nanos())
+         │  └─ Value: expr#16: d.sub(earlier)
+         ├─ Stmt[3]: Let (span: 7:5-7:39)
+         │  ├─ Name: started
+         │  ├─ Mutable: false
+         │  ├─ Type: <inferred>
+         │  └─ Value: expr#20: time.Duration.now()
+         ├─ Stmt[4]: Let (span: 8:5-8:40)
+         │  ├─ Name: finished
+         │  ├─ Mutable: false
+         │  ├─ Type: <inferred>
+         │  └─ Value: expr#24: time.Duration.now()
+         ├─ Stmt[5]: Let (span: 9:5-9:41)
+         │  ├─ Name: elapsed
+         │  ├─ Mutable: false
+         │  ├─ Type: <inferred>
+         │  └─ Value: expr#28: finished.sub(started)
+         └─ Stmt[6]: Return (span: 10:5-10:107)
+            └─ Expr: expr#47: (((((((diff.as_seconds() + diff.as_millis())) + diff.as_micros())) + diff.as_nanos())) + elapsed.as_nanos())

--- a/testdata/golden/stdlib/time_duration_conversions.ast
+++ b/testdata/golden/stdlib/time_duration_conversions.ast
@@ -1,42 +1,52 @@
-time_duration_conversions.sg (span: 1:1-12:1)
+time_duration_conversions.sg (span: 1:1-14:1)
 ├─ Item[0]: Import (span: 1:1-1:28)
 │  ├─ Module: stdlib::time
 │  └─ Alias: time
-└─ Item[1]: Fn (span: 3:1-11:2)
+└─ Item[1]: Fn (span: 3:1-13:2)
    ├─ Name: duration_total
    ├─ Params: ()
    ├─ Return: int64
    └─ Body:
-      └─ Stmt[0]: Block (span: 3:30-11:2)
+      └─ Stmt[0]: Block (span: 3:30-13:2)
          ├─ Stmt[0]: Let (span: 4:5-4:52)
          │  ├─ Name: d
          │  ├─ Mutable: false
          │  ├─ Type: <inferred>
          │  └─ Value: expr#6: time.Duration.new(1_234_567_890 to int64)
-         ├─ Stmt[1]: Let (span: 5:5-5:56)
+         ├─ Stmt[1]: Let (span: 5:5-5:20)
+         │  ├─ Name: copied
+         │  ├─ Mutable: false
+         │  ├─ Type: <inferred>
+         │  └─ Value: expr#7: d
+         ├─ Stmt[2]: Let (span: 6:5-6:56)
          │  ├─ Name: earlier
          │  ├─ Mutable: false
          │  ├─ Type: <inferred>
-         │  └─ Value: expr#12: time.Duration.new(234_567_890 to int64)
-         ├─ Stmt[2]: Let (span: 6:5-6:31)
+         │  └─ Value: expr#13: time.Duration.new(234_567_890 to int64)
+         ├─ Stmt[3]: Let (span: 7:5-7:31)
          │  ├─ Name: diff
          │  ├─ Mutable: false
          │  ├─ Type: <inferred>
-         │  └─ Value: expr#16: d.sub(earlier)
-         ├─ Stmt[3]: Let (span: 7:5-7:39)
+         │  └─ Value: expr#17: d.sub(earlier)
+         ├─ Stmt[4]: Let (span: 8:5-8:41)
+         │  ├─ Name: copy_diff
+         │  ├─ Mutable: false
+         │  ├─ Type: <inferred>
+         │  └─ Value: expr#21: copied.sub(earlier)
+         ├─ Stmt[5]: Let (span: 9:5-9:39)
          │  ├─ Name: started
          │  ├─ Mutable: false
          │  ├─ Type: <inferred>
-         │  └─ Value: expr#20: time.Duration.now()
-         ├─ Stmt[4]: Let (span: 8:5-8:40)
+         │  └─ Value: expr#25: time.Duration.now()
+         ├─ Stmt[6]: Let (span: 10:5-10:40)
          │  ├─ Name: finished
          │  ├─ Mutable: false
          │  ├─ Type: <inferred>
-         │  └─ Value: expr#24: time.Duration.now()
-         ├─ Stmt[5]: Let (span: 9:5-9:41)
+         │  └─ Value: expr#29: time.Duration.now()
+         ├─ Stmt[7]: Let (span: 11:5-11:41)
          │  ├─ Name: elapsed
          │  ├─ Mutable: false
          │  ├─ Type: <inferred>
-         │  └─ Value: expr#28: finished.sub(started)
-         └─ Stmt[6]: Return (span: 10:5-10:107)
-            └─ Expr: expr#47: (((((((diff.as_seconds() + diff.as_millis())) + diff.as_micros())) + diff.as_nanos())) + elapsed.as_nanos())
+         │  └─ Value: expr#33: finished.sub(started)
+         └─ Stmt[8]: Return (span: 12:5-12:132)
+            └─ Expr: expr#56: (((((((((diff.as_seconds() + diff.as_millis())) + diff.as_micros())) + diff.as_nanos())) + copy_diff.as_seconds())) + elapsed.as_nanos())

--- a/testdata/golden/stdlib/time_duration_conversions.fmt
+++ b/testdata/golden/stdlib/time_duration_conversions.fmt
@@ -1,0 +1,12 @@
+import stdlib/time as time;
+
+fn duration(ns: int64) -> time.Duration {
+    return time.Duration { __opaque = ns };
+}
+
+fn duration_total() -> int64 {
+    let d = duration(1_234_567_890:int64);
+    let earlier = duration(234_567_890:int64);
+    let diff = d.sub(earlier);
+    return diff.as_seconds() + diff.as_millis() + diff.as_micros() + diff.as_nanos();
+}

--- a/testdata/golden/stdlib/time_duration_conversions.fmt
+++ b/testdata/golden/stdlib/time_duration_conversions.fmt
@@ -1,12 +1,11 @@
 import stdlib/time as time;
 
-fn duration(ns: int64) -> time.Duration {
-    return time.Duration { __opaque = ns };
-}
-
 fn duration_total() -> int64 {
-    let d = duration(1_234_567_890:int64);
-    let earlier = duration(234_567_890:int64);
+    let d = time.Duration.new(1_234_567_890:int64);
+    let earlier = time.Duration.new(234_567_890:int64);
     let diff = d.sub(earlier);
-    return diff.as_seconds() + diff.as_millis() + diff.as_micros() + diff.as_nanos();
+    let started = time.Duration.now();
+    let finished = time.Duration.now();
+    let elapsed = finished.sub(started);
+    return diff.as_seconds() + diff.as_millis() + diff.as_micros() + diff.as_nanos() + elapsed.as_nanos();
 }

--- a/testdata/golden/stdlib/time_duration_conversions.fmt
+++ b/testdata/golden/stdlib/time_duration_conversions.fmt
@@ -2,10 +2,12 @@ import stdlib/time as time;
 
 fn duration_total() -> int64 {
     let d = time.Duration.new(1_234_567_890:int64);
+    let copied = d;
     let earlier = time.Duration.new(234_567_890:int64);
     let diff = d.sub(earlier);
+    let copy_diff = copied.sub(earlier);
     let started = time.Duration.now();
     let finished = time.Duration.now();
     let elapsed = finished.sub(started);
-    return diff.as_seconds() + diff.as_millis() + diff.as_micros() + diff.as_nanos() + elapsed.as_nanos();
+    return diff.as_seconds() + diff.as_millis() + diff.as_micros() + diff.as_nanos() + copy_diff.as_seconds() + elapsed.as_nanos();
 }

--- a/testdata/golden/stdlib/time_duration_conversions.sg
+++ b/testdata/golden/stdlib/time_duration_conversions.sg
@@ -1,0 +1,12 @@
+import stdlib/time as time;
+
+fn duration(ns: int64) -> time.Duration {
+    return time.Duration { __opaque = ns };
+}
+
+fn duration_total() -> int64 {
+    let d = duration(1_234_567_890:int64);
+    let earlier = duration(234_567_890:int64);
+    let diff = d.sub(earlier);
+    return diff.as_seconds() + diff.as_millis() + diff.as_micros() + diff.as_nanos();
+}

--- a/testdata/golden/stdlib/time_duration_conversions.sg
+++ b/testdata/golden/stdlib/time_duration_conversions.sg
@@ -1,12 +1,11 @@
 import stdlib/time as time;
 
-fn duration(ns: int64) -> time.Duration {
-    return time.Duration { __opaque = ns };
-}
-
 fn duration_total() -> int64 {
-    let d = duration(1_234_567_890:int64);
-    let earlier = duration(234_567_890:int64);
+    let d = time.Duration.new(1_234_567_890:int64);
+    let earlier = time.Duration.new(234_567_890:int64);
     let diff = d.sub(earlier);
-    return diff.as_seconds() + diff.as_millis() + diff.as_micros() + diff.as_nanos();
+    let started = time.Duration.now();
+    let finished = time.Duration.now();
+    let elapsed = finished.sub(started);
+    return diff.as_seconds() + diff.as_millis() + diff.as_micros() + diff.as_nanos() + elapsed.as_nanos();
 }

--- a/testdata/golden/stdlib/time_duration_conversions.sg
+++ b/testdata/golden/stdlib/time_duration_conversions.sg
@@ -2,10 +2,12 @@ import stdlib/time as time;
 
 fn duration_total() -> int64 {
     let d = time.Duration.new(1_234_567_890:int64);
+    let copied = d;
     let earlier = time.Duration.new(234_567_890:int64);
     let diff = d.sub(earlier);
+    let copy_diff = copied.sub(earlier);
     let started = time.Duration.now();
     let finished = time.Duration.now();
     let elapsed = finished.sub(started);
-    return diff.as_seconds() + diff.as_millis() + diff.as_micros() + diff.as_nanos() + elapsed.as_nanos();
+    return diff.as_seconds() + diff.as_millis() + diff.as_micros() + diff.as_nanos() + copy_diff.as_seconds() + elapsed.as_nanos();
 }

--- a/testdata/golden/stdlib/time_duration_conversions.tokens
+++ b/testdata/golden/stdlib/time_duration_conversions.tokens
@@ -27,91 +27,112 @@
  27: RParen          ")" at 4:50-4:51
  28: Semicolon       ";" at 4:51-4:52
  29: KwLet           "let" at 5:5-5:8 (leading: Newline, Space)
- 30: Ident           "earlier" at 5:9-5:16 (leading: Space)
- 31: Assign          "=" at 5:17-5:18 (leading: Space)
- 32: Ident           "time" at 5:19-5:23 (leading: Space)
- 33: Dot             "." at 5:23-5:24
- 34: Ident           "Duration" at 5:24-5:32
- 35: Dot             "." at 5:32-5:33
- 36: Ident           "new" at 5:33-5:36
- 37: LParen          "(" at 5:36-5:37
- 38: IntLit          "234_567_890" at 5:37-5:48
- 39: Colon           ":" at 5:48-5:49
- 40: Ident           "int64" at 5:49-5:54
- 41: RParen          ")" at 5:54-5:55
- 42: Semicolon       ";" at 5:55-5:56
- 43: KwLet           "let" at 6:5-6:8 (leading: Newline, Space)
- 44: Ident           "diff" at 6:9-6:13 (leading: Space)
- 45: Assign          "=" at 6:14-6:15 (leading: Space)
- 46: Ident           "d" at 6:16-6:17 (leading: Space)
- 47: Dot             "." at 6:17-6:18
- 48: Ident           "sub" at 6:18-6:21
- 49: LParen          "(" at 6:21-6:22
- 50: Ident           "earlier" at 6:22-6:29
- 51: RParen          ")" at 6:29-6:30
- 52: Semicolon       ";" at 6:30-6:31
- 53: KwLet           "let" at 7:5-7:8 (leading: Newline, Space)
- 54: Ident           "started" at 7:9-7:16 (leading: Space)
- 55: Assign          "=" at 7:17-7:18 (leading: Space)
- 56: Ident           "time" at 7:19-7:23 (leading: Space)
- 57: Dot             "." at 7:23-7:24
- 58: Ident           "Duration" at 7:24-7:32
- 59: Dot             "." at 7:32-7:33
- 60: Ident           "now" at 7:33-7:36
- 61: LParen          "(" at 7:36-7:37
- 62: RParen          ")" at 7:37-7:38
- 63: Semicolon       ";" at 7:38-7:39
- 64: KwLet           "let" at 8:5-8:8 (leading: Newline, Space)
- 65: Ident           "finished" at 8:9-8:17 (leading: Space)
- 66: Assign          "=" at 8:18-8:19 (leading: Space)
- 67: Ident           "time" at 8:20-8:24 (leading: Space)
- 68: Dot             "." at 8:24-8:25
- 69: Ident           "Duration" at 8:25-8:33
- 70: Dot             "." at 8:33-8:34
- 71: Ident           "now" at 8:34-8:37
- 72: LParen          "(" at 8:37-8:38
- 73: RParen          ")" at 8:38-8:39
- 74: Semicolon       ";" at 8:39-8:40
- 75: KwLet           "let" at 9:5-9:8 (leading: Newline, Space)
- 76: Ident           "elapsed" at 9:9-9:16 (leading: Space)
- 77: Assign          "=" at 9:17-9:18 (leading: Space)
- 78: Ident           "finished" at 9:19-9:27 (leading: Space)
- 79: Dot             "." at 9:27-9:28
- 80: Ident           "sub" at 9:28-9:31
- 81: LParen          "(" at 9:31-9:32
- 82: Ident           "started" at 9:32-9:39
- 83: RParen          ")" at 9:39-9:40
- 84: Semicolon       ";" at 9:40-9:41
- 85: KwReturn        "return" at 10:5-10:11 (leading: Newline, Space)
- 86: Ident           "diff" at 10:12-10:16 (leading: Space)
- 87: Dot             "." at 10:16-10:17
- 88: Ident           "as_seconds" at 10:17-10:27
- 89: LParen          "(" at 10:27-10:28
- 90: RParen          ")" at 10:28-10:29
- 91: Plus            "+" at 10:30-10:31 (leading: Space)
- 92: Ident           "diff" at 10:32-10:36 (leading: Space)
- 93: Dot             "." at 10:36-10:37
- 94: Ident           "as_millis" at 10:37-10:46
- 95: LParen          "(" at 10:46-10:47
- 96: RParen          ")" at 10:47-10:48
- 97: Plus            "+" at 10:49-10:50 (leading: Space)
- 98: Ident           "diff" at 10:51-10:55 (leading: Space)
- 99: Dot             "." at 10:55-10:56
-100: Ident           "as_micros" at 10:56-10:65
-101: LParen          "(" at 10:65-10:66
-102: RParen          ")" at 10:66-10:67
-103: Plus            "+" at 10:68-10:69 (leading: Space)
-104: Ident           "diff" at 10:70-10:74 (leading: Space)
-105: Dot             "." at 10:74-10:75
-106: Ident           "as_nanos" at 10:75-10:83
-107: LParen          "(" at 10:83-10:84
-108: RParen          ")" at 10:84-10:85
-109: Plus            "+" at 10:86-10:87 (leading: Space)
-110: Ident           "elapsed" at 10:88-10:95 (leading: Space)
-111: Dot             "." at 10:95-10:96
-112: Ident           "as_nanos" at 10:96-10:104
-113: LParen          "(" at 10:104-10:105
-114: RParen          ")" at 10:105-10:106
-115: Semicolon       ";" at 10:106-10:107
-116: RBrace          "}" at 11:1-11:2 (leading: Newline)
-117: EOF             at 12:1-12:1
+ 30: Ident           "copied" at 5:9-5:15 (leading: Space)
+ 31: Assign          "=" at 5:16-5:17 (leading: Space)
+ 32: Ident           "d" at 5:18-5:19 (leading: Space)
+ 33: Semicolon       ";" at 5:19-5:20
+ 34: KwLet           "let" at 6:5-6:8 (leading: Newline, Space)
+ 35: Ident           "earlier" at 6:9-6:16 (leading: Space)
+ 36: Assign          "=" at 6:17-6:18 (leading: Space)
+ 37: Ident           "time" at 6:19-6:23 (leading: Space)
+ 38: Dot             "." at 6:23-6:24
+ 39: Ident           "Duration" at 6:24-6:32
+ 40: Dot             "." at 6:32-6:33
+ 41: Ident           "new" at 6:33-6:36
+ 42: LParen          "(" at 6:36-6:37
+ 43: IntLit          "234_567_890" at 6:37-6:48
+ 44: Colon           ":" at 6:48-6:49
+ 45: Ident           "int64" at 6:49-6:54
+ 46: RParen          ")" at 6:54-6:55
+ 47: Semicolon       ";" at 6:55-6:56
+ 48: KwLet           "let" at 7:5-7:8 (leading: Newline, Space)
+ 49: Ident           "diff" at 7:9-7:13 (leading: Space)
+ 50: Assign          "=" at 7:14-7:15 (leading: Space)
+ 51: Ident           "d" at 7:16-7:17 (leading: Space)
+ 52: Dot             "." at 7:17-7:18
+ 53: Ident           "sub" at 7:18-7:21
+ 54: LParen          "(" at 7:21-7:22
+ 55: Ident           "earlier" at 7:22-7:29
+ 56: RParen          ")" at 7:29-7:30
+ 57: Semicolon       ";" at 7:30-7:31
+ 58: KwLet           "let" at 8:5-8:8 (leading: Newline, Space)
+ 59: Ident           "copy_diff" at 8:9-8:18 (leading: Space)
+ 60: Assign          "=" at 8:19-8:20 (leading: Space)
+ 61: Ident           "copied" at 8:21-8:27 (leading: Space)
+ 62: Dot             "." at 8:27-8:28
+ 63: Ident           "sub" at 8:28-8:31
+ 64: LParen          "(" at 8:31-8:32
+ 65: Ident           "earlier" at 8:32-8:39
+ 66: RParen          ")" at 8:39-8:40
+ 67: Semicolon       ";" at 8:40-8:41
+ 68: KwLet           "let" at 9:5-9:8 (leading: Newline, Space)
+ 69: Ident           "started" at 9:9-9:16 (leading: Space)
+ 70: Assign          "=" at 9:17-9:18 (leading: Space)
+ 71: Ident           "time" at 9:19-9:23 (leading: Space)
+ 72: Dot             "." at 9:23-9:24
+ 73: Ident           "Duration" at 9:24-9:32
+ 74: Dot             "." at 9:32-9:33
+ 75: Ident           "now" at 9:33-9:36
+ 76: LParen          "(" at 9:36-9:37
+ 77: RParen          ")" at 9:37-9:38
+ 78: Semicolon       ";" at 9:38-9:39
+ 79: KwLet           "let" at 10:5-10:8 (leading: Newline, Space)
+ 80: Ident           "finished" at 10:9-10:17 (leading: Space)
+ 81: Assign          "=" at 10:18-10:19 (leading: Space)
+ 82: Ident           "time" at 10:20-10:24 (leading: Space)
+ 83: Dot             "." at 10:24-10:25
+ 84: Ident           "Duration" at 10:25-10:33
+ 85: Dot             "." at 10:33-10:34
+ 86: Ident           "now" at 10:34-10:37
+ 87: LParen          "(" at 10:37-10:38
+ 88: RParen          ")" at 10:38-10:39
+ 89: Semicolon       ";" at 10:39-10:40
+ 90: KwLet           "let" at 11:5-11:8 (leading: Newline, Space)
+ 91: Ident           "elapsed" at 11:9-11:16 (leading: Space)
+ 92: Assign          "=" at 11:17-11:18 (leading: Space)
+ 93: Ident           "finished" at 11:19-11:27 (leading: Space)
+ 94: Dot             "." at 11:27-11:28
+ 95: Ident           "sub" at 11:28-11:31
+ 96: LParen          "(" at 11:31-11:32
+ 97: Ident           "started" at 11:32-11:39
+ 98: RParen          ")" at 11:39-11:40
+ 99: Semicolon       ";" at 11:40-11:41
+100: KwReturn        "return" at 12:5-12:11 (leading: Newline, Space)
+101: Ident           "diff" at 12:12-12:16 (leading: Space)
+102: Dot             "." at 12:16-12:17
+103: Ident           "as_seconds" at 12:17-12:27
+104: LParen          "(" at 12:27-12:28
+105: RParen          ")" at 12:28-12:29
+106: Plus            "+" at 12:30-12:31 (leading: Space)
+107: Ident           "diff" at 12:32-12:36 (leading: Space)
+108: Dot             "." at 12:36-12:37
+109: Ident           "as_millis" at 12:37-12:46
+110: LParen          "(" at 12:46-12:47
+111: RParen          ")" at 12:47-12:48
+112: Plus            "+" at 12:49-12:50 (leading: Space)
+113: Ident           "diff" at 12:51-12:55 (leading: Space)
+114: Dot             "." at 12:55-12:56
+115: Ident           "as_micros" at 12:56-12:65
+116: LParen          "(" at 12:65-12:66
+117: RParen          ")" at 12:66-12:67
+118: Plus            "+" at 12:68-12:69 (leading: Space)
+119: Ident           "diff" at 12:70-12:74 (leading: Space)
+120: Dot             "." at 12:74-12:75
+121: Ident           "as_nanos" at 12:75-12:83
+122: LParen          "(" at 12:83-12:84
+123: RParen          ")" at 12:84-12:85
+124: Plus            "+" at 12:86-12:87 (leading: Space)
+125: Ident           "copy_diff" at 12:88-12:97 (leading: Space)
+126: Dot             "." at 12:97-12:98
+127: Ident           "as_seconds" at 12:98-12:108
+128: LParen          "(" at 12:108-12:109
+129: RParen          ")" at 12:109-12:110
+130: Plus            "+" at 12:111-12:112 (leading: Space)
+131: Ident           "elapsed" at 12:113-12:120 (leading: Space)
+132: Dot             "." at 12:120-12:121
+133: Ident           "as_nanos" at 12:121-12:129
+134: LParen          "(" at 12:129-12:130
+135: RParen          ")" at 12:130-12:131
+136: Semicolon       ";" at 12:131-12:132
+137: RBrace          "}" at 13:1-13:2 (leading: Newline)
+138: EOF             at 14:1-14:1

--- a/testdata/golden/stdlib/time_duration_conversions.tokens
+++ b/testdata/golden/stdlib/time_duration_conversions.tokens
@@ -6,89 +6,112 @@
   6: Ident           "time" at 1:23-1:27 (leading: Space)
   7: Semicolon       ";" at 1:27-1:28
   8: KwFn            "fn" at 3:1-3:3 (leading: Newline)
-  9: Ident           "duration" at 3:4-3:12 (leading: Space)
- 10: LParen          "(" at 3:12-3:13
- 11: Ident           "ns" at 3:13-3:15
- 12: Colon           ":" at 3:15-3:16
- 13: Ident           "int64" at 3:17-3:22 (leading: Space)
- 14: RParen          ")" at 3:22-3:23
- 15: Arrow           "->" at 3:24-3:26 (leading: Space)
- 16: Ident           "time" at 3:27-3:31 (leading: Space)
- 17: Dot             "." at 3:31-3:32
- 18: Ident           "Duration" at 3:32-3:40
- 19: LBrace          "{" at 3:41-3:42 (leading: Space)
- 20: KwReturn        "return" at 4:5-4:11 (leading: Newline, Space)
- 21: Ident           "time" at 4:12-4:16 (leading: Space)
- 22: Dot             "." at 4:16-4:17
- 23: Ident           "Duration" at 4:17-4:25
- 24: LBrace          "{" at 4:26-4:27 (leading: Space)
- 25: Ident           "__opaque" at 4:28-4:36 (leading: Space)
- 26: Assign          "=" at 4:37-4:38 (leading: Space)
- 27: Ident           "ns" at 4:39-4:41 (leading: Space)
- 28: RBrace          "}" at 4:42-4:43 (leading: Space)
- 29: Semicolon       ";" at 4:43-4:44
- 30: RBrace          "}" at 5:1-5:2 (leading: Newline)
- 31: KwFn            "fn" at 7:1-7:3 (leading: Newline)
- 32: Ident           "duration_total" at 7:4-7:18 (leading: Space)
- 33: LParen          "(" at 7:18-7:19
- 34: RParen          ")" at 7:19-7:20
- 35: Arrow           "->" at 7:21-7:23 (leading: Space)
- 36: Ident           "int64" at 7:24-7:29 (leading: Space)
- 37: LBrace          "{" at 7:30-7:31 (leading: Space)
- 38: KwLet           "let" at 8:5-8:8 (leading: Newline, Space)
- 39: Ident           "d" at 8:9-8:10 (leading: Space)
- 40: Assign          "=" at 8:11-8:12 (leading: Space)
- 41: Ident           "duration" at 8:13-8:21 (leading: Space)
- 42: LParen          "(" at 8:21-8:22
- 43: IntLit          "1_234_567_890" at 8:22-8:35
- 44: Colon           ":" at 8:35-8:36
- 45: Ident           "int64" at 8:36-8:41
- 46: RParen          ")" at 8:41-8:42
- 47: Semicolon       ";" at 8:42-8:43
- 48: KwLet           "let" at 9:5-9:8 (leading: Newline, Space)
- 49: Ident           "earlier" at 9:9-9:16 (leading: Space)
- 50: Assign          "=" at 9:17-9:18 (leading: Space)
- 51: Ident           "duration" at 9:19-9:27 (leading: Space)
- 52: LParen          "(" at 9:27-9:28
- 53: IntLit          "234_567_890" at 9:28-9:39
- 54: Colon           ":" at 9:39-9:40
- 55: Ident           "int64" at 9:40-9:45
- 56: RParen          ")" at 9:45-9:46
- 57: Semicolon       ";" at 9:46-9:47
- 58: KwLet           "let" at 10:5-10:8 (leading: Newline, Space)
- 59: Ident           "diff" at 10:9-10:13 (leading: Space)
- 60: Assign          "=" at 10:14-10:15 (leading: Space)
- 61: Ident           "d" at 10:16-10:17 (leading: Space)
- 62: Dot             "." at 10:17-10:18
- 63: Ident           "sub" at 10:18-10:21
- 64: LParen          "(" at 10:21-10:22
- 65: Ident           "earlier" at 10:22-10:29
- 66: RParen          ")" at 10:29-10:30
- 67: Semicolon       ";" at 10:30-10:31
- 68: KwReturn        "return" at 11:5-11:11 (leading: Newline, Space)
- 69: Ident           "diff" at 11:12-11:16 (leading: Space)
- 70: Dot             "." at 11:16-11:17
- 71: Ident           "as_seconds" at 11:17-11:27
- 72: LParen          "(" at 11:27-11:28
- 73: RParen          ")" at 11:28-11:29
- 74: Plus            "+" at 11:30-11:31 (leading: Space)
- 75: Ident           "diff" at 11:32-11:36 (leading: Space)
- 76: Dot             "." at 11:36-11:37
- 77: Ident           "as_millis" at 11:37-11:46
- 78: LParen          "(" at 11:46-11:47
- 79: RParen          ")" at 11:47-11:48
- 80: Plus            "+" at 11:49-11:50 (leading: Space)
- 81: Ident           "diff" at 11:51-11:55 (leading: Space)
- 82: Dot             "." at 11:55-11:56
- 83: Ident           "as_micros" at 11:56-11:65
- 84: LParen          "(" at 11:65-11:66
- 85: RParen          ")" at 11:66-11:67
- 86: Plus            "+" at 11:68-11:69 (leading: Space)
- 87: Ident           "diff" at 11:70-11:74 (leading: Space)
- 88: Dot             "." at 11:74-11:75
- 89: Ident           "as_nanos" at 11:75-11:83
- 90: LParen          "(" at 11:83-11:84
- 91: RParen          ")" at 11:84-11:85
- 92: Semicolon       ";" at 11:85-11:86
- 93: RBrace          "}" at 12:1-12:2 (leading: Newline)
- 94: EOF             at 13:1-13:1
+  9: Ident           "duration_total" at 3:4-3:18 (leading: Space)
+ 10: LParen          "(" at 3:18-3:19
+ 11: RParen          ")" at 3:19-3:20
+ 12: Arrow           "->" at 3:21-3:23 (leading: Space)
+ 13: Ident           "int64" at 3:24-3:29 (leading: Space)
+ 14: LBrace          "{" at 3:30-3:31 (leading: Space)
+ 15: KwLet           "let" at 4:5-4:8 (leading: Newline, Space)
+ 16: Ident           "d" at 4:9-4:10 (leading: Space)
+ 17: Assign          "=" at 4:11-4:12 (leading: Space)
+ 18: Ident           "time" at 4:13-4:17 (leading: Space)
+ 19: Dot             "." at 4:17-4:18
+ 20: Ident           "Duration" at 4:18-4:26
+ 21: Dot             "." at 4:26-4:27
+ 22: Ident           "new" at 4:27-4:30
+ 23: LParen          "(" at 4:30-4:31
+ 24: IntLit          "1_234_567_890" at 4:31-4:44
+ 25: Colon           ":" at 4:44-4:45
+ 26: Ident           "int64" at 4:45-4:50
+ 27: RParen          ")" at 4:50-4:51
+ 28: Semicolon       ";" at 4:51-4:52
+ 29: KwLet           "let" at 5:5-5:8 (leading: Newline, Space)
+ 30: Ident           "earlier" at 5:9-5:16 (leading: Space)
+ 31: Assign          "=" at 5:17-5:18 (leading: Space)
+ 32: Ident           "time" at 5:19-5:23 (leading: Space)
+ 33: Dot             "." at 5:23-5:24
+ 34: Ident           "Duration" at 5:24-5:32
+ 35: Dot             "." at 5:32-5:33
+ 36: Ident           "new" at 5:33-5:36
+ 37: LParen          "(" at 5:36-5:37
+ 38: IntLit          "234_567_890" at 5:37-5:48
+ 39: Colon           ":" at 5:48-5:49
+ 40: Ident           "int64" at 5:49-5:54
+ 41: RParen          ")" at 5:54-5:55
+ 42: Semicolon       ";" at 5:55-5:56
+ 43: KwLet           "let" at 6:5-6:8 (leading: Newline, Space)
+ 44: Ident           "diff" at 6:9-6:13 (leading: Space)
+ 45: Assign          "=" at 6:14-6:15 (leading: Space)
+ 46: Ident           "d" at 6:16-6:17 (leading: Space)
+ 47: Dot             "." at 6:17-6:18
+ 48: Ident           "sub" at 6:18-6:21
+ 49: LParen          "(" at 6:21-6:22
+ 50: Ident           "earlier" at 6:22-6:29
+ 51: RParen          ")" at 6:29-6:30
+ 52: Semicolon       ";" at 6:30-6:31
+ 53: KwLet           "let" at 7:5-7:8 (leading: Newline, Space)
+ 54: Ident           "started" at 7:9-7:16 (leading: Space)
+ 55: Assign          "=" at 7:17-7:18 (leading: Space)
+ 56: Ident           "time" at 7:19-7:23 (leading: Space)
+ 57: Dot             "." at 7:23-7:24
+ 58: Ident           "Duration" at 7:24-7:32
+ 59: Dot             "." at 7:32-7:33
+ 60: Ident           "now" at 7:33-7:36
+ 61: LParen          "(" at 7:36-7:37
+ 62: RParen          ")" at 7:37-7:38
+ 63: Semicolon       ";" at 7:38-7:39
+ 64: KwLet           "let" at 8:5-8:8 (leading: Newline, Space)
+ 65: Ident           "finished" at 8:9-8:17 (leading: Space)
+ 66: Assign          "=" at 8:18-8:19 (leading: Space)
+ 67: Ident           "time" at 8:20-8:24 (leading: Space)
+ 68: Dot             "." at 8:24-8:25
+ 69: Ident           "Duration" at 8:25-8:33
+ 70: Dot             "." at 8:33-8:34
+ 71: Ident           "now" at 8:34-8:37
+ 72: LParen          "(" at 8:37-8:38
+ 73: RParen          ")" at 8:38-8:39
+ 74: Semicolon       ";" at 8:39-8:40
+ 75: KwLet           "let" at 9:5-9:8 (leading: Newline, Space)
+ 76: Ident           "elapsed" at 9:9-9:16 (leading: Space)
+ 77: Assign          "=" at 9:17-9:18 (leading: Space)
+ 78: Ident           "finished" at 9:19-9:27 (leading: Space)
+ 79: Dot             "." at 9:27-9:28
+ 80: Ident           "sub" at 9:28-9:31
+ 81: LParen          "(" at 9:31-9:32
+ 82: Ident           "started" at 9:32-9:39
+ 83: RParen          ")" at 9:39-9:40
+ 84: Semicolon       ";" at 9:40-9:41
+ 85: KwReturn        "return" at 10:5-10:11 (leading: Newline, Space)
+ 86: Ident           "diff" at 10:12-10:16 (leading: Space)
+ 87: Dot             "." at 10:16-10:17
+ 88: Ident           "as_seconds" at 10:17-10:27
+ 89: LParen          "(" at 10:27-10:28
+ 90: RParen          ")" at 10:28-10:29
+ 91: Plus            "+" at 10:30-10:31 (leading: Space)
+ 92: Ident           "diff" at 10:32-10:36 (leading: Space)
+ 93: Dot             "." at 10:36-10:37
+ 94: Ident           "as_millis" at 10:37-10:46
+ 95: LParen          "(" at 10:46-10:47
+ 96: RParen          ")" at 10:47-10:48
+ 97: Plus            "+" at 10:49-10:50 (leading: Space)
+ 98: Ident           "diff" at 10:51-10:55 (leading: Space)
+ 99: Dot             "." at 10:55-10:56
+100: Ident           "as_micros" at 10:56-10:65
+101: LParen          "(" at 10:65-10:66
+102: RParen          ")" at 10:66-10:67
+103: Plus            "+" at 10:68-10:69 (leading: Space)
+104: Ident           "diff" at 10:70-10:74 (leading: Space)
+105: Dot             "." at 10:74-10:75
+106: Ident           "as_nanos" at 10:75-10:83
+107: LParen          "(" at 10:83-10:84
+108: RParen          ")" at 10:84-10:85
+109: Plus            "+" at 10:86-10:87 (leading: Space)
+110: Ident           "elapsed" at 10:88-10:95 (leading: Space)
+111: Dot             "." at 10:95-10:96
+112: Ident           "as_nanos" at 10:96-10:104
+113: LParen          "(" at 10:104-10:105
+114: RParen          ")" at 10:105-10:106
+115: Semicolon       ";" at 10:106-10:107
+116: RBrace          "}" at 11:1-11:2 (leading: Newline)
+117: EOF             at 12:1-12:1

--- a/testdata/golden/stdlib/time_duration_conversions.tokens
+++ b/testdata/golden/stdlib/time_duration_conversions.tokens
@@ -1,0 +1,94 @@
+  1: KwImport        "import" at 1:1-1:7
+  2: Ident           "stdlib" at 1:8-1:14 (leading: Space)
+  3: Slash           "/" at 1:14-1:15
+  4: Ident           "time" at 1:15-1:19
+  5: KwAs            "as" at 1:20-1:22 (leading: Space)
+  6: Ident           "time" at 1:23-1:27 (leading: Space)
+  7: Semicolon       ";" at 1:27-1:28
+  8: KwFn            "fn" at 3:1-3:3 (leading: Newline)
+  9: Ident           "duration" at 3:4-3:12 (leading: Space)
+ 10: LParen          "(" at 3:12-3:13
+ 11: Ident           "ns" at 3:13-3:15
+ 12: Colon           ":" at 3:15-3:16
+ 13: Ident           "int64" at 3:17-3:22 (leading: Space)
+ 14: RParen          ")" at 3:22-3:23
+ 15: Arrow           "->" at 3:24-3:26 (leading: Space)
+ 16: Ident           "time" at 3:27-3:31 (leading: Space)
+ 17: Dot             "." at 3:31-3:32
+ 18: Ident           "Duration" at 3:32-3:40
+ 19: LBrace          "{" at 3:41-3:42 (leading: Space)
+ 20: KwReturn        "return" at 4:5-4:11 (leading: Newline, Space)
+ 21: Ident           "time" at 4:12-4:16 (leading: Space)
+ 22: Dot             "." at 4:16-4:17
+ 23: Ident           "Duration" at 4:17-4:25
+ 24: LBrace          "{" at 4:26-4:27 (leading: Space)
+ 25: Ident           "__opaque" at 4:28-4:36 (leading: Space)
+ 26: Assign          "=" at 4:37-4:38 (leading: Space)
+ 27: Ident           "ns" at 4:39-4:41 (leading: Space)
+ 28: RBrace          "}" at 4:42-4:43 (leading: Space)
+ 29: Semicolon       ";" at 4:43-4:44
+ 30: RBrace          "}" at 5:1-5:2 (leading: Newline)
+ 31: KwFn            "fn" at 7:1-7:3 (leading: Newline)
+ 32: Ident           "duration_total" at 7:4-7:18 (leading: Space)
+ 33: LParen          "(" at 7:18-7:19
+ 34: RParen          ")" at 7:19-7:20
+ 35: Arrow           "->" at 7:21-7:23 (leading: Space)
+ 36: Ident           "int64" at 7:24-7:29 (leading: Space)
+ 37: LBrace          "{" at 7:30-7:31 (leading: Space)
+ 38: KwLet           "let" at 8:5-8:8 (leading: Newline, Space)
+ 39: Ident           "d" at 8:9-8:10 (leading: Space)
+ 40: Assign          "=" at 8:11-8:12 (leading: Space)
+ 41: Ident           "duration" at 8:13-8:21 (leading: Space)
+ 42: LParen          "(" at 8:21-8:22
+ 43: IntLit          "1_234_567_890" at 8:22-8:35
+ 44: Colon           ":" at 8:35-8:36
+ 45: Ident           "int64" at 8:36-8:41
+ 46: RParen          ")" at 8:41-8:42
+ 47: Semicolon       ";" at 8:42-8:43
+ 48: KwLet           "let" at 9:5-9:8 (leading: Newline, Space)
+ 49: Ident           "earlier" at 9:9-9:16 (leading: Space)
+ 50: Assign          "=" at 9:17-9:18 (leading: Space)
+ 51: Ident           "duration" at 9:19-9:27 (leading: Space)
+ 52: LParen          "(" at 9:27-9:28
+ 53: IntLit          "234_567_890" at 9:28-9:39
+ 54: Colon           ":" at 9:39-9:40
+ 55: Ident           "int64" at 9:40-9:45
+ 56: RParen          ")" at 9:45-9:46
+ 57: Semicolon       ";" at 9:46-9:47
+ 58: KwLet           "let" at 10:5-10:8 (leading: Newline, Space)
+ 59: Ident           "diff" at 10:9-10:13 (leading: Space)
+ 60: Assign          "=" at 10:14-10:15 (leading: Space)
+ 61: Ident           "d" at 10:16-10:17 (leading: Space)
+ 62: Dot             "." at 10:17-10:18
+ 63: Ident           "sub" at 10:18-10:21
+ 64: LParen          "(" at 10:21-10:22
+ 65: Ident           "earlier" at 10:22-10:29
+ 66: RParen          ")" at 10:29-10:30
+ 67: Semicolon       ";" at 10:30-10:31
+ 68: KwReturn        "return" at 11:5-11:11 (leading: Newline, Space)
+ 69: Ident           "diff" at 11:12-11:16 (leading: Space)
+ 70: Dot             "." at 11:16-11:17
+ 71: Ident           "as_seconds" at 11:17-11:27
+ 72: LParen          "(" at 11:27-11:28
+ 73: RParen          ")" at 11:28-11:29
+ 74: Plus            "+" at 11:30-11:31 (leading: Space)
+ 75: Ident           "diff" at 11:32-11:36 (leading: Space)
+ 76: Dot             "." at 11:36-11:37
+ 77: Ident           "as_millis" at 11:37-11:46
+ 78: LParen          "(" at 11:46-11:47
+ 79: RParen          ")" at 11:47-11:48
+ 80: Plus            "+" at 11:49-11:50 (leading: Space)
+ 81: Ident           "diff" at 11:51-11:55 (leading: Space)
+ 82: Dot             "." at 11:55-11:56
+ 83: Ident           "as_micros" at 11:56-11:65
+ 84: LParen          "(" at 11:65-11:66
+ 85: RParen          ")" at 11:66-11:67
+ 86: Plus            "+" at 11:68-11:69 (leading: Space)
+ 87: Ident           "diff" at 11:70-11:74 (leading: Space)
+ 88: Dot             "." at 11:74-11:75
+ 89: Ident           "as_nanos" at 11:75-11:83
+ 90: LParen          "(" at 11:83-11:84
+ 91: RParen          ")" at 11:84-11:85
+ 92: Semicolon       ";" at 11:85-11:86
+ 93: RBrace          "}" at 12:1-12:2 (leading: Newline)
+ 94: EOF             at 13:1-13:1


### PR DESCRIPTION
## Summary
- make `stdlib/time.Duration` copyable and change `as_*` APIs from `float` to whole-unit `int64`
- lower `Duration.sub` and `Duration.as_*` in both VM and LLVM backends
- add `Duration.new(nanos)` and `Duration.now()` builders so callers do not construct `__opaque` directly
- teach sema to resolve module-qualified static type methods like `time.Duration.new()`
- add VM/LLVM unit coverage plus a golden regression for stdlib time duration conversions

Closes #82

## Checks
- `SURGE_SKIP_TIMEOUT_TESTS=1 GOCACHE=/tmp/surge-go-cache SURGE_STDLIB=/home/zov/projects/surge/surge go test ./internal/vm ./internal/backend/llvm ./internal/sema`
- `GOCACHE=/tmp/surge-go-cache GOLANGCI_LINT_CACHE=/tmp/surge-golangci-lint-cache SURGE_STDLIB=/home/zov/projects/surge/surge make check`
- `GOCACHE=/tmp/surge-go-cache GOLANGCI_LINT_CACHE=/tmp/surge-golangci-lint-cache SURGE_STDLIB=/home/zov/projects/surge/surge make golden-update`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Duration is copyable.
  * Added Duration.new(nanos) and Duration.now() for creating durations and monotonic timestamps.
  * Duration.sub accepts a duration operand by reference.

* **Behavior Changes**
  * Unit conversions (as_seconds, as_millis, as_micros, as_nanos) now return whole-number integers (int64) instead of floats.
  * Examples updated to use Duration.now() and return int64.

* **Documentation**
  * stdlib/time Duration API and examples clarified with explicit signatures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->