### PR TITLE
fix(mir): short-circuit logical operators

### DIFF
--- a/STATS.md
+++ b/STATS.md
@@ -5,14 +5,14 @@
 ## 📊 Main code (without tests)
 
 - **Files:** 677 (Go: 647, C: 30)
-- **Lines of code:** 154164 (Go: 140965, C: 13199)
+- **Lines of code:** 154168 (Go: 140969, C: 13199)
 
 ## 📁 Directory breakdown
 
 | Directory | Files | Lines |
 |------------|--------|-------|
 | `cmd/` | 27 | 4669 |
-| `internal/` | 619 | 136281 |
+| `internal/` | 619 | 136285 |
 | `runtime/native/` (C code) | 30 | 13199 |
 
 ## 🏆 Top 10 packages by size
@@ -22,7 +22,7 @@
 | 1 | `internal/sema` | 28288 |
 | 2 | `internal/vm` | 22982 |
 | 3 | `internal/backend/llvm` | 11786 |
-| 4 | `internal/mir` | 10244 |
+| 4 | `internal/mir` | 10248 |
 | 5 | `internal/parser` | 8960 |
 | 6 | `internal/hir` | 7094 |
 | 7 | `internal/driver` | 6039 |
@@ -38,7 +38,7 @@
 ## 📈 Total volume (code + tests)
 
 - **Files:** 846
-- **Lines of code:** 188624
+- **Lines of code:** 188628
 
 ## 📊 Percentage breakdown
 

--- a/STATS.md
+++ b/STATS.md
@@ -5,14 +5,14 @@
 ## 📊 Main code (without tests)
 
 - **Files:** 677 (Go: 647, C: 30)
-- **Lines of code:** 154159 (Go: 140960, C: 13199)
+- **Lines of code:** 154164 (Go: 140965, C: 13199)
 
 ## 📁 Directory breakdown
 
 | Directory | Files | Lines |
 |------------|--------|-------|
 | `cmd/` | 27 | 4669 |
-| `internal/` | 619 | 136276 |
+| `internal/` | 619 | 136281 |
 | `runtime/native/` (C code) | 30 | 13199 |
 
 ## 🏆 Top 10 packages by size
@@ -22,7 +22,7 @@
 | 1 | `internal/sema` | 28288 |
 | 2 | `internal/vm` | 22982 |
 | 3 | `internal/backend/llvm` | 11786 |
-| 4 | `internal/mir` | 10239 |
+| 4 | `internal/mir` | 10244 |
 | 5 | `internal/parser` | 8960 |
 | 6 | `internal/hir` | 7094 |
 | 7 | `internal/driver` | 6039 |
@@ -33,12 +33,12 @@
 ## 🧪 Test files
 
 - **Files:** 169
-- **Lines of code:** 34453
+- **Lines of code:** 34460
 
 ## 📈 Total volume (code + tests)
 
 - **Files:** 846
-- **Lines of code:** 188612
+- **Lines of code:** 188624
 
 ## 📊 Percentage breakdown
 

--- a/STATS.md
+++ b/STATS.md
@@ -5,14 +5,14 @@
 ## 📊 Main code (without tests)
 
 - **Files:** 677 (Go: 647, C: 30)
-- **Lines of code:** 154168 (Go: 140969, C: 13199)
+- **Lines of code:** 154201 (Go: 141002, C: 13199)
 
 ## 📁 Directory breakdown
 
 | Directory | Files | Lines |
 |------------|--------|-------|
 | `cmd/` | 27 | 4669 |
-| `internal/` | 619 | 136285 |
+| `internal/` | 619 | 136318 |
 | `runtime/native/` (C code) | 30 | 13199 |
 
 ## 🏆 Top 10 packages by size
@@ -22,7 +22,7 @@
 | 1 | `internal/sema` | 28288 |
 | 2 | `internal/vm` | 22982 |
 | 3 | `internal/backend/llvm` | 11786 |
-| 4 | `internal/mir` | 10248 |
+| 4 | `internal/mir` | 10281 |
 | 5 | `internal/parser` | 8960 |
 | 6 | `internal/hir` | 7094 |
 | 7 | `internal/driver` | 6039 |
@@ -32,13 +32,13 @@
 
 ## 🧪 Test files
 
-- **Files:** 169
-- **Lines of code:** 34460
+- **Files:** 170
+- **Lines of code:** 34572
 
 ## 📈 Total volume (code + tests)
 
-- **Files:** 846
-- **Lines of code:** 188628
+- **Files:** 847
+- **Lines of code:** 188773
 
 ## 📊 Percentage breakdown
 

--- a/STATS.md
+++ b/STATS.md
@@ -5,14 +5,14 @@
 ## 📊 Main code (without tests)
 
 - **Files:** 677 (Go: 647, C: 30)
-- **Lines of code:** 154098 (Go: 140899, C: 13199)
+- **Lines of code:** 154159 (Go: 140960, C: 13199)
 
 ## 📁 Directory breakdown
 
 | Directory | Files | Lines |
 |------------|--------|-------|
 | `cmd/` | 27 | 4669 |
-| `internal/` | 619 | 136215 |
+| `internal/` | 619 | 136276 |
 | `runtime/native/` (C code) | 30 | 13199 |
 
 ## 🏆 Top 10 packages by size
