### PR TITLE
fix(llvm): lower fields through array element refs

### DIFF
--- a/internal/backend/llvm/emit.go
+++ b/internal/backend/llvm/emit.go
@@ -15,6 +15,11 @@ type funcSig struct {
 	paramTypes []types.TypeID
 }
 
+type addrOfTarget struct {
+	place mir.Place
+	ty    types.TypeID
+}
+
 type stringConst struct {
 	raw        string
 	bytes      []byte
@@ -44,6 +49,7 @@ type funcEmitter struct {
 	tmpID           int
 	inlineBlock     int
 	localAlloca     map[mir.LocalID]string
+	addrOfTargets   map[mir.LocalID]addrOfTarget
 	paramLocals     []mir.LocalID
 	blockTerminated bool
 }

--- a/internal/backend/llvm/emit_calls_test.go
+++ b/internal/backend/llvm/emit_calls_test.go
@@ -81,6 +81,18 @@ fn main() -> int {
 func emitLLVMFromSource(t *testing.T, sourceCode string) string {
 	t.Helper()
 
+	mirMod, result := lowerMIRFromSource(t, sourceCode)
+
+	ir, err := EmitModule(mirMod, result.Sema.TypeInterner, result.Symbols.Table)
+	if err != nil {
+		t.Fatalf("emit LLVM IR: %v", err)
+	}
+	return ir
+}
+
+func lowerMIRFromSource(t *testing.T, sourceCode string) (*mir.Module, *driver.DiagnoseResult) {
+	t.Helper()
+
 	tmpFile, err := os.CreateTemp(t.TempDir(), "emit-call-*.sg")
 	if err != nil {
 		t.Fatalf("create temp source: %v", err)
@@ -152,9 +164,5 @@ func emitLLVMFromSource(t *testing.T, sourceCode string) string {
 		t.Fatalf("validate MIR: %v", err)
 	}
 
-	ir, err := EmitModule(mirMod, result.Sema.TypeInterner, result.Symbols.Table)
-	if err != nil {
-		t.Fatalf("emit LLVM IR: %v", err)
-	}
-	return ir
+	return mirMod, result
 }

--- a/internal/backend/llvm/emit_func.go
+++ b/internal/backend/llvm/emit_func.go
@@ -43,6 +43,7 @@ func (e *Emitter) emitFunction(f *mir.Func) error {
 		}
 		fe.localAlloca[localID] = fmt.Sprintf("l%d", i)
 	}
+	fe.addrOfTargets = fe.collectAddrOfTargets()
 
 	order := fe.blockOrder()
 	for _, bb := range order {

--- a/internal/backend/llvm/emit_helpers_place.go
+++ b/internal/backend/llvm/emit_helpers_place.go
@@ -56,7 +56,8 @@ func (fe *funcEmitter) emitPlacePtr(place mir.Place) (ptr, ty string, err error)
 				return "", "", err
 			}
 			curIsValue = false
-			if i+1 < len(place.Proj) && isHandleValueType(fe.emitter.types, curType) {
+			valueType := resolveValueType(fe.emitter.types, curType)
+			if i+1 < len(place.Proj) && isHandleValueType(fe.emitter.types, valueType) {
 				next := place.Proj[i+1].Kind
 				if next == mir.PlaceProjField {
 					tmpVal := fe.nextTemp()
@@ -66,11 +67,12 @@ func (fe *funcEmitter) emitPlacePtr(place mir.Place) (ptr, ty string, err error)
 				}
 			}
 		case mir.PlaceProjField:
-			fieldIdx, fieldType, err := fe.structFieldInfo(curType, proj)
+			fieldBaseType := resolveValueType(fe.emitter.types, curType)
+			fieldIdx, fieldType, err := fe.structFieldInfo(fieldBaseType, proj)
 			if err != nil {
 				return "", "", err
 			}
-			layoutInfo, err := fe.emitter.layoutOf(curType)
+			layoutInfo, err := fe.emitter.layoutOf(fieldBaseType)
 			if err != nil {
 				return "", "", err
 			}

--- a/internal/backend/llvm/emit_helpers_place.go
+++ b/internal/backend/llvm/emit_helpers_place.go
@@ -290,13 +290,13 @@ func (fe *funcEmitter) projectType(cur placeProjectionType, proj mir.PlaceProj, 
 			cur = placeProjectionType{ty: next, storageLocal: storageLocal(nextPlace)}
 		}
 		_, fieldType, err := fe.structFieldInfo(resolveValueType(fe.emitter.types, cur.ty), proj)
-		return placeProjectionType{ty: fieldType}, err
+		return placeProjectionType{ty: fieldType, storageLocal: mir.NoLocalID}, err
 	case mir.PlaceProjIndex:
 		elemType, _, ok := arrayElemType(fe.emitter.types, cur.ty)
 		if !ok {
 			return placeProjectionType{}, fmt.Errorf("index projection on non-array type")
 		}
-		return placeProjectionType{ty: elemType}, nil
+		return placeProjectionType{ty: elemType, storageLocal: mir.NoLocalID}, nil
 	default:
 		return placeProjectionType{}, fmt.Errorf("unsupported place projection kind %v", proj.Kind)
 	}

--- a/internal/backend/llvm/emit_helpers_place.go
+++ b/internal/backend/llvm/emit_helpers_place.go
@@ -14,6 +14,7 @@ func (fe *funcEmitter) emitPlacePtr(place mir.Place) (ptr, ty string, err error)
 	var curPtr string
 	var curType types.TypeID
 	curIsValue := false
+	curStorageLocal := mir.NoLocalID
 	switch place.Kind {
 	case mir.PlaceLocal:
 		name, ok := fe.localAlloca[place.Local]
@@ -22,6 +23,7 @@ func (fe *funcEmitter) emitPlacePtr(place mir.Place) (ptr, ty string, err error)
 		}
 		curPtr = fmt.Sprintf("%%%s", name)
 		curType = fe.f.Locals[place.Local].Type
+		curStorageLocal = place.Local
 	case mir.PlaceGlobal:
 		name := fe.emitter.globalNames[place.Global]
 		if name == "" {
@@ -45,28 +47,45 @@ func (fe *funcEmitter) emitPlacePtr(place mir.Place) (ptr, ty string, err error)
 			}
 			tmp := fe.nextTemp()
 			fmt.Fprintf(&fe.emitter.buf, "  %s = load ptr, ptr %s\n", tmp, curPtr)
-			nextType, ok := derefType(fe.emitter.types, curType)
+			nextType, nextPlace, ok := fe.derefStorageType(curStorageLocal, curType)
 			if !ok {
 				return "", "", fmt.Errorf("unsupported place deref type %s (id=%d)", types.Label(fe.emitter.types, curType), curType)
 			}
 			curPtr = tmp
 			curType = nextType
+			curStorageLocal = storageLocal(nextPlace)
 			curLLVMType, err = llvmValueType(fe.emitter.types, curType)
 			if err != nil {
 				return "", "", err
 			}
 			curIsValue = false
-			valueType := resolveValueType(fe.emitter.types, curType)
-			if i+1 < len(place.Proj) && isHandleValueType(fe.emitter.types, valueType) {
+			if i+1 < len(place.Proj) && !isRefType(fe.emitter.types, curType) && isHandleValueType(fe.emitter.types, resolveValueType(fe.emitter.types, curType)) {
 				next := place.Proj[i+1].Kind
 				if next == mir.PlaceProjField {
 					tmpVal := fe.nextTemp()
 					fmt.Fprintf(&fe.emitter.buf, "  %s = load ptr, ptr %s\n", tmpVal, curPtr)
 					curPtr = tmpVal
 					curIsValue = true
+					curStorageLocal = mir.NoLocalID
 				}
 			}
 		case mir.PlaceProjField:
+			for isRefType(fe.emitter.types, curType) {
+				nextType, nextPlace, ok := fe.derefStorageType(curStorageLocal, curType)
+				if !ok {
+					return "", "", fmt.Errorf("unsupported field reference type %s (id=%d)", types.Label(fe.emitter.types, curType), curType)
+				}
+				tmp := fe.nextTemp()
+				fmt.Fprintf(&fe.emitter.buf, "  %s = load ptr, ptr %s\n", tmp, curPtr)
+				curPtr = tmp
+				curType = nextType
+				curStorageLocal = storageLocal(nextPlace)
+				curLLVMType, err = llvmValueType(fe.emitter.types, curType)
+				if err != nil {
+					return "", "", err
+				}
+				curIsValue = false
+			}
 			fieldBaseType := resolveValueType(fe.emitter.types, curType)
 			fieldIdx, fieldType, err := fe.structFieldInfo(fieldBaseType, proj)
 			if err != nil {
@@ -96,6 +115,7 @@ func (fe *funcEmitter) emitPlacePtr(place mir.Place) (ptr, ty string, err error)
 			curType = fieldType
 			curLLVMType = fieldLLVMType
 			curIsValue = false
+			curStorageLocal = mir.NoLocalID
 		case mir.PlaceProjIndex:
 			if proj.IndexLocal == mir.NoLocalID {
 				return "", "", fmt.Errorf("missing index local")
@@ -141,12 +161,128 @@ func (fe *funcEmitter) emitPlacePtr(place mir.Place) (ptr, ty string, err error)
 				curLLVMType = elemLLVM
 			}
 			curIsValue = false
+			curStorageLocal = mir.NoLocalID
 		default:
 			return "", "", fmt.Errorf("unsupported place projection kind %v", proj.Kind)
 		}
 	}
 
 	return curPtr, curLLVMType, nil
+}
+
+func (fe *funcEmitter) derefStorageType(local mir.LocalID, curType types.TypeID) (types.TypeID, *mir.Place, bool) {
+	if local != mir.NoLocalID && fe.addrOfTargets != nil {
+		if target, ok := fe.addrOfTargets[local]; ok && target.ty != types.NoTypeID {
+			return target.ty, &target.place, true
+		}
+	}
+	next, ok := derefType(fe.emitter.types, curType)
+	return next, nil, ok
+}
+
+func storageLocal(place *mir.Place) mir.LocalID {
+	if place == nil || place.Kind != mir.PlaceLocal || len(place.Proj) != 0 {
+		return mir.NoLocalID
+	}
+	return place.Local
+}
+
+func (fe *funcEmitter) collectAddrOfTargets() map[mir.LocalID]addrOfTarget {
+	if fe == nil || fe.f == nil {
+		return nil
+	}
+	targets := make(map[mir.LocalID]addrOfTarget)
+	conflicts := make(map[mir.LocalID]struct{})
+	for bi := range fe.f.Blocks {
+		for ii := range fe.f.Blocks[bi].Instrs {
+			ins := &fe.f.Blocks[bi].Instrs[ii]
+			if ins.Kind != mir.InstrAssign || ins.Assign.Dst.Kind != mir.PlaceLocal || len(ins.Assign.Dst.Proj) != 0 {
+				continue
+			}
+			local := ins.Assign.Dst.Local
+			if ins.Assign.Src.Kind != mir.RValueUse {
+				conflicts[local] = struct{}{}
+				continue
+			}
+			use := ins.Assign.Src.Use
+			if use.Kind != mir.OperandAddrOf && use.Kind != mir.OperandAddrOfMut {
+				conflicts[local] = struct{}{}
+				continue
+			}
+			ty, err := fe.projectedPlaceType(use.Place)
+			if err != nil || ty == types.NoTypeID {
+				conflicts[local] = struct{}{}
+				continue
+			}
+			next := addrOfTarget{place: use.Place, ty: ty}
+			if existing, ok := targets[local]; ok && !sameAddrOfTarget(existing, next) {
+				conflicts[local] = struct{}{}
+				continue
+			}
+			targets[local] = next
+		}
+	}
+	for local := range conflicts {
+		delete(targets, local)
+	}
+	if len(targets) == 0 {
+		return nil
+	}
+	return targets
+}
+
+func sameAddrOfTarget(a, b addrOfTarget) bool {
+	if a.ty != b.ty || a.place.Kind != b.place.Kind || a.place.Local != b.place.Local || a.place.Global != b.place.Global {
+		return false
+	}
+	if len(a.place.Proj) != len(b.place.Proj) {
+		return false
+	}
+	for i := range a.place.Proj {
+		if a.place.Proj[i] != b.place.Proj[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func (fe *funcEmitter) projectedPlaceType(place mir.Place) (types.TypeID, error) {
+	base := place
+	base.Proj = nil
+	cur, err := fe.placeBaseType(base)
+	if err != nil {
+		return types.NoTypeID, err
+	}
+	for _, proj := range place.Proj {
+		next, err := fe.projectType(cur, proj)
+		if err != nil {
+			return types.NoTypeID, err
+		}
+		cur = next
+	}
+	return cur, nil
+}
+
+func (fe *funcEmitter) projectType(cur types.TypeID, proj mir.PlaceProj) (types.TypeID, error) {
+	switch proj.Kind {
+	case mir.PlaceProjDeref:
+		next, ok := derefType(fe.emitter.types, cur)
+		if !ok {
+			return types.NoTypeID, fmt.Errorf("unsupported place deref type %s (id=%d)", types.Label(fe.emitter.types, cur), cur)
+		}
+		return next, nil
+	case mir.PlaceProjField:
+		_, fieldType, err := fe.structFieldInfo(resolveValueType(fe.emitter.types, cur), proj)
+		return fieldType, err
+	case mir.PlaceProjIndex:
+		elemType, _, ok := arrayElemType(fe.emitter.types, cur)
+		if !ok {
+			return types.NoTypeID, fmt.Errorf("index projection on non-array type")
+		}
+		return elemType, nil
+	default:
+		return types.NoTypeID, fmt.Errorf("unsupported place projection kind %v", proj.Kind)
+	}
 }
 
 func (fe *funcEmitter) placeBaseType(place mir.Place) (types.TypeID, error) {

--- a/internal/backend/llvm/emit_helpers_place.go
+++ b/internal/backend/llvm/emit_helpers_place.go
@@ -171,8 +171,12 @@ func (fe *funcEmitter) emitPlacePtr(place mir.Place) (ptr, ty string, err error)
 }
 
 func (fe *funcEmitter) derefStorageType(local mir.LocalID, curType types.TypeID) (types.TypeID, *mir.Place, bool) {
-	if local != mir.NoLocalID && fe.addrOfTargets != nil {
-		if target, ok := fe.addrOfTargets[local]; ok && target.ty != types.NoTypeID {
+	return fe.derefStorageTypeWithTargets(local, curType, fe.addrOfTargets)
+}
+
+func (fe *funcEmitter) derefStorageTypeWithTargets(local mir.LocalID, curType types.TypeID, targets map[mir.LocalID]addrOfTarget) (types.TypeID, *mir.Place, bool) {
+	if local != mir.NoLocalID && targets != nil {
+		if target, ok := targets[local]; ok && target.ty != types.NoTypeID {
 			return target.ty, &target.place, true
 		}
 	}
@@ -185,6 +189,11 @@ func storageLocal(place *mir.Place) mir.LocalID {
 		return mir.NoLocalID
 	}
 	return place.Local
+}
+
+type placeProjectionType struct {
+	ty           types.TypeID
+	storageLocal mir.LocalID
 }
 
 func (fe *funcEmitter) collectAddrOfTargets() map[mir.LocalID]addrOfTarget {
@@ -209,7 +218,7 @@ func (fe *funcEmitter) collectAddrOfTargets() map[mir.LocalID]addrOfTarget {
 				conflicts[local] = struct{}{}
 				continue
 			}
-			ty, err := fe.projectedPlaceType(use.Place)
+			ty, err := fe.projectedPlaceTypeWithTargets(use.Place, targets)
 			if err != nil || ty == types.NoTypeID {
 				conflicts[local] = struct{}{}
 				continue
@@ -246,42 +255,50 @@ func sameAddrOfTarget(a, b addrOfTarget) bool {
 	return true
 }
 
-func (fe *funcEmitter) projectedPlaceType(place mir.Place) (types.TypeID, error) {
+func (fe *funcEmitter) projectedPlaceTypeWithTargets(place mir.Place, targets map[mir.LocalID]addrOfTarget) (types.TypeID, error) {
 	base := place
 	base.Proj = nil
 	cur, err := fe.placeBaseType(base)
 	if err != nil {
 		return types.NoTypeID, err
 	}
+	state := placeProjectionType{ty: cur, storageLocal: storageLocal(&base)}
 	for _, proj := range place.Proj {
-		next, err := fe.projectType(cur, proj)
+		next, err := fe.projectType(state, proj, targets)
 		if err != nil {
 			return types.NoTypeID, err
 		}
-		cur = next
+		state = next
 	}
-	return cur, nil
+	return state.ty, nil
 }
 
-func (fe *funcEmitter) projectType(cur types.TypeID, proj mir.PlaceProj) (types.TypeID, error) {
+func (fe *funcEmitter) projectType(cur placeProjectionType, proj mir.PlaceProj, targets map[mir.LocalID]addrOfTarget) (placeProjectionType, error) {
 	switch proj.Kind {
 	case mir.PlaceProjDeref:
-		next, ok := derefType(fe.emitter.types, cur)
+		next, nextPlace, ok := fe.derefStorageTypeWithTargets(cur.storageLocal, cur.ty, targets)
 		if !ok {
-			return types.NoTypeID, fmt.Errorf("unsupported place deref type %s (id=%d)", types.Label(fe.emitter.types, cur), cur)
+			return placeProjectionType{}, fmt.Errorf("unsupported place deref type %s (id=%d)", types.Label(fe.emitter.types, cur.ty), cur.ty)
 		}
-		return next, nil
+		return placeProjectionType{ty: next, storageLocal: storageLocal(nextPlace)}, nil
 	case mir.PlaceProjField:
-		_, fieldType, err := fe.structFieldInfo(resolveValueType(fe.emitter.types, cur), proj)
-		return fieldType, err
-	case mir.PlaceProjIndex:
-		elemType, _, ok := arrayElemType(fe.emitter.types, cur)
-		if !ok {
-			return types.NoTypeID, fmt.Errorf("index projection on non-array type")
+		for isRefType(fe.emitter.types, cur.ty) {
+			next, nextPlace, ok := fe.derefStorageTypeWithTargets(cur.storageLocal, cur.ty, targets)
+			if !ok {
+				return placeProjectionType{}, fmt.Errorf("unsupported field reference type %s (id=%d)", types.Label(fe.emitter.types, cur.ty), cur.ty)
+			}
+			cur = placeProjectionType{ty: next, storageLocal: storageLocal(nextPlace)}
 		}
-		return elemType, nil
+		_, fieldType, err := fe.structFieldInfo(resolveValueType(fe.emitter.types, cur.ty), proj)
+		return placeProjectionType{ty: fieldType}, err
+	case mir.PlaceProjIndex:
+		elemType, _, ok := arrayElemType(fe.emitter.types, cur.ty)
+		if !ok {
+			return placeProjectionType{}, fmt.Errorf("index projection on non-array type")
+		}
+		return placeProjectionType{ty: elemType}, nil
 	default:
-		return types.NoTypeID, fmt.Errorf("unsupported place projection kind %v", proj.Kind)
+		return placeProjectionType{}, fmt.Errorf("unsupported place projection kind %v", proj.Kind)
 	}
 }
 

--- a/internal/backend/llvm/emit_helpers_place_test.go
+++ b/internal/backend/llvm/emit_helpers_place_test.go
@@ -35,6 +35,7 @@ fn main() -> int {
 
 	mirMod, result := lowerMIRFromSource(t, sourceCode)
 	mainFn := findMIRFunc(t, mirMod, "main")
+	docLocal := findMIRLocal(t, mainFn, "doc")
 	entryLocal := findMIRLocal(t, mainFn, "entry")
 	keyLocal := findMIRLocal(t, mainFn, "key")
 	fe := &funcEmitter{
@@ -72,6 +73,29 @@ fn main() -> int {
 			types.Label(result.Sema.TypeInterner, projected.ty),
 			types.Label(result.Sema.TypeInterner, entryTarget.ty),
 		)
+	}
+
+	entries, err := fe.projectType(
+		placeProjectionType{ty: mainFn.Locals[docLocal].Type, storageLocal: docLocal},
+		mir.PlaceProj{Kind: mir.PlaceProjField, FieldName: "entries", FieldIdx: -1},
+		targets,
+	)
+	if err != nil {
+		t.Fatalf("project entries field: %v", err)
+	}
+	if entries.storageLocal != mir.NoLocalID {
+		t.Fatalf("field projection storage local = %d, want NoLocalID", entries.storageLocal)
+	}
+	entryElem, err := fe.projectType(
+		entries,
+		mir.PlaceProj{Kind: mir.PlaceProjIndex},
+		targets,
+	)
+	if err != nil {
+		t.Fatalf("project entries index: %v", err)
+	}
+	if entryElem.storageLocal != mir.NoLocalID {
+		t.Fatalf("index projection storage local = %d, want NoLocalID", entryElem.storageLocal)
 	}
 }
 

--- a/internal/backend/llvm/emit_helpers_place_test.go
+++ b/internal/backend/llvm/emit_helpers_place_test.go
@@ -1,0 +1,98 @@
+package llvm
+
+import (
+	"testing"
+
+	"surge/internal/mir"
+	"surge/internal/types"
+)
+
+func TestCollectAddrOfTargetsProjectsFieldBorrowThroughReferenceLocal(t *testing.T) {
+	sourceCode := `type Entry = {
+    key: string,
+    value: string,
+};
+
+type Doc = {
+    entries: Entry[],
+};
+
+@entrypoint
+fn main() -> int {
+    let doc: Doc = Doc {
+        entries = [
+            Entry { key = "HOST", value = "localhost" },
+            Entry { key = "PORT", value = "5432" },
+        ],
+    };
+    let i: int = 1;
+    let entry = &doc.entries[i];
+    let key = &entry.key;
+    print(key.__clone());
+    return 0;
+}
+`
+
+	mirMod, result := lowerMIRFromSource(t, sourceCode)
+	mainFn := findMIRFunc(t, mirMod, "main")
+	entryLocal := findMIRLocal(t, mainFn, "entry")
+	keyLocal := findMIRLocal(t, mainFn, "key")
+	fe := &funcEmitter{
+		emitter: &Emitter{mod: mirMod, types: result.Sema.TypeInterner},
+		f:       mainFn,
+	}
+
+	targets := fe.collectAddrOfTargets()
+	entryTarget, ok := targets[entryLocal]
+	if !ok {
+		t.Fatalf("missing addr_of target for entry local")
+	}
+	keyTarget, ok := targets[keyLocal]
+	if !ok {
+		t.Fatalf("missing addr_of target for key local")
+	}
+	if entryTarget.ty == mainFn.Locals[entryLocal].Type {
+		t.Fatalf("entry target kept reference-cell type %s", types.Label(result.Sema.TypeInterner, entryTarget.ty))
+	}
+	if keyTarget.ty != result.Sema.TypeInterner.Builtins().String {
+		t.Fatalf("key target type = %s, want string", types.Label(result.Sema.TypeInterner, keyTarget.ty))
+	}
+
+	projected, err := fe.projectType(
+		placeProjectionType{ty: mainFn.Locals[entryLocal].Type, storageLocal: entryLocal},
+		mir.PlaceProj{Kind: mir.PlaceProjDeref},
+		targets,
+	)
+	if err != nil {
+		t.Fatalf("project entry deref: %v", err)
+	}
+	if projected.ty != entryTarget.ty {
+		t.Fatalf(
+			"projected entry deref type = %s, want addr_of target %s",
+			types.Label(result.Sema.TypeInterner, projected.ty),
+			types.Label(result.Sema.TypeInterner, entryTarget.ty),
+		)
+	}
+}
+
+func findMIRFunc(t *testing.T, mod *mir.Module, name string) *mir.Func {
+	t.Helper()
+	for _, fn := range mod.Funcs {
+		if fn != nil && fn.Name == name {
+			return fn
+		}
+	}
+	t.Fatalf("missing MIR function %q", name)
+	return nil
+}
+
+func findMIRLocal(t *testing.T, fn *mir.Func, name string) mir.LocalID {
+	t.Helper()
+	for i, local := range fn.Locals {
+		if local.Name == name {
+			return mir.LocalID(i)
+		}
+	}
+	t.Fatalf("missing MIR local %q", name)
+	return mir.NoLocalID
+}

--- a/internal/vm/llvm_smoke_test.go
+++ b/internal/vm/llvm_smoke_test.go
@@ -26,6 +26,7 @@ func TestLLVMSmoke(t *testing.T) {
 		name string
 		file string
 	}{
+		{name: "array_element_ref_field", file: "array_element_ref_field.sg"},
 		{name: "array_field_mut_ref_reborrow", file: "array_field_mut_ref_reborrow.sg"},
 		{name: "hello_print", file: "hello_print.sg"},
 		{name: "time_monotonic_now", file: "time_monotonic_now.sg"},

--- a/testdata/llvm_smoke/array_element_ref_field.sg
+++ b/testdata/llvm_smoke/array_element_ref_field.sg
@@ -18,8 +18,11 @@ fn main() -> int {
     let mut i: int = 0;
     while i < (doc.entries.__len() to int) {
         let entry = &doc.entries[i];
+        let key = &entry.key;
         let nested = &entry;
         print(entry.key + "=" + entry.value);
+        print(";");
+        print(key.__clone());
         print(";");
         print(nested.key.__clone() + "=" + nested.value.__clone());
         print("\n");

--- a/testdata/llvm_smoke/array_element_ref_field.sg
+++ b/testdata/llvm_smoke/array_element_ref_field.sg
@@ -1,0 +1,21 @@
+type Entry = {
+    key: string,
+    value: string,
+};
+
+type Doc = {
+    entries: Entry[],
+};
+
+@entrypoint
+fn main() -> int {
+    let doc: Doc = Doc { entries = [Entry { key = "HOST", value = "localhost" }] };
+    let mut i: int = 0;
+    while i < (doc.entries.__len() to int) {
+        let entry = &doc.entries[i];
+        print(entry.key + "=" + entry.value);
+        print("\n");
+        i = i + 1;
+    }
+    return 0;
+}

--- a/testdata/llvm_smoke/array_element_ref_field.sg
+++ b/testdata/llvm_smoke/array_element_ref_field.sg
@@ -9,11 +9,19 @@ type Doc = {
 
 @entrypoint
 fn main() -> int {
-    let doc: Doc = Doc { entries = [Entry { key = "HOST", value = "localhost" }] };
+    let doc: Doc = Doc {
+        entries = [
+            Entry { key = "HOST", value = "localhost" },
+            Entry { key = "PORT", value = "5432" },
+        ],
+    };
     let mut i: int = 0;
     while i < (doc.entries.__len() to int) {
         let entry = &doc.entries[i];
+        let nested = &entry;
         print(entry.key + "=" + entry.value);
+        print(";");
+        print(nested.key.__clone() + "=" + nested.value.__clone());
         print("\n");
         i = i + 1;
     }


### PR DESCRIPTION
## Summary
- fix LLVM place projection so field access through referenced array elements resolves the underlying value type
- add an LLVM smoke fixture that reproduces the borrowed array element field access from issue #88

## Tests
- SURGE_STDLIB=/tmp/surge-issue-88 ./surge diag /tmp/surge-llvm-array-ref.sg
- SURGE_STDLIB=/tmp/surge-issue-88 ./surge run /tmp/surge-llvm-array-ref.sg
- SURGE_STDLIB=/tmp/surge-issue-88 ./surge build /tmp/surge-llvm-array-ref.sg
- SURGE_STDLIB=/tmp/surge-issue-88 ./surge build testdata/llvm_smoke/array_element_ref_field.sg
- GOCACHE=/tmp/surge-go-cache SURGE_STDLIB=/tmp/surge-issue-88 go test ./internal/vm -run 'TestLLVMSmoke/array_element_ref_field' -count=1
- GOCACHE=/tmp/surge-go-cache SURGE_STDLIB=/tmp/surge-issue-88 go test ./internal/backend/llvm -count=1
- GOCACHE=/tmp/surge-go-cache SURGE_STDLIB=/tmp/surge-issue-88 go test ./internal/vm -run TestLLVMSmoke -count=1
- GOCACHE=/tmp/surge-go-cache GOLANGCI_LINT_CACHE=/tmp/surge-golangci-lint-cache SURGE_STDLIB=/tmp/surge-issue-88 make check
- GOCACHE=/tmp/surge-go-cache SURGE_STDLIB=/tmp/surge-issue-88 make golden-update

Closes #88

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixes for dereference and field access via nested/borrowed storage so values and addresses resolve consistently at runtime.

* **New Features**
  * Improved emitter tracking of address-of/borrowed locals for more accurate projected types during code generation.

* **Tests**
  * Added a smoke test covering array-element reference + field access.
  * Added a unit test validating collection/projection of address-of targets.

* **Refactor**
  * Separated MIR-lowering from emission in test helpers for reuse.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->