### PR TITLE
[codex] fix runtime net poll wakeups

### DIFF
--- a/internal/vm/mt_correctness_test.go
+++ b/internal/vm/mt_correctness_test.go
@@ -741,6 +741,158 @@ fn main(port: uint) -> int {
 	}
 }
 
+func TestMTNetWaiterWakeupLatency(t *testing.T) {
+	ensureLLVMToolchain(t)
+
+	source := `import stdlib/net as net;
+
+fn pong() -> byte[] {
+    let mut out: byte[] = [];
+    out.push(88:byte);
+    return out;
+}
+
+async fn serve_one(listener: TcpListener, count: uint) -> int {
+    let accept_task = net.accept(&listener).await();
+    compare accept_task {
+        Success(conn_res) => {
+            compare conn_res {
+                Success(conn) => {
+                    let mut seen: uint = 0:uint;
+                    while seen < count {
+                        let read_task = net.read_some(&conn, 16:uint).await();
+                        let read_ok: bool = compare read_task {
+                            Success(read_res) => compare read_res {
+                                Success(bytes) => bytes.__len() != 0:uint;
+                                _ => false;
+                            };
+                            Cancelled() => false;
+                        };
+                        if !read_ok {
+                            let _ = net.close_conn(own conn);
+                            return 2;
+                        }
+                        let data = pong();
+                        let write_task = net.write_all(&conn, data).await();
+                        let write_ok: bool = compare write_task {
+                            Success(write_res) => compare write_res {
+                                Success(_) => true;
+                                _ => false;
+                            };
+                            Cancelled() => false;
+                        };
+                        if !write_ok {
+                            let _ = net.close_conn(own conn);
+                            return 3;
+                        }
+                        seen = seen + 1:uint;
+                    }
+                    let _ = net.close_conn(own conn);
+                    return 0;
+                }
+                _ => {
+                    return 1;
+                }
+            };
+        }
+        Cancelled() => {
+            return 1;
+        }
+    };
+    return 1;
+}
+
+@entrypoint("argv")
+fn main(port: uint, count: uint) -> int {
+    let listen_res = net.listen("127.0.0.1", port);
+    compare listen_res {
+        Success(listener) => {
+            let result = serve_one(listener, count).await();
+            return compare result {
+                Success(code) => code;
+                Cancelled() => 99;
+            };
+        }
+        err => {
+            print("listen_err=" + (err.code to string));
+            return 1;
+        }
+    };
+    return 1;
+}
+`
+
+	outputPath := buildLLVMProgramFromSource(t, source)
+	port := pickFreePort(t)
+	count := 20
+	cmd := exec.Command(outputPath, strconv.Itoa(port), strconv.Itoa(count))
+	cmd.Env = mtEnv(t)
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start ping server: %v", err)
+	}
+
+	waitCh := make(chan error, 1)
+	go func() {
+		waitCh <- cmd.Wait()
+	}()
+
+	fail := func(format string, args ...any) {
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+		<-waitCh
+		t.Fatalf(format+"\nstdout:\n%s\nstderr:\n%s", append(args, outBuf.String(), errBuf.String())...)
+	}
+
+	addr := net.JoinHostPort("127.0.0.1", strconv.Itoa(port))
+	conn, err := dialWithRetry(addr, time.Now().Add(10*time.Second))
+	if err != nil {
+		fail("dial ping server: %v", err)
+	}
+	if err = conn.SetDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		_ = conn.Close()
+		fail("set deadline: %v", err)
+	}
+
+	started := time.Now()
+	for range count {
+		if _, err = conn.Write([]byte("PING\n")); err != nil {
+			_ = conn.Close()
+			fail("write ping: %v", err)
+		}
+		var buf [1]byte
+		if _, err = io.ReadFull(conn, buf[:]); err != nil {
+			_ = conn.Close()
+			fail("read pong: %v", err)
+		}
+		if buf[0] != 'X' {
+			_ = conn.Close()
+			fail("unexpected response: %q", buf[0])
+		}
+	}
+	elapsed := time.Since(started)
+	_ = conn.Close()
+
+	select {
+	case err := <-waitCh:
+		if err != nil {
+			t.Fatalf("ping server exit: %v\nstdout:\n%s\nstderr:\n%s", err, outBuf.String(), errBuf.String())
+		}
+	case <-time.After(5 * time.Second):
+		_ = cmd.Process.Kill()
+		<-waitCh
+		t.Fatalf("ping server timed out\nstdout:\n%s\nstderr:\n%s", outBuf.String(), errBuf.String())
+	}
+
+	if elapsed > 800*time.Millisecond {
+		t.Fatalf("persistent ping loop too slow: %s for %d requests", elapsed, count)
+	}
+}
+
 func runMTHTTPKeepaliveScenario(addr string) error {
 	conn, err := dialWithRetry(addr, time.Now().Add(10*time.Second))
 	if err != nil {

--- a/runtime/native/rt_async_internal.h
+++ b/runtime/native/rt_async_internal.h
@@ -357,6 +357,7 @@ poll_outcome poll_task(rt_executor* ex, rt_task* task);
 poll_outcome poll_blocking_task(rt_executor* ex, rt_task* task);
 poll_outcome poll_net_task(const rt_executor* ex, const rt_task* task);
 int poll_net_waiters(rt_executor* ex, int timeout_ms);
+void rt_net_wake_poll(void);
 int run_ready_one(rt_executor* ex);
 void run_until_done(rt_executor* ex, const rt_task* task, uint8_t* out_kind, uint64_t* out_bits);
 

--- a/runtime/native/rt_async_state.c
+++ b/runtime/native/rt_async_state.c
@@ -1329,6 +1329,10 @@ void park_current(rt_executor* ex, waker_key key) {
         return;
     }
     trace_exec_inc(&trace_park_committed_total);
+    waker_kind kind = (waker_kind)key.kind;
+    if (kind == WAKER_NET_ACCEPT || kind == WAKER_NET_READ || kind == WAKER_NET_WRITE) {
+        rt_net_wake_poll();
+    }
     pthread_cond_signal(&ex->io_cv);
 }
 

--- a/runtime/native/rt_net.c
+++ b/runtime/native/rt_net.c
@@ -55,6 +55,84 @@ typedef struct NetPollFd {
     uint8_t want_write;
 } NetPollFd;
 
+static int net_poll_wake_read_fd = -1;
+static int net_poll_wake_write_fd = -1;
+
+static int net_set_nonblocking_cloexec(int fd) {
+    int flags = fcntl(fd, F_GETFL, 0);
+    if (flags < 0 || fcntl(fd, F_SETFL, flags | O_NONBLOCK) < 0) {
+        return 0;
+    }
+    flags = fcntl(fd, F_GETFD, 0);
+    if (flags < 0 || fcntl(fd, F_SETFD, flags | FD_CLOEXEC) < 0) {
+        return 0;
+    }
+    return 1;
+}
+
+static int net_poll_wake_init(void) {
+    if (net_poll_wake_read_fd >= 0 && net_poll_wake_write_fd >= 0) {
+        return 1;
+    }
+    int fds[2] = {-1, -1};
+    if (pipe(fds) != 0) {
+        return 0;
+    }
+    if (!net_set_nonblocking_cloexec(fds[0]) || !net_set_nonblocking_cloexec(fds[1])) {
+        close(fds[0]);
+        close(fds[1]);
+        return 0;
+    }
+    net_poll_wake_read_fd = fds[0];
+    net_poll_wake_write_fd = fds[1];
+    return 1;
+}
+
+void rt_net_wake_poll(void) {
+    if (net_poll_wake_write_fd < 0) {
+        return;
+    }
+    uint8_t byte = 1;
+    ssize_t n = -1;
+    do {
+        n = write(net_poll_wake_write_fd, &byte, 1);
+    } while (n < 0 && errno == EINTR);
+    (void)n;
+}
+
+static void net_poll_wake_drain(void) {
+    if (net_poll_wake_read_fd < 0) {
+        return;
+    }
+    uint8_t buf[64];
+    for (;;) {
+        ssize_t n = read(net_poll_wake_read_fd, buf, sizeof(buf));
+        if (n > 0) {
+            continue;
+        }
+        if (n < 0 && errno == EINTR) {
+            continue;
+        }
+        break;
+    }
+}
+
+static void complete_net_waiters(rt_executor* ex, waker_key key) {
+    uint64_t task_id = 0;
+    while (pop_waiter(ex, key, &task_id)) {
+        rt_task* task = get_task(ex, task_id);
+        if (task == NULL || task_status_load(task) == TASK_DONE) {
+            continue;
+        }
+        if (task->kind == TASK_KIND_NET_ACCEPT || task->kind == TASK_KIND_NET_READ ||
+            task->kind == TASK_KIND_NET_WRITE) {
+            mark_done(ex, task, TASK_RESULT_SUCCESS, 0);
+            continue;
+        }
+        wake_task(ex, task_id, 0);
+    }
+}
+
 static const char* net_error_message(uint64_t code) {
     switch (code) {
         case NET_ERR_WOULD_BLOCK:
@@ -616,32 +694,43 @@ int poll_net_waiters(rt_executor* ex, int timeout_ms) {
         rt_free((uint8_t*)fds, (uint64_t)cap * (uint64_t)sizeof(NetPollFd), _Alignof(NetPollFd));
         return 0;
     }
-    if (count > (size_t)((nfds_t)-1)) {
+    int wake_fd = net_poll_wake_init() ? net_poll_wake_read_fd : -1;
+    size_t wake_count = wake_fd >= 0 ? 1U : 0U;
+    size_t poll_count = count + wake_count;
+    if (poll_count < count || poll_count > (size_t)((nfds_t)-1)) {
         rt_free((uint8_t*)fds, (uint64_t)cap * (uint64_t)sizeof(NetPollFd), _Alignof(NetPollFd));
         return 0;
     }
 
     struct pollfd* pfds = (struct pollfd*)rt_alloc(
-        (uint64_t)count * (uint64_t)sizeof(struct pollfd), _Alignof(struct pollfd));
+        (uint64_t)poll_count * (uint64_t)sizeof(struct pollfd), _Alignof(struct pollfd));
     if (pfds == NULL) {
         rt_free((uint8_t*)fds, (uint64_t)cap * (uint64_t)sizeof(NetPollFd), _Alignof(NetPollFd));
         return 0;
     }
+    size_t offset = 0;
+    if (wake_fd >= 0) {
+        pfds[0].fd = wake_fd;
+        pfds[0].events = POLLIN;
+        pfds[0].revents = 0;
+        offset = 1;
+    }
     for (size_t i = 0; i < count; i++) {
-        pfds[i].fd = fds[i].fd;
-        pfds[i].events = 0;
-        pfds[i].revents = 0;
+        size_t poll_idx = offset + i;
+        pfds[poll_idx].fd = fds[i].fd;
+        pfds[poll_idx].events = 0;
+        pfds[poll_idx].revents = 0;
         if (fds[i].want_read) {
-            pfds[i].events |= POLLIN;
+            pfds[poll_idx].events |= POLLIN;
         }
         if (fds[i].want_write) {
-            pfds[i].events |= POLLOUT;
+            pfds[poll_idx].events |= POLLOUT;
         }
     }
 
     rt_unlock(ex);
     int n = -1;
-    nfds_t nfds = (nfds_t)count;
+    nfds_t nfds = (nfds_t)poll_count;
     do {
         n = poll(pfds, nfds, timeout_ms);
     } while (n < 0 && errno == EINTR);
@@ -649,47 +738,53 @@ int poll_net_waiters(rt_executor* ex, int timeout_ms) {
     if (n < 0) {
         for (size_t i = 0; i < count; i++) {
             if (fds[i].want_read) {
-                wake_key_all(ex, net_read_key(fds[i].fd));
-                wake_key_all(ex, net_accept_key(fds[i].fd));
+                complete_net_waiters(ex, net_read_key(fds[i].fd));
+                complete_net_waiters(ex, net_accept_key(fds[i].fd));
             }
             if (fds[i].want_write) {
-                wake_key_all(ex, net_write_key(fds[i].fd));
+                complete_net_waiters(ex, net_write_key(fds[i].fd));
             }
         }
         rt_free((uint8_t*)pfds,
-                (uint64_t)count * (uint64_t)sizeof(struct pollfd),
+                (uint64_t)poll_count * (uint64_t)sizeof(struct pollfd),
                 _Alignof(struct pollfd));
         rt_free((uint8_t*)fds, (uint64_t)cap * (uint64_t)sizeof(NetPollFd), _Alignof(NetPollFd));
         return 1;
     }
     if (n == 0) {
         rt_free((uint8_t*)pfds,
-                (uint64_t)count * (uint64_t)sizeof(struct pollfd),
+                (uint64_t)poll_count * (uint64_t)sizeof(struct pollfd),
                 _Alignof(struct pollfd));
         rt_free((uint8_t*)fds, (uint64_t)cap * (uint64_t)sizeof(NetPollFd), _Alignof(NetPollFd));
         return 0;
     }
 
     int woke = 0;
+    if (wake_fd >= 0 && pfds[0].revents != 0) {
+        net_poll_wake_drain();
+        woke = 1;
+    }
     for (size_t i = 0; i < count; i++) {
-        if (pfds[i].revents == 0) {
+        size_t poll_idx = offset + i;
+        if (pfds[poll_idx].revents == 0) {
             continue;
         }
-        bool read_ready = (pfds[i].revents & (POLLIN | POLLERR | POLLHUP)) != 0;
-        bool write_ready = (pfds[i].revents & (POLLOUT | POLLERR | POLLHUP)) != 0;
+        bool read_ready = (pfds[poll_idx].revents & (POLLIN | POLLERR | POLLHUP)) != 0;
+        bool write_ready = (pfds[poll_idx].revents & (POLLOUT | POLLERR | POLLHUP)) != 0;
         if (read_ready) {
-            wake_key_all(ex, net_read_key(fds[i].fd));
-            wake_key_all(ex, net_accept_key(fds[i].fd));
+            complete_net_waiters(ex, net_read_key(fds[i].fd));
+            complete_net_waiters(ex, net_accept_key(fds[i].fd));
             woke = 1;
         }
         if (write_ready) {
-            wake_key_all(ex, net_write_key(fds[i].fd));
+            complete_net_waiters(ex, net_write_key(fds[i].fd));
             woke = 1;
         }
     }
 
-    rt_free(
-        (uint8_t*)pfds, (uint64_t)count * (uint64_t)sizeof(struct pollfd), _Alignof(struct pollfd));
+    rt_free((uint8_t*)pfds,
+            (uint64_t)poll_count * (uint64_t)sizeof(struct pollfd),
+            _Alignof(struct pollfd));
     rt_free((uint8_t*)fds, (uint64_t)cap * (uint64_t)sizeof(NetPollFd), _Alignof(NetPollFd));
     return woke;
 }


### PR DESCRIPTION
## Summary

- Wake the native runtime net poller when accept/read/write waiters park.
- Complete ready net waiter tasks directly after `poll()` reports readiness.
- Add a regression test that catches the former 50ms persistent TCP request delay.

Closes #102

## Validation

- `SURGE_SKIP_TIMEOUT_TESTS=0 GOCACHE=/tmp/surge-go-cache go test ./internal/vm -run TestMTNetWaiterWakeupLatency -count=1 -v`
- `make test`
- `make c-check`
- `git diff --check`

## Note

Local `make check` still fails on lint findings in the ignored nested `surgekv/scripts/bench_load.go`; the staged runtime/test diff is clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced reliability of concurrent async network operations.
  * Optimized network event polling and wake-up handling to reduce latency.
  * Improved task completion semantics in multi-threaded networking scenarios.

* **Tests**
  * Added correctness test validating async network waiter wake-up latency performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->