### PR TITLE
fix(llvm): lower concrete clone methods

### DIFF
--- a/internal/backend/llvm/emit_intrinsics.go
+++ b/internal/backend/llvm/emit_intrinsics.go
@@ -334,6 +334,9 @@ func (fe *funcEmitter) emitCloneIntrinsic(call *mir.CallInstr) (bool, error) {
 		return true, err
 	}
 	if !isStringLike(fe.emitter.types, srcType) {
+		if _, ok := fe.emitter.resolveFuncIDForCall(fe.f, call); ok {
+			return false, nil
+		}
 		return true, fmt.Errorf("__clone unsupported for type")
 	}
 	ptr, dstTy, err := fe.emitPlacePtr(call.Dst)

--- a/internal/backend/llvm/emit_intrinsics_clone_test.go
+++ b/internal/backend/llvm/emit_intrinsics_clone_test.go
@@ -29,3 +29,43 @@ fn main() -> int {
 		t.Fatalf("task clone did not load the task handle before calling rt_task_clone:\n%s", ir)
 	}
 }
+
+func TestEmitCloneErrorPayloadInErringCompare(t *testing.T) {
+	sourceCode := `pragma module;
+
+pub tag Help(string);
+pub tag ErrorDiag(Error);
+
+pub type ParseDiag = Help(string) | ErrorDiag(Error);
+
+extern<ParseDiag> {
+    pub fn pretty(self: &ParseDiag) -> string! {
+        return compare self {
+            Help(s) => clone(s);
+            ErrorDiag(e) => clone(e);
+        };
+    }
+}
+
+@entrypoint
+fn main() -> int {
+    let diag: ParseDiag = ErrorDiag(Error { message = "boom", code = 1:uint });
+    compare diag.pretty() {
+        Success(text) => {
+            print(text);
+            return 0;
+        }
+        err => {
+            print(err.message);
+            return 1;
+        }
+    };
+}
+`
+
+	ir := emitLLVMFromSource(t, sourceCode)
+
+	if regexp.MustCompile(`call [^(]+ @__clone\(`).MatchString(ir) {
+		t.Fatalf("Error clone leaked as an unresolved external __clone call:\n%s", ir)
+	}
+}


### PR DESCRIPTION
## Summary
- let LLVM `__clone` intrinsic handling fall back to concrete user/core clone methods for non-string types
- add a regression test for `clone(e)` where `e` is an `&Error` payload in an `Erring<string, Error>` compare arm

Closes #85.

## Checks
- `GOCACHE=/tmp/surge-go-cache SURGE_STDLIB=/tmp/surge-issue-85 go test ./internal/backend/llvm -run TestEmitCloneErrorPayloadInErringCompare -count=1`
- `GOCACHE=/tmp/surge-go-cache SURGE_STDLIB=/tmp/surge-issue-85 go test ./internal/backend/llvm`
- `GOCACHE=/tmp/surge-go-cache SURGE_STDLIB=/tmp/surge-issue-85 go run ./cmd/surge build /tmp/pretty_repro`
- `GOCACHE=/tmp/surge-go-cache GOLANGCI_LINT_CACHE=/tmp/surge-golangci-lint-cache SURGE_STDLIB=/tmp/surge-issue-85 make check`

## Golden
- Not run: this is LLVM lowering only; no parser, formatter, diagnostics, or golden fixture surface changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clone operation handling by enhancing function resolution strategy for error payload types, preventing unresolved external function calls during compilation and improving overall system stability.

* **Tests**
  * Added comprehensive test coverage to verify that clone operations on error payloads within complex function scenarios compile correctly without unresolved external references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->