@@ -22,7 +22,7 @@
 | 1 | `internal/sema` | 28288 |
 | 2 | `internal/vm` | 22982 |
 | 3 | `internal/backend/llvm` | 11786 |
-| 4 | `internal/mir` | 10178 |
+| 4 | `internal/mir` | 10239 |
 | 5 | `internal/parser` | 8960 |
 | 6 | `internal/hir` | 7094 |
 | 7 | `internal/driver` | 6039 |
@@ -32,16 +32,16 @@
 
 ## 🧪 Test files
 
-- **Files:** 168
-- **Lines of code:** 34401
+- **Files:** 169
+- **Lines of code:** 34453
 
 ## 📈 Total volume (code + tests)
 
-- **Files:** 845
-- **Lines of code:** 188499
+- **Files:** 846
+- **Lines of code:** 188612
 
 ## 📊 Percentage breakdown
 
-- **Main code (Go + C):** 81% (Go: 74%, C: 7%)
+- **Main code (Go + C):** 81% (Go: 74%, C: 6%)
 - **Tests:** 18%
 

--- a/internal/mir/lower_expr_cf.go
+++ b/internal/mir/lower_expr_cf.go
@@ -1,6 +1,8 @@
 package mir
 
 import (
+	"fmt"
+
 	"surge/internal/ast"
 	"surge/internal/hir"
 	"surge/internal/types"
@@ -114,6 +116,9 @@ func (l *funcLowerer) lowerIfExpr(e *hir.Expr, data hir.IfData, consume bool) (O
 func (l *funcLowerer) lowerLogicalShortCircuitExpr(e *hir.Expr, data hir.BinaryOpData, consume bool) (Operand, error) {
 	if l == nil || e == nil {
 		return Operand{}, nil
+	}
+	if data.Op != ast.ExprBinaryLogicalAnd && data.Op != ast.ExprBinaryLogicalOr {
+		return Operand{}, fmt.Errorf("mir: logical short-circuit: unsupported op %s", data.Op)
 	}
 	resultTy := e.Type
 	if resultTy == types.NoTypeID && l.types != nil {

--- a/internal/mir/lower_expr_cf.go
+++ b/internal/mir/lower_expr_cf.go
@@ -1,6 +1,7 @@
 package mir
 
 import (
+	"surge/internal/ast"
 	"surge/internal/hir"
 	"surge/internal/types"
 )
@@ -108,6 +109,63 @@ func (l *funcLowerer) lowerIfExpr(e *hir.Expr, data hir.IfData, consume bool) (O
 		return l.constNothing(e.Type), nil
 	}
 	return l.placeOperand(Place{Local: resultLocal}, e.Type, consume), nil
+}
+
+func (l *funcLowerer) lowerLogicalShortCircuitExpr(e *hir.Expr, data hir.BinaryOpData, consume bool) (Operand, error) {
+	if l == nil || e == nil {
+		return Operand{}, nil
+	}
+	resultTy := e.Type
+	if resultTy == types.NoTypeID && l.types != nil {
+		resultTy = l.types.Builtins().Bool
+	}
+	resultLocal := l.newTemp(resultTy, "logic", e.Span)
+
+	left, err := l.lowerValueExpr(data.Left, false)
+	if err != nil {
+		return Operand{}, err
+	}
+
+	rhsBB := l.newBlock()
+	shortBB := l.newBlock()
+	joinBB := l.newBlock()
+
+	thenBB := rhsBB
+	elseBB := shortBB
+	shortValue := false
+	if data.Op == ast.ExprBinaryLogicalOr {
+		thenBB = shortBB
+		elseBB = rhsBB
+		shortValue = true
+	}
+	l.setTerm(&Terminator{Kind: TermIf, If: IfTerm{Cond: left, Then: thenBB, Else: elseBB}})
+
+	l.startBlock(shortBB)
+	l.emit(&Instr{Kind: InstrAssign, Assign: AssignInstr{
+		Dst: Place{Local: resultLocal},
+		Src: RValue{Kind: RValueUse, Use: Operand{Kind: OperandConst, Type: resultTy, Const: Const{
+			Kind:      ConstBool,
+			Type:      resultTy,
+			BoolValue: shortValue,
+		}}},
+	}})
+	l.setTerm(&Terminator{Kind: TermGoto, Goto: GotoTerm{Target: joinBB}})
+
+	l.startBlock(rhsBB)
+	right, err := l.lowerValueExpr(data.Right, false)
+	if err != nil {
+		return Operand{}, err
+	}
+	l.emit(&Instr{Kind: InstrAssign, Assign: AssignInstr{
+		Dst: Place{Local: resultLocal},
+		Src: RValue{Kind: RValueUse, Use: right},
+	}})
+	if !l.curBlock().Terminated() {
+		l.setTerm(&Terminator{Kind: TermGoto, Goto: GotoTerm{Target: joinBB}})
+	}
+
+	l.startBlock(joinBB)
+	return l.placeOperand(Place{Local: resultLocal}, resultTy, consume), nil
 }
 
 func (l *funcLowerer) lowerBlockExpr(e *hir.Expr, data hir.BlockExprData, consume bool) (Operand, error) {

--- a/internal/mir/lower_expr_cf.go
+++ b/internal/mir/lower_expr_cf.go
@@ -120,15 +120,29 @@ func (l *funcLowerer) lowerLogicalShortCircuitExpr(e *hir.Expr, data hir.BinaryO
 	if !isLogicalShortCircuitOp(data.Op) {
 		return Operand{}, fmt.Errorf("mir: logical short-circuit: unsupported op %s", data.Op)
 	}
-	resultTy := e.Type
-	if resultTy == types.NoTypeID && l.types != nil {
-		resultTy = l.types.Builtins().Bool
+	resultTy, typeErr := l.logicalShortCircuitResultType(e, data, types.NoTypeID)
+	left := Operand{}
+	leftReady := false
+	if typeErr != nil {
+		var err error
+		left, err = l.lowerValueExpr(data.Left, false)
+		if err != nil {
+			return Operand{}, err
+		}
+		leftReady = true
+		resultTy, typeErr = l.logicalShortCircuitResultType(e, data, left.Type)
+		if typeErr != nil {
+			return Operand{}, typeErr
+		}
 	}
 	resultLocal := l.newTemp(resultTy, "logic", e.Span)
 
-	left, err := l.lowerValueExpr(data.Left, false)
-	if err != nil {
-		return Operand{}, err
+	if !leftReady {
+		var err error
+		left, err = l.lowerValueExpr(data.Left, false)
+		if err != nil {
+			return Operand{}, err
+		}
 	}
 
 	rhsBB := l.newBlock()
@@ -175,6 +189,25 @@ func (l *funcLowerer) lowerLogicalShortCircuitExpr(e *hir.Expr, data hir.BinaryO
 
 func isLogicalShortCircuitOp(op ast.ExprBinaryOp) bool {
 	return op == ast.ExprBinaryLogicalAnd || op == ast.ExprBinaryLogicalOr
+}
+
+func (l *funcLowerer) logicalShortCircuitResultType(e *hir.Expr, data hir.BinaryOpData, leftTy types.TypeID) (types.TypeID, error) {
+	if e != nil && e.Type != types.NoTypeID {
+		return e.Type, nil
+	}
+	if l != nil && l.types != nil {
+		return l.types.Builtins().Bool, nil
+	}
+	if leftTy != types.NoTypeID {
+		return leftTy, nil
+	}
+	if data.Left != nil && data.Left.Type != types.NoTypeID {
+		return data.Left.Type, nil
+	}
+	if data.Right != nil && data.Right.Type != types.NoTypeID {
+		return data.Right.Type, nil
+	}
+	return types.NoTypeID, fmt.Errorf("mir: logical short-circuit: unable to resolve result type")
 }
 
 func (l *funcLowerer) lowerBlockExpr(e *hir.Expr, data hir.BlockExprData, consume bool) (Operand, error) {

--- a/internal/mir/lower_expr_cf.go
+++ b/internal/mir/lower_expr_cf.go
@@ -117,7 +117,7 @@ func (l *funcLowerer) lowerLogicalShortCircuitExpr(e *hir.Expr, data hir.BinaryO
 	if l == nil || e == nil {
 		return Operand{}, nil
 	}
-	if data.Op != ast.ExprBinaryLogicalAnd && data.Op != ast.ExprBinaryLogicalOr {
+	if !isLogicalShortCircuitOp(data.Op) {
 		return Operand{}, fmt.Errorf("mir: logical short-circuit: unsupported op %s", data.Op)
 	}
 	resultTy := e.Type
@@ -171,6 +171,10 @@ func (l *funcLowerer) lowerLogicalShortCircuitExpr(e *hir.Expr, data hir.BinaryO
 
 	l.startBlock(joinBB)
 	return l.placeOperand(Place{Local: resultLocal}, resultTy, consume), nil
+}
+
+func isLogicalShortCircuitOp(op ast.ExprBinaryOp) bool {
+	return op == ast.ExprBinaryLogicalAnd || op == ast.ExprBinaryLogicalOr
 }
 
 func (l *funcLowerer) lowerBlockExpr(e *hir.Expr, data hir.BlockExprData, consume bool) (Operand, error) {

--- a/internal/mir/lower_expr_cf_test.go
+++ b/internal/mir/lower_expr_cf_test.go
@@ -1,0 +1,112 @@
+package mir
+
+import (
+	"strings"
+	"testing"
+
+	"surge/internal/ast"
+	"surge/internal/hir"
+	"surge/internal/symbols"
+	"surge/internal/types"
+)
+
+func TestLowerLogicalShortCircuitExprUsesOperandTypeWithoutInterner(t *testing.T) {
+	boolTy := types.NewInterner().Builtins().Bool
+	leftSym := symbols.SymbolID(1)
+	rightSym := symbols.SymbolID(2)
+	l := newLogicalShortCircuitTestLowerer(nil)
+	l.f.Locals = append(l.f.Locals,
+		Local{Name: "left", Type: boolTy, Flags: LocalFlagCopy},
+		Local{Name: "right", Type: boolTy, Flags: LocalFlagCopy},
+	)
+	l.symToLocal[leftSym] = 0
+	l.symToLocal[rightSym] = 1
+
+	op, err := l.lowerLogicalShortCircuitExpr(
+		&hir.Expr{
+			Kind: hir.ExprBinaryOp,
+			Type: types.NoTypeID,
+			Data: hir.BinaryOpData{
+				Op: ast.ExprBinaryLogicalAnd,
+				Left: &hir.Expr{
+					Kind: hir.ExprVarRef,
+					Type: types.NoTypeID,
+					Data: hir.VarRefData{Name: "left", SymbolID: leftSym},
+				},
+				Right: &hir.Expr{
+					Kind: hir.ExprVarRef,
+					Type: types.NoTypeID,
+					Data: hir.VarRefData{Name: "right", SymbolID: rightSym},
+				},
+			},
+		},
+		hir.BinaryOpData{
+			Op: ast.ExprBinaryLogicalAnd,
+			Left: &hir.Expr{
+				Kind: hir.ExprVarRef,
+				Type: types.NoTypeID,
+				Data: hir.VarRefData{Name: "left", SymbolID: leftSym},
+			},
+			Right: &hir.Expr{
+				Kind: hir.ExprVarRef,
+				Type: types.NoTypeID,
+				Data: hir.VarRefData{Name: "right", SymbolID: rightSym},
+			},
+		},
+		false,
+	)
+	if err != nil {
+		t.Fatalf("lowerLogicalShortCircuitExpr failed: %v", err)
+	}
+	if op.Type != boolTy {
+		t.Fatalf("result type = %v, want %v", op.Type, boolTy)
+	}
+	if got := l.f.Locals[2].Type; got != boolTy {
+		t.Fatalf("short-circuit temp type = %v, want %v", got, boolTy)
+	}
+}
+
+func TestLowerLogicalShortCircuitExprRejectsMissingResultType(t *testing.T) {
+	l := newLogicalShortCircuitTestLowerer(nil)
+	expr := &hir.Expr{
+		Kind: hir.ExprBinaryOp,
+		Type: types.NoTypeID,
+		Data: hir.BinaryOpData{
+			Op:    ast.ExprBinaryLogicalOr,
+			Left:  boolLiteral(types.NoTypeID, false),
+			Right: boolLiteral(types.NoTypeID, true),
+		},
+	}
+
+	_, err := l.lowerLogicalShortCircuitExpr(expr, expr.Data.(hir.BinaryOpData), false)
+	if err == nil {
+		t.Fatal("expected missing result type error")
+	}
+	if !strings.Contains(err.Error(), "unable to resolve result type") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(l.f.Locals) != 0 {
+		t.Fatalf("created %d locals before resolving result type", len(l.f.Locals))
+	}
+}
+
+func newLogicalShortCircuitTestLowerer(typesIn *types.Interner) *funcLowerer {
+	l := &funcLowerer{
+		types:      typesIn,
+		symToLocal: make(map[symbols.SymbolID]LocalID),
+		nextTemp:   1,
+	}
+	l.f = &Func{Name: "test"}
+	entry := l.newBlock()
+	l.f.Entry = entry
+	l.cur = entry
+	return l
+}
+
+func boolLiteral(ty types.TypeID, value bool) *hir.Expr {
+	return &hir.Expr{
+		Kind: hir.ExprLiteral,
+		Type: ty,
+		Data: hir.LiteralData{Kind: hir.LiteralBool, BoolValue: value},
+	}
+}

--- a/internal/mir/lower_expr_ops.go
+++ b/internal/mir/lower_expr_ops.go
@@ -167,7 +167,7 @@ func (l *funcLowerer) lowerBinaryOpExpr(e *hir.Expr, consume bool) (Operand, err
 	if base, ok := assignmentBaseOp(data.Op); ok {
 		return l.lowerCompoundAssignExpr(e, data, base, consume)
 	}
-	if data.Op == ast.ExprBinaryLogicalAnd || data.Op == ast.ExprBinaryLogicalOr {
+	if isLogicalShortCircuitOp(data.Op) {
 		return l.lowerLogicalShortCircuitExpr(e, data, consume)
 	}
 	left, err := l.lowerValueExpr(data.Left, false)

--- a/internal/mir/lower_expr_ops.go
+++ b/internal/mir/lower_expr_ops.go
@@ -167,6 +167,9 @@ func (l *funcLowerer) lowerBinaryOpExpr(e *hir.Expr, consume bool) (Operand, err
 	if base, ok := assignmentBaseOp(data.Op); ok {
 		return l.lowerCompoundAssignExpr(e, data, base, consume)
 	}
+	if data.Op == ast.ExprBinaryLogicalAnd || data.Op == ast.ExprBinaryLogicalOr {
+		return l.lowerLogicalShortCircuitExpr(e, data, consume)
+	}
 	left, err := l.lowerValueExpr(data.Left, false)
 	if err != nil {
 		return Operand{}, err

--- a/internal/types/operators.go
+++ b/internal/types/operators.go
@@ -81,7 +81,7 @@ var binarySpecTable = map[ast.ExprBinaryOp][]BinarySpec{
 		{Left: FamilyBool, Right: FamilyBool, Result: BinaryResultBool, Flags: BinaryFlagShortCircuit},
 	},
 	ast.ExprBinaryNullCoalescing: {
-		{Left: FamilyOptional | FamilyResult | FamilyAny, Right: FamilyAny, Result: BinaryResultLeft, Flags: BinaryFlagShortCircuit},
+		{Left: FamilyOptional | FamilyResult | FamilyAny, Right: FamilyAny, Result: BinaryResultLeft},
 	},
 	ast.ExprBinaryRange: {
 		{Left: FamilyNumeric | FamilyAny, Right: FamilyNumeric | FamilyAny, Result: BinaryResultRange},

--- a/internal/vm/vm_short_circuit_test.go
+++ b/internal/vm/vm_short_circuit_test.go
@@ -1,0 +1,52 @@
+//go:build !golden
+// +build !golden
+
+package vm_test
+
+import "testing"
+
+func TestLogicalOperatorsShortCircuit(t *testing.T) {
+	source := `
+fn rhs_panic() -> bool {
+    panic("rhs evaluated");
+    return false;
+}
+
+@entrypoint
+fn main() -> int {
+    let s: string = "abc";
+    let i: int = 3;
+
+    if !(true && true) {
+        return 1;
+    }
+    if !(false || true) {
+        return 2;
+    }
+    if i < (s.__len() to int) && s[i] == 34:uint32 {
+        return 3;
+    }
+    if true || rhs_panic() {
+        return 0;
+    }
+
+    return 4;
+}
+`
+
+	for _, backend := range []string{backendVM, backendLLVM} {
+		t.Run(backend, func(t *testing.T) {
+			t.Setenv(backendEnvVar, backend)
+			res := runProgramFromSource(t, source, runOptions{})
+			if res.exitCode != 0 {
+				t.Fatalf("exit code: want 0, got %d\nstderr:\n%s", res.exitCode, res.stderr)
+			}
+			if res.stderr != "" {
+				t.Fatalf("unexpected stderr:\n%s", res.stderr)
+			}
+			if res.stdout != "" {
+				t.Fatalf("unexpected stdout:\n%s", res.stdout)
+			}
+		})
+	}
+}

--- a/internal/vm/vm_short_circuit_test.go
+++ b/internal/vm/vm_short_circuit_test.go
@@ -12,6 +12,10 @@ fn rhs_panic() -> bool {
     return false;
 }
 
+fn rhs_false() -> bool {
+    return false;
+}
+
 @entrypoint
 fn main() -> int {
     let s: string = "abc";
@@ -25,6 +29,9 @@ fn main() -> int {
     }
     if i < (s.__len() to int) && s[i] == 34:uint32 {
         return 3;
+    }
+    if true && rhs_false() {
+        return 5;
     }
     if true || rhs_panic() {
         return 0;

--- a/testdata/golden/mir/is_heir_ops.mir
+++ b/testdata/golden/mir/is_heir_ops.mir
@@ -20,7 +20,7 @@ fn main:
     L3: bool [copy] name=tmp_is2
     L4: bool [copy] name=b
     L5: bool [copy] name=tmp_heir3
-    L6: bool [copy] name=tmp_bin4
+    L6: bool [copy] name=tmp_logic4
   bb0:
     L1 = struct_lit type#1485 {x=const 1, y=const 2}
     L0 = move L1
@@ -28,9 +28,16 @@ fn main:
     L2 = copy L3
     L5 = heir_test copy L0 heir type#1484
     L4 = copy L5
-    L6 = (copy L2 && copy L4)
-    if copy L6 then bb1 else bb2
+    if copy L2 then bb1 else bb2
   bb1:
-    return const 1
+    L6 = copy L4
+    goto bb3
   bb2:
+    L6 = const false
+    goto bb3
+  bb3:
+    if copy L6 then bb4 else bb5
+  bb4:
+    return const 1
+  bb5:
     return const 0

--- a/testdata/golden/mir/magic_ops_call.mir
+++ b/testdata/golden/mir/magic_ops_call.mir
@@ -35,30 +35,37 @@ fn __eq:
   locals:
     L0: &type#1484 [copy,ref] name=self
     L1: &type#1484 [copy,ref] name=other
-    L2: type#1484 name=tmp_un1
-    L3: int [copy] name=tmp_field2
-    L4: type#1484 name=tmp_un3
-    L5: int [copy] name=tmp_field4
-    L6: bool [copy] name=tmp_call5
-    L7: type#1484 name=tmp_un6
-    L8: int [copy] name=tmp_field7
-    L9: type#1484 name=tmp_un8
-    L10: int [copy] name=tmp_field9
-    L11: bool [copy] name=tmp_call10
-    L12: bool [copy] name=tmp_bin11
+    L2: bool [copy] name=tmp_logic1
+    L3: type#1484 name=tmp_un2
+    L4: int [copy] name=tmp_field3
+    L5: type#1484 name=tmp_un4
+    L6: int [copy] name=tmp_field5
+    L7: bool [copy] name=tmp_call6
+    L8: type#1484 name=tmp_un7
+    L9: int [copy] name=tmp_field8
+    L10: type#1484 name=tmp_un9
+    L11: int [copy] name=tmp_field10
+    L12: bool [copy] name=tmp_call11
   bb0:
-    L2 = (* copy L0)
-    L3 = field copy L2.x
-    L4 = (* copy L1)
-    L5 = field copy L4.x
-    L6 = call __eq(copy L3, copy L5)
-    L7 = (* copy L0)
-    L8 = field copy L7.y
-    L9 = (* copy L1)
-    L10 = field copy L9.y
-    L11 = call __eq(copy L8, copy L10)
-    L12 = (copy L6 && copy L11)
-    return copy L12
+    L3 = (* copy L0)
+    L4 = field copy L3.x
+    L5 = (* copy L1)
+    L6 = field copy L5.x
+    L7 = call __eq(copy L4, copy L6)
+    if copy L7 then bb1 else bb2
+  bb1:
+    L8 = (* copy L0)
+    L9 = field copy L8.y
+    L10 = (* copy L1)
+    L11 = field copy L10.y
+    L12 = call __eq(copy L9, copy L11)
+    L2 = copy L12
+    goto bb3
+  bb2:
+    L2 = const false
+    goto bb3
+  bb3:
+    return copy L2
 
 fn __lt:
   locals:
@@ -111,7 +118,7 @@ fn main:
     L9: bool [copy] name=tmp_call5
     L10: type#1484 name=neg
     L11: type#1484 name=tmp_call6
-    L12: bool [copy] name=tmp_bin7
+    L12: bool [copy] name=tmp_logic7
     L13: int [copy] name=tmp_field8
     L14: int [copy] name=tmp_field9
     L15: int [copy] name=tmp_call10
@@ -128,12 +135,19 @@ fn main:
     L8 = copy L9
     L11 = call __neg(addr_of L0)
     L10 = move L11
-    L12 = (copy L6 || copy L8)
-    if copy L12 then bb1 else bb2
+    if copy L6 then bb2 else bb1
   bb1:
+    L12 = copy L8
+    goto bb3
+  bb2:
+    L12 = const true
+    goto bb3
+  bb3:
+    if copy L12 then bb4 else bb5
+  bb4:
     L13 = field copy L4.x
     L14 = field copy L10.y
     L15 = call __add(copy L13, copy L14)
     return copy L15
-  bb2:
+  bb5:
     return const 0

--- a/testdata/golden/mir/short_circuit.ast
+++ b/testdata/golden/mir/short_circuit.ast
@@ -1,0 +1,44 @@
+short_circuit.sg (span: 1:1-16:1)
+├─ Item[0]: Fn (span: 1:1-3:2)
+│  ├─ Name: rhs
+│  ├─ Params: ()
+│  ├─ Return: bool
+│  └─ Body:
+│     └─ Stmt[0]: Block (span: 1:18-3:2)
+│        └─ Stmt[0]: Return (span: 2:5-2:17)
+│           └─ Expr: expr#1: true
+└─ Item[1]: Fn (span: 5:1-15:2)
+   ├─ Name: main
+   ├─ Params: ()
+   ├─ Return: int
+   └─ Body:
+      └─ Stmt[0]: Block (span: 5:18-15:2)
+         ├─ Stmt[0]: Let (span: 6:5-6:27)
+         │  ├─ Name: s
+         │  ├─ Mutable: false
+         │  ├─ Type: string
+         │  └─ Value: expr#2: "abc"
+         ├─ Stmt[1]: Let (span: 7:5-7:20)
+         │  ├─ Name: i
+         │  ├─ Mutable: false
+         │  ├─ Type: int
+         │  └─ Value: expr#3: 3
+         ├─ Stmt[2]: Let (span: 8:5-8:69)
+         │  ├─ Name: guarded
+         │  ├─ Mutable: false
+         │  ├─ Type: bool
+         │  └─ Value: expr#17: (((i < (s.__len() to int))) && ((s[i] == (34 to uint32))))
+         ├─ Stmt[3]: Let (span: 9:5-9:40)
+         │  ├─ Name: fallback
+         │  ├─ Mutable: false
+         │  ├─ Type: bool
+         │  └─ Value: expr#21: (true || rhs())
+         ├─ Stmt[4]: If (span: 11:5-13:6)
+         │  ├─ Cond: expr#25: (guarded || !fallback)
+         │  ├─ Then:
+Block (span: 11:29-13:6)
+         │  │  └─ Stmt[0]: Return (span: 12:9-12:18)
+         │  │     └─ Expr: expr#26: 1
+         │  └─ Else: <none>
+         └─ Stmt[5]: Return (span: 14:5-14:14)
+            └─ Expr: expr#27: 0

--- a/testdata/golden/mir/short_circuit.fmt
+++ b/testdata/golden/mir/short_circuit.fmt
@@ -1,0 +1,15 @@
+fn rhs() -> bool {
+    return true;
+}
+
+fn main() -> int {
+    let s: string = "abc";
+    let i: int = 3;
+    let guarded: bool = i < (s.__len() to int) && s[i] == 34:uint32;
+    let fallback: bool = true || rhs();
+
+    if guarded || !fallback {
+        return 1;
+    }
+    return 0;
+}

--- a/testdata/golden/mir/short_circuit.mir
+++ b/testdata/golden/mir/short_circuit.mir
@@ -1,0 +1,68 @@
+
+== MIR ==
+funcs=2
+
+fn main:
+  locals:
+    L0: string name=s
+    L1: int [copy] name=i
+    L2: bool [copy] name=guarded
+    L3: bool [copy] name=tmp_logic1
+    L4: uint [copy] name=tmp_call2
+    L5: int [copy] name=tmp_cast3
+    L6: bool [copy] name=tmp_call4
+    L7: uint32 [copy] name=tmp_idx5
+    L8: uint32 [copy] name=tmp_cast6
+    L9: bool [copy] name=tmp_call7
+    L10: bool [copy] name=fallback
+    L11: bool [copy] name=tmp_logic8
+    L12: bool [copy] name=tmp_call9
+    L13: bool [copy] name=tmp_logic10
+    L14: bool [copy] name=tmp_call11
+  bb0:
+    L0 = const "\"abc\""
+    L1 = const 3
+    L4 = call __len(addr_of L0)
+    L5 = cast copy L4 to int
+    L6 = call __lt(copy L1, copy L5)
+    if copy L6 then bb1 else bb2
+  bb1:
+    L7 = index copy L0[copy L1]
+    L8 = cast const 34 to uint32
+    L9 = call __eq(copy L7, copy L8)
+    L3 = copy L9
+    goto bb3
+  bb2:
+    L3 = const false
+    goto bb3
+  bb3:
+    L2 = copy L3
+    if const true then bb5 else bb4
+  bb4:
+    L12 = call rhs()
+    L11 = copy L12
+    goto bb6
+  bb5:
+    L11 = const true
+    goto bb6
+  bb6:
+    L10 = copy L11
+    if copy L2 then bb8 else bb7
+  bb7:
+    L14 = call __not(copy L10)
+    L13 = copy L14
+    goto bb9
+  bb8:
+    L13 = const true
+    goto bb9
+  bb9:
+    if copy L13 then bb10 else bb11
+  bb10:
+    return const 1
+  bb11:
+    return const 0
+
+fn rhs:
+  locals:
+  bb0:
+    return const true

--- a/testdata/golden/mir/short_circuit.sg
+++ b/testdata/golden/mir/short_circuit.sg
@@ -1,0 +1,15 @@
+fn rhs() -> bool {
+    return true;
+}
+
+fn main() -> int {
+    let s: string = "abc";
+    let i: int = 3;
+    let guarded: bool = i < (s.__len() to int) && s[i] == 34:uint32;
+    let fallback: bool = true || rhs();
+
+    if guarded || !fallback {
+        return 1;
+    }
+    return 0;
+}

--- a/testdata/golden/mir/short_circuit.tokens
+++ b/testdata/golden/mir/short_circuit.tokens
@@ -1,0 +1,84 @@
+  1: KwFn            "fn" at 1:1-1:3
+  2: Ident           "rhs" at 1:4-1:7 (leading: Space)
+  3: LParen          "(" at 1:7-1:8
+  4: RParen          ")" at 1:8-1:9
+  5: Arrow           "->" at 1:10-1:12 (leading: Space)
+  6: Ident           "bool" at 1:13-1:17 (leading: Space)
+  7: LBrace          "{" at 1:18-1:19 (leading: Space)
+  8: KwReturn        "return" at 2:5-2:11 (leading: Newline, Space)
+  9: KwTrue          "true" at 2:12-2:16 (leading: Space)
+ 10: Semicolon       ";" at 2:16-2:17
+ 11: RBrace          "}" at 3:1-3:2 (leading: Newline)
+ 12: KwFn            "fn" at 5:1-5:3 (leading: Newline)
+ 13: Ident           "main" at 5:4-5:8 (leading: Space)
+ 14: LParen          "(" at 5:8-5:9
+ 15: RParen          ")" at 5:9-5:10
+ 16: Arrow           "->" at 5:11-5:13 (leading: Space)
+ 17: Ident           "int" at 5:14-5:17 (leading: Space)
+ 18: LBrace          "{" at 5:18-5:19 (leading: Space)
+ 19: KwLet           "let" at 6:5-6:8 (leading: Newline, Space)
+ 20: Ident           "s" at 6:9-6:10 (leading: Space)
+ 21: Colon           ":" at 6:10-6:11
+ 22: Ident           "string" at 6:12-6:18 (leading: Space)
+ 23: Assign          "=" at 6:19-6:20 (leading: Space)
+ 24: StringLit       "\"abc\"" at 6:21-6:26 (leading: Space)
+ 25: Semicolon       ";" at 6:26-6:27
+ 26: KwLet           "let" at 7:5-7:8 (leading: Newline, Space)
+ 27: Ident           "i" at 7:9-7:10 (leading: Space)
+ 28: Colon           ":" at 7:10-7:11
+ 29: Ident           "int" at 7:12-7:15 (leading: Space)
+ 30: Assign          "=" at 7:16-7:17 (leading: Space)
+ 31: IntLit          "3" at 7:18-7:19 (leading: Space)
+ 32: Semicolon       ";" at 7:19-7:20
+ 33: KwLet           "let" at 8:5-8:8 (leading: Newline, Space)
+ 34: Ident           "guarded" at 8:9-8:16 (leading: Space)
+ 35: Colon           ":" at 8:16-8:17
+ 36: Ident           "bool" at 8:18-8:22 (leading: Space)
+ 37: Assign          "=" at 8:23-8:24 (leading: Space)
+ 38: Ident           "i" at 8:25-8:26 (leading: Space)
+ 39: Lt              "<" at 8:27-8:28 (leading: Space)
+ 40: LParen          "(" at 8:29-8:30 (leading: Space)
+ 41: Ident           "s" at 8:30-8:31
+ 42: Dot             "." at 8:31-8:32
+ 43: Ident           "__len" at 8:32-8:37
+ 44: LParen          "(" at 8:37-8:38
+ 45: RParen          ")" at 8:38-8:39
+ 46: KwTo            "to" at 8:40-8:42 (leading: Space)
+ 47: Ident           "int" at 8:43-8:46 (leading: Space)
+ 48: RParen          ")" at 8:46-8:47
+ 49: AndAnd          "&&" at 8:48-8:50 (leading: Space)
+ 50: Ident           "s" at 8:51-8:52 (leading: Space)
+ 51: LBracket        "[" at 8:52-8:53
+ 52: Ident           "i" at 8:53-8:54
+ 53: RBracket        "]" at 8:54-8:55
+ 54: EqEq            "==" at 8:56-8:58 (leading: Space)
+ 55: IntLit          "34" at 8:59-8:61 (leading: Space)
+ 56: Colon           ":" at 8:61-8:62
+ 57: Ident           "uint32" at 8:62-8:68
+ 58: Semicolon       ";" at 8:68-8:69
+ 59: KwLet           "let" at 9:5-9:8 (leading: Newline, Space)
+ 60: Ident           "fallback" at 9:9-9:17 (leading: Space)
+ 61: Colon           ":" at 9:17-9:18
+ 62: Ident           "bool" at 9:19-9:23 (leading: Space)
+ 63: Assign          "=" at 9:24-9:25 (leading: Space)
+ 64: KwTrue          "true" at 9:26-9:30 (leading: Space)
+ 65: OrOr            "||" at 9:31-9:33 (leading: Space)
+ 66: Ident           "rhs" at 9:34-9:37 (leading: Space)
+ 67: LParen          "(" at 9:37-9:38
+ 68: RParen          ")" at 9:38-9:39
+ 69: Semicolon       ";" at 9:39-9:40
+ 70: KwIf            "if" at 11:5-11:7 (leading: Newline, Space)
+ 71: Ident           "guarded" at 11:8-11:15 (leading: Space)
+ 72: OrOr            "||" at 11:16-11:18 (leading: Space)
+ 73: Bang            "!" at 11:19-11:20 (leading: Space)
+ 74: Ident           "fallback" at 11:20-11:28
+ 75: LBrace          "{" at 11:29-11:30 (leading: Space)
+ 76: KwReturn        "return" at 12:9-12:15 (leading: Newline, Space)
+ 77: IntLit          "1" at 12:16-12:17 (leading: Space)
+ 78: Semicolon       ";" at 12:17-12:18
+ 79: RBrace          "}" at 13:5-13:6 (leading: Newline, Space)
+ 80: KwReturn        "return" at 14:5-14:11 (leading: Newline, Space)
+ 81: IntLit          "0" at 14:12-14:13 (leading: Space)
+ 82: Semicolon       ";" at 14:13-14:14
+ 83: RBrace          "}" at 15:1-15:2 (leading: Newline)
+ 84: EOF             at 16:1-16:1


### PR DESCRIPTION
## Summary
- Lower `&&` and `||` to MIR control-flow so the RHS is evaluated only when needed.
- Add a VM/LLVM regression unit test for the issue #87 bounds-check repro and `||` short-circuiting.
- Add MIR golden coverage and update affected MIR goldens to reflect control-flow lowering.
- Keep `STATS.md` updated from the pre-commit check.

Closes #87.

## Tests
- `GOCACHE=/tmp/surge-go-cache SURGE_STDLIB=/tmp/surge-issue-87 SURGE_SKIP_TIMEOUT_TESTS=0 go test ./internal/vm -run TestLogicalOperatorsShortCircuit -count=1`
- `GOCACHE=/tmp/surge-go-cache GOLANGCI_LINT_CACHE=/tmp/surge-golangci-lint-cache SURGE_STDLIB=/tmp/surge-issue-87 make check`
- `GOCACHE=/tmp/surge-go-cache SURGE_STDLIB=/tmp/surge-issue-87 make golden-update`
- pre-commit `make check`

## Manual repro
- `GOCACHE=/tmp/surge-go-cache SURGE_STDLIB=/tmp/surge-issue-87 go run ./cmd/surge run target/issue87_short_circuit.sg`
- `GOCACHE=/tmp/surge-go-cache SURGE_STDLIB=/tmp/surge-issue-87 go run ./cmd/surge run --backend llvm target/issue87_short_circuit.sg`

Both printed `ok` and exited 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Short-circuit evaluation for logical operators (&& and ||): right-hand expressions are only evaluated when needed.

* **Tests**
  * Added cross-backend tests and multiple golden fixtures covering MIR/AST/format/token outputs and focused unit tests for short-circuit logic.

* **Documentation**
  * Refreshed project statistics/report to reflect updated code and test metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->