### PR TITLE
fix(lsp): resolve shadowed call targets

### DIFF
--- a/internal/lsp/analysis.go
+++ b/internal/lsp/analysis.go
@@ -129,6 +129,9 @@ func resolveSymbolAt(af *diagnose.AnalysisFile, file *source.File, offset uint32
 		return resolvedSymbol{}
 	}
 	if af.Builder != nil && tok.Span != (source.Span{}) {
+		if resolved := resolveCallTargetSymbolAt(af, offset, tok); resolved.Sym != nil {
+			return resolved
+		}
 		if identID := findIdentExprBySpan(af.Builder, tok.Span); identID.IsValid() {
 			if symID, ok := af.Symbols.ExprSymbols[identID]; ok && symID.IsValid() {
 				if sym := af.Symbols.Table.Symbols.Get(symID); sym != nil {
@@ -152,6 +155,73 @@ func resolveSymbolAt(af *diagnose.AnalysisFile, file *source.File, offset uint32
 		}
 	}
 	return resolvedSymbol{}
+}
+
+func resolveCallTargetSymbolAt(af *diagnose.AnalysisFile, offset uint32, tok token.Token) resolvedSymbol {
+	if af == nil || af.Builder == nil || af.Builder.Exprs == nil || af.Symbols == nil ||
+		af.Symbols.ExprSymbols == nil || af.Symbols.Table == nil || af.Symbols.Table.Symbols == nil {
+		return resolvedSymbol{}
+	}
+	var (
+		bestID    symbols.SymbolID
+		bestSym   *symbols.Symbol
+		bestWidth uint32
+	)
+	for i := uint32(1); i <= af.Builder.Exprs.Arena.Len(); i++ {
+		exprID := ast.ExprID(i)
+		expr := af.Builder.Exprs.Get(exprID)
+		if expr == nil || expr.Kind != ast.ExprCall {
+			continue
+		}
+		call, ok := af.Builder.Exprs.Call(exprID)
+		if !ok || call == nil || !callTargetContainsOffset(af, call.Target, offset, tok) {
+			continue
+		}
+		symID := af.Symbols.ExprSymbols[exprID]
+		if !symID.IsValid() {
+			continue
+		}
+		sym := af.Symbols.Table.Symbols.Get(symID)
+		if sym == nil {
+			continue
+		}
+		width := expr.Span.End - expr.Span.Start
+		if bestSym == nil || width < bestWidth {
+			bestID = symID
+			bestSym = sym
+			bestWidth = width
+		}
+	}
+	if bestSym == nil {
+		return resolvedSymbol{}
+	}
+	return resolvedSymbol{ID: bestID, Sym: bestSym}
+}
+
+func callTargetContainsOffset(af *diagnose.AnalysisFile, targetID ast.ExprID, offset uint32, tok token.Token) bool {
+	if af == nil || af.Builder == nil || af.Builder.Exprs == nil || !targetID.IsValid() {
+		return false
+	}
+	target := af.Builder.Exprs.Get(targetID)
+	if target == nil || offset < target.Span.Start || offset >= target.Span.End {
+		return false
+	}
+	switch target.Kind {
+	case ast.ExprIdent:
+		return target.Span == tok.Span
+	case ast.ExprMember:
+		member, ok := af.Builder.Exprs.Member(targetID)
+		if !ok || member == nil {
+			return false
+		}
+		recv := af.Builder.Exprs.Get(member.Target)
+		if recv != nil && offset >= recv.Span.Start && offset < recv.Span.End {
+			return false
+		}
+		return lookupName(af, member.Field) == tok.Text
+	default:
+		return false
+	}
 }
 
 func symbolForItemAtOffset(af *diagnose.AnalysisFile, file *source.File, offset uint32) symbols.SymbolID {

--- a/internal/lsp/hover_test.go
+++ b/internal/lsp/hover_test.go
@@ -75,3 +75,46 @@ func TestHoverTargets(t *testing.T) {
 		t.Fatalf("unexpected hover range: %+v", *varHover.Range)
 	}
 }
+
+func TestHoverAndDefinitionUseResolvedCallSymbolWhenNameShadowsMethod(t *testing.T) {
+	src := strings.Join([]string{
+		"fn fail(msg: string) -> nothing {",
+		"    return nothing;",
+		"}",
+		"",
+		"type Box = {}",
+		"",
+		"extern<Box> {",
+		"    fn fail(self: Box, msg: string) -> nothing {",
+		"        fail(msg);",
+		"    }",
+		"}",
+		"",
+	}, "\n")
+	snapshot, uri := analyzeSnapshot(t, src)
+
+	callIdx := strings.LastIndex(src, "fail(msg);")
+	if callIdx < 0 {
+		t.Fatal("missing inner fail call")
+	}
+	callPos := positionForOffsetUTF16(src, callIdx)
+
+	callHover := buildHover(snapshot, uri, callPos)
+	if callHover == nil {
+		t.Fatal("expected hover for inner fail call")
+	}
+	if !strings.Contains(callHover.Contents.Value, "fn fail(msg: string) -> nothing") {
+		t.Fatalf("expected hover for free fail function, got %q", callHover.Contents.Value)
+	}
+	if strings.Contains(callHover.Contents.Value, "self: Box") {
+		t.Fatalf("hover resolved to shadowing method instead of free function: %q", callHover.Contents.Value)
+	}
+
+	locs := buildDefinition(snapshot, uri, callPos)
+	if len(locs) != 1 {
+		t.Fatalf("expected one definition location, got %d", len(locs))
+	}
+	if locs[0].Range.Start.Line != 0 {
+		t.Fatalf("expected definition to point at free fail function on line 0, got %+v", locs[0].Range)
+	}
+}


### PR DESCRIPTION
## Summary
- make LSP hover/definition prefer the sema-resolved `ExprCall` symbol when the cursor is on a call target
- fix shadowed call target resolution where a method name hides a free function in lexical scope
- add regression coverage for hover and definition

## Root cause
The analyzer already stores the correct sema-resolved call symbol, but LSP symbol lookup fell back to the identifier/lexical scope path first. Inside an `extern<T>` block that allowed the method named `panic`/`fail` to shadow the free function call target in hover and definition results.

## Checks
- `GOCACHE=/tmp/surge-go-cache SURGE_STDLIB=/tmp/surge-lsp-panic go test ./internal/lsp -run TestHoverAndDefinitionUseResolvedCallSymbolWhenNameShadowsMethod -count=1`
- `GOCACHE=/tmp/surge-go-cache SURGE_STDLIB=/tmp/surge-lsp-panic go test ./internal/lsp`
- `GOCACHE=/tmp/surge-go-cache GOLANGCI_LINT_CACHE=/tmp/surge-golangci-lint-cache SURGE_STDLIB=/tmp/surge-lsp-panic make check`

## Golden
Not run: LSP-only behavior; no parser, formatter, diagnostic, or golden output changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved symbol resolution in call expressions to correctly identify the target symbol, even when method names shadow free function names. This ensures "Go to Definition" and hover information display accurate symbol details.

* **Tests**
  * Added test coverage for symbol resolution in shadowing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->