### PR TITLE
fix(driver): reject wrong explicit module import paths

### DIFF
--- a/STATS.md
+++ b/STATS.md
@@ -4,15 +4,15 @@
 
 ## 📊 Main code (without tests)
 
-- **Files:** 676 (Go: 646, C: 30)
-- **Lines of code:** 153995 (Go: 140796, C: 13199)
+- **Files:** 677 (Go: 647, C: 30)
+- **Lines of code:** 154098 (Go: 140899, C: 13199)
 
 ## 📁 Directory breakdown
 
 | Directory | Files | Lines |
 |------------|--------|-------|
 | `cmd/` | 27 | 4669 |
-| `internal/` | 618 | 136112 |
+| `internal/` | 619 | 136215 |
 | `runtime/native/` (C code) | 30 | 13199 |
 
 ## 🏆 Top 10 packages by size
@@ -25,20 +25,20 @@
 | 4 | `internal/mir` | 10178 |
 | 5 | `internal/parser` | 8960 |
 | 6 | `internal/hir` | 7094 |
-| 7 | `internal/driver` | 6009 |
-| 8 | `internal/mono` | 5120 |
-| 9 | `internal/lsp` | 5082 |
+| 7 | `internal/driver` | 6039 |
+| 8 | `internal/lsp` | 5152 |
+| 9 | `internal/mono` | 5120 |
 | 10 | `cmd/surge` | 4669 |
 
 ## 🧪 Test files
 
-- **Files:** 167
-- **Lines of code:** 34205
+- **Files:** 168
+- **Lines of code:** 34401
 
 ## 📈 Total volume (code + tests)
 
-- **Files:** 843
-- **Lines of code:** 188200
+- **Files:** 845
+- **Lines of code:** 188499
 
 ## 📊 Percentage breakdown
 

--- a/internal/driver/dcache.go
+++ b/internal/driver/dcache.go
@@ -17,7 +17,7 @@ import (
 )
 
 // Current schema version - increment when DiskPayload format changes
-const diskCacheSchemaVersion uint16 = 1
+const diskCacheSchemaVersion uint16 = 4
 
 // DiskCache хранит полезные артефакты по ModuleHash на диске.
 // Сейчас — только заглушка под будущие экспорты семантики.
@@ -39,9 +39,12 @@ type DiskPayload struct {
 	Kind            uint8 // ModuleKind
 	NoStd           bool
 	HasModulePragma bool
+	HasExplicitName bool
 
-	// Imports (paths only, spans not cached)
-	ImportPaths []string
+	// Imports (spans not cached)
+	ImportPaths         []string
+	ImportRelative      []bool
+	ImportSegmentCounts []int
 
 	// Files (paths and hashes)
 	FilePaths  []string
@@ -186,6 +189,7 @@ func moduleToDiskPayload(meta *project.ModuleMeta, broken bool, depHash project.
 		Kind:            uint8(meta.Kind),
 		NoStd:           meta.NoStd,
 		HasModulePragma: meta.HasModulePragma,
+		HasExplicitName: meta.HasExplicitName,
 		ContentHash:     meta.ContentHash,
 		ModuleHash:      meta.ModuleHash,
 		DependencyHash:  depHash,
@@ -194,8 +198,12 @@ func moduleToDiskPayload(meta *project.ModuleMeta, broken bool, depHash project.
 
 	// Extract import paths
 	payload.ImportPaths = make([]string, len(meta.Imports))
+	payload.ImportRelative = make([]bool, len(meta.Imports))
+	payload.ImportSegmentCounts = make([]int, len(meta.Imports))
 	for i, imp := range meta.Imports {
 		payload.ImportPaths[i] = imp.Path
+		payload.ImportRelative[i] = imp.IsRelative
+		payload.ImportSegmentCounts[i] = imp.SegmentCount
 	}
 
 	// Extract file paths and hashes
@@ -222,6 +230,7 @@ func diskPayloadToModule(payload *DiskPayload) *project.ModuleMeta {
 		Kind:            project.ModuleKind(payload.Kind),
 		NoStd:           payload.NoStd,
 		HasModulePragma: payload.HasModulePragma,
+		HasExplicitName: payload.HasExplicitName,
 		ContentHash:     payload.ContentHash,
 		ModuleHash:      payload.ModuleHash,
 	}
@@ -229,9 +238,16 @@ func diskPayloadToModule(payload *DiskPayload) *project.ModuleMeta {
 	// Restore imports (without spans - use zero spans)
 	meta.Imports = make([]project.ImportMeta, len(payload.ImportPaths))
 	for i, path := range payload.ImportPaths {
+		isRelative := i < len(payload.ImportRelative) && payload.ImportRelative[i]
+		segmentCount := 0
+		if i < len(payload.ImportSegmentCounts) {
+			segmentCount = payload.ImportSegmentCounts[i]
+		}
 		meta.Imports[i] = project.ImportMeta{
-			Path: path,
-			Span: source.Span{}, // Zero span - not cached
+			Path:         path,
+			Span:         source.Span{}, // Zero span - not cached
+			IsRelative:   isRelative,
+			SegmentCount: segmentCount,
 		}
 	}
 

--- a/internal/driver/diagnose.go
+++ b/internal/driver/diagnose.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -469,20 +468,6 @@ type moduleRecord struct {
 	checkedEntrypoints bool
 }
 
-func moduleHasExplicitName(meta *project.ModuleMeta) bool {
-	if meta == nil {
-		return false
-	}
-	if !meta.HasModulePragma {
-		return false
-	}
-	if meta.Dir == "" {
-		return false
-	}
-	dirBase := filepath.Base(meta.Dir)
-	return dirBase != "" && dirBase != meta.Name
-}
-
 func runModuleGraph(
 	ctx context.Context,
 	fs *source.FileSet,
@@ -594,7 +579,7 @@ func runModuleGraph(
 			importedPath := normalizeExportsKey(imp.Path)
 			actualPath := normalizeExportsKey(depRec.Meta.Path)
 			if importedPath != "" && actualPath != "" && importedPath != actualPath {
-				if moduleHasExplicitName(depRec.Meta) && rec != nil && rec.Bag != nil && path.Base(importedPath) != depRec.Meta.Name {
+				if rec != nil && rec.Bag != nil && shouldReportWrongExplicitImport(imp, depRec.Meta, importedPath, actualPath) {
 					reporter := &diag.BagReporter{Bag: rec.Bag}
 					msg := fmt.Sprintf("module is named %q, not %q", depRec.Meta.Path, imp.Path)
 					if b := diag.ReportError(reporter, diag.ProjWrongModuleNameInImport, imp.Span, msg); b != nil {

--- a/internal/driver/import_resolution.go
+++ b/internal/driver/import_resolution.go
@@ -1,0 +1,20 @@
+package driver
+
+import (
+	"path"
+
+	"surge/internal/project"
+)
+
+func shouldReportWrongExplicitImport(imp project.ImportMeta, meta *project.ModuleMeta, importedPath, actualPath string) bool {
+	if meta == nil || !meta.HasExplicitName || importedPath == "" || actualPath == "" || importedPath == actualPath {
+		return false
+	}
+	if imp.IsRelative {
+		return true
+	}
+	if path.Base(importedPath) != meta.Name {
+		return true
+	}
+	return imp.SegmentCount > 1
+}

--- a/internal/driver/import_resolution_test.go
+++ b/internal/driver/import_resolution_test.go
@@ -1,0 +1,153 @@
+package driver
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"surge/internal/diag"
+)
+
+func TestDiagnoseReportsWrongRelativeImportToExplicitModuleSameName(t *testing.T) {
+	stdlibRoot := detectStdlibRootFrom(".")
+	if stdlibRoot == "" {
+		t.Skip("stdlib root not found")
+	}
+	t.Setenv("SURGE_STDLIB", stdlibRoot)
+
+	root, err := os.MkdirTemp(".", "issue67-")
+	if err != nil {
+		t.Fatalf("mkdir temp project: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.RemoveAll(root)
+	})
+
+	writeTestFile(t, filepath.Join(root, "actual", "chess", "chess.sg"), `
+pragma module::chess;
+
+pub fn initial_game() -> int {
+    return 42;
+}
+`)
+	mainPath := filepath.Join(root, "caller", "main.sg")
+	writeTestFile(t, mainPath, `
+import ./actual/chess::initial_game;
+
+fn use_game() -> int {
+    return initial_game();
+}
+`)
+	okPath := filepath.Join(root, "ok.sg")
+	writeTestFile(t, okPath, `
+import chess::initial_game;
+
+fn use_game() -> int {
+    return initial_game();
+}
+`)
+	wrongAbsolutePath := filepath.Join(root, "wrong_absolute.sg")
+	writeTestFile(t, wrongAbsolutePath, `
+import missing_parent/chess::initial_game;
+
+fn use_game() -> int {
+    return initial_game();
+}
+`)
+	resetExplicitModuleDirCacheForTest()
+
+	opts := DiagnoseOptions{Stage: DiagnoseStageSema, MaxDiagnostics: 32}
+	res, err := DiagnoseWithOptions(t.Context(), mainPath, &opts)
+	if err != nil {
+		t.Fatalf("DiagnoseWithOptions error: %v", err)
+	}
+	if !hasDiagCode(res.Bag, diag.ProjWrongModuleNameInImport) {
+		t.Fatalf("expected PRJ5010 for wrong relative import, got %v", bagMessages(res.Bag))
+	}
+
+	okRes, err := DiagnoseWithOptions(t.Context(), okPath, &opts)
+	if err != nil {
+		t.Fatalf("DiagnoseWithOptions ok import error: %v", err)
+	}
+	if hasDiagCode(okRes.Bag, diag.ProjWrongModuleNameInImport) {
+		t.Fatalf("unexpected PRJ5010 for explicit-name import, got %v", bagMessages(okRes.Bag))
+	}
+
+	wrongAbsoluteRes, err := DiagnoseWithOptions(t.Context(), wrongAbsolutePath, &opts)
+	if err != nil {
+		t.Fatalf("DiagnoseWithOptions wrong absolute import error: %v", err)
+	}
+	if !hasDiagCode(wrongAbsoluteRes.Bag, diag.ProjWrongModuleNameInImport) {
+		t.Fatalf("expected PRJ5010 for wrong absolute import, got %v", bagMessages(wrongAbsoluteRes.Bag))
+	}
+}
+
+func TestDiagnoseSuppressesWrongImportForInconsistentExplicitModule(t *testing.T) {
+	stdlibRoot := detectStdlibRootFrom(".")
+	if stdlibRoot == "" {
+		t.Skip("stdlib root not found")
+	}
+	t.Setenv("SURGE_STDLIB", stdlibRoot)
+
+	root, err := os.MkdirTemp(".", "issue67-inconsistent-")
+	if err != nil {
+		t.Fatalf("mkdir temp project: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.RemoveAll(root)
+	})
+
+	writeTestFile(t, filepath.Join(root, "actual", "chess", "chess.sg"), `
+pragma module::chess;
+
+pub fn initial_game() -> int {
+    return 42;
+}
+`)
+	writeTestFile(t, filepath.Join(root, "actual", "chess", "extra.sg"), `
+pragma module;
+
+pub fn extra() -> int {
+    return 1;
+}
+`)
+	mainPath := filepath.Join(root, "caller", "main.sg")
+	writeTestFile(t, mainPath, `
+import missing_parent/chess::initial_game;
+
+fn use_game() -> int {
+    return initial_game();
+}
+`)
+	resetExplicitModuleDirCacheForTest()
+
+	opts := DiagnoseOptions{Stage: DiagnoseStageSema, MaxDiagnostics: 32}
+	res, err := DiagnoseWithOptions(t.Context(), mainPath, &opts)
+	if err != nil {
+		t.Fatalf("DiagnoseWithOptions error: %v", err)
+	}
+	if !hasDiagCode(res.Bag, diag.ProjDependencyFailed) {
+		t.Fatalf("expected dependency failure diagnostic, got %v", bagMessages(res.Bag))
+	}
+	if hasDiagCode(res.Bag, diag.ProjWrongModuleNameInImport) {
+		t.Fatalf("unexpected PRJ5010 cascade for inconsistent module, got %v", bagMessages(res.Bag))
+	}
+}
+
+func writeTestFile(t *testing.T, path, src string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(strings.TrimSpace(src)+"\n"), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func resetExplicitModuleDirCacheForTest() {
+	explicitModuleDirCache.mu.Lock()
+	defer explicitModuleDirCache.mu.Unlock()
+	explicitModuleDirCache.byBase = nil
+	explicitModuleDirCache.scanned = nil
+}

--- a/internal/driver/parallel_diagnose_module_graph.go
+++ b/internal/driver/parallel_diagnose_module_graph.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"path"
 	"path/filepath"
 	"sort"
 
@@ -220,7 +219,7 @@ func resolveDirModuleGraph(ctx context.Context, fileSet *source.FileSet, results
 			importedPath := normalizeExportsKey(imp.Path)
 			actualPath := normalizeExportsKey(depRec.Meta.Path)
 			if importedPath != "" && actualPath != "" && importedPath != actualPath {
-				if moduleHasExplicitName(depRec.Meta) && rec.Bag != nil && path.Base(importedPath) != depRec.Meta.Name {
+				if rec.Bag != nil && shouldReportWrongExplicitImport(imp, depRec.Meta, importedPath, actualPath) {
 					reporter := &diag.BagReporter{Bag: rec.Bag}
 					msg := fmt.Sprintf("module is named %q, not %q", depRec.Meta.Path, imp.Path)
 					if b := diag.ReportError(reporter, diag.ProjWrongModuleNameInImport, imp.Span, msg); b != nil {

--- a/internal/driver/project.go
+++ b/internal/driver/project.go
@@ -240,6 +240,7 @@ func buildModuleMeta(
 		Kind:            kind,
 		NoStd:           hasNoStd && !hasStd,
 		HasModulePragma: hasPragma,
+		HasExplicitName: len(explicitNames) == 1 && len(filesWithExplicit) == len(files),
 		Span:            files[0].node.Span,
 		Imports:         imports,
 		Files:           fileMetas,
@@ -315,6 +316,7 @@ func collectImports(
 		}
 
 		rawPath := strings.Join(segments, "/")
+		isRelative := segments[0] == "." || segments[0] == ".."
 		normImport, err := project.ResolveImportPath(fullModulePath, baseDir, segments)
 		if err != nil {
 			if reporter != nil {
@@ -333,8 +335,10 @@ func collectImports(
 		baseExists := moduleFileExists(fs, baseDir, normImport, mapping)
 		if baseExists {
 			imports = append(imports, project.ImportMeta{
-				Path: normImport,
-				Span: item.Span,
+				Path:         normImport,
+				Span:         item.Span,
+				IsRelative:   isRelative,
+				SegmentCount: len(segments),
 			})
 			continue
 		}
@@ -346,8 +350,10 @@ func collectImports(
 				if candidatePath, err := project.ResolveImportPath(fullModulePath, baseDir, candidateSegments); err == nil {
 					if moduleFileExists(fs, baseDir, candidatePath, mapping) {
 						imports = append(imports, project.ImportMeta{
-							Path: candidatePath,
-							Span: item.Span,
+							Path:         candidatePath,
+							Span:         item.Span,
+							IsRelative:   isRelative,
+							SegmentCount: len(segments),
 						})
 						hasCandidate = true
 					}
@@ -371,8 +377,10 @@ func collectImports(
 				}
 				if moduleFileExists(fs, baseDir, candidatePath, mapping) {
 					imports = append(imports, project.ImportMeta{
-						Path: candidatePath,
-						Span: item.Span,
+						Path:         candidatePath,
+						Span:         item.Span,
+						IsRelative:   isRelative,
+						SegmentCount: len(segments),
 					})
 					hasCandidate = true
 				}
@@ -384,8 +392,10 @@ func collectImports(
 		}
 
 		imports = append(imports, project.ImportMeta{
-			Path: normImport,
-			Span: item.Span,
+			Path:         normImport,
+			Span:         item.Span,
+			IsRelative:   isRelative,
+			SegmentCount: len(segments),
 		})
 	}
 

--- a/internal/project/modulemeta.go
+++ b/internal/project/modulemeta.go
@@ -11,8 +11,10 @@ import (
 
 // ImportMeta captures metadata for a single module import.
 type ImportMeta struct {
-	Path string
-	Span source.Span
+	Path         string
+	Span         source.Span
+	IsRelative   bool
+	SegmentCount int
 }
 
 // ModuleKind distinguishes between library modules and executables.
@@ -42,6 +44,7 @@ type ModuleMeta struct {
 	Kind            ModuleKind // module или binary
 	NoStd           bool       // признак pragma no_std, согласованный для всего модуля
 	HasModulePragma bool
+	HasExplicitName bool
 	Span            source.Span  // span всего файла (или места объявления модуля)
 	Imports         []ImportMeta // нормализованные пути импортов с их спанами
 	Files           []ModuleFileMeta

--- a/testdata/golden/sema/invalid/relative_import_explicit_module_same_name/actual/chess/_chess.sg
+++ b/testdata/golden/sema/invalid/relative_import_explicit_module_same_name/actual/chess/_chess.sg
@@ -1,0 +1,5 @@
+pragma module::chess;
+
+pub fn initial_game() -> int {
+    return 42;
+}

--- a/testdata/golden/sema/invalid/relative_import_explicit_module_same_name/caller/main.ast
+++ b/testdata/golden/sema/invalid/relative_import_explicit_module_same_name/caller/main.ast
@@ -1,0 +1,12 @@
+main.sg (span: 1:1-6:1)
+├─ Item[0]: Import (span: 1:1-1:37)
+│  ├─ Module: .::actual::chess
+│  └─ One: initial_game
+└─ Item[1]: Fn (span: 3:1-5:2)
+   ├─ Name: use_game
+   ├─ Params: ()
+   ├─ Return: int
+   └─ Body:
+      └─ Stmt[0]: Block (span: 3:22-5:2)
+         └─ Stmt[0]: Return (span: 4:5-4:27)
+            └─ Expr: expr#2: initial_game()

--- a/testdata/golden/sema/invalid/relative_import_explicit_module_same_name/caller/main.diag
+++ b/testdata/golden/sema/invalid/relative_import_explicit_module_same_name/caller/main.diag
@@ -1,0 +1,1 @@
+error PRJ5010 testdata/golden/sema/invalid/relative_import_explicit_module_same_name/caller/main.sg:1:1 module is named "testdata/golden/sema/invalid/relative_import_explicit_module_same_name/actual/chess", not "testdata/golden/sema/invalid/relative_import_explicit_module_same_name/caller/actual/chess"

--- a/testdata/golden/sema/invalid/relative_import_explicit_module_same_name/caller/main.fmt
+++ b/testdata/golden/sema/invalid/relative_import_explicit_module_same_name/caller/main.fmt
@@ -1,0 +1,5 @@
+import ./actual/chess::initial_game;
+
+fn use_game() -> int {
+    return initial_game();
+}

--- a/testdata/golden/sema/invalid/relative_import_explicit_module_same_name/caller/main.sg
+++ b/testdata/golden/sema/invalid/relative_import_explicit_module_same_name/caller/main.sg
@@ -1,0 +1,5 @@
+import ./actual/chess::initial_game;
+
+fn use_game() -> int {
+    return initial_game();
+}

--- a/testdata/golden/sema/invalid/relative_import_explicit_module_same_name/caller/main.tokens
+++ b/testdata/golden/sema/invalid/relative_import_explicit_module_same_name/caller/main.tokens
@@ -1,0 +1,23 @@
+  1: KwImport        "import" at 1:1-1:7
+  2: Dot             "." at 1:8-1:9 (leading: Space)
+  3: Slash           "/" at 1:9-1:10
+  4: Ident           "actual" at 1:10-1:16
+  5: Slash           "/" at 1:16-1:17
+  6: Ident           "chess" at 1:17-1:22
+  7: ColonColon      "::" at 1:22-1:24
+  8: Ident           "initial_game" at 1:24-1:36
+  9: Semicolon       ";" at 1:36-1:37
+ 10: KwFn            "fn" at 3:1-3:3 (leading: Newline)
+ 11: Ident           "use_game" at 3:4-3:12 (leading: Space)
+ 12: LParen          "(" at 3:12-3:13
+ 13: RParen          ")" at 3:13-3:14
+ 14: Arrow           "->" at 3:15-3:17 (leading: Space)
+ 15: Ident           "int" at 3:18-3:21 (leading: Space)
+ 16: LBrace          "{" at 3:22-3:23 (leading: Space)
+ 17: KwReturn        "return" at 4:5-4:11 (leading: Newline, Space)
+ 18: Ident           "initial_game" at 4:12-4:24 (leading: Space)
+ 19: LParen          "(" at 4:24-4:25
+ 20: RParen          ")" at 4:25-4:26
+ 21: Semicolon       ";" at 4:26-4:27
+ 22: RBrace          "}" at 5:1-5:2 (leading: Newline)
+ 23: EOF             at 6:1-6:1


### PR DESCRIPTION
## Summary
- reject explicit-module fallback when a relative or path-shaped import resolves to a different canonical module path
- keep bare explicit-name imports like `import chess::...` working
- persist import shape metadata through module/disk cache
- add unit coverage plus a sema golden regression for issue #67
- update `STATS.md`

## Root cause
The module graph compared the imported path and actual resolved module path, but only reported `PRJ5010` when the imported path's last segment differed from the module name. A wrong path like `caller/actual/chess` could therefore bind to an explicit module named `chess` elsewhere and pass diagnostics.

## Checks
- `GOCACHE=/tmp/surge-go-cache SURGE_STDLIB=/tmp/surge-issue-67 go test ./internal/driver ./internal/project -count=1`
- `GOCACHE=/tmp/surge-go-cache SURGE_STDLIB=/tmp/surge-issue-67 go run ./cmd/surge diag testdata/golden/sema/valid/import_all.sg --format short`
- `GOCACHE=/tmp/surge-go-cache SURGE_STDLIB=/tmp/surge-issue-67 go run ./cmd/surge diag testdata/golden/sema/valid/module_multitest/main.sg --format short`
- `GOCACHE=/tmp/surge-go-cache SURGE_STDLIB=/tmp/surge-issue-67 go run ./cmd/surge diag testdata/golden/sema/invalid/relative_import_explicit_module_same_name/caller/main.sg --format short`
- `GOCACHE=/tmp/surge-go-cache GOLANGCI_LINT_CACHE=/tmp/surge-golangci-lint-cache SURGE_STDLIB=/tmp/surge-issue-67 make check`
- `GOCACHE=/tmp/surge-go-cache SURGE_STDLIB=/tmp/surge-issue-67 make golden-update`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostic reporting for relative and explicit-module imports, reducing false "wrong module name" reports and suppressing cascading errors when dependency resolution fails.

* **Tests**
  * Added unit tests and golden fixtures covering explicit-module and relative-import scenarios, including a sample module and caller to validate diagnostics and formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->