### PR TITLE
fix(stdlib/net): buffer TCP reads and writes

### DIFF
--- a/core/intrinsics.sg
+++ b/core/intrinsics.sg
@@ -95,6 +95,8 @@ pub type NetResult<T> = Erring<T, NetError>;
 @intrinsic fn rt_net_accept(l: &TcpListener) -> NetResult<TcpConn>;
 @intrinsic fn rt_net_read(c: &TcpConn, buf: *byte, cap: uint) -> NetResult<uint>;
 @intrinsic fn rt_net_write(c: &TcpConn, buf: *byte, length: uint) -> NetResult<uint>;
+@intrinsic fn rt_net_read_bytes(c: &TcpConn, cap: uint) -> NetResult<byte[]>;
+@intrinsic fn rt_net_write_bytes(c: &TcpConn, data: &byte[], offset: uint, length: uint) -> NetResult<uint>;
 
 @intrinsic fn rt_net_wait_accept(l: &TcpListener) -> Task<nothing>;
 @intrinsic fn rt_net_wait_readable(c: &TcpConn) -> Task<nothing>;

--- a/internal/backend/llvm/builtins.go
+++ b/internal/backend/llvm/builtins.go
@@ -53,6 +53,8 @@ func runtimeDecls() []builtinDecl {
 		{name: "rt_net_accept", ret: "ptr", params: []string{"ptr"}},
 		{name: "rt_net_read", ret: "ptr", params: []string{"ptr", "ptr", "i64"}},
 		{name: "rt_net_write", ret: "ptr", params: []string{"ptr", "ptr", "i64"}},
+		{name: "rt_net_read_bytes", ret: "ptr", params: []string{"ptr", "i64"}},
+		{name: "rt_net_write_bytes", ret: "ptr", params: []string{"ptr", "ptr", "i64", "i64"}},
 		{name: "rt_net_wait_accept", ret: "ptr", params: []string{"ptr"}},
 		{name: "rt_net_wait_readable", ret: "ptr", params: []string{"ptr"}},
 		{name: "rt_net_wait_writable", ret: "ptr", params: []string{"ptr"}},

--- a/internal/backend/llvm/emit_intrinsics_net.go
+++ b/internal/backend/llvm/emit_intrinsics_net.go
@@ -31,6 +31,10 @@ func (fe *funcEmitter) emitNetIntrinsic(call *mir.CallInstr) (bool, error) {
 		return true, fe.emitNetRead(call)
 	case "rt_net_write":
 		return true, fe.emitNetWrite(call)
+	case "rt_net_read_bytes":
+		return true, fe.emitNetReadBytes(call)
+	case "rt_net_write_bytes":
+		return true, fe.emitNetWriteBytes(call)
 	case "rt_net_wait_accept":
 		return true, fe.emitNetWait(call, "rt_net_wait_accept", "TcpListener")
 	case "rt_net_wait_readable":
@@ -137,6 +141,48 @@ func (fe *funcEmitter) emitNetWrite(call *mir.CallInstr) error {
 	return fe.storePtrResult(call, tmp)
 }
 
+func (fe *funcEmitter) emitNetReadBytes(call *mir.CallInstr) error {
+	if len(call.Args) != 2 {
+		return fmt.Errorf("rt_net_read_bytes requires 2 arguments")
+	}
+	connVal, err := fe.emitNetHandle(&call.Args[0], "TcpConn")
+	if err != nil {
+		return err
+	}
+	cap64, err := fe.emitUintOperandToI64(&call.Args[1], "net read cap out of range")
+	if err != nil {
+		return err
+	}
+	tmp := fe.nextTemp()
+	fmt.Fprintf(&fe.emitter.buf, "  %s = call ptr @rt_net_read_bytes(ptr %s, i64 %s)\n", tmp, connVal, cap64)
+	return fe.storePtrResult(call, tmp)
+}
+
+func (fe *funcEmitter) emitNetWriteBytes(call *mir.CallInstr) error {
+	if len(call.Args) != 4 {
+		return fmt.Errorf("rt_net_write_bytes requires 4 arguments")
+	}
+	connVal, err := fe.emitNetHandle(&call.Args[0], "TcpConn")
+	if err != nil {
+		return err
+	}
+	bytesVal, err := fe.emitNetByteArrayHandle(&call.Args[1])
+	if err != nil {
+		return err
+	}
+	offset64, err := fe.emitUintOperandToI64(&call.Args[2], "net write length out of range")
+	if err != nil {
+		return err
+	}
+	len64, err := fe.emitUintOperandToI64(&call.Args[3], "net write length out of range")
+	if err != nil {
+		return err
+	}
+	tmp := fe.nextTemp()
+	fmt.Fprintf(&fe.emitter.buf, "  %s = call ptr @rt_net_write_bytes(ptr %s, ptr %s, i64 %s, i64 %s)\n", tmp, connVal, bytesVal, offset64, len64)
+	return fe.storePtrResult(call, tmp)
+}
+
 func (fe *funcEmitter) emitNetUnary(call *mir.CallInstr, name, kind string) error {
 	if len(call.Args) != 1 {
 		return fmt.Errorf("%s requires 1 argument", name)
@@ -186,6 +232,31 @@ func (fe *funcEmitter) emitNetHandle(op *mir.Operand, kind string) (string, erro
 	}
 	if op.Kind == mir.OperandAddrOf || op.Kind == mir.OperandAddrOfMut {
 		return val, nil
+	}
+	opType := op.Type
+	if opType == types.NoTypeID && op.Kind != mir.OperandConst {
+		if baseType, err := fe.placeBaseType(op.Place); err == nil {
+			opType = baseType
+		}
+	}
+	if op.Kind == mir.OperandAddrOf || op.Kind == mir.OperandAddrOfMut || isRefType(fe.emitter.types, opType) {
+		tmp := fe.nextTemp()
+		fmt.Fprintf(&fe.emitter.buf, "  %s = load ptr, ptr %s\n", tmp, val)
+		return tmp, nil
+	}
+	return val, nil
+}
+
+func (fe *funcEmitter) emitNetByteArrayHandle(op *mir.Operand) (string, error) {
+	if op == nil {
+		return "", fmt.Errorf("missing byte[] handle")
+	}
+	val, ty, err := fe.emitValueOperand(op)
+	if err != nil {
+		return "", err
+	}
+	if ty != "ptr" {
+		return "", fmt.Errorf("expected byte[] handle, got %s", ty)
 	}
 	opType := op.Type
 	if opType == types.NoTypeID && op.Kind != mir.OperandConst {

--- a/internal/backend/llvm/emit_intrinsics_net_test.go
+++ b/internal/backend/llvm/emit_intrinsics_net_test.go
@@ -1,0 +1,32 @@
+package llvm
+
+import (
+	"regexp"
+	"testing"
+)
+
+func TestEmitNetBufferedWritePassesArrayHandle(t *testing.T) {
+	sourceCode := `@entrypoint
+fn main() -> int {
+    let conn: TcpConn = { __opaque: 0 };
+    let data: byte[] = [];
+    let read_res: NetResult<byte[]> = rt_net_read_bytes(&conn, 64:uint);
+    let _ = read_res;
+    let write_res: NetResult<uint> = rt_net_write_bytes(&conn, &data, 0:uint, data.__len());
+    let _ = write_res;
+    return 0;
+}
+`
+
+	ir := emitLLVMFromSource(t, sourceCode)
+
+	if !regexp.MustCompile(`call ptr @rt_net_read_bytes\(`).MatchString(ir) {
+		t.Fatalf("expected buffered net read intrinsic in IR:\n%s", ir)
+	}
+	if !regexp.MustCompile(`call ptr @rt_net_write_bytes\(`).MatchString(ir) {
+		t.Fatalf("expected buffered net write intrinsic in IR:\n%s", ir)
+	}
+	if regexp.MustCompile(`call ptr @rt_net_write_bytes\([^,]+, ptr %l\d+,`).MatchString(ir) {
+		t.Fatalf("rt_net_write_bytes received a local slot instead of an array handle:\n%s", ir)
+	}
+}

--- a/internal/vm/intrinsic.go
+++ b/internal/vm/intrinsic.go
@@ -240,6 +240,10 @@ func (vm *VM) callIntrinsic(frame *Frame, call *mir.CallInstr, writes *[]LocalWr
 		return vm.handleNetRead(frame, call, writes)
 	case "rt_net_write":
 		return vm.handleNetWrite(frame, call, writes)
+	case "rt_net_read_bytes":
+		return vm.handleNetReadBytes(frame, call, writes)
+	case "rt_net_write_bytes":
+		return vm.handleNetWriteBytes(frame, call, writes)
 	case "rt_net_wait_accept":
 		return vm.handleNetWaitAccept(frame, call, writes)
 	case "rt_net_wait_readable":

--- a/internal/vm/intrinsic_net_bytes.go
+++ b/internal/vm/intrinsic_net_bytes.go
@@ -1,0 +1,200 @@
+package vm
+
+import (
+	"syscall"
+
+	"surge/internal/mir"
+	"surge/internal/types"
+)
+
+func (vm *VM) handleNetReadBytes(frame *Frame, call *mir.CallInstr, writes *[]LocalWrite) *VMError {
+	if !call.HasDst {
+		return nil
+	}
+	if len(call.Args) != 2 {
+		return vm.eb.makeError(PanicTypeMismatch, "rt_net_read_bytes requires 2 arguments")
+	}
+	connVal, vmErr := vm.evalOperand(frame, &call.Args[0])
+	if vmErr != nil {
+		return vmErr
+	}
+	defer vm.dropValue(connVal)
+	handle, vmErr := vm.netConnHandleFromValue(connVal)
+	if vmErr != nil {
+		return vmErr
+	}
+	capVal, vmErr := vm.evalOperand(frame, &call.Args[1])
+	if vmErr != nil {
+		return vmErr
+	}
+	defer vm.dropValue(capVal)
+	capacity, vmErr := vm.uintValueToInt(capVal, "net read cap out of range")
+	if vmErr != nil {
+		return vmErr
+	}
+
+	dstLocal := call.Dst.Local
+	dstType := frame.Locals[dstLocal].TypeID
+	errType, vmErr := vm.erringErrorType(dstType)
+	if vmErr != nil {
+		return vmErr
+	}
+
+	entry := vm.netConns[handle]
+	if entry == nil || entry.closed {
+		return vm.netWriteError(frame, dstLocal, errType, netErrNotConnected, writes)
+	}
+	var data []byte
+	if capacity > 0 {
+		data = make([]byte, capacity)
+		var n int
+		var err error
+		for {
+			n, err = syscall.Read(entry.fd, data)
+			if err == syscall.EINTR {
+				continue
+			}
+			break
+		}
+		if err != nil {
+			return vm.netWriteError(frame, dstLocal, errType, netErrorCodeFromErr(err), writes)
+		}
+		data = data[:n]
+	}
+
+	arrType, elemType, vmErr := vm.netByteArrayPayloadType(dstType)
+	if vmErr != nil {
+		return vmErr
+	}
+	elems := make([]Value, len(data))
+	for i, b := range data {
+		elems[i] = MakeInt(int64(b), elemType)
+	}
+	arrHandle := vm.Heap.AllocArray(arrType, elems)
+	arrVal := MakeHandleArray(arrHandle, arrType)
+	return vm.netWriteSuccess(frame, dstLocal, dstType, arrVal, writes)
+}
+
+func (vm *VM) handleNetWriteBytes(frame *Frame, call *mir.CallInstr, writes *[]LocalWrite) *VMError {
+	if !call.HasDst {
+		return nil
+	}
+	if len(call.Args) != 4 {
+		return vm.eb.makeError(PanicTypeMismatch, "rt_net_write_bytes requires 4 arguments")
+	}
+	connVal, vmErr := vm.evalOperand(frame, &call.Args[0])
+	if vmErr != nil {
+		return vmErr
+	}
+	defer vm.dropValue(connVal)
+	handle, vmErr := vm.netConnHandleFromValue(connVal)
+	if vmErr != nil {
+		return vmErr
+	}
+	arrVal, vmErr := vm.evalOperand(frame, &call.Args[1])
+	if vmErr != nil {
+		return vmErr
+	}
+	defer vm.dropValue(arrVal)
+	offsetVal, vmErr := vm.evalOperand(frame, &call.Args[2])
+	if vmErr != nil {
+		return vmErr
+	}
+	defer vm.dropValue(offsetVal)
+	lenVal, vmErr := vm.evalOperand(frame, &call.Args[3])
+	if vmErr != nil {
+		return vmErr
+	}
+	defer vm.dropValue(lenVal)
+	offset, vmErr := vm.uintValueToInt(offsetVal, "net write offset out of range")
+	if vmErr != nil {
+		return vmErr
+	}
+	length, vmErr := vm.uintValueToInt(lenVal, "net write length out of range")
+	if vmErr != nil {
+		return vmErr
+	}
+
+	dstLocal := call.Dst.Local
+	dstType := frame.Locals[dstLocal].TypeID
+	errType, vmErr := vm.erringErrorType(dstType)
+	if vmErr != nil {
+		return vmErr
+	}
+
+	entry := vm.netConns[handle]
+	if entry == nil || entry.closed {
+		return vm.netWriteError(frame, dstLocal, errType, netErrNotConnected, writes)
+	}
+	if arrVal.Kind == VKRef || arrVal.Kind == VKRefMut {
+		loaded, loadErr := vm.loadLocationRaw(arrVal.Loc)
+		if loadErr != nil {
+			return loadErr
+		}
+		arrVal = loaded
+	}
+	if arrVal.Kind != VKHandleArray {
+		return vm.eb.typeMismatch("byte[]", arrVal.Kind.String())
+	}
+	view, vmErr := vm.arrayViewFromHandle(arrVal.H)
+	if vmErr != nil {
+		return vmErr
+	}
+	if offset > view.length || length > view.length-offset {
+		return vm.netWriteError(frame, dstLocal, errType, netErrIo, writes)
+	}
+	data := make([]byte, length)
+	for i := range length {
+		b, convErr := vm.valueToUint8(view.baseObj.Arr[view.start+offset+i])
+		if convErr != nil {
+			return convErr
+		}
+		data[i] = b
+	}
+	var n int
+	var err error
+	if len(data) > 0 {
+		for {
+			n, err = syscall.Write(entry.fd, data)
+			if err == syscall.EINTR {
+				continue
+			}
+			break
+		}
+		if err != nil {
+			return vm.netWriteError(frame, dstLocal, errType, netErrorCodeFromErr(err), writes)
+		}
+	}
+
+	layout, vmErr := vm.tagLayoutFor(dstType)
+	if vmErr != nil {
+		return vmErr
+	}
+	tc, ok := layout.CaseByName("Success")
+	if !ok || len(tc.PayloadTypes) != 1 {
+		return vm.eb.makeError(PanicTypeMismatch, "Erring missing Success tag payload")
+	}
+	countVal, makeErr := vm.makeUintForType(tc.PayloadTypes[0], uint64(n)) //nolint:gosec // n from syscall.Write is non-negative.
+	if makeErr != nil {
+		return makeErr
+	}
+	return vm.netWriteSuccess(frame, dstLocal, dstType, countVal, writes)
+}
+
+func (vm *VM) netByteArrayPayloadType(dstType types.TypeID) (arrayType, elementType types.TypeID, vmErr *VMError) {
+	layout, vmErr := vm.tagLayoutFor(dstType)
+	if vmErr != nil {
+		return types.NoTypeID, types.NoTypeID, vmErr
+	}
+	tc, ok := layout.CaseByName("Success")
+	if !ok || len(tc.PayloadTypes) != 1 {
+		return types.NoTypeID, types.NoTypeID, vm.eb.makeError(PanicTypeMismatch, "Erring missing Success tag payload")
+	}
+	arrayType = tc.PayloadTypes[0]
+	baseArrType := vm.valueType(arrayType)
+	elementType, ok = vm.Types.ArrayInfo(baseArrType)
+	if !ok || vm.valueType(elementType) != vm.Types.Builtins().Uint8 {
+		return types.NoTypeID, types.NoTypeID, vm.eb.makeError(PanicTypeMismatch, "rt_net_read_bytes requires byte[] payload")
+	}
+	return arrayType, elementType, nil
+}

--- a/internal/vm/mt_correctness_test.go
+++ b/internal/vm/mt_correctness_test.go
@@ -748,7 +748,11 @@ func TestMTNetWaiterWakeupLatency(t *testing.T) {
 
 fn pong() -> byte[] {
     let mut out: byte[] = [];
-    out.push(88:byte);
+    out.push(80:byte);
+    out.push(79:byte);
+    out.push(78:byte);
+    out.push(71:byte);
+    out.push(10:byte);
     return out;
 }
 
@@ -864,14 +868,14 @@ fn main(port: uint, count: uint) -> int {
 			_ = conn.Close()
 			fail("write ping: %v", err)
 		}
-		var buf [1]byte
+		var buf [5]byte
 		if _, err = io.ReadFull(conn, buf[:]); err != nil {
 			_ = conn.Close()
 			fail("read pong: %v", err)
 		}
-		if buf[0] != 'X' {
+		if string(buf[:]) != "PONG\n" {
 			_ = conn.Close()
-			fail("unexpected response: %q", buf[0])
+			fail("unexpected response: %q", string(buf[:]))
 		}
 	}
 	elapsed := time.Since(started)

--- a/runtime/native/rt.h
+++ b/runtime/native/rt.h
@@ -66,6 +66,8 @@ void* rt_net_close_conn(void* conn);
 void* rt_net_accept(const void* listener);
 void* rt_net_read(const void* conn, uint8_t* buf, uint64_t cap);
 void* rt_net_write(const void* conn, const uint8_t* buf, uint64_t len);
+void* rt_net_read_bytes(const void* conn, uint64_t cap);
+void* rt_net_write_bytes(const void* conn, const void* bytes, uint64_t offset, uint64_t len);
 void* rt_net_wait_accept(const void* listener);
 void* rt_net_wait_readable(const void* conn);
 void* rt_net_wait_writable(const void* conn);

--- a/runtime/native/rt_net.c
+++ b/runtime/native/rt_net.c
@@ -55,6 +55,12 @@ typedef struct NetPollFd {
     uint8_t want_write;
 } NetPollFd;
 
+typedef struct SurgeArrayHeader {
+    uint64_t len;
+    uint64_t cap;
+    void* data;
+} SurgeArrayHeader;
+
 static int net_poll_wake_read_fd = -1;
 static int net_poll_wake_write_fd = -1;
 
@@ -226,6 +232,31 @@ static void* net_make_success_nothing(void) {
     }
     mem[payload_offset] = 0;
     return mem;
+}
+
+static void* net_make_success_bytes(uint8_t* data, uint64_t len, uint64_t cap) {
+    SurgeArrayHeader* header = (SurgeArrayHeader*)rt_alloc((uint64_t)sizeof(SurgeArrayHeader),
+                                                           (uint64_t)alignof(SurgeArrayHeader));
+    if (header == NULL) {
+        if (data != NULL) {
+            rt_free(data, cap, (uint64_t)alignof(uint8_t));
+        }
+        return net_make_error(NET_ERR_IO);
+    }
+    header->len = len;
+    header->cap = cap;
+    header->data = data;
+    void* out = net_make_success_ptr((void*)header);
+    if (out == NULL) {
+        if (data != NULL) {
+            rt_free(data, cap, (uint64_t)alignof(uint8_t));
+        }
+        rt_free((uint8_t*)header,
+                (uint64_t)sizeof(SurgeArrayHeader),
+                (uint64_t)alignof(SurgeArrayHeader));
+        return net_make_error(NET_ERR_IO);
+    }
+    return out;
 }
 
 static char* net_copy_addr(void* addr, uint64_t* out_len, uint64_t* err_code) {
@@ -513,6 +544,66 @@ void* rt_net_write(const void* conn, const uint8_t* buf, uint64_t len) {
     ssize_t n = -1;
     do {
         n = write(c->fd, buf, (size_t)len);
+    } while (n < 0 && errno == EINTR);
+    if (n < 0) {
+        return net_make_error(net_error_code_from_errno(errno));
+    }
+    void* count = rt_biguint_from_u64((uint64_t)n);
+    return net_make_success_ptr(count);
+}
+
+void* rt_net_read_bytes(const void* conn, uint64_t cap) {
+    const NetConn* c = net_conn_from_borrowed(conn);
+    if (c == NULL || c->closed) {
+        return net_make_error(NET_ERR_NOT_CONNECTED);
+    }
+    if (cap == 0) {
+        return net_make_success_bytes(NULL, 0, 0);
+    }
+    if (cap > (uint64_t)SSIZE_MAX) {
+        return net_make_error(NET_ERR_IO);
+    }
+    uint8_t* data = (uint8_t*)rt_alloc(cap, (uint64_t)alignof(uint8_t));
+    if (data == NULL) {
+        return net_make_error(NET_ERR_IO);
+    }
+    ssize_t n = -1;
+    do {
+        n = read(c->fd, data, (size_t)cap);
+    } while (n < 0 && errno == EINTR);
+    if (n < 0) {
+        uint64_t code = net_error_code_from_errno(errno);
+        rt_free(data, cap, (uint64_t)alignof(uint8_t));
+        return net_make_error(code);
+    }
+    if (n == 0) {
+        rt_free(data, cap, (uint64_t)alignof(uint8_t));
+        return net_make_success_bytes(NULL, 0, 0);
+    }
+    return net_make_success_bytes(data, (uint64_t)n, cap);
+}
+
+void* rt_net_write_bytes(const void* conn, const void* bytes, uint64_t offset, uint64_t len) {
+    const NetConn* c = net_conn_from_borrowed(conn);
+    if (c == NULL || c->closed) {
+        return net_make_error(NET_ERR_NOT_CONNECTED);
+    }
+    const SurgeArrayHeader* header = (const SurgeArrayHeader*)bytes;
+    if (header == NULL || offset > header->len || len > header->len - offset ||
+        len > (uint64_t)SSIZE_MAX) {
+        return net_make_error(NET_ERR_IO);
+    }
+    if (len == 0) {
+        void* count = rt_biguint_from_u64(0);
+        return net_make_success_ptr(count);
+    }
+    const uint8_t* data = (const uint8_t*)header->data;
+    if (data == NULL) {
+        return net_make_error(NET_ERR_IO);
+    }
+    ssize_t n = -1;
+    do {
+        n = write(c->fd, data + offset, (size_t)len);
     } while (n < 0 && errno == EINTR);
     if (n < 0) {
         return net_make_error(net_error_code_from_errno(errno));

--- a/stdlib/net/net.sg
+++ b/stdlib/net/net.sg
@@ -81,45 +81,29 @@ async fn read_some_owned(handle: int, cap: uint) -> NetResult<byte[]> {
         return Success(empty_bytes());
     }
     let conn: TcpConn = { __opaque: handle };
-    let buf = rt_alloc(1:uint, 1:uint);
-    let mut out: byte[] = [];
-    out.reserve(cap);
-    let mut read_total: uint = 0:uint;
-    while read_total < cap {
-        let res = rt_net_read(&conn, buf, 1:uint);
+    while true {
+        let res = rt_net_read_bytes(&conn, cap);
         compare res {
-            Success(n) => {
-                if n == 0:uint {
-                    break;
-                }
-                let b: byte = *buf;
-                out.push(b);
-                read_total = read_total + n;
-                0:int;
+            Success(bytes) => {
+                return Success(bytes);
             }
             err => {
                 if is_would_block(&err) {
-                    if read_total > 0:uint {
-                        break;
-                    }
                     let wait_res = rt_net_wait_readable(&conn).await();
                     compare wait_res {
                         Success(_) => {}
                         Cancelled() => {
-                            rt_free(buf, 1:uint, 1:uint);
                             return net_error(NET_ERR_IO, "read cancelled");
                         }
                     };
-                    0:int;
+                    continue;
                 } else {
-                    rt_free(buf, 1:uint, 1:uint);
                     return err;
                 }
             }
         };
     }
-    rt_free(buf, 1:uint, 1:uint);
-    return Success(out);
+    return Success(empty_bytes());
 }
 
 async fn write_some_owned(handle: int, data: byte[]) -> NetResult<uint> {
@@ -128,43 +112,33 @@ async fn write_some_owned(handle: int, data: byte[]) -> NetResult<uint> {
         return Success(0:uint);
     }
     let conn: TcpConn = { __opaque: handle };
-    let buf = rt_alloc(1:uint, 1:uint);
     let mut written: uint = 0:uint;
     while written < length {
-        let idx: int = written to int;
-        *buf = clone(data[idx]);
-        let res = rt_net_write(&conn, buf, 1:uint);
+        let res = rt_net_write_bytes(&conn, &data, written, length - written);
         compare res {
             Success(n) => {
                 if n == 0:uint {
-                    rt_free(buf, 1:uint, 1:uint);
                     return net_error(NET_ERR_IO, "write made no progress");
                 }
                 written = written + n;
-                0:int;
+                break;
             }
             err => {
                 if is_would_block(&err) {
-                    if written > 0:uint {
-                        break;
-                    }
                     let wait_res = rt_net_wait_writable(&conn).await();
                     compare wait_res {
                         Success(_) => {}
                         Cancelled() => {
-                            rt_free(buf, 1:uint, 1:uint);
                             return net_error(NET_ERR_IO, "write cancelled");
                         }
                     };
                     0:int;
                 } else {
-                    rt_free(buf, 1:uint, 1:uint);
                     return err;
                 }
             }
         };
     }
-    rt_free(buf, 1:uint, 1:uint);
     return Success(written);
 }
 
@@ -174,16 +148,12 @@ async fn write_all_owned(handle: int, data: byte[]) -> NetResult<nothing> {
         return Success(nothing);
     }
     let conn: TcpConn = { __opaque: handle };
-    let buf = rt_alloc(1:uint, 1:uint);
     let mut written: uint = 0:uint;
     while written < length {
-        let idx: int = written to int;
-        *buf = clone(data[idx]);
-        let res = rt_net_write(&conn, buf, 1:uint);
+        let res = rt_net_write_bytes(&conn, &data, written, length - written);
         compare res {
             Success(n) => {
                 if n == 0:uint {
-                    rt_free(buf, 1:uint, 1:uint);
                     return net_error(NET_ERR_IO, "write made no progress");
                 }
                 written = written + n;
@@ -195,19 +165,16 @@ async fn write_all_owned(handle: int, data: byte[]) -> NetResult<nothing> {
                     compare wait_res {
                         Success(_) => {}
                         Cancelled() => {
-                            rt_free(buf, 1:uint, 1:uint);
                             return net_error(NET_ERR_IO, "write cancelled");
                         }
                     };
                     0:int;
                 } else {
-                    rt_free(buf, 1:uint, 1:uint);
                     return err;
                 }
             }
         };
     }
-    rt_free(buf, 1:uint, 1:uint);
     return Success(nothing);
 }
 

--- a/testdata/golden/core_stdlib/intrinsics.ast
+++ b/testdata/golden/core_stdlib/intrinsics.ast
@@ -1,4 +1,4 @@
-intrinsics.sg (span: 1:1-872:1)
+intrinsics.sg (span: 1:1-874:1)
 ├─ Item[0]: Type (span: 3:1-3:23)
 │  ├─ Name: byte
 │  ├─ Kind: Alias
@@ -253,170 +253,180 @@ intrinsics.sg (span: 1:1-872:1)
 │  ├─ Params: (c: &TcpConn, buf: *byte, length: uint)
 │  ├─ Return: NetResult<uint>
 │  └─ Body: <none>
-├─ Item[48]: Fn (span: 99:1-99:68)
+├─ Item[48]: Fn (span: 98:1-98:78)
+│  ├─ Name: rt_net_read_bytes
+│  ├─ Params: (c: &TcpConn, cap: uint)
+│  ├─ Return: NetResult<byte[]>
+│  └─ Body: <none>
+├─ Item[49]: Fn (span: 99:1-99:109)
+│  ├─ Name: rt_net_write_bytes
+│  ├─ Params: (c: &TcpConn, data: &byte[], offset: uint, length: uint)
+│  ├─ Return: NetResult<uint>
+│  └─ Body: <none>
+├─ Item[50]: Fn (span: 101:1-101:68)
 │  ├─ Name: rt_net_wait_accept
 │  ├─ Params: (l: &TcpListener)
 │  ├─ Return: Task<nothing>
 │  └─ Body: <none>
-├─ Item[49]: Fn (span: 100:1-100:66)
+├─ Item[51]: Fn (span: 102:1-102:66)
 │  ├─ Name: rt_net_wait_readable
 │  ├─ Params: (c: &TcpConn)
 │  ├─ Return: Task<nothing>
 │  └─ Body: <none>
-├─ Item[50]: Fn (span: 101:1-101:66)
+├─ Item[52]: Fn (span: 103:1-103:66)
 │  ├─ Name: rt_net_wait_writable
 │  ├─ Params: (c: &TcpConn)
 │  ├─ Return: Task<nothing>
 │  └─ Body: <none>
-├─ Item[51]: Extern (span: 103:1-107:2)
+├─ Item[53]: Extern (span: 105:1-109:2)
 │  ├─ Target: TcpConn
 │  ├─ Members:
 │  │  └─ Fn[0]: new
 │  │     ├─ Params: ()
 │  │     ├─ Return: TcpConn
 │  │     └─ Body:
-│  │        Stmt[0]: Block (span: 104:29-106:6)
-│  │        └─ Stmt[0]: Return (span: 105:9-105:32)
+│  │        Stmt[0]: Block (span: 106:29-108:6)
+│  │        └─ Stmt[0]: Return (span: 107:9-107:32)
 │  │           └─ Expr: expr#8: <ExprKind(22)>
-├─ Item[52]: Fn (span: 110:1-110:50)
+├─ Item[54]: Fn (span: 112:1-112:50)
 │  ├─ Name: rt_string_ptr
 │  ├─ Params: (s: &string)
 │  ├─ Return: *byte
 │  └─ Body: <none>
-├─ Item[53]: Fn (span: 112:1-112:49)
+├─ Item[55]: Fn (span: 114:1-114:49)
 │  ├─ Name: rt_string_len
 │  ├─ Params: (s: &string)
 │  ├─ Return: uint
 │  └─ Body: <none>
-├─ Item[54]: Fn (span: 113:1-113:55)
+├─ Item[56]: Fn (span: 115:1-115:55)
 │  ├─ Name: rt_string_len_bytes
 │  ├─ Params: (s: &string)
 │  ├─ Return: uint
 │  └─ Body: <none>
-├─ Item[55]: Fn (span: 114:1-114:72)
+├─ Item[57]: Fn (span: 116:1-116:72)
 │  ├─ Name: rt_string_from_bytes
 │  ├─ Params: (ptr: *byte, length: uint)
 │  ├─ Return: string
 │  └─ Body: <none>
-├─ Item[56]: Fn (span: 115:1-115:74)
+├─ Item[58]: Fn (span: 117:1-117:74)
 │  ├─ Name: rt_string_from_utf16
 │  ├─ Params: (ptr: *uint16, length: uint)
 │  ├─ Return: string
 │  └─ Body: <none>
-├─ Item[57]: Fn (span: 116:1-116:65)
+├─ Item[59]: Fn (span: 118:1-118:65)
 │  ├─ Name: rt_string_index
 │  ├─ Params: (s: &string, index: int)
 │  ├─ Return: uint32
 │  └─ Body: <none>
-├─ Item[58]: Fn (span: 117:1-117:68)
+├─ Item[60]: Fn (span: 119:1-119:68)
 │  ├─ Name: rt_string_slice
 │  ├─ Params: (s: &string, r: Range<int>)
 │  ├─ Return: string
 │  └─ Body: <none>
-├─ Item[59]: Fn (span: 118:1-118:66)
+├─ Item[61]: Fn (span: 120:1-120:66)
 │  ├─ Name: rt_string_concat
 │  ├─ Params: (a: &string, b: &string)
 │  ├─ Return: string
 │  └─ Body: <none>
-├─ Item[60]: Fn (span: 119:1-119:60)
+├─ Item[62]: Fn (span: 121:1-121:60)
 │  ├─ Name: rt_string_eq
 │  ├─ Params: (a: &string, b: &string)
 │  ├─ Return: bool
 │  └─ Body: <none>
-├─ Item[61]: Fn (span: 120:1-120:61)
+├─ Item[63]: Fn (span: 122:1-122:61)
 │  ├─ Name: rt_string_bytes_view
 │  ├─ Params: (s: &string)
 │  ├─ Return: BytesView
 │  └─ Body: <none>
-├─ Item[62]: Fn (span: 122:1-122:62)
+├─ Item[64]: Fn (span: 124:1-124:62)
 │  ├─ Name: rt_string_force_flatten
 │  ├─ Params: (s: &string)
 │  ├─ Return: nothing
 │  └─ Body: <none>
-├─ Item[63]: Fn (span: 125:1-125:79)
+├─ Item[65]: Fn (span: 127:1-127:79)
 │  ├─ Name: rt_array_reserve
 │  ├─ Generics: <T>
 │  ├─ Params: (a: &mut Array<T>, new_cap: uint)
 │  ├─ Return: nothing
 │  └─ Body: <none>
-├─ Item[64]: Fn (span: 126:1-126:71)
+├─ Item[66]: Fn (span: 128:1-128:71)
 │  ├─ Name: rt_array_push
 │  ├─ Generics: <T>
 │  ├─ Params: (a: &mut Array<T>, value: T)
 │  ├─ Return: nothing
 │  └─ Body: <none>
-├─ Item[65]: Fn (span: 127:1-127:62)
+├─ Item[67]: Fn (span: 129:1-129:62)
 │  ├─ Name: rt_array_pop
 │  ├─ Generics: <T>
 │  ├─ Params: (a: &mut Array<T>)
 │  ├─ Return: Option<T>
 │  └─ Body: <none>
-├─ Item[66]: Fn (span: 128:1-128:75)
+├─ Item[68]: Fn (span: 130:1-130:75)
 │  ├─ Name: rt_array_get_mut
 │  ├─ Generics: <T>
 │  ├─ Params: (a: &mut Array<T>, index: int)
 │  ├─ Return: &mut T
 │  └─ Body: <none>
-├─ Item[67]: Fn (span: 129:1-129:106)
+├─ Item[69]: Fn (span: 131:1-131:106)
 │  ├─ Name: rt_array_get_mut
 │  ├─ Generics: <T, N>
 │  ├─ Params: (a: &mut ArrayFixed<T, N>, index: int)
 │  ├─ Return: &mut T
 │  └─ Body: <none>
-├─ Item[68]: Fn (span: 132:1-132:47)
+├─ Item[70]: Fn (span: 134:1-134:47)
 │  ├─ Name: rt_map_new
 │  ├─ Generics: <K, V>
 │  ├─ Params: ()
 │  ├─ Return: Map<K, V>
 │  └─ Body: <none>
-├─ Item[69]: Fn (span: 133:1-133:55)
+├─ Item[71]: Fn (span: 135:1-135:55)
 │  ├─ Name: rt_map_len
 │  ├─ Generics: <K, V>
 │  ├─ Params: (m: &Map<K, V>)
 │  ├─ Return: uint
 │  └─ Body: <none>
-├─ Item[70]: Fn (span: 134:1-134:69)
+├─ Item[72]: Fn (span: 136:1-136:69)
 │  ├─ Name: rt_map_contains
 │  ├─ Generics: <K, V>
 │  ├─ Params: (m: &Map<K, V>, key: &K)
 │  ├─ Return: bool
 │  └─ Body: <none>
-├─ Item[71]: Fn (span: 135:1-135:74)
+├─ Item[73]: Fn (span: 137:1-137:74)
 │  ├─ Name: rt_map_get_ref
 │  ├─ Generics: <K, V>
 │  ├─ Params: (m: &Map<K, V>, key: &K)
 │  ├─ Return: Option<&V>
 │  └─ Body: <none>
-├─ Item[72]: Fn (span: 136:1-136:82)
+├─ Item[74]: Fn (span: 138:1-138:82)
 │  ├─ Name: rt_map_get_mut
 │  ├─ Generics: <K, V>
 │  ├─ Params: (m: &mut Map<K, V>, key: &K)
 │  ├─ Return: Option<&mut V>
 │  └─ Body: <none>
-├─ Item[73]: Fn (span: 137:1-137:85)
+├─ Item[75]: Fn (span: 139:1-139:85)
 │  ├─ Name: rt_map_insert
 │  ├─ Generics: <K, V>
 │  ├─ Params: (m: &mut Map<K, V>, key: K, value: V)
 │  ├─ Return: Option<V>
 │  └─ Body: <none>
-├─ Item[74]: Fn (span: 138:1-138:76)
+├─ Item[76]: Fn (span: 140:1-140:76)
 │  ├─ Name: rt_map_remove
 │  ├─ Generics: <K, V>
 │  ├─ Params: (m: &mut Map<K, V>, key: &K)
 │  ├─ Return: Option<V>
 │  └─ Body: <none>
-├─ Item[75]: Fn (span: 139:1-139:55)
+├─ Item[77]: Fn (span: 141:1-141:55)
 │  ├─ Name: rt_map_keys
 │  ├─ Generics: <K, V>
 │  ├─ Params: (m: &Map<K, V>)
 │  ├─ Return: K[]
 │  └─ Body: <none>
-├─ Item[76]: Fn (span: 142:1-143:29)
+├─ Item[78]: Fn (span: 144:1-145:29)
 │  ├─ Name: readline
 │  ├─ Params: ()
 │  ├─ Return: string
 │  └─ Body: <none>
-├─ Item[77]: Type (span: 145:1-148:3)
+├─ Item[79]: Type (span: 147:1-150:3)
 │  ├─ Name: Range
 │  ├─ Kind: Struct
 │  ├─ Visibility: public
@@ -424,34 +434,34 @@ intrinsics.sg (span: 1:1-872:1)
 │  ├─ Attributes: @intrinsic
 │  └─ Struct:
 │     └─ Field[0]: __state: *byte
-├─ Item[78]: Fn (span: 151:1-151:89)
+├─ Item[80]: Fn (span: 153:1-153:89)
 │  ├─ Name: rt_range_int_new
 │  ├─ Params: (start: int, end: int, inclusive: bool)
 │  ├─ Return: Range<int>
 │  └─ Body: <none>
-├─ Item[79]: Fn (span: 152:1-152:86)
+├─ Item[81]: Fn (span: 154:1-154:86)
 │  ├─ Name: rt_range_int_from_start
 │  ├─ Params: (start: int, inclusive: bool)
 │  ├─ Return: Range<int>
 │  └─ Body: <none>
-├─ Item[80]: Fn (span: 153:1-153:80)
+├─ Item[82]: Fn (span: 155:1-155:80)
 │  ├─ Name: rt_range_int_to_end
 │  ├─ Params: (end: int, inclusive: bool)
 │  ├─ Return: Range<int>
 │  └─ Body: <none>
-├─ Item[81]: Fn (span: 154:1-154:68)
+├─ Item[83]: Fn (span: 156:1-156:68)
 │  ├─ Name: rt_range_int_full
 │  ├─ Params: (inclusive: bool)
 │  ├─ Return: Range<int>
 │  └─ Body: <none>
-├─ Item[82]: Extern (span: 156:1-158:2)
+├─ Item[84]: Extern (span: 158:1-160:2)
 │  ├─ Target: Range<T>
 │  ├─ Members:
 │  │  └─ Fn[0]: next
 │  │     ├─ Params: (self: &mut Range<T>)
 │  │     ├─ Return: Option<T>
 │  │     └─ Attributes: @intrinsic
-├─ Item[83]: Type (span: 160:1-167:3)
+├─ Item[85]: Type (span: 162:1-169:3)
 │  ├─ Name: HeapStats
 │  ├─ Kind: Struct
 │  ├─ Visibility: public
@@ -462,32 +472,32 @@ intrinsics.sg (span: 1:1-872:1)
 │     ├─ Field[3]: live_bytes: uint
 │     ├─ Field[4]: rc_increments: uint
 │     └─ Field[5]: rc_decrements: uint
-├─ Item[84]: Fn (span: 173:1-173:48)
+├─ Item[86]: Fn (span: 175:1-175:48)
 │  ├─ Name: rt_heap_stats
 │  ├─ Params: ()
 │  ├─ Return: HeapStats
 │  └─ Body: <none>
-├─ Item[85]: Fn (span: 175:1-175:44)
+├─ Item[87]: Fn (span: 177:1-177:44)
 │  ├─ Name: rt_heap_dump
 │  ├─ Params: ()
 │  ├─ Return: string
 │  └─ Body: <none>
-├─ Item[86]: Fn (span: 177:1-177:45)
+├─ Item[88]: Fn (span: 179:1-179:45)
 │  ├─ Name: rt_worker_count
 │  ├─ Params: ()
 │  ├─ Return: uint
 │  └─ Body: <none>
-├─ Item[87]: Type (span: 179:1-181:3)
+├─ Item[89]: Type (span: 181:1-183:3)
 │  ├─ Name: Task
 │  ├─ Kind: Struct
 │  ├─ Visibility: public
 │  ├─ Generics: <T>
 │  └─ Struct:
 │     └─ Field[0]: __opaque: int
-├─ Item[88]: Tag (span: 183:1-183:21)
+├─ Item[90]: Tag (span: 185:1-185:21)
 │  ├─ Name: Cancelled
 │  └─ Visibility: public
-├─ Item[89]: Type (span: 184:1-184:49)
+├─ Item[91]: Type (span: 186:1-186:49)
 │  ├─ Name: TaskResult
 │  ├─ Kind: Union
 │  ├─ Visibility: public
@@ -495,33 +505,33 @@ intrinsics.sg (span: 1:1-872:1)
 │  └─ Union:
 │     ├─ Member[0]: Success(T)
 │     └─ Member[1]: Cancelled
-├─ Item[90]: Fn (span: 186:1-186:54)
+├─ Item[92]: Fn (span: 188:1-188:54)
 │  ├─ Name: rt_scope_enter
 │  ├─ Params: (failfast: bool)
 │  ├─ Return: uint
 │  └─ Body: <none>
-├─ Item[91]: Fn (span: 187:1-187:82)
+├─ Item[93]: Fn (span: 189:1-189:82)
 │  ├─ Name: rt_scope_register_child
 │  ├─ Generics: <T>
 │  ├─ Params: (scope: uint, child: Task<T>)
 │  ├─ Return: nothing
 │  └─ Body: <none>
-├─ Item[92]: Fn (span: 188:1-188:59)
+├─ Item[94]: Fn (span: 190:1-190:59)
 │  ├─ Name: rt_scope_cancel_all
 │  ├─ Params: (scope: uint)
 │  ├─ Return: nothing
 │  └─ Body: <none>
-├─ Item[93]: Fn (span: 189:1-189:54)
+├─ Item[95]: Fn (span: 191:1-191:54)
 │  ├─ Name: rt_scope_join_all
 │  ├─ Params: (scope: uint)
 │  ├─ Return: bool
 │  └─ Body: <none>
-├─ Item[94]: Fn (span: 190:1-190:53)
+├─ Item[96]: Fn (span: 192:1-192:53)
 │  ├─ Name: rt_scope_exit
 │  ├─ Params: (scope: uint)
 │  ├─ Return: nothing
 │  └─ Body: <none>
-├─ Item[95]: Extern (span: 192:1-196:2)
+├─ Item[97]: Extern (span: 194:1-198:2)
 │  ├─ Target: Task<T>
 │  ├─ Members:
 │  │  ├─ Fn[0]: clone
@@ -536,23 +546,23 @@ intrinsics.sg (span: 1:1-872:1)
 │  │     ├─ Params: (self: own Task<T>)
 │  │     ├─ Return: TaskResult<T>
 │  │     └─ Attributes: @intrinsic
-├─ Item[96]: Fn (span: 200:1-201:38)
+├─ Item[98]: Fn (span: 202:1-203:38)
 │  ├─ Name: checkpoint
 │  ├─ Params: ()
 │  ├─ Return: Task<nothing>
 │  └─ Body: <none>
-├─ Item[97]: Fn (span: 204:1-204:52)
+├─ Item[99]: Fn (span: 206:1-206:52)
 │  ├─ Name: sleep
 │  ├─ Params: (ms: uint)
 │  ├─ Return: Task<nothing>
 │  └─ Body: <none>
-├─ Item[98]: Fn (span: 208:1-208:69)
+├─ Item[100]: Fn (span: 210:1-210:69)
 │  ├─ Name: timeout
 │  ├─ Generics: <T>
 │  ├─ Params: (t: Task<T>, ms: uint)
 │  ├─ Return: TaskResult<T>
 │  └─ Body: <none>
-├─ Item[99]: Type (span: 211:1-215:3)
+├─ Item[101]: Type (span: 213:1-217:3)
 │  ├─ Name: Channel
 │  ├─ Kind: Struct
 │  ├─ Visibility: public
@@ -560,7 +570,7 @@ intrinsics.sg (span: 1:1-872:1)
 │  ├─ Attributes: @copy, @intrinsic
 │  └─ Struct:
 │     └─ Field[0]: __opaque: *byte
-├─ Item[100]: Extern (span: 217:1-230:2)
+├─ Item[102]: Extern (span: 219:1-232:2)
 │  ├─ Target: Channel<T>
 │  ├─ Members:
 │  │  ├─ Fn[0]: new
@@ -587,34 +597,34 @@ intrinsics.sg (span: 1:1-872:1)
 │  │     ├─ Params: (self: &Channel<T>)
 │  │     ├─ Return: nothing
 │  │     └─ Attributes: @intrinsic
-├─ Item[101]: Fn (span: 232:1-233:54)
+├─ Item[103]: Fn (span: 234:1-235:54)
 │  ├─ Name: make_channel
 │  ├─ Generics: <T>
 │  ├─ Params: (capacity: uint)
 │  ├─ Return: own Channel<T>
 │  └─ Body: <none>
-├─ Item[102]: Contract (span: 235:1-238:2)
-├─ Item[103]: Contract (span: 240:1-242:2)
-├─ Item[104]: Contract (span: 244:1-246:2)
-├─ Item[105]: Fn (span: 248:1-250:2)
+├─ Item[104]: Contract (span: 237:1-240:2)
+├─ Item[105]: Contract (span: 242:1-244:2)
+├─ Item[106]: Contract (span: 246:1-248:2)
+├─ Item[107]: Fn (span: 250:1-252:2)
 │  ├─ Name: max_value
 │  ├─ Generics: <T>
 │  ├─ Params: ()
 │  ├─ Return: T
 │  └─ Body:
-│     └─ Stmt[0]: Block (span: 248:40-250:2)
-│        └─ Stmt[0]: Return (span: 249:5-249:28)
+│     └─ Stmt[0]: Block (span: 250:40-252:2)
+│        └─ Stmt[0]: Return (span: 251:5-251:28)
 │           └─ Expr: expr#11: T.__max_value()
-├─ Item[106]: Fn (span: 252:1-254:2)
+├─ Item[108]: Fn (span: 254:1-256:2)
 │  ├─ Name: min_value
 │  ├─ Generics: <T>
 │  ├─ Params: ()
 │  ├─ Return: T
 │  └─ Body:
-│     └─ Stmt[0]: Block (span: 252:40-254:2)
-│        └─ Stmt[0]: Return (span: 253:5-253:28)
+│     └─ Stmt[0]: Block (span: 254:40-256:2)
+│        └─ Stmt[0]: Return (span: 255:5-255:28)
 │           └─ Expr: expr#14: T.__min_value()
-├─ Item[107]: Extern (span: 256:1-295:2)
+├─ Item[109]: Extern (span: 258:1-297:2)
 │  ├─ Target: int
 │  ├─ Members:
 │  │  ├─ Fn[0]: __add
@@ -702,8 +712,8 @@ intrinsics.sg (span: 1:1-872:1)
 │  │  │  ├─ Return: string
 │  │  │  ├─ Attributes: @overload
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 277:60-279:6)
-│  │  │     └─ Stmt[0]: Return (span: 278:9-278:34)
+│  │  │     Stmt[0]: Block (span: 279:60-281:6)
+│  │  │     └─ Stmt[0]: Return (span: 280:9-280:34)
 │  │  │        └─ Expr: expr#18: (*self) to string
 │  │  ├─ Fn[21]: __to
 │  │  │  ├─ Params: (self: int, target: float)
@@ -761,7 +771,7 @@ intrinsics.sg (span: 1:1-872:1)
 │  │     ├─ Params: (s: &string)
 │  │     ├─ Return: Erring<int, Error>
 │  │     └─ Attributes: @intrinsic
-├─ Item[108]: Extern (span: 297:1-335:2)
+├─ Item[110]: Extern (span: 299:1-337:2)
 │  ├─ Target: uint
 │  ├─ Members:
 │  │  ├─ Fn[0]: __add
@@ -845,8 +855,8 @@ intrinsics.sg (span: 1:1-872:1)
 │  │  │  ├─ Return: string
 │  │  │  ├─ Attributes: @overload
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 317:61-319:6)
-│  │  │     └─ Stmt[0]: Return (span: 318:9-318:34)
+│  │  │     Stmt[0]: Block (span: 319:61-321:6)
+│  │  │     └─ Stmt[0]: Return (span: 320:9-320:34)
 │  │  │        └─ Expr: expr#22: (*self) to string
 │  │  ├─ Fn[20]: __to
 │  │  │  ├─ Params: (self: uint, target: int)
@@ -904,22 +914,22 @@ intrinsics.sg (span: 1:1-872:1)
 │  │     ├─ Params: (s: &string)
 │  │     ├─ Return: Erring<uint, Error>
 │  │     └─ Attributes: @intrinsic
-├─ Item[109]: Extern (span: 337:1-364:2)
+├─ Item[111]: Extern (span: 339:1-366:2)
 │  ├─ Target: int8
 │  ├─ Members:
 │  │  ├─ Fn[0]: __min_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: int8
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 338:34-338:57)
-│  │  │     └─ Stmt[0]: Return (span: 338:36-338:55)
+│  │  │     Stmt[0]: Block (span: 340:34-340:57)
+│  │  │     └─ Stmt[0]: Return (span: 340:36-340:55)
 │  │  │        └─ Expr: expr#26: (-128) to int8
 │  │  ├─ Fn[1]: __max_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: int8
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 339:34-339:56)
-│  │  │     └─ Stmt[0]: Return (span: 339:36-339:54)
+│  │  │     Stmt[0]: Block (span: 341:34-341:56)
+│  │  │     └─ Stmt[0]: Return (span: 341:36-341:54)
 │  │  │        └─ Expr: expr#29: (127) to int8
 │  │  ├─ Fn[2]: __add
 │  │  │  ├─ Params: (self: int8, other: int8)
@@ -1017,22 +1027,22 @@ intrinsics.sg (span: 1:1-872:1)
 │  │     ├─ Params: (s: &string)
 │  │     ├─ Return: Erring<int8, Error>
 │  │     └─ Attributes: @intrinsic
-├─ Item[110]: Extern (span: 366:1-393:2)
+├─ Item[112]: Extern (span: 368:1-395:2)
 │  ├─ Target: int16
 │  ├─ Members:
 │  │  ├─ Fn[0]: __min_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: int16
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 367:35-367:62)
-│  │  │     └─ Stmt[0]: Return (span: 367:37-367:60)
+│  │  │     Stmt[0]: Block (span: 369:35-369:62)
+│  │  │     └─ Stmt[0]: Return (span: 369:37-369:60)
 │  │  │        └─ Expr: expr#33: (-32_768) to int16
 │  │  ├─ Fn[1]: __max_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: int16
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 368:35-368:61)
-│  │  │     └─ Stmt[0]: Return (span: 368:37-368:59)
+│  │  │     Stmt[0]: Block (span: 370:35-370:61)
+│  │  │     └─ Stmt[0]: Return (span: 370:37-370:59)
 │  │  │        └─ Expr: expr#36: (32_767) to int16
 │  │  ├─ Fn[2]: __add
 │  │  │  ├─ Params: (self: int16, other: int16)
@@ -1130,22 +1140,22 @@ intrinsics.sg (span: 1:1-872:1)
 │  │     ├─ Params: (s: &string)
 │  │     ├─ Return: Erring<int16, Error>
 │  │     └─ Attributes: @intrinsic
-├─ Item[111]: Extern (span: 395:1-422:2)
+├─ Item[113]: Extern (span: 397:1-424:2)
 │  ├─ Target: int32
 │  ├─ Members:
 │  │  ├─ Fn[0]: __min_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: int32
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 396:35-396:69)
-│  │  │     └─ Stmt[0]: Return (span: 396:37-396:67)
+│  │  │     Stmt[0]: Block (span: 398:35-398:69)
+│  │  │     └─ Stmt[0]: Return (span: 398:37-398:67)
 │  │  │        └─ Expr: expr#40: (-2_147_483_648) to int32
 │  │  ├─ Fn[1]: __max_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: int32
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 397:35-397:68)
-│  │  │     └─ Stmt[0]: Return (span: 397:37-397:66)
+│  │  │     Stmt[0]: Block (span: 399:35-399:68)
+│  │  │     └─ Stmt[0]: Return (span: 399:37-399:66)
 │  │  │        └─ Expr: expr#43: (2_147_483_647) to int32
 │  │  ├─ Fn[2]: __add
 │  │  │  ├─ Params: (self: int32, other: int32)
@@ -1243,22 +1253,22 @@ intrinsics.sg (span: 1:1-872:1)
 │  │     ├─ Params: (s: &string)
 │  │     ├─ Return: Erring<int32, Error>
 │  │     └─ Attributes: @intrinsic
-├─ Item[112]: Extern (span: 424:1-451:2)
+├─ Item[114]: Extern (span: 426:1-453:2)
 │  ├─ Target: int64
 │  ├─ Members:
 │  │  ├─ Fn[0]: __min_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: int64
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 425:35-425:81)
-│  │  │     └─ Stmt[0]: Return (span: 425:37-425:79)
+│  │  │     Stmt[0]: Block (span: 427:35-427:81)
+│  │  │     └─ Stmt[0]: Return (span: 427:37-427:79)
 │  │  │        └─ Expr: expr#47: (-9_223_372_036_854_775_808) to int64
 │  │  ├─ Fn[1]: __max_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: int64
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 426:35-426:80)
-│  │  │     └─ Stmt[0]: Return (span: 426:37-426:78)
+│  │  │     Stmt[0]: Block (span: 428:35-428:80)
+│  │  │     └─ Stmt[0]: Return (span: 428:37-428:78)
 │  │  │        └─ Expr: expr#50: (9_223_372_036_854_775_807) to int64
 │  │  ├─ Fn[2]: __add
 │  │  │  ├─ Params: (self: int64, other: int64)
@@ -1356,22 +1366,22 @@ intrinsics.sg (span: 1:1-872:1)
 │  │     ├─ Params: (s: &string)
 │  │     ├─ Return: Erring<int64, Error>
 │  │     └─ Attributes: @intrinsic
-├─ Item[113]: Extern (span: 453:1-479:2)
+├─ Item[115]: Extern (span: 455:1-481:2)
 │  ├─ Target: uint8
 │  ├─ Members:
 │  │  ├─ Fn[0]: __min_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: uint8
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 454:35-454:56)
-│  │  │     └─ Stmt[0]: Return (span: 454:37-454:54)
+│  │  │     Stmt[0]: Block (span: 456:35-456:56)
+│  │  │     └─ Stmt[0]: Return (span: 456:37-456:54)
 │  │  │        └─ Expr: expr#53: (0) to uint8
 │  │  ├─ Fn[1]: __max_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: uint8
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 455:35-455:58)
-│  │  │     └─ Stmt[0]: Return (span: 455:37-455:56)
+│  │  │     Stmt[0]: Block (span: 457:35-457:58)
+│  │  │     └─ Stmt[0]: Return (span: 457:37-457:56)
 │  │  │        └─ Expr: expr#56: (255) to uint8
 │  │  ├─ Fn[2]: __add
 │  │  │  ├─ Params: (self: uint8, other: uint8)
@@ -1465,22 +1475,22 @@ intrinsics.sg (span: 1:1-872:1)
 │  │     ├─ Params: (s: &string)
 │  │     ├─ Return: Erring<uint8, Error>
 │  │     └─ Attributes: @intrinsic
-├─ Item[114]: Extern (span: 481:1-507:2)
+├─ Item[116]: Extern (span: 483:1-509:2)
 │  ├─ Target: uint16
 │  ├─ Members:
 │  │  ├─ Fn[0]: __min_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: uint16
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 482:36-482:58)
-│  │  │     └─ Stmt[0]: Return (span: 482:38-482:56)
+│  │  │     Stmt[0]: Block (span: 484:36-484:58)
+│  │  │     └─ Stmt[0]: Return (span: 484:38-484:56)
 │  │  │        └─ Expr: expr#59: (0) to uint16
 │  │  ├─ Fn[1]: __max_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: uint16
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 483:36-483:63)
-│  │  │     └─ Stmt[0]: Return (span: 483:38-483:61)
+│  │  │     Stmt[0]: Block (span: 485:36-485:63)
+│  │  │     └─ Stmt[0]: Return (span: 485:38-485:61)
 │  │  │        └─ Expr: expr#62: (65_535) to uint16
 │  │  ├─ Fn[2]: __add
 │  │  │  ├─ Params: (self: uint16, other: uint16)
@@ -1574,22 +1584,22 @@ intrinsics.sg (span: 1:1-872:1)
 │  │     ├─ Params: (s: &string)
 │  │     ├─ Return: Erring<uint16, Error>
 │  │     └─ Attributes: @intrinsic
-├─ Item[115]: Extern (span: 509:1-535:2)
+├─ Item[117]: Extern (span: 511:1-537:2)
 │  ├─ Target: uint32
 │  ├─ Members:
 │  │  ├─ Fn[0]: __min_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: uint32
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 510:36-510:58)
-│  │  │     └─ Stmt[0]: Return (span: 510:38-510:56)
+│  │  │     Stmt[0]: Block (span: 512:36-512:58)
+│  │  │     └─ Stmt[0]: Return (span: 512:38-512:56)
 │  │  │        └─ Expr: expr#65: (0) to uint32
 │  │  ├─ Fn[1]: __max_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: uint32
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 511:36-511:70)
-│  │  │     └─ Stmt[0]: Return (span: 511:38-511:68)
+│  │  │     Stmt[0]: Block (span: 513:36-513:70)
+│  │  │     └─ Stmt[0]: Return (span: 513:38-513:68)
 │  │  │        └─ Expr: expr#68: (4_294_967_295) to uint32
 │  │  ├─ Fn[2]: __add
 │  │  │  ├─ Params: (self: uint32, other: uint32)
@@ -1683,22 +1693,22 @@ intrinsics.sg (span: 1:1-872:1)
 │  │     ├─ Params: (s: &string)
 │  │     ├─ Return: Erring<uint32, Error>
 │  │     └─ Attributes: @intrinsic
-├─ Item[116]: Extern (span: 537:1-563:2)
+├─ Item[118]: Extern (span: 539:1-565:2)
 │  ├─ Target: uint64
 │  ├─ Members:
 │  │  ├─ Fn[0]: __min_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: uint64
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 538:36-538:58)
-│  │  │     └─ Stmt[0]: Return (span: 538:38-538:56)
+│  │  │     Stmt[0]: Block (span: 540:36-540:58)
+│  │  │     └─ Stmt[0]: Return (span: 540:38-540:56)
 │  │  │        └─ Expr: expr#71: (0) to uint64
 │  │  ├─ Fn[1]: __max_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: uint64
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 539:36-539:83)
-│  │  │     └─ Stmt[0]: Return (span: 539:38-539:81)
+│  │  │     Stmt[0]: Block (span: 541:36-541:83)
+│  │  │     └─ Stmt[0]: Return (span: 541:38-541:81)
 │  │  │        └─ Expr: expr#74: (18_446_744_073_709_551_615) to uint64
 │  │  ├─ Fn[2]: __add
 │  │  │  ├─ Params: (self: uint64, other: uint64)
@@ -1792,22 +1802,22 @@ intrinsics.sg (span: 1:1-872:1)
 │  │     ├─ Params: (s: &string)
 │  │     ├─ Return: Erring<uint64, Error>
 │  │     └─ Attributes: @intrinsic
-├─ Item[117]: Extern (span: 565:1-586:2)
+├─ Item[119]: Extern (span: 567:1-588:2)
 │  ├─ Target: float16
 │  ├─ Members:
 │  │  ├─ Fn[0]: __min_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: float16
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 566:37-566:67)
-│  │  │     └─ Stmt[0]: Return (span: 566:39-566:65)
+│  │  │     Stmt[0]: Block (span: 568:37-568:67)
+│  │  │     └─ Stmt[0]: Return (span: 568:39-568:65)
 │  │  │        └─ Expr: expr#78: (-65504.0) to float16
 │  │  ├─ Fn[1]: __max_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: float16
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 567:37-567:66)
-│  │  │     └─ Stmt[0]: Return (span: 567:39-567:64)
+│  │  │     Stmt[0]: Block (span: 569:37-569:66)
+│  │  │     └─ Stmt[0]: Return (span: 569:39-569:64)
 │  │  │        └─ Expr: expr#81: (65504.0) to float16
 │  │  ├─ Fn[2]: __add
 │  │  │  ├─ Params: (self: float16, other: float16)
@@ -1881,22 +1891,22 @@ intrinsics.sg (span: 1:1-872:1)
 │  │     ├─ Params: (s: &string)
 │  │     ├─ Return: Erring<float16, Error>
 │  │     └─ Attributes: @intrinsic
-├─ Item[118]: Extern (span: 588:1-609:2)
+├─ Item[120]: Extern (span: 590:1-611:2)
 │  ├─ Target: float32
 │  ├─ Members:
 │  │  ├─ Fn[0]: __min_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: float32
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 589:37-589:86)
-│  │  │     └─ Stmt[0]: Return (span: 589:39-589:84)
+│  │  │     Stmt[0]: Block (span: 591:37-591:86)
+│  │  │     └─ Stmt[0]: Return (span: 591:39-591:84)
 │  │  │        └─ Expr: expr#85: (-3.402_823_466_385_2886e+38) to float32
 │  │  ├─ Fn[1]: __max_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: float32
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 590:37-590:85)
-│  │  │     └─ Stmt[0]: Return (span: 590:39-590:83)
+│  │  │     Stmt[0]: Block (span: 592:37-592:85)
+│  │  │     └─ Stmt[0]: Return (span: 592:39-592:83)
 │  │  │        └─ Expr: expr#88: (3.402_823_466_385_2886e+38) to float32
 │  │  ├─ Fn[2]: __add
 │  │  │  ├─ Params: (self: float32, other: float32)
@@ -1970,22 +1980,22 @@ intrinsics.sg (span: 1:1-872:1)
 │  │     ├─ Params: (s: &string)
 │  │     ├─ Return: Erring<float32, Error>
 │  │     └─ Attributes: @intrinsic
-├─ Item[119]: Extern (span: 611:1-632:2)
+├─ Item[121]: Extern (span: 613:1-634:2)
 │  ├─ Target: float64
 │  ├─ Members:
 │  │  ├─ Fn[0]: __min_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: float64
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 612:37-612:87)
-│  │  │     └─ Stmt[0]: Return (span: 612:39-612:85)
+│  │  │     Stmt[0]: Block (span: 614:37-614:87)
+│  │  │     └─ Stmt[0]: Return (span: 614:39-614:85)
 │  │  │        └─ Expr: expr#92: (-1.797_693_134_862_3157e+308) to float64
 │  │  ├─ Fn[1]: __max_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: float64
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 613:37-613:86)
-│  │  │     └─ Stmt[0]: Return (span: 613:39-613:84)
+│  │  │     Stmt[0]: Block (span: 615:37-615:86)
+│  │  │     └─ Stmt[0]: Return (span: 615:39-615:84)
 │  │  │        └─ Expr: expr#95: (1.797_693_134_862_3157e+308) to float64
 │  │  ├─ Fn[2]: __add
 │  │  │  ├─ Params: (self: float64, other: float64)
@@ -2059,7 +2069,7 @@ intrinsics.sg (span: 1:1-872:1)
 │  │     ├─ Params: (s: &string)
 │  │     ├─ Return: Erring<float64, Error>
 │  │     └─ Attributes: @intrinsic
-├─ Item[120]: Extern (span: 634:1-668:2)
+├─ Item[122]: Extern (span: 636:1-670:2)
 │  ├─ Target: float
 │  ├─ Members:
 │  │  ├─ Fn[0]: __add
@@ -2127,8 +2137,8 @@ intrinsics.sg (span: 1:1-872:1)
 │  │  │  ├─ Return: string
 │  │  │  ├─ Attributes: @overload
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 650:62-652:6)
-│  │  │     └─ Stmt[0]: Return (span: 651:9-651:34)
+│  │  │     Stmt[0]: Block (span: 652:62-654:6)
+│  │  │     └─ Stmt[0]: Return (span: 653:9-653:34)
 │  │  │        └─ Expr: expr#99: (*self) to string
 │  │  ├─ Fn[16]: __to
 │  │  │  ├─ Params: (self: float, target: int)
@@ -2186,7 +2196,7 @@ intrinsics.sg (span: 1:1-872:1)
 │  │     ├─ Params: (s: &string)
 │  │     ├─ Return: Erring<float, Error>
 │  │     └─ Attributes: @intrinsic
-├─ Item[121]: Extern (span: 670:1-703:2)
+├─ Item[123]: Extern (span: 672:1-705:2)
 │  ├─ Target: string
 │  ├─ Members:
 │  │  ├─ Fn[0]: __add
@@ -2202,8 +2212,8 @@ intrinsics.sg (span: 1:1-872:1)
 │  │  │  ├─ Return: string
 │  │  │  ├─ Attributes: @overload
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 673:66-675:6)
-│  │  │     └─ Stmt[0]: Return (span: 674:9-674:38)
+│  │  │     Stmt[0]: Block (span: 675:66-677:6)
+│  │  │     └─ Stmt[0]: Return (span: 676:9-676:38)
 │  │  │        └─ Expr: expr#104: (self * (other to int))
 │  │  ├─ Fn[3]: __eq
 │  │  │  ├─ Params: (self: &string, other: &string)
@@ -2230,56 +2240,56 @@ intrinsics.sg (span: 1:1-872:1)
 │  │  │  ├─ Return: string
 │  │  │  ├─ Attributes: @overload
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 681:63-683:6)
-│  │  │     └─ Stmt[0]: Return (span: 682:9-682:31)
+│  │  │     Stmt[0]: Block (span: 683:63-685:6)
+│  │  │     └─ Stmt[0]: Return (span: 684:9-684:31)
 │  │  │        └─ Expr: expr#107: self.__clone()
 │  │  ├─ Fn[9]: __to
 │  │  │  ├─ Params: (self: &string, _: byte[])
 │  │  │  ├─ Return: byte[]
 │  │  │  ├─ Attributes: @overload
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 685:53-698:6)
-│  │  │     ├─ Stmt[0]: Let (span: 686:9-686:33)
+│  │  │     Stmt[0]: Block (span: 687:53-700:6)
+│  │  │     ├─ Stmt[0]: Let (span: 688:9-688:33)
 │  │  │     │  ├─ Name: view
 │  │  │     │  ├─ Mutable: false
 │  │  │     │  ├─ Type: <inferred>
 │  │  │     │  └─ Value: expr#110: self.bytes()
-│  │  │     ├─ Stmt[1]: Let (span: 687:9-687:41)
+│  │  │     ├─ Stmt[1]: Let (span: 689:9-689:41)
 │  │  │     │  ├─ Name: length
 │  │  │     │  ├─ Mutable: false
 │  │  │     │  ├─ Type: uint
 │  │  │     │  └─ Value: expr#113: view.__len()
-│  │  │     ├─ Stmt[2]: Let (span: 688:9-688:34)
+│  │  │     ├─ Stmt[2]: Let (span: 690:9-690:34)
 │  │  │     │  ├─ Name: out
 │  │  │     │  ├─ Mutable: true
 │  │  │     │  ├─ Type: byte[]
 │  │  │     │  └─ Value: expr#114: <ExprKind(8)>
-│  │  │     ├─ Stmt[3]: Expr (span: 689:9-689:29)
+│  │  │     ├─ Stmt[3]: Expr (span: 691:9-691:29)
 │  │  │     │  └─ Expr: expr#118: out.reserve(length)
-│  │  │     ├─ Stmt[4]: Let (span: 690:9-690:40)
+│  │  │     ├─ Stmt[4]: Let (span: 692:9-692:40)
 │  │  │     │  ├─ Name: len_i
 │  │  │     │  ├─ Mutable: false
 │  │  │     │  ├─ Type: int
 │  │  │     │  └─ Value: expr#120: length to int
-│  │  │     ├─ Stmt[5]: Let (span: 691:9-691:28)
+│  │  │     ├─ Stmt[5]: Let (span: 693:9-693:28)
 │  │  │     │  ├─ Name: i
 │  │  │     │  ├─ Mutable: true
 │  │  │     │  ├─ Type: int
 │  │  │     │  └─ Value: expr#121: 0
-│  │  │     ├─ Stmt[6]: While (span: 692:9-696:10)
+│  │  │     ├─ Stmt[6]: While (span: 694:9-698:10)
 │  │  │     │  ├─ Cond: expr#124: (i < len_i)
 │  │  │     │  └─ Body:
-Block (span: 692:25-696:10)
-│  │  │     │     ├─ Stmt[0]: Let (span: 693:13-693:35)
+Block (span: 694:25-698:10)
+│  │  │     │     ├─ Stmt[0]: Let (span: 695:13-695:35)
 │  │  │     │     │  ├─ Name: b
 │  │  │     │     │  ├─ Mutable: false
 │  │  │     │     │  ├─ Type: byte
 │  │  │     │     │  └─ Value: expr#127: view[i]
-│  │  │     │     ├─ Stmt[1]: Expr (span: 694:13-694:25)
+│  │  │     │     ├─ Stmt[1]: Expr (span: 696:13-696:25)
 │  │  │     │     │  └─ Expr: expr#131: out.push(b)
-│  │  │     │     └─ Stmt[2]: Expr (span: 695:13-695:23)
+│  │  │     │     └─ Stmt[2]: Expr (span: 697:13-697:23)
 │  │  │     │        └─ Expr: expr#136: (i = ((i + 1)))
-│  │  │     └─ Stmt[7]: Return (span: 697:9-697:20)
+│  │  │     └─ Stmt[7]: Return (span: 699:9-699:20)
 │  │  │        └─ Expr: expr#137: out
 │  │  ├─ Fn[10]: __len
 │  │  │  ├─ Params: (self: &string)
@@ -2297,7 +2307,7 @@ Block (span: 692:25-696:10)
 │  │     ├─ Params: (self: &string, index: Range<int>)
 │  │     ├─ Return: string
 │  │     └─ Attributes: @intrinsic, @overload
-├─ Item[122]: Type (span: 705:1-710:3)
+├─ Item[124]: Type (span: 707:1-712:3)
 │  ├─ Name: BytesView
 │  ├─ Kind: Struct
 │  ├─ Visibility: public
@@ -2306,7 +2316,7 @@ Block (span: 692:25-696:10)
 │     ├─ Field[0]: owner: string
 │     ├─ Field[1]: ptr: *byte
 │     └─ Field[2]: len: uint
-├─ Item[123]: Extern (span: 712:1-715:2)
+├─ Item[125]: Extern (span: 714:1-717:2)
 │  ├─ Target: BytesView
 │  ├─ Members:
 │  │  ├─ Fn[0]: __len
@@ -2317,7 +2327,7 @@ Block (span: 692:25-696:10)
 │  │     ├─ Params: (self: &BytesView, index: int)
 │  │     ├─ Return: uint8
 │  │     └─ Attributes: @intrinsic
-├─ Item[124]: Extern (span: 717:1-728:2)
+├─ Item[126]: Extern (span: 719:1-730:2)
 │  ├─ Target: bool
 │  ├─ Members:
 │  │  ├─ Fn[0]: __eq
@@ -2341,8 +2351,8 @@ Block (span: 692:25-696:10)
 │  │  │  ├─ Return: string
 │  │  │  ├─ Attributes: @overload
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 722:61-724:6)
-│  │  │     └─ Stmt[0]: Return (span: 723:9-723:34)
+│  │  │     Stmt[0]: Block (span: 724:61-726:6)
+│  │  │     └─ Stmt[0]: Return (span: 725:9-725:34)
 │  │  │        └─ Expr: expr#141: (*self) to string
 │  │  ├─ Fn[5]: __to
 │  │  │  ├─ Params: (self: bool, target: int)
@@ -2352,7 +2362,7 @@ Block (span: 692:25-696:10)
 │  │     ├─ Params: (s: &string)
 │  │     ├─ Return: Erring<bool, Error>
 │  │     └─ Attributes: @intrinsic
-├─ Item[125]: Extern (span: 730:1-737:2)
+├─ Item[127]: Extern (span: 732:1-739:2)
 │  ├─ Target: Array<T>
 │  ├─ Members:
 │  │  ├─ Fn[0]: __add
@@ -2379,7 +2389,7 @@ Block (span: 692:25-696:10)
 │  │     ├─ Params: (self: &Array<T>)
 │  │     ├─ Return: uint
 │  │     └─ Attributes: @intrinsic
-├─ Item[126]: Extern (span: 739:1-746:2)
+├─ Item[128]: Extern (span: 741:1-748:2)
 │  ├─ Target: ArrayFixed<T, N>
 │  ├─ Members:
 │  │  ├─ Fn[0]: __add
@@ -2406,62 +2416,62 @@ Block (span: 692:25-696:10)
 │  │     ├─ Params: (self: &ArrayFixed<T, N>)
 │  │     ├─ Return: uint
 │  │     └─ Attributes: @intrinsic
-├─ Item[127]: Fn (span: 748:1-749:26)
+├─ Item[129]: Fn (span: 750:1-751:26)
 │  ├─ Name: default
 │  ├─ Generics: <T>
 │  ├─ Params: ()
 │  ├─ Return: T
 │  └─ Body: <none>
-├─ Item[128]: Fn (span: 751:1-752:29)
+├─ Item[130]: Fn (span: 753:1-754:29)
 │  ├─ Name: size_of
 │  ├─ Generics: <T>
 │  ├─ Params: ()
 │  ├─ Return: uint
 │  └─ Body: <none>
-├─ Item[129]: Fn (span: 754:1-755:30)
+├─ Item[131]: Fn (span: 756:1-757:30)
 │  ├─ Name: align_of
 │  ├─ Generics: <T>
 │  ├─ Params: ()
 │  ├─ Return: uint
 │  └─ Body: <none>
-├─ Item[130]: Contract (span: 757:1-760:2)
-├─ Item[131]: Fn (span: 762:1-763:44)
+├─ Item[132]: Contract (span: 759:1-762:2)
+├─ Item[133]: Fn (span: 764:1-765:44)
 │  ├─ Name: exit
 │  ├─ Generics: <E>
 │  ├─ Params: (e: E)
 │  ├─ Return: nothing
 │  └─ Body: <none>
-├─ Item[132]: Fn (span: 765:1-766:54)
+├─ Item[134]: Fn (span: 767:1-768:54)
 │  ├─ Name: rt_panic
 │  ├─ Params: (ptr: *byte, length: uint)
 │  ├─ Return: nothing
 │  └─ Body: <none>
-├─ Item[133]: Fn (span: 768:1-772:2)
+├─ Item[135]: Fn (span: 770:1-774:2)
 │  ├─ Name: panic
 │  ├─ Params: (msg: string)
 │  ├─ Return: nothing
 │  └─ Body:
-│     └─ Stmt[0]: Block (span: 768:38-772:2)
-│        ├─ Stmt[0]: Let (span: 769:5-769:35)
+│     └─ Stmt[0]: Block (span: 770:38-774:2)
+│        ├─ Stmt[0]: Let (span: 771:5-771:35)
 │        │  ├─ Name: ptr
 │        │  ├─ Mutable: false
 │        │  ├─ Type: <inferred>
 │        │  └─ Value: expr#145: rt_string_ptr(&msg)
-│        ├─ Stmt[1]: Let (span: 770:5-770:44)
+│        ├─ Stmt[1]: Let (span: 772:5-772:44)
 │        │  ├─ Name: length
 │        │  ├─ Mutable: false
 │        │  ├─ Type: <inferred>
 │        │  └─ Value: expr#149: rt_string_len_bytes(&msg)
-│        └─ Stmt[2]: Expr (span: 771:5-771:27)
+│        └─ Stmt[2]: Expr (span: 773:5-773:27)
 │           └─ Expr: expr#153: rt_panic(ptr, length)
-├─ Item[134]: Type (span: 774:1-777:3)
+├─ Item[136]: Type (span: 776:1-779:3)
 │  ├─ Name: RwLock
 │  ├─ Kind: Struct
 │  ├─ Visibility: public
 │  ├─ Attributes: @intrinsic
 │  └─ Struct:
 │     └─ Field[0]: __opaque: *byte
-├─ Item[135]: Extern (span: 779:1-787:2)
+├─ Item[137]: Extern (span: 781:1-789:2)
 │  ├─ Target: RwLock
 │  ├─ Members:
 │  │  ├─ Fn[0]: new
@@ -2492,97 +2502,97 @@ Block (span: 692:25-696:10)
 │  │     ├─ Params: (self: &mut RwLock)
 │  │     ├─ Return: bool
 │  │     └─ Attributes: @intrinsic
-├─ Item[136]: Fn (span: 795:1-796:38)
+├─ Item[138]: Fn (span: 797:1-798:38)
 │  ├─ Name: atomic_load
 │  ├─ Params: (ptr: &int)
 │  ├─ Return: int
 │  └─ Body: <none>
-├─ Item[137]: Fn (span: 798:1-800:40)
+├─ Item[139]: Fn (span: 800:1-802:40)
 │  ├─ Name: atomic_load
 │  ├─ Params: (ptr: &uint)
 │  ├─ Return: uint
 │  └─ Body: <none>
-├─ Item[138]: Fn (span: 802:1-804:40)
+├─ Item[140]: Fn (span: 804:1-806:40)
 │  ├─ Name: atomic_load
 │  ├─ Params: (ptr: &bool)
 │  ├─ Return: bool
 │  └─ Body: <none>
-├─ Item[139]: Fn (span: 807:1-808:59)
+├─ Item[141]: Fn (span: 809:1-810:59)
 │  ├─ Name: atomic_store
 │  ├─ Params: (ptr: &mut int, value: int)
 │  ├─ Return: nothing
 │  └─ Body: <none>
-├─ Item[140]: Fn (span: 810:1-812:61)
+├─ Item[142]: Fn (span: 812:1-814:61)
 │  ├─ Name: atomic_store
 │  ├─ Params: (ptr: &mut uint, value: uint)
 │  ├─ Return: nothing
 │  └─ Body: <none>
-├─ Item[141]: Fn (span: 814:1-816:61)
+├─ Item[143]: Fn (span: 816:1-818:61)
 │  ├─ Name: atomic_store
 │  ├─ Params: (ptr: &mut bool, value: bool)
 │  ├─ Return: nothing
 │  └─ Body: <none>
-├─ Item[142]: Fn (span: 819:1-820:60)
+├─ Item[144]: Fn (span: 821:1-822:60)
 │  ├─ Name: atomic_exchange
 │  ├─ Params: (ptr: &mut int, new_val: int)
 │  ├─ Return: int
 │  └─ Body: <none>
-├─ Item[143]: Fn (span: 822:1-824:63)
+├─ Item[145]: Fn (span: 824:1-826:63)
 │  ├─ Name: atomic_exchange
 │  ├─ Params: (ptr: &mut uint, new_val: uint)
 │  ├─ Return: uint
 │  └─ Body: <none>
-├─ Item[144]: Fn (span: 826:1-828:63)
+├─ Item[146]: Fn (span: 828:1-830:63)
 │  ├─ Name: atomic_exchange
 │  ├─ Params: (ptr: &mut bool, new_val: bool)
 │  ├─ Return: bool
 │  └─ Body: <none>
-├─ Item[145]: Fn (span: 832:1-833:84)
+├─ Item[147]: Fn (span: 834:1-835:84)
 │  ├─ Name: atomic_compare_exchange
 │  ├─ Params: (ptr: &mut int, expected: int, desired: int)
 │  ├─ Return: bool
 │  └─ Body: <none>
-├─ Item[146]: Fn (span: 835:1-837:87)
+├─ Item[148]: Fn (span: 837:1-839:87)
 │  ├─ Name: atomic_compare_exchange
 │  ├─ Params: (ptr: &mut uint, expected: uint, desired: uint)
 │  ├─ Return: bool
 │  └─ Body: <none>
-├─ Item[147]: Fn (span: 839:1-841:87)
+├─ Item[149]: Fn (span: 841:1-843:87)
 │  ├─ Name: atomic_compare_exchange
 │  ├─ Params: (ptr: &mut bool, expected: bool, desired: bool)
 │  ├─ Return: bool
 │  └─ Body: <none>
-├─ Item[148]: Fn (span: 844:1-845:59)
+├─ Item[150]: Fn (span: 846:1-847:59)
 │  ├─ Name: atomic_fetch_add
 │  ├─ Params: (ptr: &mut int, delta: int)
 │  ├─ Return: int
 │  └─ Body: <none>
-├─ Item[149]: Fn (span: 847:1-849:62)
+├─ Item[151]: Fn (span: 849:1-851:62)
 │  ├─ Name: atomic_fetch_add
 │  ├─ Params: (ptr: &mut uint, delta: uint)
 │  ├─ Return: uint
 │  └─ Body: <none>
-├─ Item[150]: Fn (span: 852:1-853:59)
+├─ Item[152]: Fn (span: 854:1-855:59)
 │  ├─ Name: atomic_fetch_sub
 │  ├─ Params: (ptr: &mut int, delta: int)
 │  ├─ Return: int
 │  └─ Body: <none>
-├─ Item[151]: Fn (span: 855:1-857:62)
+├─ Item[153]: Fn (span: 857:1-859:62)
 │  ├─ Name: atomic_fetch_sub
 │  ├─ Params: (ptr: &mut uint, delta: uint)
 │  ├─ Return: uint
 │  └─ Body: <none>
-├─ Item[152]: Fn (span: 862:1-863:30)
+├─ Item[154]: Fn (span: 864:1-865:30)
 │  ├─ Name: rt_argv
 │  ├─ Params: ()
 │  ├─ Return: string[]
 │  └─ Body: <none>
-├─ Item[153]: Fn (span: 866:1-867:38)
+├─ Item[155]: Fn (span: 868:1-869:38)
 │  ├─ Name: rt_stdin_read_all
 │  ├─ Params: ()
 │  ├─ Return: string
 │  └─ Body: <none>
-└─ Item[154]: Fn (span: 870:1-871:38)
+└─ Item[156]: Fn (span: 872:1-873:38)
    ├─ Name: rt_exit
    ├─ Params: (code: int)
    ├─ Return: nothing

--- a/testdata/golden/core_stdlib/intrinsics.fmt
+++ b/testdata/golden/core_stdlib/intrinsics.fmt
@@ -95,6 +95,8 @@ pub type NetResult<T> = Erring<T, NetError>;
 @intrinsic fn rt_net_accept(l: &TcpListener) -> NetResult<TcpConn>;
 @intrinsic fn rt_net_read(c: &TcpConn, buf: *byte, cap: uint) -> NetResult<uint>;
 @intrinsic fn rt_net_write(c: &TcpConn, buf: *byte, length: uint) -> NetResult<uint>;
+@intrinsic fn rt_net_read_bytes(c: &TcpConn, cap: uint) -> NetResult<byte[]>;
+@intrinsic fn rt_net_write_bytes(c: &TcpConn, data: &byte[], offset: uint, length: uint) -> NetResult<uint>;
 
 @intrinsic fn rt_net_wait_accept(l: &TcpListener) -> Task<nothing>;
 @intrinsic fn rt_net_wait_readable(c: &TcpConn) -> Task<nothing>;

--- a/testdata/golden/core_stdlib/intrinsics.sg
+++ b/testdata/golden/core_stdlib/intrinsics.sg
@@ -95,6 +95,8 @@ pub type NetResult<T> = Erring<T, NetError>;
 @intrinsic fn rt_net_accept(l: &TcpListener) -> NetResult<TcpConn>;
 @intrinsic fn rt_net_read(c: &TcpConn, buf: *byte, cap: uint) -> NetResult<uint>;
 @intrinsic fn rt_net_write(c: &TcpConn, buf: *byte, length: uint) -> NetResult<uint>;
+@intrinsic fn rt_net_read_bytes(c: &TcpConn, cap: uint) -> NetResult<byte[]>;
+@intrinsic fn rt_net_write_bytes(c: &TcpConn, data: &byte[], offset: uint, length: uint) -> NetResult<uint>;
 
 @intrinsic fn rt_net_wait_accept(l: &TcpListener) -> Task<nothing>;
 @intrinsic fn rt_net_wait_readable(c: &TcpConn) -> Task<nothing>;

--- a/testdata/golden/core_stdlib/intrinsics.tokens
+++ b/testdata/golden/core_stdlib/intrinsics.tokens
@@ -879,8726 +879,8779 @@
 879: Ident           "uint" at 97:80-97:84
 880: Gt              ">" at 97:84-97:85
 881: Semicolon       ";" at 97:85-97:86
-882: At              "@" at 99:1-99:2 (leading: Newline)
-883: Ident           "intrinsic" at 99:2-99:11
-884: KwFn            "fn" at 99:12-99:14 (leading: Space)
-885: Ident           "rt_net_wait_accept" at 99:15-99:33 (leading: Space)
-886: LParen          "(" at 99:33-99:34
-887: Ident           "l" at 99:34-99:35
-888: Colon           ":" at 99:35-99:36
-889: Amp             "&" at 99:37-99:38 (leading: Space)
-890: Ident           "TcpListener" at 99:38-99:49
-891: RParen          ")" at 99:49-99:50
-892: Arrow           "->" at 99:51-99:53 (leading: Space)
-893: Ident           "Task" at 99:54-99:58 (leading: Space)
-894: Lt              "<" at 99:58-99:59
-895: NothingLit      "nothing" at 99:59-99:66
-896: Gt              ">" at 99:66-99:67
-897: Semicolon       ";" at 99:67-99:68
-898: At              "@" at 100:1-100:2 (leading: Newline)
-899: Ident           "intrinsic" at 100:2-100:11
-900: KwFn            "fn" at 100:12-100:14 (leading: Space)
-901: Ident           "rt_net_wait_readable" at 100:15-100:35 (leading: Space)
-902: LParen          "(" at 100:35-100:36
-903: Ident           "c" at 100:36-100:37
-904: Colon           ":" at 100:37-100:38
-905: Amp             "&" at 100:39-100:40 (leading: Space)
-906: Ident           "TcpConn" at 100:40-100:47
-907: RParen          ")" at 100:47-100:48
-908: Arrow           "->" at 100:49-100:51 (leading: Space)
-909: Ident           "Task" at 100:52-100:56 (leading: Space)
-910: Lt              "<" at 100:56-100:57
-911: NothingLit      "nothing" at 100:57-100:64
-912: Gt              ">" at 100:64-100:65
-913: Semicolon       ";" at 100:65-100:66
-914: At              "@" at 101:1-101:2 (leading: Newline)
-915: Ident           "intrinsic" at 101:2-101:11
-916: KwFn            "fn" at 101:12-101:14 (leading: Space)
-917: Ident           "rt_net_wait_writable" at 101:15-101:35 (leading: Space)
-918: LParen          "(" at 101:35-101:36
-919: Ident           "c" at 101:36-101:37
-920: Colon           ":" at 101:37-101:38
-921: Amp             "&" at 101:39-101:40 (leading: Space)
-922: Ident           "TcpConn" at 101:40-101:47
-923: RParen          ")" at 101:47-101:48
-924: Arrow           "->" at 101:49-101:51 (leading: Space)
-925: Ident           "Task" at 101:52-101:56 (leading: Space)
-926: Lt              "<" at 101:56-101:57
-927: NothingLit      "nothing" at 101:57-101:64
-928: Gt              ">" at 101:64-101:65
-929: Semicolon       ";" at 101:65-101:66
-930: KwExtern        "extern" at 103:1-103:7 (leading: Newline)
-931: Lt              "<" at 103:7-103:8
-932: Ident           "TcpConn" at 103:8-103:15
-933: Gt              ">" at 103:15-103:16
-934: LBrace          "{" at 103:17-103:18 (leading: Space)
-935: KwPub           "pub" at 104:5-104:8 (leading: Newline, Space)
-936: KwFn            "fn" at 104:9-104:11 (leading: Space)
-937: Ident           "new" at 104:12-104:15 (leading: Space)
-938: LParen          "(" at 104:15-104:16
-939: RParen          ")" at 104:16-104:17
-940: Arrow           "->" at 104:18-104:20 (leading: Space)
-941: Ident           "TcpConn" at 104:21-104:28 (leading: Space)
-942: LBrace          "{" at 104:29-104:30 (leading: Space)
-943: KwReturn        "return" at 105:9-105:15 (leading: Newline, Space)
-944: LBrace          "{" at 105:16-105:17 (leading: Space)
-945: Ident           "__opaque" at 105:18-105:26 (leading: Space)
-946: Colon           ":" at 105:26-105:27
-947: IntLit          "0" at 105:28-105:29 (leading: Space)
-948: RBrace          "}" at 105:30-105:31 (leading: Space)
-949: Semicolon       ";" at 105:31-105:32
-950: RBrace          "}" at 106:5-106:6 (leading: Newline, Space)
-951: RBrace          "}" at 107:1-107:2 (leading: Newline)
-952: At              "@" at 110:1-110:2 (leading: Newline, LineComment, Newline)
-953: Ident           "intrinsic" at 110:2-110:11
-954: KwFn            "fn" at 110:12-110:14 (leading: Space)
-955: Ident           "rt_string_ptr" at 110:15-110:28 (leading: Space)
-956: LParen          "(" at 110:28-110:29
-957: Ident           "s" at 110:29-110:30
-958: Colon           ":" at 110:30-110:31
-959: Amp             "&" at 110:32-110:33 (leading: Space)
-960: Ident           "string" at 110:33-110:39
-961: RParen          ")" at 110:39-110:40
-962: Arrow           "->" at 110:41-110:43 (leading: Space)
-963: Star            "*" at 110:44-110:45 (leading: Space)
-964: Ident           "byte" at 110:45-110:49
-965: Semicolon       ";" at 110:49-110:50
-966: At              "@" at 112:1-112:2 (leading: Newline, LineComment, Newline)
-967: Ident           "intrinsic" at 112:2-112:11
-968: KwFn            "fn" at 112:12-112:14 (leading: Space)
-969: Ident           "rt_string_len" at 112:15-112:28 (leading: Space)
-970: LParen          "(" at 112:28-112:29
-971: Ident           "s" at 112:29-112:30
-972: Colon           ":" at 112:30-112:31
-973: Amp             "&" at 112:32-112:33 (leading: Space)
-974: Ident           "string" at 112:33-112:39
-975: RParen          ")" at 112:39-112:40
-976: Arrow           "->" at 112:41-112:43 (leading: Space)
-977: Ident           "uint" at 112:44-112:48 (leading: Space)
-978: Semicolon       ";" at 112:48-112:49
-979: At              "@" at 113:1-113:2 (leading: Newline)
-980: Ident           "intrinsic" at 113:2-113:11
-981: KwFn            "fn" at 113:12-113:14 (leading: Space)
-982: Ident           "rt_string_len_bytes" at 113:15-113:34 (leading: Space)
-983: LParen          "(" at 113:34-113:35
-984: Ident           "s" at 113:35-113:36
-985: Colon           ":" at 113:36-113:37
-986: Amp             "&" at 113:38-113:39 (leading: Space)
-987: Ident           "string" at 113:39-113:45
-988: RParen          ")" at 113:45-113:46
-989: Arrow           "->" at 113:47-113:49 (leading: Space)
-990: Ident           "uint" at 113:50-113:54 (leading: Space)
-991: Semicolon       ";" at 113:54-113:55
-992: At              "@" at 114:1-114:2 (leading: Newline)
-993: Ident           "intrinsic" at 114:2-114:11
-994: KwFn            "fn" at 114:12-114:14 (leading: Space)
-995: Ident           "rt_string_from_bytes" at 114:15-114:35 (leading: Space)
-996: LParen          "(" at 114:35-114:36
-997: Ident           "ptr" at 114:36-114:39
-998: Colon           ":" at 114:39-114:40
-999: Star            "*" at 114:41-114:42 (leading: Space)
-1000: Ident           "byte" at 114:42-114:46
-1001: Comma           "," at 114:46-114:47
-1002: Ident           "length" at 114:48-114:54 (leading: Space)
-1003: Colon           ":" at 114:54-114:55
-1004: Ident           "uint" at 114:56-114:60 (leading: Space)
-1005: RParen          ")" at 114:60-114:61
-1006: Arrow           "->" at 114:62-114:64 (leading: Space)
-1007: Ident           "string" at 114:65-114:71 (leading: Space)
-1008: Semicolon       ";" at 114:71-114:72
-1009: At              "@" at 115:1-115:2 (leading: Newline)
-1010: Ident           "intrinsic" at 115:2-115:11
-1011: KwFn            "fn" at 115:12-115:14 (leading: Space)
-1012: Ident           "rt_string_from_utf16" at 115:15-115:35 (leading: Space)
-1013: LParen          "(" at 115:35-115:36
-1014: Ident           "ptr" at 115:36-115:39
-1015: Colon           ":" at 115:39-115:40
-1016: Star            "*" at 115:41-115:42 (leading: Space)
-1017: Ident           "uint16" at 115:42-115:48
-1018: Comma           "," at 115:48-115:49
-1019: Ident           "length" at 115:50-115:56 (leading: Space)
-1020: Colon           ":" at 115:56-115:57
-1021: Ident           "uint" at 115:58-115:62 (leading: Space)
-1022: RParen          ")" at 115:62-115:63
-1023: Arrow           "->" at 115:64-115:66 (leading: Space)
-1024: Ident           "string" at 115:67-115:73 (leading: Space)
-1025: Semicolon       ";" at 115:73-115:74
-1026: At              "@" at 116:1-116:2 (leading: Newline)
-1027: Ident           "intrinsic" at 116:2-116:11
-1028: KwFn            "fn" at 116:12-116:14 (leading: Space)
-1029: Ident           "rt_string_index" at 116:15-116:30 (leading: Space)
-1030: LParen          "(" at 116:30-116:31
-1031: Ident           "s" at 116:31-116:32
-1032: Colon           ":" at 116:32-116:33
-1033: Amp             "&" at 116:34-116:35 (leading: Space)
-1034: Ident           "string" at 116:35-116:41
-1035: Comma           "," at 116:41-116:42
-1036: Ident           "index" at 116:43-116:48 (leading: Space)
-1037: Colon           ":" at 116:48-116:49
-1038: Ident           "int" at 116:50-116:53 (leading: Space)
-1039: RParen          ")" at 116:53-116:54
-1040: Arrow           "->" at 116:55-116:57 (leading: Space)
-1041: Ident           "uint32" at 116:58-116:64 (leading: Space)
-1042: Semicolon       ";" at 116:64-116:65
-1043: At              "@" at 117:1-117:2 (leading: Newline)
-1044: Ident           "intrinsic" at 117:2-117:11
-1045: KwFn            "fn" at 117:12-117:14 (leading: Space)
-1046: Ident           "rt_string_slice" at 117:15-117:30 (leading: Space)
-1047: LParen          "(" at 117:30-117:31
-1048: Ident           "s" at 117:31-117:32
-1049: Colon           ":" at 117:32-117:33
-1050: Amp             "&" at 117:34-117:35 (leading: Space)
-1051: Ident           "string" at 117:35-117:41
-1052: Comma           "," at 117:41-117:42
-1053: Ident           "r" at 117:43-117:44 (leading: Space)
-1054: Colon           ":" at 117:44-117:45
-1055: Ident           "Range" at 117:46-117:51 (leading: Space)
-1056: Lt              "<" at 117:51-117:52
-1057: Ident           "int" at 117:52-117:55
-1058: Gt              ">" at 117:55-117:56
-1059: RParen          ")" at 117:56-117:57
-1060: Arrow           "->" at 117:58-117:60 (leading: Space)
-1061: Ident           "string" at 117:61-117:67 (leading: Space)
-1062: Semicolon       ";" at 117:67-117:68
-1063: At              "@" at 118:1-118:2 (leading: Newline)
-1064: Ident           "intrinsic" at 118:2-118:11
-1065: KwFn            "fn" at 118:12-118:14 (leading: Space)
-1066: Ident           "rt_string_concat" at 118:15-118:31 (leading: Space)
-1067: LParen          "(" at 118:31-118:32
-1068: Ident           "a" at 118:32-118:33
-1069: Colon           ":" at 118:33-118:34
-1070: Amp             "&" at 118:35-118:36 (leading: Space)
-1071: Ident           "string" at 118:36-118:42
-1072: Comma           "," at 118:42-118:43
-1073: Ident           "b" at 118:44-118:45 (leading: Space)
-1074: Colon           ":" at 118:45-118:46
-1075: Amp             "&" at 118:47-118:48 (leading: Space)
-1076: Ident           "string" at 118:48-118:54
-1077: RParen          ")" at 118:54-118:55
-1078: Arrow           "->" at 118:56-118:58 (leading: Space)
-1079: Ident           "string" at 118:59-118:65 (leading: Space)
-1080: Semicolon       ";" at 118:65-118:66
-1081: At              "@" at 119:1-119:2 (leading: Newline)
-1082: Ident           "intrinsic" at 119:2-119:11
-1083: KwFn            "fn" at 119:12-119:14 (leading: Space)
-1084: Ident           "rt_string_eq" at 119:15-119:27 (leading: Space)
-1085: LParen          "(" at 119:27-119:28
-1086: Ident           "a" at 119:28-119:29
-1087: Colon           ":" at 119:29-119:30
-1088: Amp             "&" at 119:31-119:32 (leading: Space)
-1089: Ident           "string" at 119:32-119:38
-1090: Comma           "," at 119:38-119:39
-1091: Ident           "b" at 119:40-119:41 (leading: Space)
-1092: Colon           ":" at 119:41-119:42
-1093: Amp             "&" at 119:43-119:44 (leading: Space)
-1094: Ident           "string" at 119:44-119:50
-1095: RParen          ")" at 119:50-119:51
-1096: Arrow           "->" at 119:52-119:54 (leading: Space)
-1097: Ident           "bool" at 119:55-119:59 (leading: Space)
-1098: Semicolon       ";" at 119:59-119:60
-1099: At              "@" at 120:1-120:2 (leading: Newline)
-1100: Ident           "intrinsic" at 120:2-120:11
-1101: KwFn            "fn" at 120:12-120:14 (leading: Space)
-1102: Ident           "rt_string_bytes_view" at 120:15-120:35 (leading: Space)
-1103: LParen          "(" at 120:35-120:36
-1104: Ident           "s" at 120:36-120:37
-1105: Colon           ":" at 120:37-120:38
-1106: Amp             "&" at 120:39-120:40 (leading: Space)
-1107: Ident           "string" at 120:40-120:46
-1108: RParen          ")" at 120:46-120:47
-1109: Arrow           "->" at 120:48-120:50 (leading: Space)
-1110: Ident           "BytesView" at 120:51-120:60 (leading: Space)
-1111: Semicolon       ";" at 120:60-120:61
-1112: At              "@" at 122:1-122:2 (leading: Newline, LineComment, Newline)
-1113: Ident           "intrinsic" at 122:2-122:11
-1114: KwFn            "fn" at 122:12-122:14 (leading: Space)
-1115: Ident           "rt_string_force_flatten" at 122:15-122:38 (leading: Space)
-1116: LParen          "(" at 122:38-122:39
-1117: Ident           "s" at 122:39-122:40
-1118: Colon           ":" at 122:40-122:41
-1119: Amp             "&" at 122:42-122:43 (leading: Space)
-1120: Ident           "string" at 122:43-122:49
-1121: RParen          ")" at 122:49-122:50
-1122: Arrow           "->" at 122:51-122:53 (leading: Space)
-1123: NothingLit      "nothing" at 122:54-122:61 (leading: Space)
-1124: Semicolon       ";" at 122:61-122:62
-1125: At              "@" at 125:1-125:2 (leading: Newline, LineComment, Newline)
-1126: Ident           "intrinsic" at 125:2-125:11
-1127: KwFn            "fn" at 125:12-125:14 (leading: Space)
-1128: Ident           "rt_array_reserve" at 125:15-125:31 (leading: Space)
-1129: Lt              "<" at 125:31-125:32
-1130: Ident           "T" at 125:32-125:33
-1131: Gt              ">" at 125:33-125:34
-1132: LParen          "(" at 125:34-125:35
-1133: Ident           "a" at 125:35-125:36
-1134: Colon           ":" at 125:36-125:37
-1135: Amp             "&" at 125:38-125:39 (leading: Space)
-1136: KwMut           "mut" at 125:39-125:42
-1137: Ident           "Array" at 125:43-125:48 (leading: Space)
-1138: Lt              "<" at 125:48-125:49
-1139: Ident           "T" at 125:49-125:50
-1140: Gt              ">" at 125:50-125:51
-1141: Comma           "," at 125:51-125:52
-1142: Ident           "new_cap" at 125:53-125:60 (leading: Space)
-1143: Colon           ":" at 125:60-125:61
-1144: Ident           "uint" at 125:62-125:66 (leading: Space)
-1145: RParen          ")" at 125:66-125:67
-1146: Arrow           "->" at 125:68-125:70 (leading: Space)
-1147: NothingLit      "nothing" at 125:71-125:78 (leading: Space)
-1148: Semicolon       ";" at 125:78-125:79
-1149: At              "@" at 126:1-126:2 (leading: Newline)
-1150: Ident           "intrinsic" at 126:2-126:11
-1151: KwFn            "fn" at 126:12-126:14 (leading: Space)
-1152: Ident           "rt_array_push" at 126:15-126:28 (leading: Space)
-1153: Lt              "<" at 126:28-126:29
-1154: Ident           "T" at 126:29-126:30
-1155: Gt              ">" at 126:30-126:31
-1156: LParen          "(" at 126:31-126:32
-1157: Ident           "a" at 126:32-126:33
-1158: Colon           ":" at 126:33-126:34
-1159: Amp             "&" at 126:35-126:36 (leading: Space)
-1160: KwMut           "mut" at 126:36-126:39
-1161: Ident           "Array" at 126:40-126:45 (leading: Space)
-1162: Lt              "<" at 126:45-126:46
-1163: Ident           "T" at 126:46-126:47
-1164: Gt              ">" at 126:47-126:48
-1165: Comma           "," at 126:48-126:49
-1166: Ident           "value" at 126:50-126:55 (leading: Space)
-1167: Colon           ":" at 126:55-126:56
-1168: Ident           "T" at 126:57-126:58 (leading: Space)
-1169: RParen          ")" at 126:58-126:59
-1170: Arrow           "->" at 126:60-126:62 (leading: Space)
-1171: NothingLit      "nothing" at 126:63-126:70 (leading: Space)
-1172: Semicolon       ";" at 126:70-126:71
-1173: At              "@" at 127:1-127:2 (leading: Newline)
-1174: Ident           "intrinsic" at 127:2-127:11
-1175: KwFn            "fn" at 127:12-127:14 (leading: Space)
-1176: Ident           "rt_array_pop" at 127:15-127:27 (leading: Space)
-1177: Lt              "<" at 127:27-127:28
-1178: Ident           "T" at 127:28-127:29
-1179: Gt              ">" at 127:29-127:30
-1180: LParen          "(" at 127:30-127:31
-1181: Ident           "a" at 127:31-127:32
-1182: Colon           ":" at 127:32-127:33
-1183: Amp             "&" at 127:34-127:35 (leading: Space)
-1184: KwMut           "mut" at 127:35-127:38
-1185: Ident           "Array" at 127:39-127:44 (leading: Space)
-1186: Lt              "<" at 127:44-127:45
-1187: Ident           "T" at 127:45-127:46
-1188: Gt              ">" at 127:46-127:47
-1189: RParen          ")" at 127:47-127:48
-1190: Arrow           "->" at 127:49-127:51 (leading: Space)
-1191: Ident           "Option" at 127:52-127:58 (leading: Space)
-1192: Lt              "<" at 127:58-127:59
-1193: Ident           "T" at 127:59-127:60
-1194: Gt              ">" at 127:60-127:61
-1195: Semicolon       ";" at 127:61-127:62
-1196: At              "@" at 128:1-128:2 (leading: Newline)
-1197: Ident           "intrinsic" at 128:2-128:11
-1198: KwFn            "fn" at 128:12-128:14 (leading: Space)
-1199: Ident           "rt_array_get_mut" at 128:15-128:31 (leading: Space)
-1200: Lt              "<" at 128:31-128:32
-1201: Ident           "T" at 128:32-128:33
-1202: Gt              ">" at 128:33-128:34
-1203: LParen          "(" at 128:34-128:35
-1204: Ident           "a" at 128:35-128:36
-1205: Colon           ":" at 128:36-128:37
-1206: Amp             "&" at 128:38-128:39 (leading: Space)
-1207: KwMut           "mut" at 128:39-128:42
-1208: Ident           "Array" at 128:43-128:48 (leading: Space)
-1209: Lt              "<" at 128:48-128:49
-1210: Ident           "T" at 128:49-128:50
-1211: Gt              ">" at 128:50-128:51
-1212: Comma           "," at 128:51-128:52
-1213: Ident           "index" at 128:53-128:58 (leading: Space)
-1214: Colon           ":" at 128:58-128:59
-1215: Ident           "int" at 128:60-128:63 (leading: Space)
-1216: RParen          ")" at 128:63-128:64
-1217: Arrow           "->" at 128:65-128:67 (leading: Space)
-1218: Amp             "&" at 128:68-128:69 (leading: Space)
-1219: KwMut           "mut" at 128:69-128:72
-1220: Ident           "T" at 128:73-128:74 (leading: Space)
-1221: Semicolon       ";" at 128:74-128:75
-1222: At              "@" at 129:1-129:2 (leading: Newline)
-1223: Ident           "intrinsic" at 129:2-129:11
-1224: At              "@" at 129:12-129:13 (leading: Space)
-1225: Ident           "overload" at 129:13-129:21
-1226: KwFn            "fn" at 129:22-129:24 (leading: Space)
-1227: Ident           "rt_array_get_mut" at 129:25-129:41 (leading: Space)
-1228: Lt              "<" at 129:41-129:42
-1229: Ident           "T" at 129:42-129:43
-1230: Comma           "," at 129:43-129:44
-1231: KwConst         "const" at 129:45-129:50 (leading: Space)
-1232: Ident           "N" at 129:51-129:52 (leading: Space)
-1233: Colon           ":" at 129:52-129:53
-1234: Ident           "int" at 129:53-129:56
-1235: Gt              ">" at 129:56-129:57
-1236: LParen          "(" at 129:57-129:58
-1237: Ident           "a" at 129:58-129:59
-1238: Colon           ":" at 129:59-129:60
-1239: Amp             "&" at 129:61-129:62 (leading: Space)
-1240: KwMut           "mut" at 129:62-129:65
-1241: Ident           "ArrayFixed" at 129:66-129:76 (leading: Space)
-1242: Lt              "<" at 129:76-129:77
-1243: Ident           "T" at 129:77-129:78
-1244: Comma           "," at 129:78-129:79
-1245: Ident           "N" at 129:80-129:81 (leading: Space)
-1246: Gt              ">" at 129:81-129:82
-1247: Comma           "," at 129:82-129:83
-1248: Ident           "index" at 129:84-129:89 (leading: Space)
-1249: Colon           ":" at 129:89-129:90
-1250: Ident           "int" at 129:91-129:94 (leading: Space)
-1251: RParen          ")" at 129:94-129:95
-1252: Arrow           "->" at 129:96-129:98 (leading: Space)
-1253: Amp             "&" at 129:99-129:100 (leading: Space)
-1254: KwMut           "mut" at 129:100-129:103
-1255: Ident           "T" at 129:104-129:105 (leading: Space)
-1256: Semicolon       ";" at 129:105-129:106
-1257: At              "@" at 132:1-132:2 (leading: Newline, LineComment, Newline)
-1258: Ident           "intrinsic" at 132:2-132:11
-1259: KwFn            "fn" at 132:12-132:14 (leading: Space)
-1260: Ident           "rt_map_new" at 132:15-132:25 (leading: Space)
-1261: Lt              "<" at 132:25-132:26
-1262: Ident           "K" at 132:26-132:27
-1263: Comma           "," at 132:27-132:28
-1264: Ident           "V" at 132:29-132:30 (leading: Space)
-1265: Gt              ">" at 132:30-132:31
-1266: LParen          "(" at 132:31-132:32
-1267: RParen          ")" at 132:32-132:33
-1268: Arrow           "->" at 132:34-132:36 (leading: Space)
-1269: Ident           "Map" at 132:37-132:40 (leading: Space)
-1270: Lt              "<" at 132:40-132:41
-1271: Ident           "K" at 132:41-132:42
-1272: Comma           "," at 132:42-132:43
-1273: Ident           "V" at 132:44-132:45 (leading: Space)
-1274: Gt              ">" at 132:45-132:46
-1275: Semicolon       ";" at 132:46-132:47
-1276: At              "@" at 133:1-133:2 (leading: Newline)
-1277: Ident           "intrinsic" at 133:2-133:11
-1278: KwFn            "fn" at 133:12-133:14 (leading: Space)
-1279: Ident           "rt_map_len" at 133:15-133:25 (leading: Space)
-1280: Lt              "<" at 133:25-133:26
-1281: Ident           "K" at 133:26-133:27
-1282: Comma           "," at 133:27-133:28
-1283: Ident           "V" at 133:29-133:30 (leading: Space)
-1284: Gt              ">" at 133:30-133:31
-1285: LParen          "(" at 133:31-133:32
-1286: Ident           "m" at 133:32-133:33
-1287: Colon           ":" at 133:33-133:34
-1288: Amp             "&" at 133:35-133:36 (leading: Space)
-1289: Ident           "Map" at 133:36-133:39
-1290: Lt              "<" at 133:39-133:40
-1291: Ident           "K" at 133:40-133:41
-1292: Comma           "," at 133:41-133:42
-1293: Ident           "V" at 133:43-133:44 (leading: Space)
-1294: Gt              ">" at 133:44-133:45
-1295: RParen          ")" at 133:45-133:46
-1296: Arrow           "->" at 133:47-133:49 (leading: Space)
-1297: Ident           "uint" at 133:50-133:54 (leading: Space)
-1298: Semicolon       ";" at 133:54-133:55
-1299: At              "@" at 134:1-134:2 (leading: Newline)
-1300: Ident           "intrinsic" at 134:2-134:11
-1301: KwFn            "fn" at 134:12-134:14 (leading: Space)
-1302: Ident           "rt_map_contains" at 134:15-134:30 (leading: Space)
-1303: Lt              "<" at 134:30-134:31
-1304: Ident           "K" at 134:31-134:32
-1305: Comma           "," at 134:32-134:33
-1306: Ident           "V" at 134:34-134:35 (leading: Space)
-1307: Gt              ">" at 134:35-134:36
-1308: LParen          "(" at 134:36-134:37
-1309: Ident           "m" at 134:37-134:38
-1310: Colon           ":" at 134:38-134:39
-1311: Amp             "&" at 134:40-134:41 (leading: Space)
-1312: Ident           "Map" at 134:41-134:44
-1313: Lt              "<" at 134:44-134:45
-1314: Ident           "K" at 134:45-134:46
-1315: Comma           "," at 134:46-134:47
-1316: Ident           "V" at 134:48-134:49 (leading: Space)
-1317: Gt              ">" at 134:49-134:50
-1318: Comma           "," at 134:50-134:51
-1319: Ident           "key" at 134:52-134:55 (leading: Space)
-1320: Colon           ":" at 134:55-134:56
-1321: Amp             "&" at 134:57-134:58 (leading: Space)
-1322: Ident           "K" at 134:58-134:59
-1323: RParen          ")" at 134:59-134:60
-1324: Arrow           "->" at 134:61-134:63 (leading: Space)
-1325: Ident           "bool" at 134:64-134:68 (leading: Space)
-1326: Semicolon       ";" at 134:68-134:69
-1327: At              "@" at 135:1-135:2 (leading: Newline)
-1328: Ident           "intrinsic" at 135:2-135:11
-1329: KwFn            "fn" at 135:12-135:14 (leading: Space)
-1330: Ident           "rt_map_get_ref" at 135:15-135:29 (leading: Space)
-1331: Lt              "<" at 135:29-135:30
-1332: Ident           "K" at 135:30-135:31
-1333: Comma           "," at 135:31-135:32
-1334: Ident           "V" at 135:33-135:34 (leading: Space)
-1335: Gt              ">" at 135:34-135:35
-1336: LParen          "(" at 135:35-135:36
-1337: Ident           "m" at 135:36-135:37
-1338: Colon           ":" at 135:37-135:38
-1339: Amp             "&" at 135:39-135:40 (leading: Space)
-1340: Ident           "Map" at 135:40-135:43
-1341: Lt              "<" at 135:43-135:44
-1342: Ident           "K" at 135:44-135:45
-1343: Comma           "," at 135:45-135:46
-1344: Ident           "V" at 135:47-135:48 (leading: Space)
-1345: Gt              ">" at 135:48-135:49
-1346: Comma           "," at 135:49-135:50
-1347: Ident           "key" at 135:51-135:54 (leading: Space)
-1348: Colon           ":" at 135:54-135:55
-1349: Amp             "&" at 135:56-135:57 (leading: Space)
-1350: Ident           "K" at 135:57-135:58
-1351: RParen          ")" at 135:58-135:59
-1352: Arrow           "->" at 135:60-135:62 (leading: Space)
-1353: Ident           "Option" at 135:63-135:69 (leading: Space)
-1354: Lt              "<" at 135:69-135:70
-1355: Amp             "&" at 135:70-135:71
-1356: Ident           "V" at 135:71-135:72
-1357: Gt              ">" at 135:72-135:73
-1358: Semicolon       ";" at 135:73-135:74
-1359: At              "@" at 136:1-136:2 (leading: Newline)
-1360: Ident           "intrinsic" at 136:2-136:11
-1361: KwFn            "fn" at 136:12-136:14 (leading: Space)
-1362: Ident           "rt_map_get_mut" at 136:15-136:29 (leading: Space)
-1363: Lt              "<" at 136:29-136:30
-1364: Ident           "K" at 136:30-136:31
-1365: Comma           "," at 136:31-136:32
-1366: Ident           "V" at 136:33-136:34 (leading: Space)
-1367: Gt              ">" at 136:34-136:35
-1368: LParen          "(" at 136:35-136:36
-1369: Ident           "m" at 136:36-136:37
-1370: Colon           ":" at 136:37-136:38
-1371: Amp             "&" at 136:39-136:40 (leading: Space)
-1372: KwMut           "mut" at 136:40-136:43
-1373: Ident           "Map" at 136:44-136:47 (leading: Space)
-1374: Lt              "<" at 136:47-136:48
-1375: Ident           "K" at 136:48-136:49
-1376: Comma           "," at 136:49-136:50
-1377: Ident           "V" at 136:51-136:52 (leading: Space)
-1378: Gt              ">" at 136:52-136:53
-1379: Comma           "," at 136:53-136:54
-1380: Ident           "key" at 136:55-136:58 (leading: Space)
-1381: Colon           ":" at 136:58-136:59
-1382: Amp             "&" at 136:60-136:61 (leading: Space)
-1383: Ident           "K" at 136:61-136:62
-1384: RParen          ")" at 136:62-136:63
-1385: Arrow           "->" at 136:64-136:66 (leading: Space)
-1386: Ident           "Option" at 136:67-136:73 (leading: Space)
-1387: Lt              "<" at 136:73-136:74
-1388: Amp             "&" at 136:74-136:75
-1389: KwMut           "mut" at 136:75-136:78
-1390: Ident           "V" at 136:79-136:80 (leading: Space)
-1391: Gt              ">" at 136:80-136:81
-1392: Semicolon       ";" at 136:81-136:82
-1393: At              "@" at 137:1-137:2 (leading: Newline)
-1394: Ident           "intrinsic" at 137:2-137:11
-1395: KwFn            "fn" at 137:12-137:14 (leading: Space)
-1396: Ident           "rt_map_insert" at 137:15-137:28 (leading: Space)
-1397: Lt              "<" at 137:28-137:29
-1398: Ident           "K" at 137:29-137:30
-1399: Comma           "," at 137:30-137:31
-1400: Ident           "V" at 137:32-137:33 (leading: Space)
-1401: Gt              ">" at 137:33-137:34
-1402: LParen          "(" at 137:34-137:35
-1403: Ident           "m" at 137:35-137:36
-1404: Colon           ":" at 137:36-137:37
-1405: Amp             "&" at 137:38-137:39 (leading: Space)
-1406: KwMut           "mut" at 137:39-137:42
-1407: Ident           "Map" at 137:43-137:46 (leading: Space)
-1408: Lt              "<" at 137:46-137:47
-1409: Ident           "K" at 137:47-137:48
-1410: Comma           "," at 137:48-137:49
-1411: Ident           "V" at 137:50-137:51 (leading: Space)
-1412: Gt              ">" at 137:51-137:52
-1413: Comma           "," at 137:52-137:53
-1414: Ident           "key" at 137:54-137:57 (leading: Space)
-1415: Colon           ":" at 137:57-137:58
-1416: Ident           "K" at 137:59-137:60 (leading: Space)
-1417: Comma           "," at 137:60-137:61
-1418: Ident           "value" at 137:62-137:67 (leading: Space)
-1419: Colon           ":" at 137:67-137:68
-1420: Ident           "V" at 137:69-137:70 (leading: Space)
-1421: RParen          ")" at 137:70-137:71
-1422: Arrow           "->" at 137:72-137:74 (leading: Space)
-1423: Ident           "Option" at 137:75-137:81 (leading: Space)
-1424: Lt              "<" at 137:81-137:82
-1425: Ident           "V" at 137:82-137:83
-1426: Gt              ">" at 137:83-137:84
-1427: Semicolon       ";" at 137:84-137:85
-1428: At              "@" at 138:1-138:2 (leading: Newline)
-1429: Ident           "intrinsic" at 138:2-138:11
-1430: KwFn            "fn" at 138:12-138:14 (leading: Space)
-1431: Ident           "rt_map_remove" at 138:15-138:28 (leading: Space)
-1432: Lt              "<" at 138:28-138:29
-1433: Ident           "K" at 138:29-138:30
-1434: Comma           "," at 138:30-138:31
-1435: Ident           "V" at 138:32-138:33 (leading: Space)
-1436: Gt              ">" at 138:33-138:34
-1437: LParen          "(" at 138:34-138:35
-1438: Ident           "m" at 138:35-138:36
-1439: Colon           ":" at 138:36-138:37
-1440: Amp             "&" at 138:38-138:39 (leading: Space)
-1441: KwMut           "mut" at 138:39-138:42
-1442: Ident           "Map" at 138:43-138:46 (leading: Space)
-1443: Lt              "<" at 138:46-138:47
-1444: Ident           "K" at 138:47-138:48
-1445: Comma           "," at 138:48-138:49
-1446: Ident           "V" at 138:50-138:51 (leading: Space)
-1447: Gt              ">" at 138:51-138:52
-1448: Comma           "," at 138:52-138:53
-1449: Ident           "key" at 138:54-138:57 (leading: Space)
-1450: Colon           ":" at 138:57-138:58
-1451: Amp             "&" at 138:59-138:60 (leading: Space)
-1452: Ident           "K" at 138:60-138:61
-1453: RParen          ")" at 138:61-138:62
-1454: Arrow           "->" at 138:63-138:65 (leading: Space)
-1455: Ident           "Option" at 138:66-138:72 (leading: Space)
-1456: Lt              "<" at 138:72-138:73
-1457: Ident           "V" at 138:73-138:74
-1458: Gt              ">" at 138:74-138:75
-1459: Semicolon       ";" at 138:75-138:76
-1460: At              "@" at 139:1-139:2 (leading: Newline)
-1461: Ident           "intrinsic" at 139:2-139:11
-1462: KwFn            "fn" at 139:12-139:14 (leading: Space)
-1463: Ident           "rt_map_keys" at 139:15-139:26 (leading: Space)
-1464: Lt              "<" at 139:26-139:27
-1465: Ident           "K" at 139:27-139:28
-1466: Comma           "," at 139:28-139:29
-1467: Ident           "V" at 139:30-139:31 (leading: Space)
-1468: Gt              ">" at 139:31-139:32
-1469: LParen          "(" at 139:32-139:33
-1470: Ident           "m" at 139:33-139:34
-1471: Colon           ":" at 139:34-139:35
-1472: Amp             "&" at 139:36-139:37 (leading: Space)
-1473: Ident           "Map" at 139:37-139:40
-1474: Lt              "<" at 139:40-139:41
-1475: Ident           "K" at 139:41-139:42
-1476: Comma           "," at 139:42-139:43
-1477: Ident           "V" at 139:44-139:45 (leading: Space)
-1478: Gt              ">" at 139:45-139:46
-1479: RParen          ")" at 139:46-139:47
-1480: Arrow           "->" at 139:48-139:50 (leading: Space)
-1481: Ident           "K" at 139:51-139:52 (leading: Space)
-1482: LBracket        "[" at 139:52-139:53
-1483: RBracket        "]" at 139:53-139:54
-1484: Semicolon       ";" at 139:54-139:55
-1485: At              "@" at 142:1-142:2 (leading: Newline, LineComment, Newline)
-1486: Ident           "intrinsic" at 142:2-142:11
-1487: KwPub           "pub" at 143:1-143:4 (leading: Newline)
-1488: KwFn            "fn" at 143:5-143:7 (leading: Space)
-1489: Ident           "readline" at 143:8-143:16 (leading: Space)
-1490: LParen          "(" at 143:16-143:17
-1491: RParen          ")" at 143:17-143:18
-1492: Arrow           "->" at 143:19-143:21 (leading: Space)
-1493: Ident           "string" at 143:22-143:28 (leading: Space)
-1494: Semicolon       ";" at 143:28-143:29
-1495: At              "@" at 145:1-145:2 (leading: Newline)
-1496: Ident           "intrinsic" at 145:2-145:11
-1497: KwPub           "pub" at 146:1-146:4 (leading: Newline)
-1498: KwType          "type" at 146:5-146:9 (leading: Space)
-1499: Ident           "Range" at 146:10-146:15 (leading: Space)
-1500: Lt              "<" at 146:15-146:16
-1501: Ident           "T" at 146:16-146:17
-1502: Gt              ">" at 146:17-146:18
-1503: Assign          "=" at 146:19-146:20 (leading: Space)
-1504: LBrace          "{" at 146:21-146:22 (leading: Space)
-1505: Ident           "__state" at 147:5-147:12 (leading: Newline, Space)
-1506: Colon           ":" at 147:12-147:13
-1507: Star            "*" at 147:14-147:15 (leading: Space)
-1508: Ident           "byte" at 147:15-147:19
-1509: Comma           "," at 147:19-147:20
-1510: RBrace          "}" at 148:1-148:2 (leading: Newline)
-1511: Semicolon       ";" at 148:2-148:3
-1512: At              "@" at 151:1-151:2 (leading: Newline, LineComment, Newline)
-1513: Ident           "intrinsic" at 151:2-151:11
-1514: KwPub           "pub" at 151:12-151:15 (leading: Space)
-1515: KwFn            "fn" at 151:16-151:18 (leading: Space)
-1516: Ident           "rt_range_int_new" at 151:19-151:35 (leading: Space)
-1517: LParen          "(" at 151:35-151:36
-1518: Ident           "start" at 151:36-151:41
-1519: Colon           ":" at 151:41-151:42
-1520: Ident           "int" at 151:43-151:46 (leading: Space)
-1521: Comma           "," at 151:46-151:47
-1522: Ident           "end" at 151:48-151:51 (leading: Space)
-1523: Colon           ":" at 151:51-151:52
-1524: Ident           "int" at 151:53-151:56 (leading: Space)
-1525: Comma           "," at 151:56-151:57
-1526: Ident           "inclusive" at 151:58-151:67 (leading: Space)
-1527: Colon           ":" at 151:67-151:68
-1528: Ident           "bool" at 151:69-151:73 (leading: Space)
-1529: RParen          ")" at 151:73-151:74
-1530: Arrow           "->" at 151:75-151:77 (leading: Space)
-1531: Ident           "Range" at 151:78-151:83 (leading: Space)
-1532: Lt              "<" at 151:83-151:84
-1533: Ident           "int" at 151:84-151:87
-1534: Gt              ">" at 151:87-151:88
-1535: Semicolon       ";" at 151:88-151:89
-1536: At              "@" at 152:1-152:2 (leading: Newline)
-1537: Ident           "intrinsic" at 152:2-152:11
-1538: KwPub           "pub" at 152:12-152:15 (leading: Space)
-1539: KwFn            "fn" at 152:16-152:18 (leading: Space)
-1540: Ident           "rt_range_int_from_start" at 152:19-152:42 (leading: Space)
-1541: LParen          "(" at 152:42-152:43
-1542: Ident           "start" at 152:43-152:48
-1543: Colon           ":" at 152:48-152:49
-1544: Ident           "int" at 152:50-152:53 (leading: Space)
-1545: Comma           "," at 152:53-152:54
-1546: Ident           "inclusive" at 152:55-152:64 (leading: Space)
-1547: Colon           ":" at 152:64-152:65
-1548: Ident           "bool" at 152:66-152:70 (leading: Space)
-1549: RParen          ")" at 152:70-152:71
-1550: Arrow           "->" at 152:72-152:74 (leading: Space)
-1551: Ident           "Range" at 152:75-152:80 (leading: Space)
-1552: Lt              "<" at 152:80-152:81
-1553: Ident           "int" at 152:81-152:84
-1554: Gt              ">" at 152:84-152:85
-1555: Semicolon       ";" at 152:85-152:86
-1556: At              "@" at 153:1-153:2 (leading: Newline)
-1557: Ident           "intrinsic" at 153:2-153:11
-1558: KwPub           "pub" at 153:12-153:15 (leading: Space)
-1559: KwFn            "fn" at 153:16-153:18 (leading: Space)
-1560: Ident           "rt_range_int_to_end" at 153:19-153:38 (leading: Space)
-1561: LParen          "(" at 153:38-153:39
-1562: Ident           "end" at 153:39-153:42
-1563: Colon           ":" at 153:42-153:43
-1564: Ident           "int" at 153:44-153:47 (leading: Space)
-1565: Comma           "," at 153:47-153:48
-1566: Ident           "inclusive" at 153:49-153:58 (leading: Space)
-1567: Colon           ":" at 153:58-153:59
-1568: Ident           "bool" at 153:60-153:64 (leading: Space)
-1569: RParen          ")" at 153:64-153:65
-1570: Arrow           "->" at 153:66-153:68 (leading: Space)
-1571: Ident           "Range" at 153:69-153:74 (leading: Space)
-1572: Lt              "<" at 153:74-153:75
-1573: Ident           "int" at 153:75-153:78
-1574: Gt              ">" at 153:78-153:79
-1575: Semicolon       ";" at 153:79-153:80
-1576: At              "@" at 154:1-154:2 (leading: Newline)
-1577: Ident           "intrinsic" at 154:2-154:11
-1578: KwPub           "pub" at 154:12-154:15 (leading: Space)
-1579: KwFn            "fn" at 154:16-154:18 (leading: Space)
-1580: Ident           "rt_range_int_full" at 154:19-154:36 (leading: Space)
-1581: LParen          "(" at 154:36-154:37
-1582: Ident           "inclusive" at 154:37-154:46
-1583: Colon           ":" at 154:46-154:47
-1584: Ident           "bool" at 154:48-154:52 (leading: Space)
-1585: RParen          ")" at 154:52-154:53
-1586: Arrow           "->" at 154:54-154:56 (leading: Space)
-1587: Ident           "Range" at 154:57-154:62 (leading: Space)
-1588: Lt              "<" at 154:62-154:63
-1589: Ident           "int" at 154:63-154:66
-1590: Gt              ">" at 154:66-154:67
-1591: Semicolon       ";" at 154:67-154:68
-1592: KwExtern        "extern" at 156:1-156:7 (leading: Newline)
-1593: Lt              "<" at 156:7-156:8
-1594: Ident           "Range" at 156:8-156:13
-1595: Lt              "<" at 156:13-156:14
-1596: Ident           "T" at 156:14-156:15
-1597: Shr             ">>" at 156:15-156:17
-1598: LBrace          "{" at 156:18-156:19 (leading: Space)
-1599: At              "@" at 157:5-157:6 (leading: Newline, Space)
-1600: Ident           "intrinsic" at 157:6-157:15
-1601: KwPub           "pub" at 157:16-157:19 (leading: Space)
-1602: KwFn            "fn" at 157:20-157:22 (leading: Space)
-1603: Ident           "next" at 157:23-157:27 (leading: Space)
-1604: LParen          "(" at 157:27-157:28
-1605: Ident           "self" at 157:28-157:32
-1606: Colon           ":" at 157:32-157:33
-1607: Amp             "&" at 157:34-157:35 (leading: Space)
-1608: KwMut           "mut" at 157:35-157:38
-1609: Ident           "Range" at 157:39-157:44 (leading: Space)
-1610: Lt              "<" at 157:44-157:45
-1611: Ident           "T" at 157:45-157:46
-1612: Gt              ">" at 157:46-157:47
-1613: RParen          ")" at 157:47-157:48
-1614: Arrow           "->" at 157:49-157:51 (leading: Space)
-1615: Ident           "Option" at 157:52-157:58 (leading: Space)
-1616: Lt              "<" at 157:58-157:59
-1617: Ident           "T" at 157:59-157:60
-1618: Gt              ">" at 157:60-157:61
-1619: Semicolon       ";" at 157:61-157:62
-1620: RBrace          "}" at 158:1-158:2 (leading: Newline)
-1621: KwPub           "pub" at 160:1-160:4 (leading: Newline)
-1622: KwType          "type" at 160:5-160:9 (leading: Space)
-1623: Ident           "HeapStats" at 160:10-160:19 (leading: Space)
-1624: Assign          "=" at 160:20-160:21 (leading: Space)
-1625: LBrace          "{" at 160:22-160:23 (leading: Space)
-1626: Ident           "alloc_count" at 161:5-161:16 (leading: Newline, Space)
-1627: Colon           ":" at 161:16-161:17
-1628: Ident           "uint" at 161:18-161:22 (leading: Space)
-1629: Comma           "," at 161:22-161:23
-1630: Ident           "free_count" at 162:5-162:15 (leading: Newline, Space)
-1631: Colon           ":" at 162:15-162:16
-1632: Ident           "uint" at 162:17-162:21 (leading: Space)
-1633: Comma           "," at 162:21-162:22
-1634: Ident           "live_blocks" at 163:5-163:16 (leading: Newline, Space)
-1635: Colon           ":" at 163:16-163:17
-1636: Ident           "uint" at 163:18-163:22 (leading: Space)
-1637: Comma           "," at 163:22-163:23
-1638: Ident           "live_bytes" at 164:5-164:15 (leading: Newline, Space)
-1639: Colon           ":" at 164:15-164:16
-1640: Ident           "uint" at 164:17-164:21 (leading: Space)
-1641: Comma           "," at 164:21-164:22
-1642: Ident           "rc_increments" at 165:5-165:18 (leading: Newline, Space)
-1643: Colon           ":" at 165:18-165:19
-1644: Ident           "uint" at 165:20-165:24 (leading: Space)
-1645: Comma           "," at 165:24-165:25
-1646: Ident           "rc_decrements" at 166:5-166:18 (leading: Newline, Space)
-1647: Colon           ":" at 166:18-166:19
-1648: Ident           "uint" at 166:20-166:24 (leading: Space)
-1649: Comma           "," at 166:24-166:25
-1650: RBrace          "}" at 167:1-167:2 (leading: Newline)
-1651: Semicolon       ";" at 167:2-167:3
-1652: At              "@" at 173:1-173:2 (leading: Newline, LineComment, Newline, LineComment, Newline, LineComment, Newline, LineComment, Newline)
-1653: Ident           "intrinsic" at 173:2-173:11
-1654: KwPub           "pub" at 173:12-173:15 (leading: Space)
-1655: KwFn            "fn" at 173:16-173:18 (leading: Space)
-1656: Ident           "rt_heap_stats" at 173:19-173:32 (leading: Space)
-1657: LParen          "(" at 173:32-173:33
-1658: RParen          ")" at 173:33-173:34
-1659: Arrow           "->" at 173:35-173:37 (leading: Space)
-1660: Ident           "HeapStats" at 173:38-173:47 (leading: Space)
-1661: Semicolon       ";" at 173:47-173:48
-1662: At              "@" at 175:1-175:2 (leading: Newline, LineComment, Newline)
-1663: Ident           "intrinsic" at 175:2-175:11
-1664: KwPub           "pub" at 175:12-175:15 (leading: Space)
-1665: KwFn            "fn" at 175:16-175:18 (leading: Space)
-1666: Ident           "rt_heap_dump" at 175:19-175:31 (leading: Space)
-1667: LParen          "(" at 175:31-175:32
-1668: RParen          ")" at 175:32-175:33
-1669: Arrow           "->" at 175:34-175:36 (leading: Space)
-1670: Ident           "string" at 175:37-175:43 (leading: Space)
-1671: Semicolon       ";" at 175:43-175:44
-1672: At              "@" at 177:1-177:2 (leading: Newline, LineComment, Newline)
-1673: Ident           "intrinsic" at 177:2-177:11
-1674: KwPub           "pub" at 177:12-177:15 (leading: Space)
-1675: KwFn            "fn" at 177:16-177:18 (leading: Space)
-1676: Ident           "rt_worker_count" at 177:19-177:34 (leading: Space)
-1677: LParen          "(" at 177:34-177:35
-1678: RParen          ")" at 177:35-177:36
-1679: Arrow           "->" at 177:37-177:39 (leading: Space)
-1680: Ident           "uint" at 177:40-177:44 (leading: Space)
-1681: Semicolon       ";" at 177:44-177:45
-1682: KwPub           "pub" at 179:1-179:4 (leading: Newline)
-1683: KwType          "type" at 179:5-179:9 (leading: Space)
-1684: Ident           "Task" at 179:10-179:14 (leading: Space)
-1685: Lt              "<" at 179:14-179:15
-1686: Ident           "T" at 179:15-179:16
-1687: Gt              ">" at 179:16-179:17
-1688: Assign          "=" at 179:18-179:19 (leading: Space)
-1689: LBrace          "{" at 179:20-179:21 (leading: Space)
-1690: Ident           "__opaque" at 180:5-180:13 (leading: Newline, Space)
-1691: Colon           ":" at 180:13-180:14
-1692: Ident           "int" at 180:15-180:18 (leading: Space)
-1693: Comma           "," at 180:18-180:19
-1694: RBrace          "}" at 181:1-181:2 (leading: Newline)
-1695: Semicolon       ";" at 181:2-181:3
-1696: KwPub           "pub" at 183:1-183:4 (leading: Newline)
-1697: KwTag           "tag" at 183:5-183:8 (leading: Space)
-1698: Ident           "Cancelled" at 183:9-183:18 (leading: Space)
-1699: LParen          "(" at 183:18-183:19
-1700: RParen          ")" at 183:19-183:20
-1701: Semicolon       ";" at 183:20-183:21
-1702: KwPub           "pub" at 184:1-184:4 (leading: Newline)
-1703: KwType          "type" at 184:5-184:9 (leading: Space)
-1704: Ident           "TaskResult" at 184:10-184:20 (leading: Space)
-1705: Lt              "<" at 184:20-184:21
-1706: Ident           "T" at 184:21-184:22
-1707: Gt              ">" at 184:22-184:23
-1708: Assign          "=" at 184:24-184:25 (leading: Space)
-1709: Ident           "Success" at 184:26-184:33 (leading: Space)
-1710: LParen          "(" at 184:33-184:34
-1711: Ident           "T" at 184:34-184:35
-1712: RParen          ")" at 184:35-184:36
-1713: Pipe            "|" at 184:37-184:38 (leading: Space)
-1714: Ident           "Cancelled" at 184:39-184:48 (leading: Space)
-1715: Semicolon       ";" at 184:48-184:49
-1716: At              "@" at 186:1-186:2 (leading: Newline)
-1717: Ident           "intrinsic" at 186:2-186:11
-1718: KwFn            "fn" at 186:12-186:14 (leading: Space)
-1719: Ident           "rt_scope_enter" at 186:15-186:29 (leading: Space)
-1720: LParen          "(" at 186:29-186:30
-1721: Ident           "failfast" at 186:30-186:38
-1722: Colon           ":" at 186:38-186:39
-1723: Ident           "bool" at 186:40-186:44 (leading: Space)
-1724: RParen          ")" at 186:44-186:45
-1725: Arrow           "->" at 186:46-186:48 (leading: Space)
-1726: Ident           "uint" at 186:49-186:53 (leading: Space)
-1727: Semicolon       ";" at 186:53-186:54
-1728: At              "@" at 187:1-187:2 (leading: Newline)
-1729: Ident           "intrinsic" at 187:2-187:11
-1730: KwFn            "fn" at 187:12-187:14 (leading: Space)
-1731: Ident           "rt_scope_register_child" at 187:15-187:38 (leading: Space)
-1732: Lt              "<" at 187:38-187:39
-1733: Ident           "T" at 187:39-187:40
-1734: Gt              ">" at 187:40-187:41
-1735: LParen          "(" at 187:41-187:42
-1736: Ident           "scope" at 187:42-187:47
-1737: Colon           ":" at 187:47-187:48
-1738: Ident           "uint" at 187:49-187:53 (leading: Space)
-1739: Comma           "," at 187:53-187:54
-1740: Ident           "child" at 187:55-187:60 (leading: Space)
-1741: Colon           ":" at 187:60-187:61
-1742: Ident           "Task" at 187:62-187:66 (leading: Space)
-1743: Lt              "<" at 187:66-187:67
-1744: Ident           "T" at 187:67-187:68
-1745: Gt              ">" at 187:68-187:69
-1746: RParen          ")" at 187:69-187:70
-1747: Arrow           "->" at 187:71-187:73 (leading: Space)
-1748: NothingLit      "nothing" at 187:74-187:81 (leading: Space)
-1749: Semicolon       ";" at 187:81-187:82
-1750: At              "@" at 188:1-188:2 (leading: Newline)
-1751: Ident           "intrinsic" at 188:2-188:11
-1752: KwFn            "fn" at 188:12-188:14 (leading: Space)
-1753: Ident           "rt_scope_cancel_all" at 188:15-188:34 (leading: Space)
-1754: LParen          "(" at 188:34-188:35
-1755: Ident           "scope" at 188:35-188:40
-1756: Colon           ":" at 188:40-188:41
-1757: Ident           "uint" at 188:42-188:46 (leading: Space)
-1758: RParen          ")" at 188:46-188:47
-1759: Arrow           "->" at 188:48-188:50 (leading: Space)
-1760: NothingLit      "nothing" at 188:51-188:58 (leading: Space)
-1761: Semicolon       ";" at 188:58-188:59
-1762: At              "@" at 189:1-189:2 (leading: Newline)
-1763: Ident           "intrinsic" at 189:2-189:11
-1764: KwFn            "fn" at 189:12-189:14 (leading: Space)
-1765: Ident           "rt_scope_join_all" at 189:15-189:32 (leading: Space)
-1766: LParen          "(" at 189:32-189:33
-1767: Ident           "scope" at 189:33-189:38
-1768: Colon           ":" at 189:38-189:39
-1769: Ident           "uint" at 189:40-189:44 (leading: Space)
-1770: RParen          ")" at 189:44-189:45
-1771: Arrow           "->" at 189:46-189:48 (leading: Space)
-1772: Ident           "bool" at 189:49-189:53 (leading: Space)
-1773: Semicolon       ";" at 189:53-189:54
-1774: At              "@" at 190:1-190:2 (leading: Newline)
-1775: Ident           "intrinsic" at 190:2-190:11
-1776: KwFn            "fn" at 190:12-190:14 (leading: Space)
-1777: Ident           "rt_scope_exit" at 190:15-190:28 (leading: Space)
-1778: LParen          "(" at 190:28-190:29
-1779: Ident           "scope" at 190:29-190:34
-1780: Colon           ":" at 190:34-190:35
-1781: Ident           "uint" at 190:36-190:40 (leading: Space)
-1782: RParen          ")" at 190:40-190:41
-1783: Arrow           "->" at 190:42-190:44 (leading: Space)
-1784: NothingLit      "nothing" at 190:45-190:52 (leading: Space)
-1785: Semicolon       ";" at 190:52-190:53
-1786: KwExtern        "extern" at 192:1-192:7 (leading: Newline)
-1787: Lt              "<" at 192:7-192:8
-1788: Ident           "Task" at 192:8-192:12
-1789: Lt              "<" at 192:12-192:13
-1790: Ident           "T" at 192:13-192:14
-1791: Shr             ">>" at 192:14-192:16
-1792: LBrace          "{" at 192:17-192:18 (leading: Space)
-1793: At              "@" at 193:5-193:6 (leading: Newline, Space)
-1794: Ident           "intrinsic" at 193:6-193:15
-1795: KwPub           "pub" at 193:16-193:19 (leading: Space)
-1796: KwFn            "fn" at 193:20-193:22 (leading: Space)
-1797: Ident           "clone" at 193:23-193:28 (leading: Space)
-1798: LParen          "(" at 193:28-193:29
-1799: Ident           "self" at 193:29-193:33
-1800: Colon           ":" at 193:33-193:34
-1801: Amp             "&" at 193:35-193:36 (leading: Space)
-1802: Ident           "Task" at 193:36-193:40
-1803: Lt              "<" at 193:40-193:41
-1804: Ident           "T" at 193:41-193:42
-1805: Gt              ">" at 193:42-193:43
-1806: RParen          ")" at 193:43-193:44
-1807: Arrow           "->" at 193:45-193:47 (leading: Space)
-1808: Ident           "Task" at 193:48-193:52 (leading: Space)
-1809: Lt              "<" at 193:52-193:53
-1810: Ident           "T" at 193:53-193:54
-1811: Gt              ">" at 193:54-193:55
-1812: Semicolon       ";" at 193:55-193:56
-1813: At              "@" at 194:5-194:6 (leading: Newline, Space)
-1814: Ident           "intrinsic" at 194:6-194:15
-1815: KwPub           "pub" at 194:16-194:19 (leading: Space)
-1816: KwFn            "fn" at 194:20-194:22 (leading: Space)
-1817: Ident           "cancel" at 194:23-194:29 (leading: Space)
-1818: LParen          "(" at 194:29-194:30
-1819: Ident           "self" at 194:30-194:34
-1820: Colon           ":" at 194:34-194:35
-1821: Amp             "&" at 194:36-194:37 (leading: Space)
-1822: Ident           "Task" at 194:37-194:41
-1823: Lt              "<" at 194:41-194:42
-1824: Ident           "T" at 194:42-194:43
-1825: Gt              ">" at 194:43-194:44
-1826: RParen          ")" at 194:44-194:45
-1827: Arrow           "->" at 194:46-194:48 (leading: Space)
-1828: NothingLit      "nothing" at 194:49-194:56 (leading: Space)
-1829: Semicolon       ";" at 194:56-194:57
-1830: At              "@" at 195:5-195:6 (leading: Newline, Space)
-1831: Ident           "intrinsic" at 195:6-195:15
-1832: KwPub           "pub" at 195:16-195:19 (leading: Space)
-1833: KwFn            "fn" at 195:20-195:22 (leading: Space)
-1834: Ident           "await" at 195:23-195:28 (leading: Space)
-1835: LParen          "(" at 195:28-195:29
-1836: Ident           "self" at 195:29-195:33
-1837: Colon           ":" at 195:33-195:34
-1838: KwOwn           "own" at 195:35-195:38 (leading: Space)
-1839: Ident           "Task" at 195:39-195:43 (leading: Space)
-1840: Lt              "<" at 195:43-195:44
-1841: Ident           "T" at 195:44-195:45
-1842: Gt              ">" at 195:45-195:46
-1843: RParen          ")" at 195:46-195:47
-1844: Arrow           "->" at 195:48-195:50 (leading: Space)
-1845: Ident           "TaskResult" at 195:51-195:61 (leading: Space)
-1846: Lt              "<" at 195:61-195:62
-1847: Ident           "T" at 195:62-195:63
-1848: Gt              ">" at 195:63-195:64
-1849: Semicolon       ";" at 195:64-195:65
-1850: RBrace          "}" at 196:1-196:2 (leading: Newline)
-1851: At              "@" at 200:1-200:2 (leading: Newline, LineComment, Newline, LineComment, Newline)
-1852: Ident           "intrinsic" at 200:2-200:11
-1853: KwPub           "pub" at 201:1-201:4 (leading: Newline)
-1854: KwFn            "fn" at 201:5-201:7 (leading: Space)
-1855: Ident           "checkpoint" at 201:8-201:18 (leading: Space)
-1856: LParen          "(" at 201:18-201:19
-1857: RParen          ")" at 201:19-201:20
-1858: Arrow           "->" at 201:21-201:23 (leading: Space)
-1859: Ident           "Task" at 201:24-201:28 (leading: Space)
-1860: Lt              "<" at 201:28-201:29
-1861: NothingLit      "nothing" at 201:29-201:36
-1862: Gt              ">" at 201:36-201:37
-1863: Semicolon       ";" at 201:37-201:38
-1864: At              "@" at 204:1-204:2 (leading: Newline, LineComment, Newline)
-1865: Ident           "intrinsic" at 204:2-204:11
-1866: KwPub           "pub" at 204:12-204:15 (leading: Space)
-1867: KwFn            "fn" at 204:16-204:18 (leading: Space)
-1868: Ident           "sleep" at 204:19-204:24 (leading: Space)
-1869: LParen          "(" at 204:24-204:25
-1870: Ident           "ms" at 204:25-204:27
-1871: Colon           ":" at 204:27-204:28
-1872: Ident           "uint" at 204:29-204:33 (leading: Space)
-1873: RParen          ")" at 204:33-204:34
-1874: Arrow           "->" at 204:35-204:37 (leading: Space)
-1875: Ident           "Task" at 204:38-204:42 (leading: Space)
-1876: Lt              "<" at 204:42-204:43
-1877: NothingLit      "nothing" at 204:43-204:50
-1878: Gt              ">" at 204:50-204:51
-1879: Semicolon       ";" at 204:51-204:52
-1880: At              "@" at 208:1-208:2 (leading: Newline, LineComment, Newline, LineComment, Newline)
-1881: Ident           "intrinsic" at 208:2-208:11
-1882: KwPub           "pub" at 208:12-208:15 (leading: Space)
-1883: KwFn            "fn" at 208:16-208:18 (leading: Space)
-1884: Ident           "timeout" at 208:19-208:26 (leading: Space)
-1885: Lt              "<" at 208:26-208:27
-1886: Ident           "T" at 208:27-208:28
-1887: Gt              ">" at 208:28-208:29
-1888: LParen          "(" at 208:29-208:30
-1889: Ident           "t" at 208:30-208:31
-1890: Colon           ":" at 208:31-208:32
-1891: Ident           "Task" at 208:33-208:37 (leading: Space)
-1892: Lt              "<" at 208:37-208:38
-1893: Ident           "T" at 208:38-208:39
-1894: Gt              ">" at 208:39-208:40
-1895: Comma           "," at 208:40-208:41
-1896: Ident           "ms" at 208:42-208:44 (leading: Space)
-1897: Colon           ":" at 208:44-208:45
-1898: Ident           "uint" at 208:46-208:50 (leading: Space)
-1899: RParen          ")" at 208:50-208:51
-1900: Arrow           "->" at 208:52-208:54 (leading: Space)
-1901: Ident           "TaskResult" at 208:55-208:65 (leading: Space)
-1902: Lt              "<" at 208:65-208:66
-1903: Ident           "T" at 208:66-208:67
-1904: Gt              ">" at 208:67-208:68
-1905: Semicolon       ";" at 208:68-208:69
-1906: At              "@" at 211:1-211:2 (leading: Newline, LineComment, Newline)
-1907: Ident           "copy" at 211:2-211:6
-1908: At              "@" at 212:1-212:2 (leading: Newline)
-1909: Ident           "intrinsic" at 212:2-212:11
-1910: KwPub           "pub" at 213:1-213:4 (leading: Newline)
-1911: KwType          "type" at 213:5-213:9 (leading: Space)
-1912: Ident           "Channel" at 213:10-213:17 (leading: Space)
-1913: Lt              "<" at 213:17-213:18
-1914: Ident           "T" at 213:18-213:19
-1915: Gt              ">" at 213:19-213:20
-1916: Assign          "=" at 213:21-213:22 (leading: Space)
-1917: LBrace          "{" at 213:23-213:24 (leading: Space)
-1918: Ident           "__opaque" at 214:5-214:13 (leading: Newline, Space)
-1919: Colon           ":" at 214:13-214:14
-1920: Star            "*" at 214:15-214:16 (leading: Space)
-1921: Ident           "byte" at 214:16-214:20
-1922: Comma           "," at 214:20-214:21
-1923: RBrace          "}" at 215:1-215:2 (leading: Newline)
-1924: Semicolon       ";" at 215:2-215:3
-1925: KwExtern        "extern" at 217:1-217:7 (leading: Newline)
-1926: Lt              "<" at 217:7-217:8
-1927: Ident           "Channel" at 217:8-217:15
-1928: Lt              "<" at 217:15-217:16
-1929: Ident           "T" at 217:16-217:17
-1930: Shr             ">>" at 217:17-217:19
-1931: LBrace          "{" at 217:20-217:21 (leading: Space)
-1932: At              "@" at 219:5-219:6 (leading: Newline, Space, LineComment, Newline, Space)
-1933: Ident           "intrinsic" at 219:6-219:15
-1934: KwPub           "pub" at 219:16-219:19 (leading: Space)
-1935: KwFn            "fn" at 219:20-219:22 (leading: Space)
-1936: Ident           "new" at 219:23-219:26 (leading: Space)
-1937: LParen          "(" at 219:26-219:27
-1938: Ident           "capacity" at 219:27-219:35
-1939: Colon           ":" at 219:35-219:36
-1940: Ident           "uint" at 219:37-219:41 (leading: Space)
-1941: RParen          ")" at 219:41-219:42
-1942: Arrow           "->" at 219:43-219:45 (leading: Space)
-1943: KwOwn           "own" at 219:46-219:49 (leading: Space)
-1944: Ident           "Channel" at 219:50-219:57 (leading: Space)
-1945: Lt              "<" at 219:57-219:58
-1946: Ident           "T" at 219:58-219:59
-1947: Gt              ">" at 219:59-219:60
-1948: Semicolon       ";" at 219:60-219:61
-1949: At              "@" at 221:5-221:6 (leading: Newline, Space, LineComment, Newline, Space)
-1950: Ident           "intrinsic" at 221:6-221:15
-1951: KwPub           "pub" at 221:16-221:19 (leading: Space)
-1952: KwFn            "fn" at 221:20-221:22 (leading: Space)
-1953: Ident           "send" at 221:23-221:27 (leading: Space)
-1954: LParen          "(" at 221:27-221:28
-1955: Ident           "self" at 221:28-221:32
-1956: Colon           ":" at 221:32-221:33
-1957: Amp             "&" at 221:34-221:35 (leading: Space)
-1958: Ident           "Channel" at 221:35-221:42
-1959: Lt              "<" at 221:42-221:43
-1960: Ident           "T" at 221:43-221:44
-1961: Gt              ">" at 221:44-221:45
-1962: Comma           "," at 221:45-221:46
-1963: Ident           "value" at 221:47-221:52 (leading: Space)
-1964: Colon           ":" at 221:52-221:53
-1965: KwOwn           "own" at 221:54-221:57 (leading: Space)
-1966: Ident           "T" at 221:58-221:59 (leading: Space)
-1967: RParen          ")" at 221:59-221:60
-1968: Arrow           "->" at 221:61-221:63 (leading: Space)
-1969: NothingLit      "nothing" at 221:64-221:71 (leading: Space)
-1970: Semicolon       ";" at 221:71-221:72
-1971: At              "@" at 223:5-223:6 (leading: Newline, Space, LineComment, Newline, Space)
-1972: Ident           "intrinsic" at 223:6-223:15
-1973: KwPub           "pub" at 223:16-223:19 (leading: Space)
-1974: KwFn            "fn" at 223:20-223:22 (leading: Space)
-1975: Ident           "recv" at 223:23-223:27 (leading: Space)
-1976: LParen          "(" at 223:27-223:28
-1977: Ident           "self" at 223:28-223:32
-1978: Colon           ":" at 223:32-223:33
-1979: Amp             "&" at 223:34-223:35 (leading: Space)
-1980: Ident           "Channel" at 223:35-223:42
-1981: Lt              "<" at 223:42-223:43
-1982: Ident           "T" at 223:43-223:44
-1983: Gt              ">" at 223:44-223:45
-1984: RParen          ")" at 223:45-223:46
-1985: Arrow           "->" at 223:47-223:49 (leading: Space)
-1986: Ident           "Option" at 223:50-223:56 (leading: Space)
-1987: Lt              "<" at 223:56-223:57
-1988: Ident           "T" at 223:57-223:58
-1989: Gt              ">" at 223:58-223:59
-1990: Semicolon       ";" at 223:59-223:60
-1991: At              "@" at 225:5-225:6 (leading: Newline, Space, LineComment, Newline, Space)
-1992: Ident           "intrinsic" at 225:6-225:15
-1993: KwPub           "pub" at 225:16-225:19 (leading: Space)
-1994: KwFn            "fn" at 225:20-225:22 (leading: Space)
-1995: Ident           "try_send" at 225:23-225:31 (leading: Space)
-1996: LParen          "(" at 225:31-225:32
-1997: Ident           "self" at 225:32-225:36
-1998: Colon           ":" at 225:36-225:37
-1999: Amp             "&" at 225:38-225:39 (leading: Space)
-2000: Ident           "Channel" at 225:39-225:46
-2001: Lt              "<" at 225:46-225:47
-2002: Ident           "T" at 225:47-225:48
-2003: Gt              ">" at 225:48-225:49
-2004: Comma           "," at 225:49-225:50
-2005: Ident           "value" at 225:51-225:56 (leading: Space)
-2006: Colon           ":" at 225:56-225:57
-2007: KwOwn           "own" at 225:58-225:61 (leading: Space)
-2008: Ident           "T" at 225:62-225:63 (leading: Space)
-2009: RParen          ")" at 225:63-225:64
-2010: Arrow           "->" at 225:65-225:67 (leading: Space)
-2011: Ident           "bool" at 225:68-225:72 (leading: Space)
-2012: Semicolon       ";" at 225:72-225:73
-2013: At              "@" at 227:5-227:6 (leading: Newline, Space, LineComment, Newline, Space)
-2014: Ident           "intrinsic" at 227:6-227:15
-2015: KwPub           "pub" at 227:16-227:19 (leading: Space)
-2016: KwFn            "fn" at 227:20-227:22 (leading: Space)
-2017: Ident           "try_recv" at 227:23-227:31 (leading: Space)
-2018: LParen          "(" at 227:31-227:32
-2019: Ident           "self" at 227:32-227:36
-2020: Colon           ":" at 227:36-227:37
-2021: Amp             "&" at 227:38-227:39 (leading: Space)
-2022: Ident           "Channel" at 227:39-227:46
-2023: Lt              "<" at 227:46-227:47
-2024: Ident           "T" at 227:47-227:48
-2025: Gt              ">" at 227:48-227:49
-2026: RParen          ")" at 227:49-227:50
-2027: Arrow           "->" at 227:51-227:53 (leading: Space)
-2028: Ident           "Option" at 227:54-227:60 (leading: Space)
-2029: Lt              "<" at 227:60-227:61
-2030: Ident           "T" at 227:61-227:62
-2031: Gt              ">" at 227:62-227:63
-2032: Semicolon       ";" at 227:63-227:64
-2033: At              "@" at 229:5-229:6 (leading: Newline, Space, LineComment, Newline, Space)
-2034: Ident           "intrinsic" at 229:6-229:15
-2035: KwPub           "pub" at 229:16-229:19 (leading: Space)
-2036: KwFn            "fn" at 229:20-229:22 (leading: Space)
-2037: Ident           "close" at 229:23-229:28 (leading: Space)
-2038: LParen          "(" at 229:28-229:29
-2039: Ident           "self" at 229:29-229:33
-2040: Colon           ":" at 229:33-229:34
-2041: Amp             "&" at 229:35-229:36 (leading: Space)
-2042: Ident           "Channel" at 229:36-229:43
-2043: Lt              "<" at 229:43-229:44
-2044: Ident           "T" at 229:44-229:45
-2045: Gt              ">" at 229:45-229:46
-2046: RParen          ")" at 229:46-229:47
-2047: Arrow           "->" at 229:48-229:50 (leading: Space)
-2048: NothingLit      "nothing" at 229:51-229:58 (leading: Space)
-2049: Semicolon       ";" at 229:58-229:59
-2050: RBrace          "}" at 230:1-230:2 (leading: Newline)
-2051: At              "@" at 232:1-232:2 (leading: Newline)
-2052: Ident           "intrinsic" at 232:2-232:11
-2053: KwFn            "fn" at 233:1-233:3 (leading: Newline)
-2054: Ident           "make_channel" at 233:4-233:16 (leading: Space)
-2055: Lt              "<" at 233:16-233:17
-2056: Ident           "T" at 233:17-233:18
-2057: Gt              ">" at 233:18-233:19
-2058: LParen          "(" at 233:19-233:20
-2059: Ident           "capacity" at 233:20-233:28
-2060: Colon           ":" at 233:28-233:29
-2061: Ident           "uint" at 233:30-233:34 (leading: Space)
-2062: RParen          ")" at 233:34-233:35
-2063: Arrow           "->" at 233:36-233:38 (leading: Space)
-2064: KwOwn           "own" at 233:39-233:42 (leading: Space)
-2065: Ident           "Channel" at 233:43-233:50 (leading: Space)
-2066: Lt              "<" at 233:50-233:51
-2067: Ident           "T" at 233:51-233:52
-2068: Gt              ">" at 233:52-233:53
-2069: Semicolon       ";" at 233:53-233:54
-2070: KwPub           "pub" at 235:1-235:4 (leading: Newline)
-2071: KwContract      "contract" at 235:5-235:13 (leading: Space)
-2072: Ident           "Bounded" at 235:14-235:21 (leading: Space)
-2073: Lt              "<" at 235:21-235:22
-2074: Ident           "T" at 235:22-235:23
-2075: Gt              ">" at 235:23-235:24
-2076: LBrace          "{" at 235:25-235:26 (leading: Space)
-2077: KwFn            "fn" at 236:5-236:7 (leading: Newline, Space)
-2078: Ident           "__min_value" at 236:8-236:19 (leading: Space)
-2079: LParen          "(" at 236:19-236:20
-2080: RParen          ")" at 236:20-236:21
-2081: Arrow           "->" at 236:22-236:24 (leading: Space)
-2082: Ident           "T" at 236:25-236:26 (leading: Space)
-2083: Semicolon       ";" at 236:26-236:27
-2084: KwFn            "fn" at 237:5-237:7 (leading: Newline, Space)
-2085: Ident           "__max_value" at 237:8-237:19 (leading: Space)
-2086: LParen          "(" at 237:19-237:20
-2087: RParen          ")" at 237:20-237:21
-2088: Arrow           "->" at 237:22-237:24 (leading: Space)
-2089: Ident           "T" at 237:25-237:26 (leading: Space)
-2090: Semicolon       ";" at 237:26-237:27
-2091: RBrace          "}" at 238:1-238:2 (leading: Newline)
-2092: KwPub           "pub" at 240:1-240:4 (leading: Newline)
-2093: KwContract      "contract" at 240:5-240:13 (leading: Space)
-2094: Ident           "HasLength" at 240:14-240:23 (leading: Space)
-2095: Lt              "<" at 240:23-240:24
-2096: Ident           "T" at 240:24-240:25
-2097: Gt              ">" at 240:25-240:26
-2098: LBrace          "{" at 240:27-240:28 (leading: Space)
-2099: KwFn            "fn" at 241:5-241:7 (leading: Newline, Space)
-2100: Ident           "__len" at 241:8-241:13 (leading: Space)
-2101: LParen          "(" at 241:13-241:14
-2102: Ident           "self" at 241:14-241:18
-2103: Colon           ":" at 241:18-241:19
-2104: Amp             "&" at 241:20-241:21 (leading: Space)
-2105: Ident           "T" at 241:21-241:22
-2106: RParen          ")" at 241:22-241:23
-2107: Arrow           "->" at 241:24-241:26 (leading: Space)
-2108: Ident           "uint" at 241:27-241:31 (leading: Space)
-2109: Semicolon       ";" at 241:31-241:32
-2110: RBrace          "}" at 242:1-242:2 (leading: Newline)
-2111: KwPub           "pub" at 244:1-244:4 (leading: Newline)
-2112: KwContract      "contract" at 244:5-244:13 (leading: Space)
-2113: Ident           "Printable" at 244:14-244:23 (leading: Space)
-2114: Lt              "<" at 244:23-244:24
-2115: Ident           "T" at 244:24-244:25
-2116: Gt              ">" at 244:25-244:26
-2117: LBrace          "{" at 244:27-244:28 (leading: Space)
-2118: KwFn            "fn" at 245:5-245:7 (leading: Newline, Space)
-2119: Ident           "__to" at 245:8-245:12 (leading: Space)
-2120: LParen          "(" at 245:12-245:13
-2121: Ident           "self" at 245:13-245:17
-2122: Colon           ":" at 245:17-245:18
-2123: Amp             "&" at 245:19-245:20 (leading: Space)
-2124: Ident           "T" at 245:20-245:21
-2125: Comma           "," at 245:21-245:22
-2126: Ident           "target" at 245:23-245:29 (leading: Space)
-2127: Colon           ":" at 245:29-245:30
-2128: Ident           "string" at 245:31-245:37 (leading: Space)
-2129: RParen          ")" at 245:37-245:38
-2130: Arrow           "->" at 245:39-245:41 (leading: Space)
-2131: Ident           "string" at 245:42-245:48 (leading: Space)
-2132: Semicolon       ";" at 245:48-245:49
-2133: RBrace          "}" at 246:1-246:2 (leading: Newline)
-2134: KwPub           "pub" at 248:1-248:4 (leading: Newline)
-2135: KwFn            "fn" at 248:5-248:7 (leading: Space)
-2136: Ident           "max_value" at 248:8-248:17 (leading: Space)
-2137: Lt              "<" at 248:17-248:18
-2138: Ident           "T" at 248:18-248:19
-2139: Colon           ":" at 248:19-248:20
-2140: Ident           "Bounded" at 248:21-248:28 (leading: Space)
-2141: Lt              "<" at 248:28-248:29
-2142: Ident           "T" at 248:29-248:30
-2143: Shr             ">>" at 248:30-248:32
-2144: LParen          "(" at 248:32-248:33
-2145: RParen          ")" at 248:33-248:34
-2146: Arrow           "->" at 248:35-248:37 (leading: Space)
-2147: Ident           "T" at 248:38-248:39 (leading: Space)
-2148: LBrace          "{" at 248:40-248:41 (leading: Space)
-2149: KwReturn        "return" at 249:5-249:11 (leading: Newline, Space)
-2150: Ident           "T" at 249:12-249:13 (leading: Space)
-2151: Dot             "." at 249:13-249:14
-2152: Ident           "__max_value" at 249:14-249:25
-2153: LParen          "(" at 249:25-249:26
-2154: RParen          ")" at 249:26-249:27
-2155: Semicolon       ";" at 249:27-249:28
-2156: RBrace          "}" at 250:1-250:2 (leading: Newline)
-2157: KwPub           "pub" at 252:1-252:4 (leading: Newline)
-2158: KwFn            "fn" at 252:5-252:7 (leading: Space)
-2159: Ident           "min_value" at 252:8-252:17 (leading: Space)
-2160: Lt              "<" at 252:17-252:18
-2161: Ident           "T" at 252:18-252:19
-2162: Colon           ":" at 252:19-252:20
-2163: Ident           "Bounded" at 252:21-252:28 (leading: Space)
-2164: Lt              "<" at 252:28-252:29
-2165: Ident           "T" at 252:29-252:30
-2166: Shr             ">>" at 252:30-252:32
-2167: LParen          "(" at 252:32-252:33
-2168: RParen          ")" at 252:33-252:34
-2169: Arrow           "->" at 252:35-252:37 (leading: Space)
-2170: Ident           "T" at 252:38-252:39 (leading: Space)
-2171: LBrace          "{" at 252:40-252:41 (leading: Space)
-2172: KwReturn        "return" at 253:5-253:11 (leading: Newline, Space)
-2173: Ident           "T" at 253:12-253:13 (leading: Space)
-2174: Dot             "." at 253:13-253:14
-2175: Ident           "__min_value" at 253:14-253:25
-2176: LParen          "(" at 253:25-253:26
-2177: RParen          ")" at 253:26-253:27
-2178: Semicolon       ";" at 253:27-253:28
-2179: RBrace          "}" at 254:1-254:2 (leading: Newline)
-2180: KwExtern        "extern" at 256:1-256:7 (leading: Newline)
-2181: Lt              "<" at 256:7-256:8
-2182: Ident           "int" at 256:8-256:11
-2183: Gt              ">" at 256:11-256:12
-2184: LBrace          "{" at 256:13-256:14 (leading: Space)
-2185: At              "@" at 257:5-257:6 (leading: Newline, Space)
-2186: Ident           "intrinsic" at 257:6-257:15
-2187: KwFn            "fn" at 257:16-257:18 (leading: Space)
-2188: Ident           "__add" at 257:19-257:24 (leading: Space)
-2189: LParen          "(" at 257:24-257:25
-2190: Ident           "self" at 257:25-257:29
-2191: Colon           ":" at 257:29-257:30
-2192: Ident           "int" at 257:31-257:34 (leading: Space)
-2193: Comma           "," at 257:34-257:35
-2194: Ident           "other" at 257:36-257:41 (leading: Space)
-2195: Colon           ":" at 257:41-257:42
-2196: Ident           "int" at 257:43-257:46 (leading: Space)
-2197: RParen          ")" at 257:46-257:47
-2198: Arrow           "->" at 257:48-257:50 (leading: Space)
-2199: Ident           "int" at 257:51-257:54 (leading: Space)
-2200: Semicolon       ";" at 257:54-257:55
-2201: At              "@" at 258:5-258:6 (leading: Newline, Space)
-2202: Ident           "intrinsic" at 258:6-258:15
-2203: KwFn            "fn" at 258:16-258:18 (leading: Space)
-2204: Ident           "__sub" at 258:19-258:24 (leading: Space)
-2205: LParen          "(" at 258:24-258:25
-2206: Ident           "self" at 258:25-258:29
-2207: Colon           ":" at 258:29-258:30
-2208: Ident           "int" at 258:31-258:34 (leading: Space)
-2209: Comma           "," at 258:34-258:35
-2210: Ident           "other" at 258:36-258:41 (leading: Space)
-2211: Colon           ":" at 258:41-258:42
-2212: Ident           "int" at 258:43-258:46 (leading: Space)
-2213: RParen          ")" at 258:46-258:47
-2214: Arrow           "->" at 258:48-258:50 (leading: Space)
-2215: Ident           "int" at 258:51-258:54 (leading: Space)
-2216: Semicolon       ";" at 258:54-258:55
-2217: At              "@" at 259:5-259:6 (leading: Newline, Space)
-2218: Ident           "intrinsic" at 259:6-259:15
-2219: KwFn            "fn" at 259:16-259:18 (leading: Space)
-2220: Ident           "__mul" at 259:19-259:24 (leading: Space)
-2221: LParen          "(" at 259:24-259:25
-2222: Ident           "self" at 259:25-259:29
-2223: Colon           ":" at 259:29-259:30
-2224: Ident           "int" at 259:31-259:34 (leading: Space)
-2225: Comma           "," at 259:34-259:35
-2226: Ident           "other" at 259:36-259:41 (leading: Space)
-2227: Colon           ":" at 259:41-259:42
-2228: Ident           "int" at 259:43-259:46 (leading: Space)
-2229: RParen          ")" at 259:46-259:47
-2230: Arrow           "->" at 259:48-259:50 (leading: Space)
-2231: Ident           "int" at 259:51-259:54 (leading: Space)
-2232: Semicolon       ";" at 259:54-259:55
-2233: At              "@" at 260:5-260:6 (leading: Newline, Space)
-2234: Ident           "intrinsic" at 260:6-260:15
-2235: KwFn            "fn" at 260:16-260:18 (leading: Space)
-2236: Ident           "__div" at 260:19-260:24 (leading: Space)
-2237: LParen          "(" at 260:24-260:25
-2238: Ident           "self" at 260:25-260:29
-2239: Colon           ":" at 260:29-260:30
-2240: Ident           "int" at 260:31-260:34 (leading: Space)
-2241: Comma           "," at 260:34-260:35
-2242: Ident           "other" at 260:36-260:41 (leading: Space)
-2243: Colon           ":" at 260:41-260:42
-2244: Ident           "int" at 260:43-260:46 (leading: Space)
-2245: RParen          ")" at 260:46-260:47
-2246: Arrow           "->" at 260:48-260:50 (leading: Space)
-2247: Ident           "int" at 260:51-260:54 (leading: Space)
-2248: Semicolon       ";" at 260:54-260:55
-2249: At              "@" at 261:5-261:6 (leading: Newline, Space)
-2250: Ident           "intrinsic" at 261:6-261:15
-2251: KwFn            "fn" at 261:16-261:18 (leading: Space)
-2252: Ident           "__mod" at 261:19-261:24 (leading: Space)
-2253: LParen          "(" at 261:24-261:25
-2254: Ident           "self" at 261:25-261:29
-2255: Colon           ":" at 261:29-261:30
-2256: Ident           "int" at 261:31-261:34 (leading: Space)
-2257: Comma           "," at 261:34-261:35
-2258: Ident           "other" at 261:36-261:41 (leading: Space)
-2259: Colon           ":" at 261:41-261:42
-2260: Ident           "int" at 261:43-261:46 (leading: Space)
-2261: RParen          ")" at 261:46-261:47
-2262: Arrow           "->" at 261:48-261:50 (leading: Space)
-2263: Ident           "int" at 261:51-261:54 (leading: Space)
-2264: Semicolon       ";" at 261:54-261:55
-2265: At              "@" at 262:5-262:6 (leading: Newline, Space)
-2266: Ident           "intrinsic" at 262:6-262:15
-2267: KwFn            "fn" at 262:16-262:18 (leading: Space)
-2268: Ident           "__bit_and" at 262:19-262:28 (leading: Space)
-2269: LParen          "(" at 262:28-262:29
-2270: Ident           "self" at 262:29-262:33
-2271: Colon           ":" at 262:33-262:34
-2272: Ident           "int" at 262:35-262:38 (leading: Space)
-2273: Comma           "," at 262:38-262:39
-2274: Ident           "other" at 262:40-262:45 (leading: Space)
-2275: Colon           ":" at 262:45-262:46
-2276: Ident           "int" at 262:47-262:50 (leading: Space)
-2277: RParen          ")" at 262:50-262:51
-2278: Arrow           "->" at 262:52-262:54 (leading: Space)
-2279: Ident           "int" at 262:55-262:58 (leading: Space)
-2280: Semicolon       ";" at 262:58-262:59
-2281: At              "@" at 263:5-263:6 (leading: Newline, Space)
-2282: Ident           "intrinsic" at 263:6-263:15
-2283: KwFn            "fn" at 263:16-263:18 (leading: Space)
-2284: Ident           "__bit_or" at 263:19-263:27 (leading: Space)
-2285: LParen          "(" at 263:27-263:28
-2286: Ident           "self" at 263:28-263:32
-2287: Colon           ":" at 263:32-263:33
-2288: Ident           "int" at 263:34-263:37 (leading: Space)
-2289: Comma           "," at 263:37-263:38
-2290: Ident           "other" at 263:39-263:44 (leading: Space)
-2291: Colon           ":" at 263:44-263:45
-2292: Ident           "int" at 263:46-263:49 (leading: Space)
-2293: RParen          ")" at 263:49-263:50
-2294: Arrow           "->" at 263:51-263:53 (leading: Space)
-2295: Ident           "int" at 263:54-263:57 (leading: Space)
-2296: Semicolon       ";" at 263:57-263:58
-2297: At              "@" at 264:5-264:6 (leading: Newline, Space)
-2298: Ident           "intrinsic" at 264:6-264:15
-2299: KwFn            "fn" at 264:16-264:18 (leading: Space)
-2300: Ident           "__bit_xor" at 264:19-264:28 (leading: Space)
-2301: LParen          "(" at 264:28-264:29
-2302: Ident           "self" at 264:29-264:33
-2303: Colon           ":" at 264:33-264:34
-2304: Ident           "int" at 264:35-264:38 (leading: Space)
-2305: Comma           "," at 264:38-264:39
-2306: Ident           "other" at 264:40-264:45 (leading: Space)
-2307: Colon           ":" at 264:45-264:46
-2308: Ident           "int" at 264:47-264:50 (leading: Space)
-2309: RParen          ")" at 264:50-264:51
-2310: Arrow           "->" at 264:52-264:54 (leading: Space)
-2311: Ident           "int" at 264:55-264:58 (leading: Space)
-2312: Semicolon       ";" at 264:58-264:59
-2313: At              "@" at 265:5-265:6 (leading: Newline, Space)
-2314: Ident           "intrinsic" at 265:6-265:15
-2315: KwFn            "fn" at 265:16-265:18 (leading: Space)
-2316: Ident           "__shl" at 265:19-265:24 (leading: Space)
-2317: LParen          "(" at 265:24-265:25
-2318: Ident           "self" at 265:25-265:29
-2319: Colon           ":" at 265:29-265:30
-2320: Ident           "int" at 265:31-265:34 (leading: Space)
-2321: Comma           "," at 265:34-265:35
-2322: Ident           "other" at 265:36-265:41 (leading: Space)
-2323: Colon           ":" at 265:41-265:42
-2324: Ident           "int" at 265:43-265:46 (leading: Space)
-2325: RParen          ")" at 265:46-265:47
-2326: Arrow           "->" at 265:48-265:50 (leading: Space)
-2327: Ident           "int" at 265:51-265:54 (leading: Space)
-2328: Semicolon       ";" at 265:54-265:55
-2329: At              "@" at 266:5-266:6 (leading: Newline, Space)
-2330: Ident           "intrinsic" at 266:6-266:15
-2331: KwFn            "fn" at 266:16-266:18 (leading: Space)
-2332: Ident           "__shr" at 266:19-266:24 (leading: Space)
-2333: LParen          "(" at 266:24-266:25
-2334: Ident           "self" at 266:25-266:29
-2335: Colon           ":" at 266:29-266:30
-2336: Ident           "int" at 266:31-266:34 (leading: Space)
-2337: Comma           "," at 266:34-266:35
-2338: Ident           "other" at 266:36-266:41 (leading: Space)
-2339: Colon           ":" at 266:41-266:42
-2340: Ident           "int" at 266:43-266:46 (leading: Space)
-2341: RParen          ")" at 266:46-266:47
-2342: Arrow           "->" at 266:48-266:50 (leading: Space)
-2343: Ident           "int" at 266:51-266:54 (leading: Space)
-2344: Semicolon       ";" at 266:54-266:55
-2345: At              "@" at 267:5-267:6 (leading: Newline, Space)
-2346: Ident           "intrinsic" at 267:6-267:15
-2347: KwFn            "fn" at 267:16-267:18 (leading: Space)
-2348: Ident           "__lt" at 267:19-267:23 (leading: Space)
-2349: LParen          "(" at 267:23-267:24
-2350: Ident           "self" at 267:24-267:28
-2351: Colon           ":" at 267:28-267:29
-2352: Ident           "int" at 267:30-267:33 (leading: Space)
-2353: Comma           "," at 267:33-267:34
-2354: Ident           "other" at 267:35-267:40 (leading: Space)
-2355: Colon           ":" at 267:40-267:41
-2356: Ident           "int" at 267:42-267:45 (leading: Space)
-2357: RParen          ")" at 267:45-267:46
-2358: Arrow           "->" at 267:47-267:49 (leading: Space)
-2359: Ident           "bool" at 267:50-267:54 (leading: Space)
-2360: Semicolon       ";" at 267:54-267:55
-2361: At              "@" at 268:5-268:6 (leading: Newline, Space)
-2362: Ident           "intrinsic" at 268:6-268:15
-2363: KwFn            "fn" at 268:16-268:18 (leading: Space)
-2364: Ident           "__le" at 268:19-268:23 (leading: Space)
-2365: LParen          "(" at 268:23-268:24
-2366: Ident           "self" at 268:24-268:28
-2367: Colon           ":" at 268:28-268:29
-2368: Ident           "int" at 268:30-268:33 (leading: Space)
-2369: Comma           "," at 268:33-268:34
-2370: Ident           "other" at 268:35-268:40 (leading: Space)
-2371: Colon           ":" at 268:40-268:41
-2372: Ident           "int" at 268:42-268:45 (leading: Space)
-2373: RParen          ")" at 268:45-268:46
-2374: Arrow           "->" at 268:47-268:49 (leading: Space)
-2375: Ident           "bool" at 268:50-268:54 (leading: Space)
-2376: Semicolon       ";" at 268:54-268:55
-2377: At              "@" at 269:5-269:6 (leading: Newline, Space)
-2378: Ident           "intrinsic" at 269:6-269:15
-2379: KwFn            "fn" at 269:16-269:18 (leading: Space)
-2380: Ident           "__eq" at 269:19-269:23 (leading: Space)
-2381: LParen          "(" at 269:23-269:24
-2382: Ident           "self" at 269:24-269:28
-2383: Colon           ":" at 269:28-269:29
-2384: Ident           "int" at 269:30-269:33 (leading: Space)
-2385: Comma           "," at 269:33-269:34
-2386: Ident           "other" at 269:35-269:40 (leading: Space)
-2387: Colon           ":" at 269:40-269:41
-2388: Ident           "int" at 269:42-269:45 (leading: Space)
-2389: RParen          ")" at 269:45-269:46
-2390: Arrow           "->" at 269:47-269:49 (leading: Space)
-2391: Ident           "bool" at 269:50-269:54 (leading: Space)
-2392: Semicolon       ";" at 269:54-269:55
-2393: At              "@" at 270:5-270:6 (leading: Newline, Space)
-2394: Ident           "intrinsic" at 270:6-270:15
-2395: KwFn            "fn" at 270:16-270:18 (leading: Space)
-2396: Ident           "__ne" at 270:19-270:23 (leading: Space)
-2397: LParen          "(" at 270:23-270:24
-2398: Ident           "self" at 270:24-270:28
-2399: Colon           ":" at 270:28-270:29
-2400: Ident           "int" at 270:30-270:33 (leading: Space)
-2401: Comma           "," at 270:33-270:34
-2402: Ident           "other" at 270:35-270:40 (leading: Space)
-2403: Colon           ":" at 270:40-270:41
-2404: Ident           "int" at 270:42-270:45 (leading: Space)
-2405: RParen          ")" at 270:45-270:46
-2406: Arrow           "->" at 270:47-270:49 (leading: Space)
-2407: Ident           "bool" at 270:50-270:54 (leading: Space)
-2408: Semicolon       ";" at 270:54-270:55
-2409: At              "@" at 271:5-271:6 (leading: Newline, Space)
-2410: Ident           "intrinsic" at 271:6-271:15
-2411: KwFn            "fn" at 271:16-271:18 (leading: Space)
-2412: Ident           "__ge" at 271:19-271:23 (leading: Space)
-2413: LParen          "(" at 271:23-271:24
-2414: Ident           "self" at 271:24-271:28
-2415: Colon           ":" at 271:28-271:29
-2416: Ident           "int" at 271:30-271:33 (leading: Space)
-2417: Comma           "," at 271:33-271:34
-2418: Ident           "other" at 271:35-271:40 (leading: Space)
-2419: Colon           ":" at 271:40-271:41
-2420: Ident           "int" at 271:42-271:45 (leading: Space)
-2421: RParen          ")" at 271:45-271:46
-2422: Arrow           "->" at 271:47-271:49 (leading: Space)
-2423: Ident           "bool" at 271:50-271:54 (leading: Space)
-2424: Semicolon       ";" at 271:54-271:55
-2425: At              "@" at 272:5-272:6 (leading: Newline, Space)
-2426: Ident           "intrinsic" at 272:6-272:15
-2427: KwFn            "fn" at 272:16-272:18 (leading: Space)
-2428: Ident           "__gt" at 272:19-272:23 (leading: Space)
-2429: LParen          "(" at 272:23-272:24
-2430: Ident           "self" at 272:24-272:28
-2431: Colon           ":" at 272:28-272:29
-2432: Ident           "int" at 272:30-272:33 (leading: Space)
-2433: Comma           "," at 272:33-272:34
-2434: Ident           "other" at 272:35-272:40 (leading: Space)
-2435: Colon           ":" at 272:40-272:41
-2436: Ident           "int" at 272:42-272:45 (leading: Space)
-2437: RParen          ")" at 272:45-272:46
-2438: Arrow           "->" at 272:47-272:49 (leading: Space)
-2439: Ident           "bool" at 272:50-272:54 (leading: Space)
-2440: Semicolon       ";" at 272:54-272:55
-2441: At              "@" at 273:5-273:6 (leading: Newline, Space)
-2442: Ident           "intrinsic" at 273:6-273:15
-2443: KwFn            "fn" at 273:16-273:18 (leading: Space)
-2444: Ident           "__pos" at 273:19-273:24 (leading: Space)
-2445: LParen          "(" at 273:24-273:25
-2446: Ident           "self" at 273:25-273:29
-2447: Colon           ":" at 273:29-273:30
-2448: Ident           "int" at 273:31-273:34 (leading: Space)
-2449: RParen          ")" at 273:34-273:35
-2450: Arrow           "->" at 273:36-273:38 (leading: Space)
-2451: Ident           "int" at 273:39-273:42 (leading: Space)
-2452: Semicolon       ";" at 273:42-273:43
-2453: At              "@" at 274:5-274:6 (leading: Newline, Space)
-2454: Ident           "intrinsic" at 274:6-274:15
-2455: KwFn            "fn" at 274:16-274:18 (leading: Space)
-2456: Ident           "__neg" at 274:19-274:24 (leading: Space)
-2457: LParen          "(" at 274:24-274:25
-2458: Ident           "self" at 274:25-274:29
-2459: Colon           ":" at 274:29-274:30
-2460: Ident           "int" at 274:31-274:34 (leading: Space)
-2461: RParen          ")" at 274:34-274:35
-2462: Arrow           "->" at 274:36-274:38 (leading: Space)
-2463: Ident           "int" at 274:39-274:42 (leading: Space)
-2464: Semicolon       ";" at 274:42-274:43
-2465: At              "@" at 275:5-275:6 (leading: Newline, Space)
-2466: Ident           "intrinsic" at 275:6-275:15
-2467: KwFn            "fn" at 275:16-275:18 (leading: Space)
-2468: Ident           "__abs" at 275:19-275:24 (leading: Space)
-2469: LParen          "(" at 275:24-275:25
-2470: Ident           "self" at 275:25-275:29
-2471: Colon           ":" at 275:29-275:30
-2472: Ident           "int" at 275:31-275:34 (leading: Space)
-2473: RParen          ")" at 275:34-275:35
-2474: Arrow           "->" at 275:36-275:38 (leading: Space)
-2475: Ident           "int" at 275:39-275:42 (leading: Space)
-2476: Semicolon       ";" at 275:42-275:43
-2477: At              "@" at 276:5-276:6 (leading: Newline, Space)
-2478: Ident           "intrinsic" at 276:6-276:15
-2479: KwFn            "fn" at 276:16-276:18 (leading: Space)
-2480: Ident           "__to" at 276:19-276:23 (leading: Space)
-2481: LParen          "(" at 276:23-276:24
-2482: Ident           "self" at 276:24-276:28
-2483: Colon           ":" at 276:28-276:29
-2484: Ident           "int" at 276:30-276:33 (leading: Space)
-2485: Comma           "," at 276:33-276:34
-2486: Ident           "target" at 276:35-276:41 (leading: Space)
-2487: Colon           ":" at 276:41-276:42
-2488: Ident           "string" at 276:43-276:49 (leading: Space)
-2489: RParen          ")" at 276:49-276:50
-2490: Arrow           "->" at 276:51-276:53 (leading: Space)
-2491: Ident           "string" at 276:54-276:60 (leading: Space)
-2492: Semicolon       ";" at 276:60-276:61
-2493: At              "@" at 277:5-277:6 (leading: Newline, Space)
-2494: Ident           "overload" at 277:6-277:14
-2495: KwPub           "pub" at 277:15-277:18 (leading: Space)
-2496: KwFn            "fn" at 277:19-277:21 (leading: Space)
-2497: Ident           "__to" at 277:22-277:26 (leading: Space)
-2498: LParen          "(" at 277:26-277:27
-2499: Ident           "self" at 277:27-277:31
-2500: Colon           ":" at 277:31-277:32
-2501: Amp             "&" at 277:33-277:34 (leading: Space)
-2502: Ident           "int" at 277:34-277:37
-2503: Comma           "," at 277:37-277:38
-2504: Underscore      "_" at 277:39-277:40 (leading: Space)
-2505: Colon           ":" at 277:40-277:41
-2506: Ident           "string" at 277:42-277:48 (leading: Space)
-2507: RParen          ")" at 277:48-277:49
-2508: Arrow           "->" at 277:50-277:52 (leading: Space)
-2509: Ident           "string" at 277:53-277:59 (leading: Space)
-2510: LBrace          "{" at 277:60-277:61 (leading: Space)
-2511: KwReturn        "return" at 278:9-278:15 (leading: Newline, Space)
-2512: LParen          "(" at 278:16-278:17 (leading: Space)
-2513: Star            "*" at 278:17-278:18
-2514: Ident           "self" at 278:18-278:22
-2515: RParen          ")" at 278:22-278:23
-2516: KwTo            "to" at 278:24-278:26 (leading: Space)
-2517: Ident           "string" at 278:27-278:33 (leading: Space)
-2518: Semicolon       ";" at 278:33-278:34
-2519: RBrace          "}" at 279:5-279:6 (leading: Newline, Space)
-2520: At              "@" at 280:5-280:6 (leading: Newline, Space)
-2521: Ident           "intrinsic" at 280:6-280:15
-2522: At              "@" at 280:16-280:17 (leading: Space)
-2523: Ident           "overload" at 280:17-280:25
-2524: KwFn            "fn" at 280:26-280:28 (leading: Space)
-2525: Ident           "__to" at 280:29-280:33 (leading: Space)
-2526: LParen          "(" at 280:33-280:34
-2527: Ident           "self" at 280:34-280:38
-2528: Colon           ":" at 280:38-280:39
-2529: Ident           "int" at 280:40-280:43 (leading: Space)
-2530: Comma           "," at 280:43-280:44
-2531: Ident           "target" at 280:45-280:51 (leading: Space)
-2532: Colon           ":" at 280:51-280:52
-2533: Ident           "float" at 280:53-280:58 (leading: Space)
-2534: RParen          ")" at 280:58-280:59
-2535: Arrow           "->" at 280:60-280:62 (leading: Space)
-2536: Ident           "float" at 280:63-280:68 (leading: Space)
-2537: Semicolon       ";" at 280:68-280:69
-2538: At              "@" at 281:5-281:6 (leading: Newline, Space)
-2539: Ident           "intrinsic" at 281:6-281:15
-2540: At              "@" at 281:16-281:17 (leading: Space)
-2541: Ident           "overload" at 281:17-281:25
-2542: KwFn            "fn" at 281:26-281:28 (leading: Space)
-2543: Ident           "__to" at 281:29-281:33 (leading: Space)
-2544: LParen          "(" at 281:33-281:34
-2545: Ident           "self" at 281:34-281:38
-2546: Colon           ":" at 281:38-281:39
-2547: Ident           "int" at 281:40-281:43 (leading: Space)
-2548: Comma           "," at 281:43-281:44
-2549: Ident           "target" at 281:45-281:51 (leading: Space)
-2550: Colon           ":" at 281:51-281:52
-2551: Ident           "uint" at 281:53-281:57 (leading: Space)
-2552: RParen          ")" at 281:57-281:58
-2553: Arrow           "->" at 281:59-281:61 (leading: Space)
-2554: Ident           "uint" at 281:62-281:66 (leading: Space)
-2555: Semicolon       ";" at 281:66-281:67
-2556: At              "@" at 282:5-282:6 (leading: Newline, Space)
-2557: Ident           "intrinsic" at 282:6-282:15
-2558: At              "@" at 282:16-282:17 (leading: Space)
-2559: Ident           "overload" at 282:17-282:25
-2560: KwFn            "fn" at 282:26-282:28 (leading: Space)
-2561: Ident           "__to" at 282:29-282:33 (leading: Space)
-2562: LParen          "(" at 282:33-282:34
-2563: Ident           "self" at 282:34-282:38
-2564: Colon           ":" at 282:38-282:39
-2565: Ident           "int" at 282:40-282:43 (leading: Space)
-2566: Comma           "," at 282:43-282:44
-2567: Ident           "target" at 282:45-282:51 (leading: Space)
-2568: Colon           ":" at 282:51-282:52
-2569: Ident           "int8" at 282:53-282:57 (leading: Space)
-2570: RParen          ")" at 282:57-282:58
-2571: Arrow           "->" at 282:59-282:61 (leading: Space)
-2572: Ident           "int8" at 282:62-282:66 (leading: Space)
-2573: Semicolon       ";" at 282:66-282:67
-2574: At              "@" at 283:5-283:6 (leading: Newline, Space)
-2575: Ident           "intrinsic" at 283:6-283:15
-2576: At              "@" at 283:16-283:17 (leading: Space)
-2577: Ident           "overload" at 283:17-283:25
-2578: KwFn            "fn" at 283:26-283:28 (leading: Space)
-2579: Ident           "__to" at 283:29-283:33 (leading: Space)
-2580: LParen          "(" at 283:33-283:34
-2581: Ident           "self" at 283:34-283:38
-2582: Colon           ":" at 283:38-283:39
-2583: Ident           "int" at 283:40-283:43 (leading: Space)
-2584: Comma           "," at 283:43-283:44
-2585: Ident           "target" at 283:45-283:51 (leading: Space)
-2586: Colon           ":" at 283:51-283:52
-2587: Ident           "int16" at 283:53-283:58 (leading: Space)
-2588: RParen          ")" at 283:58-283:59
-2589: Arrow           "->" at 283:60-283:62 (leading: Space)
-2590: Ident           "int16" at 283:63-283:68 (leading: Space)
-2591: Semicolon       ";" at 283:68-283:69
-2592: At              "@" at 284:5-284:6 (leading: Newline, Space)
-2593: Ident           "intrinsic" at 284:6-284:15
-2594: At              "@" at 284:16-284:17 (leading: Space)
-2595: Ident           "overload" at 284:17-284:25
-2596: KwFn            "fn" at 284:26-284:28 (leading: Space)
-2597: Ident           "__to" at 284:29-284:33 (leading: Space)
-2598: LParen          "(" at 284:33-284:34
-2599: Ident           "self" at 284:34-284:38
-2600: Colon           ":" at 284:38-284:39
-2601: Ident           "int" at 284:40-284:43 (leading: Space)
-2602: Comma           "," at 284:43-284:44
-2603: Ident           "target" at 284:45-284:51 (leading: Space)
-2604: Colon           ":" at 284:51-284:52
-2605: Ident           "int32" at 284:53-284:58 (leading: Space)
-2606: RParen          ")" at 284:58-284:59
-2607: Arrow           "->" at 284:60-284:62 (leading: Space)
-2608: Ident           "int32" at 284:63-284:68 (leading: Space)
-2609: Semicolon       ";" at 284:68-284:69
-2610: At              "@" at 285:5-285:6 (leading: Newline, Space)
-2611: Ident           "intrinsic" at 285:6-285:15
-2612: At              "@" at 285:16-285:17 (leading: Space)
-2613: Ident           "overload" at 285:17-285:25
-2614: KwFn            "fn" at 285:26-285:28 (leading: Space)
-2615: Ident           "__to" at 285:29-285:33 (leading: Space)
-2616: LParen          "(" at 285:33-285:34
-2617: Ident           "self" at 285:34-285:38
-2618: Colon           ":" at 285:38-285:39
-2619: Ident           "int" at 285:40-285:43 (leading: Space)
-2620: Comma           "," at 285:43-285:44
-2621: Ident           "target" at 285:45-285:51 (leading: Space)
-2622: Colon           ":" at 285:51-285:52
-2623: Ident           "int64" at 285:53-285:58 (leading: Space)
-2624: RParen          ")" at 285:58-285:59
-2625: Arrow           "->" at 285:60-285:62 (leading: Space)
-2626: Ident           "int64" at 285:63-285:68 (leading: Space)
-2627: Semicolon       ";" at 285:68-285:69
-2628: At              "@" at 286:5-286:6 (leading: Newline, Space)
-2629: Ident           "intrinsic" at 286:6-286:15
-2630: At              "@" at 286:16-286:17 (leading: Space)
-2631: Ident           "overload" at 286:17-286:25
-2632: KwFn            "fn" at 286:26-286:28 (leading: Space)
-2633: Ident           "__to" at 286:29-286:33 (leading: Space)
-2634: LParen          "(" at 286:33-286:34
-2635: Ident           "self" at 286:34-286:38
-2636: Colon           ":" at 286:38-286:39
-2637: Ident           "int" at 286:40-286:43 (leading: Space)
-2638: Comma           "," at 286:43-286:44
-2639: Ident           "target" at 286:45-286:51 (leading: Space)
-2640: Colon           ":" at 286:51-286:52
-2641: Ident           "uint8" at 286:53-286:58 (leading: Space)
-2642: RParen          ")" at 286:58-286:59
-2643: Arrow           "->" at 286:60-286:62 (leading: Space)
-2644: Ident           "uint8" at 286:63-286:68 (leading: Space)
-2645: Semicolon       ";" at 286:68-286:69
-2646: At              "@" at 287:5-287:6 (leading: Newline, Space)
-2647: Ident           "intrinsic" at 287:6-287:15
-2648: At              "@" at 287:16-287:17 (leading: Space)
-2649: Ident           "overload" at 287:17-287:25
-2650: KwFn            "fn" at 287:26-287:28 (leading: Space)
-2651: Ident           "__to" at 287:29-287:33 (leading: Space)
-2652: LParen          "(" at 287:33-287:34
-2653: Ident           "self" at 287:34-287:38
-2654: Colon           ":" at 287:38-287:39
-2655: Ident           "int" at 287:40-287:43 (leading: Space)
-2656: Comma           "," at 287:43-287:44
-2657: Ident           "target" at 287:45-287:51 (leading: Space)
-2658: Colon           ":" at 287:51-287:52
-2659: Ident           "uint16" at 287:53-287:59 (leading: Space)
-2660: RParen          ")" at 287:59-287:60
-2661: Arrow           "->" at 287:61-287:63 (leading: Space)
-2662: Ident           "uint16" at 287:64-287:70 (leading: Space)
-2663: Semicolon       ";" at 287:70-287:71
-2664: At              "@" at 288:5-288:6 (leading: Newline, Space)
-2665: Ident           "intrinsic" at 288:6-288:15
-2666: At              "@" at 288:16-288:17 (leading: Space)
-2667: Ident           "overload" at 288:17-288:25
-2668: KwFn            "fn" at 288:26-288:28 (leading: Space)
-2669: Ident           "__to" at 288:29-288:33 (leading: Space)
-2670: LParen          "(" at 288:33-288:34
-2671: Ident           "self" at 288:34-288:38
-2672: Colon           ":" at 288:38-288:39
-2673: Ident           "int" at 288:40-288:43 (leading: Space)
-2674: Comma           "," at 288:43-288:44
-2675: Ident           "target" at 288:45-288:51 (leading: Space)
-2676: Colon           ":" at 288:51-288:52
-2677: Ident           "uint32" at 288:53-288:59 (leading: Space)
-2678: RParen          ")" at 288:59-288:60
-2679: Arrow           "->" at 288:61-288:63 (leading: Space)
-2680: Ident           "uint32" at 288:64-288:70 (leading: Space)
-2681: Semicolon       ";" at 288:70-288:71
-2682: At              "@" at 289:5-289:6 (leading: Newline, Space)
-2683: Ident           "intrinsic" at 289:6-289:15
-2684: At              "@" at 289:16-289:17 (leading: Space)
-2685: Ident           "overload" at 289:17-289:25
-2686: KwFn            "fn" at 289:26-289:28 (leading: Space)
-2687: Ident           "__to" at 289:29-289:33 (leading: Space)
-2688: LParen          "(" at 289:33-289:34
-2689: Ident           "self" at 289:34-289:38
-2690: Colon           ":" at 289:38-289:39
-2691: Ident           "int" at 289:40-289:43 (leading: Space)
-2692: Comma           "," at 289:43-289:44
-2693: Ident           "target" at 289:45-289:51 (leading: Space)
-2694: Colon           ":" at 289:51-289:52
-2695: Ident           "uint64" at 289:53-289:59 (leading: Space)
-2696: RParen          ")" at 289:59-289:60
-2697: Arrow           "->" at 289:61-289:63 (leading: Space)
-2698: Ident           "uint64" at 289:64-289:70 (leading: Space)
-2699: Semicolon       ";" at 289:70-289:71
-2700: At              "@" at 290:5-290:6 (leading: Newline, Space)
-2701: Ident           "intrinsic" at 290:6-290:15
-2702: At              "@" at 290:16-290:17 (leading: Space)
-2703: Ident           "overload" at 290:17-290:25
-2704: KwFn            "fn" at 290:26-290:28 (leading: Space)
-2705: Ident           "__to" at 290:29-290:33 (leading: Space)
-2706: LParen          "(" at 290:33-290:34
-2707: Ident           "self" at 290:34-290:38
-2708: Colon           ":" at 290:38-290:39
-2709: Ident           "int" at 290:40-290:43 (leading: Space)
-2710: Comma           "," at 290:43-290:44
-2711: Ident           "target" at 290:45-290:51 (leading: Space)
-2712: Colon           ":" at 290:51-290:52
-2713: Ident           "float16" at 290:53-290:60 (leading: Space)
-2714: RParen          ")" at 290:60-290:61
-2715: Arrow           "->" at 290:62-290:64 (leading: Space)
-2716: Ident           "float16" at 290:65-290:72 (leading: Space)
-2717: Semicolon       ";" at 290:72-290:73
-2718: At              "@" at 291:5-291:6 (leading: Newline, Space)
-2719: Ident           "intrinsic" at 291:6-291:15
-2720: At              "@" at 291:16-291:17 (leading: Space)
-2721: Ident           "overload" at 291:17-291:25
-2722: KwFn            "fn" at 291:26-291:28 (leading: Space)
-2723: Ident           "__to" at 291:29-291:33 (leading: Space)
-2724: LParen          "(" at 291:33-291:34
-2725: Ident           "self" at 291:34-291:38
-2726: Colon           ":" at 291:38-291:39
-2727: Ident           "int" at 291:40-291:43 (leading: Space)
-2728: Comma           "," at 291:43-291:44
-2729: Ident           "target" at 291:45-291:51 (leading: Space)
-2730: Colon           ":" at 291:51-291:52
-2731: Ident           "float32" at 291:53-291:60 (leading: Space)
-2732: RParen          ")" at 291:60-291:61
-2733: Arrow           "->" at 291:62-291:64 (leading: Space)
-2734: Ident           "float32" at 291:65-291:72 (leading: Space)
-2735: Semicolon       ";" at 291:72-291:73
-2736: At              "@" at 292:5-292:6 (leading: Newline, Space)
-2737: Ident           "intrinsic" at 292:6-292:15
-2738: At              "@" at 292:16-292:17 (leading: Space)
-2739: Ident           "overload" at 292:17-292:25
-2740: KwFn            "fn" at 292:26-292:28 (leading: Space)
-2741: Ident           "__to" at 292:29-292:33 (leading: Space)
-2742: LParen          "(" at 292:33-292:34
-2743: Ident           "self" at 292:34-292:38
-2744: Colon           ":" at 292:38-292:39
-2745: Ident           "int" at 292:40-292:43 (leading: Space)
-2746: Comma           "," at 292:43-292:44
-2747: Ident           "target" at 292:45-292:51 (leading: Space)
-2748: Colon           ":" at 292:51-292:52
-2749: Ident           "float64" at 292:53-292:60 (leading: Space)
-2750: RParen          ")" at 292:60-292:61
-2751: Arrow           "->" at 292:62-292:64 (leading: Space)
-2752: Ident           "float64" at 292:65-292:72 (leading: Space)
-2753: Semicolon       ";" at 292:72-292:73
-2754: At              "@" at 294:5-294:6 (leading: Newline, Space, LineComment, Newline, Space)
-2755: Ident           "intrinsic" at 294:6-294:15
-2756: KwPub           "pub" at 294:16-294:19 (leading: Space)
-2757: KwFn            "fn" at 294:20-294:22 (leading: Space)
-2758: Ident           "from_str" at 294:23-294:31 (leading: Space)
-2759: LParen          "(" at 294:31-294:32
-2760: Ident           "s" at 294:32-294:33
-2761: Colon           ":" at 294:33-294:34
-2762: Amp             "&" at 294:35-294:36 (leading: Space)
-2763: Ident           "string" at 294:36-294:42
-2764: RParen          ")" at 294:42-294:43
-2765: Arrow           "->" at 294:44-294:46 (leading: Space)
-2766: Ident           "Erring" at 294:47-294:53 (leading: Space)
-2767: Lt              "<" at 294:53-294:54
-2768: Ident           "int" at 294:54-294:57
-2769: Comma           "," at 294:57-294:58
-2770: Ident           "Error" at 294:59-294:64 (leading: Space)
-2771: Gt              ">" at 294:64-294:65
-2772: Semicolon       ";" at 294:65-294:66
-2773: RBrace          "}" at 295:1-295:2 (leading: Newline)
-2774: KwExtern        "extern" at 297:1-297:7 (leading: Newline)
-2775: Lt              "<" at 297:7-297:8
-2776: Ident           "uint" at 297:8-297:12
-2777: Gt              ">" at 297:12-297:13
-2778: LBrace          "{" at 297:14-297:15 (leading: Space)
-2779: At              "@" at 298:5-298:6 (leading: Newline, Space)
-2780: Ident           "intrinsic" at 298:6-298:15
-2781: KwFn            "fn" at 298:16-298:18 (leading: Space)
-2782: Ident           "__add" at 298:19-298:24 (leading: Space)
-2783: LParen          "(" at 298:24-298:25
-2784: Ident           "self" at 298:25-298:29
-2785: Colon           ":" at 298:29-298:30
-2786: Ident           "uint" at 298:31-298:35 (leading: Space)
-2787: Comma           "," at 298:35-298:36
-2788: Ident           "other" at 298:37-298:42 (leading: Space)
-2789: Colon           ":" at 298:42-298:43
-2790: Ident           "uint" at 298:44-298:48 (leading: Space)
-2791: RParen          ")" at 298:48-298:49
-2792: Arrow           "->" at 298:50-298:52 (leading: Space)
-2793: Ident           "uint" at 298:53-298:57 (leading: Space)
-2794: Semicolon       ";" at 298:57-298:58
-2795: At              "@" at 299:5-299:6 (leading: Newline, Space)
-2796: Ident           "intrinsic" at 299:6-299:15
-2797: KwFn            "fn" at 299:16-299:18 (leading: Space)
-2798: Ident           "__sub" at 299:19-299:24 (leading: Space)
-2799: LParen          "(" at 299:24-299:25
-2800: Ident           "self" at 299:25-299:29
-2801: Colon           ":" at 299:29-299:30
-2802: Ident           "uint" at 299:31-299:35 (leading: Space)
-2803: Comma           "," at 299:35-299:36
-2804: Ident           "other" at 299:37-299:42 (leading: Space)
-2805: Colon           ":" at 299:42-299:43
-2806: Ident           "uint" at 299:44-299:48 (leading: Space)
-2807: RParen          ")" at 299:48-299:49
-2808: Arrow           "->" at 299:50-299:52 (leading: Space)
-2809: Ident           "uint" at 299:53-299:57 (leading: Space)
-2810: Semicolon       ";" at 299:57-299:58
-2811: At              "@" at 300:5-300:6 (leading: Newline, Space)
-2812: Ident           "intrinsic" at 300:6-300:15
-2813: KwFn            "fn" at 300:16-300:18 (leading: Space)
-2814: Ident           "__mul" at 300:19-300:24 (leading: Space)
-2815: LParen          "(" at 300:24-300:25
-2816: Ident           "self" at 300:25-300:29
-2817: Colon           ":" at 300:29-300:30
-2818: Ident           "uint" at 300:31-300:35 (leading: Space)
-2819: Comma           "," at 300:35-300:36
-2820: Ident           "other" at 300:37-300:42 (leading: Space)
-2821: Colon           ":" at 300:42-300:43
-2822: Ident           "uint" at 300:44-300:48 (leading: Space)
-2823: RParen          ")" at 300:48-300:49
-2824: Arrow           "->" at 300:50-300:52 (leading: Space)
-2825: Ident           "uint" at 300:53-300:57 (leading: Space)
-2826: Semicolon       ";" at 300:57-300:58
-2827: At              "@" at 301:5-301:6 (leading: Newline, Space)
-2828: Ident           "intrinsic" at 301:6-301:15
-2829: KwFn            "fn" at 301:16-301:18 (leading: Space)
-2830: Ident           "__div" at 301:19-301:24 (leading: Space)
-2831: LParen          "(" at 301:24-301:25
-2832: Ident           "self" at 301:25-301:29
-2833: Colon           ":" at 301:29-301:30
-2834: Ident           "uint" at 301:31-301:35 (leading: Space)
-2835: Comma           "," at 301:35-301:36
-2836: Ident           "other" at 301:37-301:42 (leading: Space)
-2837: Colon           ":" at 301:42-301:43
-2838: Ident           "uint" at 301:44-301:48 (leading: Space)
-2839: RParen          ")" at 301:48-301:49
-2840: Arrow           "->" at 301:50-301:52 (leading: Space)
-2841: Ident           "uint" at 301:53-301:57 (leading: Space)
-2842: Semicolon       ";" at 301:57-301:58
-2843: At              "@" at 302:5-302:6 (leading: Newline, Space)
-2844: Ident           "intrinsic" at 302:6-302:15
-2845: KwFn            "fn" at 302:16-302:18 (leading: Space)
-2846: Ident           "__mod" at 302:19-302:24 (leading: Space)
-2847: LParen          "(" at 302:24-302:25
-2848: Ident           "self" at 302:25-302:29
-2849: Colon           ":" at 302:29-302:30
-2850: Ident           "uint" at 302:31-302:35 (leading: Space)
-2851: Comma           "," at 302:35-302:36
-2852: Ident           "other" at 302:37-302:42 (leading: Space)
-2853: Colon           ":" at 302:42-302:43
-2854: Ident           "uint" at 302:44-302:48 (leading: Space)
-2855: RParen          ")" at 302:48-302:49
-2856: Arrow           "->" at 302:50-302:52 (leading: Space)
-2857: Ident           "uint" at 302:53-302:57 (leading: Space)
-2858: Semicolon       ";" at 302:57-302:58
-2859: At              "@" at 303:5-303:6 (leading: Newline, Space)
-2860: Ident           "intrinsic" at 303:6-303:15
-2861: KwFn            "fn" at 303:16-303:18 (leading: Space)
-2862: Ident           "__bit_and" at 303:19-303:28 (leading: Space)
-2863: LParen          "(" at 303:28-303:29
-2864: Ident           "self" at 303:29-303:33
-2865: Colon           ":" at 303:33-303:34
-2866: Ident           "uint" at 303:35-303:39 (leading: Space)
-2867: Comma           "," at 303:39-303:40
-2868: Ident           "other" at 303:41-303:46 (leading: Space)
-2869: Colon           ":" at 303:46-303:47
-2870: Ident           "uint" at 303:48-303:52 (leading: Space)
-2871: RParen          ")" at 303:52-303:53
-2872: Arrow           "->" at 303:54-303:56 (leading: Space)
-2873: Ident           "uint" at 303:57-303:61 (leading: Space)
-2874: Semicolon       ";" at 303:61-303:62
-2875: At              "@" at 304:5-304:6 (leading: Newline, Space)
-2876: Ident           "intrinsic" at 304:6-304:15
-2877: KwFn            "fn" at 304:16-304:18 (leading: Space)
-2878: Ident           "__bit_or" at 304:19-304:27 (leading: Space)
-2879: LParen          "(" at 304:27-304:28
-2880: Ident           "self" at 304:28-304:32
-2881: Colon           ":" at 304:32-304:33
-2882: Ident           "uint" at 304:34-304:38 (leading: Space)
-2883: Comma           "," at 304:38-304:39
-2884: Ident           "other" at 304:40-304:45 (leading: Space)
-2885: Colon           ":" at 304:45-304:46
-2886: Ident           "uint" at 304:47-304:51 (leading: Space)
-2887: RParen          ")" at 304:51-304:52
-2888: Arrow           "->" at 304:53-304:55 (leading: Space)
-2889: Ident           "uint" at 304:56-304:60 (leading: Space)
-2890: Semicolon       ";" at 304:60-304:61
-2891: At              "@" at 305:5-305:6 (leading: Newline, Space)
-2892: Ident           "intrinsic" at 305:6-305:15
-2893: KwFn            "fn" at 305:16-305:18 (leading: Space)
-2894: Ident           "__bit_xor" at 305:19-305:28 (leading: Space)
-2895: LParen          "(" at 305:28-305:29
-2896: Ident           "self" at 305:29-305:33
-2897: Colon           ":" at 305:33-305:34
-2898: Ident           "uint" at 305:35-305:39 (leading: Space)
-2899: Comma           "," at 305:39-305:40
-2900: Ident           "other" at 305:41-305:46 (leading: Space)
-2901: Colon           ":" at 305:46-305:47
-2902: Ident           "uint" at 305:48-305:52 (leading: Space)
-2903: RParen          ")" at 305:52-305:53
-2904: Arrow           "->" at 305:54-305:56 (leading: Space)
-2905: Ident           "uint" at 305:57-305:61 (leading: Space)
-2906: Semicolon       ";" at 305:61-305:62
-2907: At              "@" at 306:5-306:6 (leading: Newline, Space)
-2908: Ident           "intrinsic" at 306:6-306:15
-2909: KwFn            "fn" at 306:16-306:18 (leading: Space)
-2910: Ident           "__shl" at 306:19-306:24 (leading: Space)
-2911: LParen          "(" at 306:24-306:25
-2912: Ident           "self" at 306:25-306:29
-2913: Colon           ":" at 306:29-306:30
-2914: Ident           "uint" at 306:31-306:35 (leading: Space)
-2915: Comma           "," at 306:35-306:36
-2916: Ident           "other" at 306:37-306:42 (leading: Space)
-2917: Colon           ":" at 306:42-306:43
-2918: Ident           "uint" at 306:44-306:48 (leading: Space)
-2919: RParen          ")" at 306:48-306:49
-2920: Arrow           "->" at 306:50-306:52 (leading: Space)
-2921: Ident           "uint" at 306:53-306:57 (leading: Space)
-2922: Semicolon       ";" at 306:57-306:58
-2923: At              "@" at 307:5-307:6 (leading: Newline, Space)
-2924: Ident           "intrinsic" at 307:6-307:15
-2925: KwFn            "fn" at 307:16-307:18 (leading: Space)
-2926: Ident           "__shr" at 307:19-307:24 (leading: Space)
-2927: LParen          "(" at 307:24-307:25
-2928: Ident           "self" at 307:25-307:29
-2929: Colon           ":" at 307:29-307:30
-2930: Ident           "uint" at 307:31-307:35 (leading: Space)
-2931: Comma           "," at 307:35-307:36
-2932: Ident           "other" at 307:37-307:42 (leading: Space)
-2933: Colon           ":" at 307:42-307:43
-2934: Ident           "uint" at 307:44-307:48 (leading: Space)
-2935: RParen          ")" at 307:48-307:49
-2936: Arrow           "->" at 307:50-307:52 (leading: Space)
-2937: Ident           "uint" at 307:53-307:57 (leading: Space)
-2938: Semicolon       ";" at 307:57-307:58
-2939: At              "@" at 308:5-308:6 (leading: Newline, Space)
-2940: Ident           "intrinsic" at 308:6-308:15
-2941: KwFn            "fn" at 308:16-308:18 (leading: Space)
-2942: Ident           "__lt" at 308:19-308:23 (leading: Space)
-2943: LParen          "(" at 308:23-308:24
-2944: Ident           "self" at 308:24-308:28
-2945: Colon           ":" at 308:28-308:29
-2946: Ident           "uint" at 308:30-308:34 (leading: Space)
-2947: Comma           "," at 308:34-308:35
-2948: Ident           "other" at 308:36-308:41 (leading: Space)
-2949: Colon           ":" at 308:41-308:42
-2950: Ident           "uint" at 308:43-308:47 (leading: Space)
-2951: RParen          ")" at 308:47-308:48
-2952: Arrow           "->" at 308:49-308:51 (leading: Space)
-2953: Ident           "bool" at 308:52-308:56 (leading: Space)
-2954: Semicolon       ";" at 308:56-308:57
-2955: At              "@" at 309:5-309:6 (leading: Newline, Space)
-2956: Ident           "intrinsic" at 309:6-309:15
-2957: KwFn            "fn" at 309:16-309:18 (leading: Space)
-2958: Ident           "__le" at 309:19-309:23 (leading: Space)
-2959: LParen          "(" at 309:23-309:24
-2960: Ident           "self" at 309:24-309:28
-2961: Colon           ":" at 309:28-309:29
-2962: Ident           "uint" at 309:30-309:34 (leading: Space)
-2963: Comma           "," at 309:34-309:35
-2964: Ident           "other" at 309:36-309:41 (leading: Space)
-2965: Colon           ":" at 309:41-309:42
-2966: Ident           "uint" at 309:43-309:47 (leading: Space)
-2967: RParen          ")" at 309:47-309:48
-2968: Arrow           "->" at 309:49-309:51 (leading: Space)
-2969: Ident           "bool" at 309:52-309:56 (leading: Space)
-2970: Semicolon       ";" at 309:56-309:57
-2971: At              "@" at 310:5-310:6 (leading: Newline, Space)
-2972: Ident           "intrinsic" at 310:6-310:15
-2973: KwFn            "fn" at 310:16-310:18 (leading: Space)
-2974: Ident           "__eq" at 310:19-310:23 (leading: Space)
-2975: LParen          "(" at 310:23-310:24
-2976: Ident           "self" at 310:24-310:28
-2977: Colon           ":" at 310:28-310:29
-2978: Ident           "uint" at 310:30-310:34 (leading: Space)
-2979: Comma           "," at 310:34-310:35
-2980: Ident           "other" at 310:36-310:41 (leading: Space)
-2981: Colon           ":" at 310:41-310:42
-2982: Ident           "uint" at 310:43-310:47 (leading: Space)
-2983: RParen          ")" at 310:47-310:48
-2984: Arrow           "->" at 310:49-310:51 (leading: Space)
-2985: Ident           "bool" at 310:52-310:56 (leading: Space)
-2986: Semicolon       ";" at 310:56-310:57
-2987: At              "@" at 311:5-311:6 (leading: Newline, Space)
-2988: Ident           "intrinsic" at 311:6-311:15
-2989: KwFn            "fn" at 311:16-311:18 (leading: Space)
-2990: Ident           "__ne" at 311:19-311:23 (leading: Space)
-2991: LParen          "(" at 311:23-311:24
-2992: Ident           "self" at 311:24-311:28
-2993: Colon           ":" at 311:28-311:29
-2994: Ident           "uint" at 311:30-311:34 (leading: Space)
-2995: Comma           "," at 311:34-311:35
-2996: Ident           "other" at 311:36-311:41 (leading: Space)
-2997: Colon           ":" at 311:41-311:42
-2998: Ident           "uint" at 311:43-311:47 (leading: Space)
-2999: RParen          ")" at 311:47-311:48
-3000: Arrow           "->" at 311:49-311:51 (leading: Space)
-3001: Ident           "bool" at 311:52-311:56 (leading: Space)
-3002: Semicolon       ";" at 311:56-311:57
-3003: At              "@" at 312:5-312:6 (leading: Newline, Space)
-3004: Ident           "intrinsic" at 312:6-312:15
-3005: KwFn            "fn" at 312:16-312:18 (leading: Space)
-3006: Ident           "__ge" at 312:19-312:23 (leading: Space)
-3007: LParen          "(" at 312:23-312:24
-3008: Ident           "self" at 312:24-312:28
-3009: Colon           ":" at 312:28-312:29
-3010: Ident           "uint" at 312:30-312:34 (leading: Space)
-3011: Comma           "," at 312:34-312:35
-3012: Ident           "other" at 312:36-312:41 (leading: Space)
-3013: Colon           ":" at 312:41-312:42
-3014: Ident           "uint" at 312:43-312:47 (leading: Space)
-3015: RParen          ")" at 312:47-312:48
-3016: Arrow           "->" at 312:49-312:51 (leading: Space)
-3017: Ident           "bool" at 312:52-312:56 (leading: Space)
-3018: Semicolon       ";" at 312:56-312:57
-3019: At              "@" at 313:5-313:6 (leading: Newline, Space)
-3020: Ident           "intrinsic" at 313:6-313:15
-3021: KwFn            "fn" at 313:16-313:18 (leading: Space)
-3022: Ident           "__gt" at 313:19-313:23 (leading: Space)
-3023: LParen          "(" at 313:23-313:24
-3024: Ident           "self" at 313:24-313:28
-3025: Colon           ":" at 313:28-313:29
-3026: Ident           "uint" at 313:30-313:34 (leading: Space)
-3027: Comma           "," at 313:34-313:35
-3028: Ident           "other" at 313:36-313:41 (leading: Space)
-3029: Colon           ":" at 313:41-313:42
-3030: Ident           "uint" at 313:43-313:47 (leading: Space)
-3031: RParen          ")" at 313:47-313:48
-3032: Arrow           "->" at 313:49-313:51 (leading: Space)
-3033: Ident           "bool" at 313:52-313:56 (leading: Space)
-3034: Semicolon       ";" at 313:56-313:57
-3035: At              "@" at 314:5-314:6 (leading: Newline, Space)
-3036: Ident           "intrinsic" at 314:6-314:15
-3037: KwFn            "fn" at 314:16-314:18 (leading: Space)
-3038: Ident           "__pos" at 314:19-314:24 (leading: Space)
-3039: LParen          "(" at 314:24-314:25
-3040: Ident           "self" at 314:25-314:29
-3041: Colon           ":" at 314:29-314:30
-3042: Ident           "uint" at 314:31-314:35 (leading: Space)
-3043: RParen          ")" at 314:35-314:36
-3044: Arrow           "->" at 314:37-314:39 (leading: Space)
-3045: Ident           "uint" at 314:40-314:44 (leading: Space)
-3046: Semicolon       ";" at 314:44-314:45
-3047: At              "@" at 315:5-315:6 (leading: Newline, Space)
-3048: Ident           "intrinsic" at 315:6-315:15
-3049: KwFn            "fn" at 315:16-315:18 (leading: Space)
-3050: Ident           "__abs" at 315:19-315:24 (leading: Space)
-3051: LParen          "(" at 315:24-315:25
-3052: Ident           "self" at 315:25-315:29
-3053: Colon           ":" at 315:29-315:30
-3054: Ident           "uint" at 315:31-315:35 (leading: Space)
-3055: RParen          ")" at 315:35-315:36
-3056: Arrow           "->" at 315:37-315:39 (leading: Space)
-3057: Ident           "uint" at 315:40-315:44 (leading: Space)
-3058: Semicolon       ";" at 315:44-315:45
-3059: At              "@" at 316:5-316:6 (leading: Newline, Space)
-3060: Ident           "intrinsic" at 316:6-316:15
-3061: KwFn            "fn" at 316:16-316:18 (leading: Space)
-3062: Ident           "__to" at 316:19-316:23 (leading: Space)
-3063: LParen          "(" at 316:23-316:24
-3064: Ident           "self" at 316:24-316:28
-3065: Colon           ":" at 316:28-316:29
-3066: Ident           "uint" at 316:30-316:34 (leading: Space)
-3067: Comma           "," at 316:34-316:35
-3068: Ident           "target" at 316:36-316:42 (leading: Space)
-3069: Colon           ":" at 316:42-316:43
-3070: Ident           "string" at 316:44-316:50 (leading: Space)
-3071: RParen          ")" at 316:50-316:51
-3072: Arrow           "->" at 316:52-316:54 (leading: Space)
-3073: Ident           "string" at 316:55-316:61 (leading: Space)
-3074: Semicolon       ";" at 316:61-316:62
-3075: At              "@" at 317:5-317:6 (leading: Newline, Space)
-3076: Ident           "overload" at 317:6-317:14
-3077: KwPub           "pub" at 317:15-317:18 (leading: Space)
-3078: KwFn            "fn" at 317:19-317:21 (leading: Space)
-3079: Ident           "__to" at 317:22-317:26 (leading: Space)
-3080: LParen          "(" at 317:26-317:27
-3081: Ident           "self" at 317:27-317:31
-3082: Colon           ":" at 317:31-317:32
-3083: Amp             "&" at 317:33-317:34 (leading: Space)
-3084: Ident           "uint" at 317:34-317:38
-3085: Comma           "," at 317:38-317:39
-3086: Underscore      "_" at 317:40-317:41 (leading: Space)
-3087: Colon           ":" at 317:41-317:42
-3088: Ident           "string" at 317:43-317:49 (leading: Space)
-3089: RParen          ")" at 317:49-317:50
-3090: Arrow           "->" at 317:51-317:53 (leading: Space)
-3091: Ident           "string" at 317:54-317:60 (leading: Space)
-3092: LBrace          "{" at 317:61-317:62 (leading: Space)
-3093: KwReturn        "return" at 318:9-318:15 (leading: Newline, Space)
-3094: LParen          "(" at 318:16-318:17 (leading: Space)
-3095: Star            "*" at 318:17-318:18
-3096: Ident           "self" at 318:18-318:22
-3097: RParen          ")" at 318:22-318:23
-3098: KwTo            "to" at 318:24-318:26 (leading: Space)
-3099: Ident           "string" at 318:27-318:33 (leading: Space)
-3100: Semicolon       ";" at 318:33-318:34
-3101: RBrace          "}" at 319:5-319:6 (leading: Newline, Space)
-3102: At              "@" at 320:5-320:6 (leading: Newline, Space)
-3103: Ident           "intrinsic" at 320:6-320:15
-3104: At              "@" at 320:16-320:17 (leading: Space)
-3105: Ident           "overload" at 320:17-320:25
-3106: KwFn            "fn" at 320:26-320:28 (leading: Space)
-3107: Ident           "__to" at 320:29-320:33 (leading: Space)
-3108: LParen          "(" at 320:33-320:34
-3109: Ident           "self" at 320:34-320:38
-3110: Colon           ":" at 320:38-320:39
-3111: Ident           "uint" at 320:40-320:44 (leading: Space)
-3112: Comma           "," at 320:44-320:45
-3113: Ident           "target" at 320:46-320:52 (leading: Space)
-3114: Colon           ":" at 320:52-320:53
-3115: Ident           "int" at 320:54-320:57 (leading: Space)
-3116: RParen          ")" at 320:57-320:58
-3117: Arrow           "->" at 320:59-320:61 (leading: Space)
-3118: Ident           "int" at 320:62-320:65 (leading: Space)
-3119: Semicolon       ";" at 320:65-320:66
-3120: At              "@" at 321:5-321:6 (leading: Newline, Space)
-3121: Ident           "intrinsic" at 321:6-321:15
-3122: At              "@" at 321:16-321:17 (leading: Space)
-3123: Ident           "overload" at 321:17-321:25
-3124: KwFn            "fn" at 321:26-321:28 (leading: Space)
-3125: Ident           "__to" at 321:29-321:33 (leading: Space)
-3126: LParen          "(" at 321:33-321:34
-3127: Ident           "self" at 321:34-321:38
-3128: Colon           ":" at 321:38-321:39
-3129: Ident           "uint" at 321:40-321:44 (leading: Space)
-3130: Comma           "," at 321:44-321:45
-3131: Ident           "target" at 321:46-321:52 (leading: Space)
-3132: Colon           ":" at 321:52-321:53
-3133: Ident           "float" at 321:54-321:59 (leading: Space)
-3134: RParen          ")" at 321:59-321:60
-3135: Arrow           "->" at 321:61-321:63 (leading: Space)
-3136: Ident           "float" at 321:64-321:69 (leading: Space)
-3137: Semicolon       ";" at 321:69-321:70
-3138: At              "@" at 322:5-322:6 (leading: Newline, Space)
-3139: Ident           "intrinsic" at 322:6-322:15
-3140: At              "@" at 322:16-322:17 (leading: Space)
-3141: Ident           "overload" at 322:17-322:25
-3142: KwFn            "fn" at 322:26-322:28 (leading: Space)
-3143: Ident           "__to" at 322:29-322:33 (leading: Space)
-3144: LParen          "(" at 322:33-322:34
-3145: Ident           "self" at 322:34-322:38
-3146: Colon           ":" at 322:38-322:39
-3147: Ident           "uint" at 322:40-322:44 (leading: Space)
-3148: Comma           "," at 322:44-322:45
-3149: Ident           "target" at 322:46-322:52 (leading: Space)
-3150: Colon           ":" at 322:52-322:53
-3151: Ident           "int8" at 322:54-322:58 (leading: Space)
-3152: RParen          ")" at 322:58-322:59
-3153: Arrow           "->" at 322:60-322:62 (leading: Space)
-3154: Ident           "int8" at 322:63-322:67 (leading: Space)
-3155: Semicolon       ";" at 322:67-322:68
-3156: At              "@" at 323:5-323:6 (leading: Newline, Space)
-3157: Ident           "intrinsic" at 323:6-323:15
-3158: At              "@" at 323:16-323:17 (leading: Space)
-3159: Ident           "overload" at 323:17-323:25
-3160: KwFn            "fn" at 323:26-323:28 (leading: Space)
-3161: Ident           "__to" at 323:29-323:33 (leading: Space)
-3162: LParen          "(" at 323:33-323:34
-3163: Ident           "self" at 323:34-323:38
-3164: Colon           ":" at 323:38-323:39
-3165: Ident           "uint" at 323:40-323:44 (leading: Space)
-3166: Comma           "," at 323:44-323:45
-3167: Ident           "target" at 323:46-323:52 (leading: Space)
-3168: Colon           ":" at 323:52-323:53
-3169: Ident           "int16" at 323:54-323:59 (leading: Space)
-3170: RParen          ")" at 323:59-323:60
-3171: Arrow           "->" at 323:61-323:63 (leading: Space)
-3172: Ident           "int16" at 323:64-323:69 (leading: Space)
-3173: Semicolon       ";" at 323:69-323:70
-3174: At              "@" at 324:5-324:6 (leading: Newline, Space)
-3175: Ident           "intrinsic" at 324:6-324:15
-3176: At              "@" at 324:16-324:17 (leading: Space)
-3177: Ident           "overload" at 324:17-324:25
-3178: KwFn            "fn" at 324:26-324:28 (leading: Space)
-3179: Ident           "__to" at 324:29-324:33 (leading: Space)
-3180: LParen          "(" at 324:33-324:34
-3181: Ident           "self" at 324:34-324:38
-3182: Colon           ":" at 324:38-324:39
-3183: Ident           "uint" at 324:40-324:44 (leading: Space)
-3184: Comma           "," at 324:44-324:45
-3185: Ident           "target" at 324:46-324:52 (leading: Space)
-3186: Colon           ":" at 324:52-324:53
-3187: Ident           "int32" at 324:54-324:59 (leading: Space)
-3188: RParen          ")" at 324:59-324:60
-3189: Arrow           "->" at 324:61-324:63 (leading: Space)
-3190: Ident           "int32" at 324:64-324:69 (leading: Space)
-3191: Semicolon       ";" at 324:69-324:70
-3192: At              "@" at 325:5-325:6 (leading: Newline, Space)
-3193: Ident           "intrinsic" at 325:6-325:15
-3194: At              "@" at 325:16-325:17 (leading: Space)
-3195: Ident           "overload" at 325:17-325:25
-3196: KwFn            "fn" at 325:26-325:28 (leading: Space)
-3197: Ident           "__to" at 325:29-325:33 (leading: Space)
-3198: LParen          "(" at 325:33-325:34
-3199: Ident           "self" at 325:34-325:38
-3200: Colon           ":" at 325:38-325:39
-3201: Ident           "uint" at 325:40-325:44 (leading: Space)
-3202: Comma           "," at 325:44-325:45
-3203: Ident           "target" at 325:46-325:52 (leading: Space)
-3204: Colon           ":" at 325:52-325:53
-3205: Ident           "int64" at 325:54-325:59 (leading: Space)
-3206: RParen          ")" at 325:59-325:60
-3207: Arrow           "->" at 325:61-325:63 (leading: Space)
-3208: Ident           "int64" at 325:64-325:69 (leading: Space)
-3209: Semicolon       ";" at 325:69-325:70
-3210: At              "@" at 326:5-326:6 (leading: Newline, Space)
-3211: Ident           "intrinsic" at 326:6-326:15
-3212: At              "@" at 326:16-326:17 (leading: Space)
-3213: Ident           "overload" at 326:17-326:25
-3214: KwFn            "fn" at 326:26-326:28 (leading: Space)
-3215: Ident           "__to" at 326:29-326:33 (leading: Space)
-3216: LParen          "(" at 326:33-326:34
-3217: Ident           "self" at 326:34-326:38
-3218: Colon           ":" at 326:38-326:39
-3219: Ident           "uint" at 326:40-326:44 (leading: Space)
-3220: Comma           "," at 326:44-326:45
-3221: Ident           "target" at 326:46-326:52 (leading: Space)
-3222: Colon           ":" at 326:52-326:53
-3223: Ident           "uint8" at 326:54-326:59 (leading: Space)
-3224: RParen          ")" at 326:59-326:60
-3225: Arrow           "->" at 326:61-326:63 (leading: Space)
-3226: Ident           "uint8" at 326:64-326:69 (leading: Space)
-3227: Semicolon       ";" at 326:69-326:70
-3228: At              "@" at 327:5-327:6 (leading: Newline, Space)
-3229: Ident           "intrinsic" at 327:6-327:15
-3230: At              "@" at 327:16-327:17 (leading: Space)
-3231: Ident           "overload" at 327:17-327:25
-3232: KwFn            "fn" at 327:26-327:28 (leading: Space)
-3233: Ident           "__to" at 327:29-327:33 (leading: Space)
-3234: LParen          "(" at 327:33-327:34
-3235: Ident           "self" at 327:34-327:38
-3236: Colon           ":" at 327:38-327:39
-3237: Ident           "uint" at 327:40-327:44 (leading: Space)
-3238: Comma           "," at 327:44-327:45
-3239: Ident           "target" at 327:46-327:52 (leading: Space)
-3240: Colon           ":" at 327:52-327:53
-3241: Ident           "uint16" at 327:54-327:60 (leading: Space)
-3242: RParen          ")" at 327:60-327:61
-3243: Arrow           "->" at 327:62-327:64 (leading: Space)
-3244: Ident           "uint16" at 327:65-327:71 (leading: Space)
-3245: Semicolon       ";" at 327:71-327:72
-3246: At              "@" at 328:5-328:6 (leading: Newline, Space)
-3247: Ident           "intrinsic" at 328:6-328:15
-3248: At              "@" at 328:16-328:17 (leading: Space)
-3249: Ident           "overload" at 328:17-328:25
-3250: KwFn            "fn" at 328:26-328:28 (leading: Space)
-3251: Ident           "__to" at 328:29-328:33 (leading: Space)
-3252: LParen          "(" at 328:33-328:34
-3253: Ident           "self" at 328:34-328:38
-3254: Colon           ":" at 328:38-328:39
-3255: Ident           "uint" at 328:40-328:44 (leading: Space)
-3256: Comma           "," at 328:44-328:45
-3257: Ident           "target" at 328:46-328:52 (leading: Space)
-3258: Colon           ":" at 328:52-328:53
-3259: Ident           "uint32" at 328:54-328:60 (leading: Space)
-3260: RParen          ")" at 328:60-328:61
-3261: Arrow           "->" at 328:62-328:64 (leading: Space)
-3262: Ident           "uint32" at 328:65-328:71 (leading: Space)
-3263: Semicolon       ";" at 328:71-328:72
-3264: At              "@" at 329:5-329:6 (leading: Newline, Space)
-3265: Ident           "intrinsic" at 329:6-329:15
-3266: At              "@" at 329:16-329:17 (leading: Space)
-3267: Ident           "overload" at 329:17-329:25
-3268: KwFn            "fn" at 329:26-329:28 (leading: Space)
-3269: Ident           "__to" at 329:29-329:33 (leading: Space)
-3270: LParen          "(" at 329:33-329:34
-3271: Ident           "self" at 329:34-329:38
-3272: Colon           ":" at 329:38-329:39
-3273: Ident           "uint" at 329:40-329:44 (leading: Space)
-3274: Comma           "," at 329:44-329:45
-3275: Ident           "target" at 329:46-329:52 (leading: Space)
-3276: Colon           ":" at 329:52-329:53
-3277: Ident           "uint64" at 329:54-329:60 (leading: Space)
-3278: RParen          ")" at 329:60-329:61
-3279: Arrow           "->" at 329:62-329:64 (leading: Space)
-3280: Ident           "uint64" at 329:65-329:71 (leading: Space)
-3281: Semicolon       ";" at 329:71-329:72
-3282: At              "@" at 330:5-330:6 (leading: Newline, Space)
-3283: Ident           "intrinsic" at 330:6-330:15
-3284: At              "@" at 330:16-330:17 (leading: Space)
-3285: Ident           "overload" at 330:17-330:25
-3286: KwFn            "fn" at 330:26-330:28 (leading: Space)
-3287: Ident           "__to" at 330:29-330:33 (leading: Space)
-3288: LParen          "(" at 330:33-330:34
-3289: Ident           "self" at 330:34-330:38
-3290: Colon           ":" at 330:38-330:39
-3291: Ident           "uint" at 330:40-330:44 (leading: Space)
-3292: Comma           "," at 330:44-330:45
-3293: Ident           "target" at 330:46-330:52 (leading: Space)
-3294: Colon           ":" at 330:52-330:53
-3295: Ident           "float16" at 330:54-330:61 (leading: Space)
-3296: RParen          ")" at 330:61-330:62
-3297: Arrow           "->" at 330:63-330:65 (leading: Space)
-3298: Ident           "float16" at 330:66-330:73 (leading: Space)
-3299: Semicolon       ";" at 330:73-330:74
-3300: At              "@" at 331:5-331:6 (leading: Newline, Space)
-3301: Ident           "intrinsic" at 331:6-331:15
-3302: At              "@" at 331:16-331:17 (leading: Space)
-3303: Ident           "overload" at 331:17-331:25
-3304: KwFn            "fn" at 331:26-331:28 (leading: Space)
-3305: Ident           "__to" at 331:29-331:33 (leading: Space)
-3306: LParen          "(" at 331:33-331:34
-3307: Ident           "self" at 331:34-331:38
-3308: Colon           ":" at 331:38-331:39
-3309: Ident           "uint" at 331:40-331:44 (leading: Space)
-3310: Comma           "," at 331:44-331:45
-3311: Ident           "target" at 331:46-331:52 (leading: Space)
-3312: Colon           ":" at 331:52-331:53
-3313: Ident           "float32" at 331:54-331:61 (leading: Space)
-3314: RParen          ")" at 331:61-331:62
-3315: Arrow           "->" at 331:63-331:65 (leading: Space)
-3316: Ident           "float32" at 331:66-331:73 (leading: Space)
-3317: Semicolon       ";" at 331:73-331:74
-3318: At              "@" at 332:5-332:6 (leading: Newline, Space)
-3319: Ident           "intrinsic" at 332:6-332:15
-3320: At              "@" at 332:16-332:17 (leading: Space)
-3321: Ident           "overload" at 332:17-332:25
-3322: KwFn            "fn" at 332:26-332:28 (leading: Space)
-3323: Ident           "__to" at 332:29-332:33 (leading: Space)
-3324: LParen          "(" at 332:33-332:34
-3325: Ident           "self" at 332:34-332:38
-3326: Colon           ":" at 332:38-332:39
-3327: Ident           "uint" at 332:40-332:44 (leading: Space)
-3328: Comma           "," at 332:44-332:45
-3329: Ident           "target" at 332:46-332:52 (leading: Space)
-3330: Colon           ":" at 332:52-332:53
-3331: Ident           "float64" at 332:54-332:61 (leading: Space)
-3332: RParen          ")" at 332:61-332:62
-3333: Arrow           "->" at 332:63-332:65 (leading: Space)
-3334: Ident           "float64" at 332:66-332:73 (leading: Space)
-3335: Semicolon       ";" at 332:73-332:74
-3336: At              "@" at 334:5-334:6 (leading: Newline, Space, LineComment, Newline, Space)
-3337: Ident           "intrinsic" at 334:6-334:15
-3338: KwPub           "pub" at 334:16-334:19 (leading: Space)
-3339: KwFn            "fn" at 334:20-334:22 (leading: Space)
-3340: Ident           "from_str" at 334:23-334:31 (leading: Space)
-3341: LParen          "(" at 334:31-334:32
-3342: Ident           "s" at 334:32-334:33
-3343: Colon           ":" at 334:33-334:34
-3344: Amp             "&" at 334:35-334:36 (leading: Space)
-3345: Ident           "string" at 334:36-334:42
-3346: RParen          ")" at 334:42-334:43
-3347: Arrow           "->" at 334:44-334:46 (leading: Space)
-3348: Ident           "Erring" at 334:47-334:53 (leading: Space)
-3349: Lt              "<" at 334:53-334:54
-3350: Ident           "uint" at 334:54-334:58
-3351: Comma           "," at 334:58-334:59
-3352: Ident           "Error" at 334:60-334:65 (leading: Space)
-3353: Gt              ">" at 334:65-334:66
-3354: Semicolon       ";" at 334:66-334:67
-3355: RBrace          "}" at 335:1-335:2 (leading: Newline)
-3356: KwExtern        "extern" at 337:1-337:7 (leading: Newline)
-3357: Lt              "<" at 337:7-337:8
-3358: Ident           "int8" at 337:8-337:12
-3359: Gt              ">" at 337:12-337:13
-3360: LBrace          "{" at 337:14-337:15 (leading: Space)
-3361: KwPub           "pub" at 338:5-338:8 (leading: Newline, Space)
-3362: KwFn            "fn" at 338:9-338:11 (leading: Space)
-3363: Ident           "__min_value" at 338:12-338:23 (leading: Space)
-3364: LParen          "(" at 338:23-338:24
-3365: RParen          ")" at 338:24-338:25
-3366: Arrow           "->" at 338:26-338:28 (leading: Space)
-3367: Ident           "int8" at 338:29-338:33 (leading: Space)
-3368: LBrace          "{" at 338:34-338:35 (leading: Space)
-3369: KwReturn        "return" at 338:36-338:42 (leading: Space)
-3370: LParen          "(" at 338:43-338:44 (leading: Space)
-3371: Minus           "-" at 338:44-338:45
-3372: IntLit          "128" at 338:45-338:48
-3373: RParen          ")" at 338:48-338:49
-3374: Colon           ":" at 338:49-338:50
-3375: Ident           "int8" at 338:50-338:54
-3376: Semicolon       ";" at 338:54-338:55
-3377: RBrace          "}" at 338:56-338:57 (leading: Space)
-3378: KwPub           "pub" at 339:5-339:8 (leading: Newline, Space)
-3379: KwFn            "fn" at 339:9-339:11 (leading: Space)
-3380: Ident           "__max_value" at 339:12-339:23 (leading: Space)
-3381: LParen          "(" at 339:23-339:24
-3382: RParen          ")" at 339:24-339:25
-3383: Arrow           "->" at 339:26-339:28 (leading: Space)
-3384: Ident           "int8" at 339:29-339:33 (leading: Space)
-3385: LBrace          "{" at 339:34-339:35 (leading: Space)
-3386: KwReturn        "return" at 339:36-339:42 (leading: Space)
-3387: LParen          "(" at 339:43-339:44 (leading: Space)
-3388: IntLit          "127" at 339:44-339:47
-3389: RParen          ")" at 339:47-339:48
-3390: Colon           ":" at 339:48-339:49
-3391: Ident           "int8" at 339:49-339:53
-3392: Semicolon       ";" at 339:53-339:54
-3393: RBrace          "}" at 339:55-339:56 (leading: Space)
-3394: At              "@" at 340:5-340:6 (leading: Newline, Space)
-3395: Ident           "intrinsic" at 340:6-340:15
-3396: KwFn            "fn" at 340:16-340:18 (leading: Space)
-3397: Ident           "__add" at 340:19-340:24 (leading: Space)
-3398: LParen          "(" at 340:24-340:25
-3399: Ident           "self" at 340:25-340:29
-3400: Colon           ":" at 340:29-340:30
-3401: Ident           "int8" at 340:31-340:35 (leading: Space)
-3402: Comma           "," at 340:35-340:36
-3403: Ident           "other" at 340:37-340:42 (leading: Space)
-3404: Colon           ":" at 340:42-340:43
-3405: Ident           "int8" at 340:44-340:48 (leading: Space)
-3406: RParen          ")" at 340:48-340:49
-3407: Arrow           "->" at 340:50-340:52 (leading: Space)
-3408: Ident           "int8" at 340:53-340:57 (leading: Space)
-3409: Semicolon       ";" at 340:57-340:58
-3410: At              "@" at 341:5-341:6 (leading: Newline, Space)
-3411: Ident           "intrinsic" at 341:6-341:15
-3412: KwFn            "fn" at 341:16-341:18 (leading: Space)
-3413: Ident           "__sub" at 341:19-341:24 (leading: Space)
-3414: LParen          "(" at 341:24-341:25
-3415: Ident           "self" at 341:25-341:29
-3416: Colon           ":" at 341:29-341:30
-3417: Ident           "int8" at 341:31-341:35 (leading: Space)
-3418: Comma           "," at 341:35-341:36
-3419: Ident           "other" at 341:37-341:42 (leading: Space)
-3420: Colon           ":" at 341:42-341:43
-3421: Ident           "int8" at 341:44-341:48 (leading: Space)
-3422: RParen          ")" at 341:48-341:49
-3423: Arrow           "->" at 341:50-341:52 (leading: Space)
-3424: Ident           "int8" at 341:53-341:57 (leading: Space)
-3425: Semicolon       ";" at 341:57-341:58
-3426: At              "@" at 342:5-342:6 (leading: Newline, Space)
-3427: Ident           "intrinsic" at 342:6-342:15
-3428: KwFn            "fn" at 342:16-342:18 (leading: Space)
-3429: Ident           "__mul" at 342:19-342:24 (leading: Space)
-3430: LParen          "(" at 342:24-342:25
-3431: Ident           "self" at 342:25-342:29
-3432: Colon           ":" at 342:29-342:30
-3433: Ident           "int8" at 342:31-342:35 (leading: Space)
-3434: Comma           "," at 342:35-342:36
-3435: Ident           "other" at 342:37-342:42 (leading: Space)
-3436: Colon           ":" at 342:42-342:43
-3437: Ident           "int8" at 342:44-342:48 (leading: Space)
-3438: RParen          ")" at 342:48-342:49
-3439: Arrow           "->" at 342:50-342:52 (leading: Space)
-3440: Ident           "int8" at 342:53-342:57 (leading: Space)
-3441: Semicolon       ";" at 342:57-342:58
-3442: At              "@" at 343:5-343:6 (leading: Newline, Space)
-3443: Ident           "intrinsic" at 343:6-343:15
-3444: KwFn            "fn" at 343:16-343:18 (leading: Space)
-3445: Ident           "__div" at 343:19-343:24 (leading: Space)
-3446: LParen          "(" at 343:24-343:25
-3447: Ident           "self" at 343:25-343:29
-3448: Colon           ":" at 343:29-343:30
-3449: Ident           "int8" at 343:31-343:35 (leading: Space)
-3450: Comma           "," at 343:35-343:36
-3451: Ident           "other" at 343:37-343:42 (leading: Space)
-3452: Colon           ":" at 343:42-343:43
-3453: Ident           "int8" at 343:44-343:48 (leading: Space)
-3454: RParen          ")" at 343:48-343:49
-3455: Arrow           "->" at 343:50-343:52 (leading: Space)
-3456: Ident           "int8" at 343:53-343:57 (leading: Space)
-3457: Semicolon       ";" at 343:57-343:58
-3458: At              "@" at 344:5-344:6 (leading: Newline, Space)
-3459: Ident           "intrinsic" at 344:6-344:15
-3460: KwFn            "fn" at 344:16-344:18 (leading: Space)
-3461: Ident           "__mod" at 344:19-344:24 (leading: Space)
-3462: LParen          "(" at 344:24-344:25
-3463: Ident           "self" at 344:25-344:29
-3464: Colon           ":" at 344:29-344:30
-3465: Ident           "int8" at 344:31-344:35 (leading: Space)
-3466: Comma           "," at 344:35-344:36
-3467: Ident           "other" at 344:37-344:42 (leading: Space)
-3468: Colon           ":" at 344:42-344:43
-3469: Ident           "int8" at 344:44-344:48 (leading: Space)
-3470: RParen          ")" at 344:48-344:49
-3471: Arrow           "->" at 344:50-344:52 (leading: Space)
-3472: Ident           "int8" at 344:53-344:57 (leading: Space)
-3473: Semicolon       ";" at 344:57-344:58
-3474: At              "@" at 345:5-345:6 (leading: Newline, Space)
-3475: Ident           "intrinsic" at 345:6-345:15
-3476: KwFn            "fn" at 345:16-345:18 (leading: Space)
-3477: Ident           "__bit_and" at 345:19-345:28 (leading: Space)
-3478: LParen          "(" at 345:28-345:29
-3479: Ident           "self" at 345:29-345:33
-3480: Colon           ":" at 345:33-345:34
-3481: Ident           "int8" at 345:35-345:39 (leading: Space)
-3482: Comma           "," at 345:39-345:40
-3483: Ident           "other" at 345:41-345:46 (leading: Space)
-3484: Colon           ":" at 345:46-345:47
-3485: Ident           "int8" at 345:48-345:52 (leading: Space)
-3486: RParen          ")" at 345:52-345:53
-3487: Arrow           "->" at 345:54-345:56 (leading: Space)
-3488: Ident           "int8" at 345:57-345:61 (leading: Space)
-3489: Semicolon       ";" at 345:61-345:62
-3490: At              "@" at 346:5-346:6 (leading: Newline, Space)
-3491: Ident           "intrinsic" at 346:6-346:15
-3492: KwFn            "fn" at 346:16-346:18 (leading: Space)
-3493: Ident           "__bit_or" at 346:19-346:27 (leading: Space)
-3494: LParen          "(" at 346:27-346:28
-3495: Ident           "self" at 346:28-346:32
-3496: Colon           ":" at 346:32-346:33
-3497: Ident           "int8" at 346:34-346:38 (leading: Space)
-3498: Comma           "," at 346:38-346:39
-3499: Ident           "other" at 346:40-346:45 (leading: Space)
-3500: Colon           ":" at 346:45-346:46
-3501: Ident           "int8" at 346:47-346:51 (leading: Space)
-3502: RParen          ")" at 346:51-346:52
-3503: Arrow           "->" at 346:53-346:55 (leading: Space)
-3504: Ident           "int8" at 346:56-346:60 (leading: Space)
-3505: Semicolon       ";" at 346:60-346:61
-3506: At              "@" at 347:5-347:6 (leading: Newline, Space)
-3507: Ident           "intrinsic" at 347:6-347:15
-3508: KwFn            "fn" at 347:16-347:18 (leading: Space)
-3509: Ident           "__bit_xor" at 347:19-347:28 (leading: Space)
-3510: LParen          "(" at 347:28-347:29
-3511: Ident           "self" at 347:29-347:33
-3512: Colon           ":" at 347:33-347:34
-3513: Ident           "int8" at 347:35-347:39 (leading: Space)
-3514: Comma           "," at 347:39-347:40
-3515: Ident           "other" at 347:41-347:46 (leading: Space)
-3516: Colon           ":" at 347:46-347:47
-3517: Ident           "int8" at 347:48-347:52 (leading: Space)
-3518: RParen          ")" at 347:52-347:53
-3519: Arrow           "->" at 347:54-347:56 (leading: Space)
-3520: Ident           "int8" at 347:57-347:61 (leading: Space)
-3521: Semicolon       ";" at 347:61-347:62
-3522: At              "@" at 348:5-348:6 (leading: Newline, Space)
-3523: Ident           "intrinsic" at 348:6-348:15
-3524: KwFn            "fn" at 348:16-348:18 (leading: Space)
-3525: Ident           "__shl" at 348:19-348:24 (leading: Space)
-3526: LParen          "(" at 348:24-348:25
-3527: Ident           "self" at 348:25-348:29
-3528: Colon           ":" at 348:29-348:30
-3529: Ident           "int8" at 348:31-348:35 (leading: Space)
-3530: Comma           "," at 348:35-348:36
-3531: Ident           "other" at 348:37-348:42 (leading: Space)
-3532: Colon           ":" at 348:42-348:43
-3533: Ident           "int8" at 348:44-348:48 (leading: Space)
-3534: RParen          ")" at 348:48-348:49
-3535: Arrow           "->" at 348:50-348:52 (leading: Space)
-3536: Ident           "int8" at 348:53-348:57 (leading: Space)
-3537: Semicolon       ";" at 348:57-348:58
-3538: At              "@" at 349:5-349:6 (leading: Newline, Space)
-3539: Ident           "intrinsic" at 349:6-349:15
-3540: KwFn            "fn" at 349:16-349:18 (leading: Space)
-3541: Ident           "__shr" at 349:19-349:24 (leading: Space)
-3542: LParen          "(" at 349:24-349:25
-3543: Ident           "self" at 349:25-349:29
-3544: Colon           ":" at 349:29-349:30
-3545: Ident           "int8" at 349:31-349:35 (leading: Space)
-3546: Comma           "," at 349:35-349:36
-3547: Ident           "other" at 349:37-349:42 (leading: Space)
-3548: Colon           ":" at 349:42-349:43
-3549: Ident           "int8" at 349:44-349:48 (leading: Space)
-3550: RParen          ")" at 349:48-349:49
-3551: Arrow           "->" at 349:50-349:52 (leading: Space)
-3552: Ident           "int8" at 349:53-349:57 (leading: Space)
-3553: Semicolon       ";" at 349:57-349:58
-3554: At              "@" at 350:5-350:6 (leading: Newline, Space)
-3555: Ident           "intrinsic" at 350:6-350:15
-3556: KwFn            "fn" at 350:16-350:18 (leading: Space)
-3557: Ident           "__lt" at 350:19-350:23 (leading: Space)
-3558: LParen          "(" at 350:23-350:24
-3559: Ident           "self" at 350:24-350:28
-3560: Colon           ":" at 350:28-350:29
-3561: Ident           "int8" at 350:30-350:34 (leading: Space)
-3562: Comma           "," at 350:34-350:35
-3563: Ident           "other" at 350:36-350:41 (leading: Space)
-3564: Colon           ":" at 350:41-350:42
-3565: Ident           "int8" at 350:43-350:47 (leading: Space)
-3566: RParen          ")" at 350:47-350:48
-3567: Arrow           "->" at 350:49-350:51 (leading: Space)
-3568: Ident           "bool" at 350:52-350:56 (leading: Space)
-3569: Semicolon       ";" at 350:56-350:57
-3570: At              "@" at 351:5-351:6 (leading: Newline, Space)
-3571: Ident           "intrinsic" at 351:6-351:15
-3572: KwFn            "fn" at 351:16-351:18 (leading: Space)
-3573: Ident           "__le" at 351:19-351:23 (leading: Space)
-3574: LParen          "(" at 351:23-351:24
-3575: Ident           "self" at 351:24-351:28
-3576: Colon           ":" at 351:28-351:29
-3577: Ident           "int8" at 351:30-351:34 (leading: Space)
-3578: Comma           "," at 351:34-351:35
-3579: Ident           "other" at 351:36-351:41 (leading: Space)
-3580: Colon           ":" at 351:41-351:42
-3581: Ident           "int8" at 351:43-351:47 (leading: Space)
-3582: RParen          ")" at 351:47-351:48
-3583: Arrow           "->" at 351:49-351:51 (leading: Space)
-3584: Ident           "bool" at 351:52-351:56 (leading: Space)
-3585: Semicolon       ";" at 351:56-351:57
-3586: At              "@" at 352:5-352:6 (leading: Newline, Space)
-3587: Ident           "intrinsic" at 352:6-352:15
-3588: KwFn            "fn" at 352:16-352:18 (leading: Space)
-3589: Ident           "__eq" at 352:19-352:23 (leading: Space)
-3590: LParen          "(" at 352:23-352:24
-3591: Ident           "self" at 352:24-352:28
-3592: Colon           ":" at 352:28-352:29
-3593: Ident           "int8" at 352:30-352:34 (leading: Space)
-3594: Comma           "," at 352:34-352:35
-3595: Ident           "other" at 352:36-352:41 (leading: Space)
-3596: Colon           ":" at 352:41-352:42
-3597: Ident           "int8" at 352:43-352:47 (leading: Space)
-3598: RParen          ")" at 352:47-352:48
-3599: Arrow           "->" at 352:49-352:51 (leading: Space)
-3600: Ident           "bool" at 352:52-352:56 (leading: Space)
-3601: Semicolon       ";" at 352:56-352:57
-3602: At              "@" at 353:5-353:6 (leading: Newline, Space)
-3603: Ident           "intrinsic" at 353:6-353:15
-3604: KwFn            "fn" at 353:16-353:18 (leading: Space)
-3605: Ident           "__ne" at 353:19-353:23 (leading: Space)
-3606: LParen          "(" at 353:23-353:24
-3607: Ident           "self" at 353:24-353:28
-3608: Colon           ":" at 353:28-353:29
-3609: Ident           "int8" at 353:30-353:34 (leading: Space)
-3610: Comma           "," at 353:34-353:35
-3611: Ident           "other" at 353:36-353:41 (leading: Space)
-3612: Colon           ":" at 353:41-353:42
-3613: Ident           "int8" at 353:43-353:47 (leading: Space)
-3614: RParen          ")" at 353:47-353:48
-3615: Arrow           "->" at 353:49-353:51 (leading: Space)
-3616: Ident           "bool" at 353:52-353:56 (leading: Space)
-3617: Semicolon       ";" at 353:56-353:57
-3618: At              "@" at 354:5-354:6 (leading: Newline, Space)
-3619: Ident           "intrinsic" at 354:6-354:15
-3620: KwFn            "fn" at 354:16-354:18 (leading: Space)
-3621: Ident           "__ge" at 354:19-354:23 (leading: Space)
-3622: LParen          "(" at 354:23-354:24
-3623: Ident           "self" at 354:24-354:28
-3624: Colon           ":" at 354:28-354:29
-3625: Ident           "int8" at 354:30-354:34 (leading: Space)
-3626: Comma           "," at 354:34-354:35
-3627: Ident           "other" at 354:36-354:41 (leading: Space)
-3628: Colon           ":" at 354:41-354:42
-3629: Ident           "int8" at 354:43-354:47 (leading: Space)
-3630: RParen          ")" at 354:47-354:48
-3631: Arrow           "->" at 354:49-354:51 (leading: Space)
-3632: Ident           "bool" at 354:52-354:56 (leading: Space)
-3633: Semicolon       ";" at 354:56-354:57
-3634: At              "@" at 355:5-355:6 (leading: Newline, Space)
-3635: Ident           "intrinsic" at 355:6-355:15
-3636: KwFn            "fn" at 355:16-355:18 (leading: Space)
-3637: Ident           "__gt" at 355:19-355:23 (leading: Space)
-3638: LParen          "(" at 355:23-355:24
-3639: Ident           "self" at 355:24-355:28
-3640: Colon           ":" at 355:28-355:29
-3641: Ident           "int8" at 355:30-355:34 (leading: Space)
-3642: Comma           "," at 355:34-355:35
-3643: Ident           "other" at 355:36-355:41 (leading: Space)
-3644: Colon           ":" at 355:41-355:42
-3645: Ident           "int8" at 355:43-355:47 (leading: Space)
-3646: RParen          ")" at 355:47-355:48
-3647: Arrow           "->" at 355:49-355:51 (leading: Space)
-3648: Ident           "bool" at 355:52-355:56 (leading: Space)
-3649: Semicolon       ";" at 355:56-355:57
-3650: At              "@" at 356:5-356:6 (leading: Newline, Space)
-3651: Ident           "intrinsic" at 356:6-356:15
-3652: KwFn            "fn" at 356:16-356:18 (leading: Space)
-3653: Ident           "__pos" at 356:19-356:24 (leading: Space)
-3654: LParen          "(" at 356:24-356:25
-3655: Ident           "self" at 356:25-356:29
-3656: Colon           ":" at 356:29-356:30
-3657: Ident           "int8" at 356:31-356:35 (leading: Space)
-3658: RParen          ")" at 356:35-356:36
-3659: Arrow           "->" at 356:37-356:39 (leading: Space)
-3660: Ident           "int8" at 356:40-356:44 (leading: Space)
-3661: Semicolon       ";" at 356:44-356:45
-3662: At              "@" at 357:5-357:6 (leading: Newline, Space)
-3663: Ident           "intrinsic" at 357:6-357:15
-3664: KwFn            "fn" at 357:16-357:18 (leading: Space)
-3665: Ident           "__neg" at 357:19-357:24 (leading: Space)
-3666: LParen          "(" at 357:24-357:25
-3667: Ident           "self" at 357:25-357:29
-3668: Colon           ":" at 357:29-357:30
-3669: Ident           "int8" at 357:31-357:35 (leading: Space)
-3670: RParen          ")" at 357:35-357:36
-3671: Arrow           "->" at 357:37-357:39 (leading: Space)
-3672: Ident           "int8" at 357:40-357:44 (leading: Space)
-3673: Semicolon       ";" at 357:44-357:45
-3674: At              "@" at 358:5-358:6 (leading: Newline, Space)
-3675: Ident           "intrinsic" at 358:6-358:15
-3676: KwFn            "fn" at 358:16-358:18 (leading: Space)
-3677: Ident           "__abs" at 358:19-358:24 (leading: Space)
-3678: LParen          "(" at 358:24-358:25
-3679: Ident           "self" at 358:25-358:29
-3680: Colon           ":" at 358:29-358:30
-3681: Ident           "int8" at 358:31-358:35 (leading: Space)
-3682: RParen          ")" at 358:35-358:36
-3683: Arrow           "->" at 358:37-358:39 (leading: Space)
-3684: Ident           "int8" at 358:40-358:44 (leading: Space)
-3685: Semicolon       ";" at 358:44-358:45
-3686: At              "@" at 359:5-359:6 (leading: Newline, Space)
-3687: Ident           "intrinsic" at 359:6-359:15
-3688: KwFn            "fn" at 359:16-359:18 (leading: Space)
-3689: Ident           "__to" at 359:19-359:23 (leading: Space)
-3690: LParen          "(" at 359:23-359:24
-3691: Ident           "self" at 359:24-359:28
-3692: Colon           ":" at 359:28-359:29
-3693: Ident           "int8" at 359:30-359:34 (leading: Space)
-3694: Comma           "," at 359:34-359:35
-3695: Ident           "target" at 359:36-359:42 (leading: Space)
-3696: Colon           ":" at 359:42-359:43
-3697: Ident           "int" at 359:44-359:47 (leading: Space)
-3698: RParen          ")" at 359:47-359:48
-3699: Arrow           "->" at 359:49-359:51 (leading: Space)
-3700: Ident           "int" at 359:52-359:55 (leading: Space)
-3701: Semicolon       ";" at 359:55-359:56
-3702: At              "@" at 360:5-360:6 (leading: Newline, Space)
-3703: Ident           "intrinsic" at 360:6-360:15
-3704: At              "@" at 360:16-360:17 (leading: Space)
-3705: Ident           "overload" at 360:17-360:25
-3706: KwFn            "fn" at 360:26-360:28 (leading: Space)
-3707: Ident           "__to" at 360:29-360:33 (leading: Space)
-3708: LParen          "(" at 360:33-360:34
-3709: Ident           "self" at 360:34-360:38
-3710: Colon           ":" at 360:38-360:39
-3711: Ident           "int8" at 360:40-360:44 (leading: Space)
-3712: Comma           "," at 360:44-360:45
-3713: Ident           "target" at 360:46-360:52 (leading: Space)
-3714: Colon           ":" at 360:52-360:53
-3715: Ident           "int16" at 360:54-360:59 (leading: Space)
-3716: RParen          ")" at 360:59-360:60
-3717: Arrow           "->" at 360:61-360:63 (leading: Space)
-3718: Ident           "int16" at 360:64-360:69 (leading: Space)
-3719: Semicolon       ";" at 360:69-360:70
-3720: At              "@" at 361:5-361:6 (leading: Newline, Space)
-3721: Ident           "intrinsic" at 361:6-361:15
-3722: At              "@" at 361:16-361:17 (leading: Space)
-3723: Ident           "overload" at 361:17-361:25
-3724: KwFn            "fn" at 361:26-361:28 (leading: Space)
-3725: Ident           "__to" at 361:29-361:33 (leading: Space)
-3726: LParen          "(" at 361:33-361:34
-3727: Ident           "self" at 361:34-361:38
-3728: Colon           ":" at 361:38-361:39
-3729: Ident           "int8" at 361:40-361:44 (leading: Space)
-3730: Comma           "," at 361:44-361:45
-3731: Ident           "target" at 361:46-361:52 (leading: Space)
-3732: Colon           ":" at 361:52-361:53
-3733: Ident           "int32" at 361:54-361:59 (leading: Space)
-3734: RParen          ")" at 361:59-361:60
-3735: Arrow           "->" at 361:61-361:63 (leading: Space)
-3736: Ident           "int32" at 361:64-361:69 (leading: Space)
-3737: Semicolon       ";" at 361:69-361:70
-3738: At              "@" at 362:5-362:6 (leading: Newline, Space)
-3739: Ident           "intrinsic" at 362:6-362:15
-3740: At              "@" at 362:16-362:17 (leading: Space)
-3741: Ident           "overload" at 362:17-362:25
-3742: KwFn            "fn" at 362:26-362:28 (leading: Space)
-3743: Ident           "__to" at 362:29-362:33 (leading: Space)
-3744: LParen          "(" at 362:33-362:34
-3745: Ident           "self" at 362:34-362:38
-3746: Colon           ":" at 362:38-362:39
-3747: Ident           "int8" at 362:40-362:44 (leading: Space)
-3748: Comma           "," at 362:44-362:45
-3749: Ident           "target" at 362:46-362:52 (leading: Space)
-3750: Colon           ":" at 362:52-362:53
-3751: Ident           "int64" at 362:54-362:59 (leading: Space)
-3752: RParen          ")" at 362:59-362:60
-3753: Arrow           "->" at 362:61-362:63 (leading: Space)
-3754: Ident           "int64" at 362:64-362:69 (leading: Space)
-3755: Semicolon       ";" at 362:69-362:70
-3756: At              "@" at 363:5-363:6 (leading: Newline, Space)
-3757: Ident           "intrinsic" at 363:6-363:15
-3758: KwPub           "pub" at 363:16-363:19 (leading: Space)
-3759: KwFn            "fn" at 363:20-363:22 (leading: Space)
-3760: Ident           "from_str" at 363:23-363:31 (leading: Space)
-3761: LParen          "(" at 363:31-363:32
-3762: Ident           "s" at 363:32-363:33
-3763: Colon           ":" at 363:33-363:34
-3764: Amp             "&" at 363:35-363:36 (leading: Space)
-3765: Ident           "string" at 363:36-363:42
-3766: RParen          ")" at 363:42-363:43
-3767: Arrow           "->" at 363:44-363:46 (leading: Space)
-3768: Ident           "Erring" at 363:47-363:53 (leading: Space)
-3769: Lt              "<" at 363:53-363:54
-3770: Ident           "int8" at 363:54-363:58
-3771: Comma           "," at 363:58-363:59
-3772: Ident           "Error" at 363:60-363:65 (leading: Space)
-3773: Gt              ">" at 363:65-363:66
-3774: Semicolon       ";" at 363:66-363:67
-3775: RBrace          "}" at 364:1-364:2 (leading: Newline)
-3776: KwExtern        "extern" at 366:1-366:7 (leading: Newline)
-3777: Lt              "<" at 366:7-366:8
-3778: Ident           "int16" at 366:8-366:13
-3779: Gt              ">" at 366:13-366:14
-3780: LBrace          "{" at 366:15-366:16 (leading: Space)
-3781: KwPub           "pub" at 367:5-367:8 (leading: Newline, Space)
-3782: KwFn            "fn" at 367:9-367:11 (leading: Space)
-3783: Ident           "__min_value" at 367:12-367:23 (leading: Space)
-3784: LParen          "(" at 367:23-367:24
-3785: RParen          ")" at 367:24-367:25
-3786: Arrow           "->" at 367:26-367:28 (leading: Space)
-3787: Ident           "int16" at 367:29-367:34 (leading: Space)
-3788: LBrace          "{" at 367:35-367:36 (leading: Space)
-3789: KwReturn        "return" at 367:37-367:43 (leading: Space)
-3790: LParen          "(" at 367:44-367:45 (leading: Space)
-3791: Minus           "-" at 367:45-367:46
-3792: IntLit          "32_768" at 367:46-367:52
-3793: RParen          ")" at 367:52-367:53
-3794: Colon           ":" at 367:53-367:54
-3795: Ident           "int16" at 367:54-367:59
-3796: Semicolon       ";" at 367:59-367:60
-3797: RBrace          "}" at 367:61-367:62 (leading: Space)
-3798: KwPub           "pub" at 368:5-368:8 (leading: Newline, Space)
-3799: KwFn            "fn" at 368:9-368:11 (leading: Space)
-3800: Ident           "__max_value" at 368:12-368:23 (leading: Space)
-3801: LParen          "(" at 368:23-368:24
-3802: RParen          ")" at 368:24-368:25
-3803: Arrow           "->" at 368:26-368:28 (leading: Space)
-3804: Ident           "int16" at 368:29-368:34 (leading: Space)
-3805: LBrace          "{" at 368:35-368:36 (leading: Space)
-3806: KwReturn        "return" at 368:37-368:43 (leading: Space)
-3807: LParen          "(" at 368:44-368:45 (leading: Space)
-3808: IntLit          "32_767" at 368:45-368:51
-3809: RParen          ")" at 368:51-368:52
-3810: Colon           ":" at 368:52-368:53
-3811: Ident           "int16" at 368:53-368:58
-3812: Semicolon       ";" at 368:58-368:59
-3813: RBrace          "}" at 368:60-368:61 (leading: Space)
-3814: At              "@" at 369:5-369:6 (leading: Newline, Space)
-3815: Ident           "intrinsic" at 369:6-369:15
-3816: KwFn            "fn" at 369:16-369:18 (leading: Space)
-3817: Ident           "__add" at 369:19-369:24 (leading: Space)
-3818: LParen          "(" at 369:24-369:25
-3819: Ident           "self" at 369:25-369:29
-3820: Colon           ":" at 369:29-369:30
-3821: Ident           "int16" at 369:31-369:36 (leading: Space)
-3822: Comma           "," at 369:36-369:37
-3823: Ident           "other" at 369:38-369:43 (leading: Space)
-3824: Colon           ":" at 369:43-369:44
-3825: Ident           "int16" at 369:45-369:50 (leading: Space)
-3826: RParen          ")" at 369:50-369:51
-3827: Arrow           "->" at 369:52-369:54 (leading: Space)
-3828: Ident           "int16" at 369:55-369:60 (leading: Space)
-3829: Semicolon       ";" at 369:60-369:61
-3830: At              "@" at 370:5-370:6 (leading: Newline, Space)
-3831: Ident           "intrinsic" at 370:6-370:15
-3832: KwFn            "fn" at 370:16-370:18 (leading: Space)
-3833: Ident           "__sub" at 370:19-370:24 (leading: Space)
-3834: LParen          "(" at 370:24-370:25
-3835: Ident           "self" at 370:25-370:29
-3836: Colon           ":" at 370:29-370:30
-3837: Ident           "int16" at 370:31-370:36 (leading: Space)
-3838: Comma           "," at 370:36-370:37
-3839: Ident           "other" at 370:38-370:43 (leading: Space)
-3840: Colon           ":" at 370:43-370:44
-3841: Ident           "int16" at 370:45-370:50 (leading: Space)
-3842: RParen          ")" at 370:50-370:51
-3843: Arrow           "->" at 370:52-370:54 (leading: Space)
-3844: Ident           "int16" at 370:55-370:60 (leading: Space)
-3845: Semicolon       ";" at 370:60-370:61
-3846: At              "@" at 371:5-371:6 (leading: Newline, Space)
-3847: Ident           "intrinsic" at 371:6-371:15
-3848: KwFn            "fn" at 371:16-371:18 (leading: Space)
-3849: Ident           "__mul" at 371:19-371:24 (leading: Space)
-3850: LParen          "(" at 371:24-371:25
-3851: Ident           "self" at 371:25-371:29
-3852: Colon           ":" at 371:29-371:30
-3853: Ident           "int16" at 371:31-371:36 (leading: Space)
-3854: Comma           "," at 371:36-371:37
-3855: Ident           "other" at 371:38-371:43 (leading: Space)
-3856: Colon           ":" at 371:43-371:44
-3857: Ident           "int16" at 371:45-371:50 (leading: Space)
-3858: RParen          ")" at 371:50-371:51
-3859: Arrow           "->" at 371:52-371:54 (leading: Space)
-3860: Ident           "int16" at 371:55-371:60 (leading: Space)
-3861: Semicolon       ";" at 371:60-371:61
-3862: At              "@" at 372:5-372:6 (leading: Newline, Space)
-3863: Ident           "intrinsic" at 372:6-372:15
-3864: KwFn            "fn" at 372:16-372:18 (leading: Space)
-3865: Ident           "__div" at 372:19-372:24 (leading: Space)
-3866: LParen          "(" at 372:24-372:25
-3867: Ident           "self" at 372:25-372:29
-3868: Colon           ":" at 372:29-372:30
-3869: Ident           "int16" at 372:31-372:36 (leading: Space)
-3870: Comma           "," at 372:36-372:37
-3871: Ident           "other" at 372:38-372:43 (leading: Space)
-3872: Colon           ":" at 372:43-372:44
-3873: Ident           "int16" at 372:45-372:50 (leading: Space)
-3874: RParen          ")" at 372:50-372:51
-3875: Arrow           "->" at 372:52-372:54 (leading: Space)
-3876: Ident           "int16" at 372:55-372:60 (leading: Space)
-3877: Semicolon       ";" at 372:60-372:61
-3878: At              "@" at 373:5-373:6 (leading: Newline, Space)
-3879: Ident           "intrinsic" at 373:6-373:15
-3880: KwFn            "fn" at 373:16-373:18 (leading: Space)
-3881: Ident           "__mod" at 373:19-373:24 (leading: Space)
-3882: LParen          "(" at 373:24-373:25
-3883: Ident           "self" at 373:25-373:29
-3884: Colon           ":" at 373:29-373:30
-3885: Ident           "int16" at 373:31-373:36 (leading: Space)
-3886: Comma           "," at 373:36-373:37
-3887: Ident           "other" at 373:38-373:43 (leading: Space)
-3888: Colon           ":" at 373:43-373:44
-3889: Ident           "int16" at 373:45-373:50 (leading: Space)
-3890: RParen          ")" at 373:50-373:51
-3891: Arrow           "->" at 373:52-373:54 (leading: Space)
-3892: Ident           "int16" at 373:55-373:60 (leading: Space)
-3893: Semicolon       ";" at 373:60-373:61
-3894: At              "@" at 374:5-374:6 (leading: Newline, Space)
-3895: Ident           "intrinsic" at 374:6-374:15
-3896: KwFn            "fn" at 374:16-374:18 (leading: Space)
-3897: Ident           "__bit_and" at 374:19-374:28 (leading: Space)
-3898: LParen          "(" at 374:28-374:29
-3899: Ident           "self" at 374:29-374:33
-3900: Colon           ":" at 374:33-374:34
-3901: Ident           "int16" at 374:35-374:40 (leading: Space)
-3902: Comma           "," at 374:40-374:41
-3903: Ident           "other" at 374:42-374:47 (leading: Space)
-3904: Colon           ":" at 374:47-374:48
-3905: Ident           "int16" at 374:49-374:54 (leading: Space)
-3906: RParen          ")" at 374:54-374:55
-3907: Arrow           "->" at 374:56-374:58 (leading: Space)
-3908: Ident           "int16" at 374:59-374:64 (leading: Space)
-3909: Semicolon       ";" at 374:64-374:65
-3910: At              "@" at 375:5-375:6 (leading: Newline, Space)
-3911: Ident           "intrinsic" at 375:6-375:15
-3912: KwFn            "fn" at 375:16-375:18 (leading: Space)
-3913: Ident           "__bit_or" at 375:19-375:27 (leading: Space)
-3914: LParen          "(" at 375:27-375:28
-3915: Ident           "self" at 375:28-375:32
-3916: Colon           ":" at 375:32-375:33
-3917: Ident           "int16" at 375:34-375:39 (leading: Space)
-3918: Comma           "," at 375:39-375:40
-3919: Ident           "other" at 375:41-375:46 (leading: Space)
-3920: Colon           ":" at 375:46-375:47
-3921: Ident           "int16" at 375:48-375:53 (leading: Space)
-3922: RParen          ")" at 375:53-375:54
-3923: Arrow           "->" at 375:55-375:57 (leading: Space)
-3924: Ident           "int16" at 375:58-375:63 (leading: Space)
-3925: Semicolon       ";" at 375:63-375:64
-3926: At              "@" at 376:5-376:6 (leading: Newline, Space)
-3927: Ident           "intrinsic" at 376:6-376:15
-3928: KwFn            "fn" at 376:16-376:18 (leading: Space)
-3929: Ident           "__bit_xor" at 376:19-376:28 (leading: Space)
-3930: LParen          "(" at 376:28-376:29
-3931: Ident           "self" at 376:29-376:33
-3932: Colon           ":" at 376:33-376:34
-3933: Ident           "int16" at 376:35-376:40 (leading: Space)
-3934: Comma           "," at 376:40-376:41
-3935: Ident           "other" at 376:42-376:47 (leading: Space)
-3936: Colon           ":" at 376:47-376:48
-3937: Ident           "int16" at 376:49-376:54 (leading: Space)
-3938: RParen          ")" at 376:54-376:55
-3939: Arrow           "->" at 376:56-376:58 (leading: Space)
-3940: Ident           "int16" at 376:59-376:64 (leading: Space)
-3941: Semicolon       ";" at 376:64-376:65
-3942: At              "@" at 377:5-377:6 (leading: Newline, Space)
-3943: Ident           "intrinsic" at 377:6-377:15
-3944: KwFn            "fn" at 377:16-377:18 (leading: Space)
-3945: Ident           "__shl" at 377:19-377:24 (leading: Space)
-3946: LParen          "(" at 377:24-377:25
-3947: Ident           "self" at 377:25-377:29
-3948: Colon           ":" at 377:29-377:30
-3949: Ident           "int16" at 377:31-377:36 (leading: Space)
-3950: Comma           "," at 377:36-377:37
-3951: Ident           "other" at 377:38-377:43 (leading: Space)
-3952: Colon           ":" at 377:43-377:44
-3953: Ident           "int16" at 377:45-377:50 (leading: Space)
-3954: RParen          ")" at 377:50-377:51
-3955: Arrow           "->" at 377:52-377:54 (leading: Space)
-3956: Ident           "int16" at 377:55-377:60 (leading: Space)
-3957: Semicolon       ";" at 377:60-377:61
-3958: At              "@" at 378:5-378:6 (leading: Newline, Space)
-3959: Ident           "intrinsic" at 378:6-378:15
-3960: KwFn            "fn" at 378:16-378:18 (leading: Space)
-3961: Ident           "__shr" at 378:19-378:24 (leading: Space)
-3962: LParen          "(" at 378:24-378:25
-3963: Ident           "self" at 378:25-378:29
-3964: Colon           ":" at 378:29-378:30
-3965: Ident           "int16" at 378:31-378:36 (leading: Space)
-3966: Comma           "," at 378:36-378:37
-3967: Ident           "other" at 378:38-378:43 (leading: Space)
-3968: Colon           ":" at 378:43-378:44
-3969: Ident           "int16" at 378:45-378:50 (leading: Space)
-3970: RParen          ")" at 378:50-378:51
-3971: Arrow           "->" at 378:52-378:54 (leading: Space)
-3972: Ident           "int16" at 378:55-378:60 (leading: Space)
-3973: Semicolon       ";" at 378:60-378:61
-3974: At              "@" at 379:5-379:6 (leading: Newline, Space)
-3975: Ident           "intrinsic" at 379:6-379:15
-3976: KwFn            "fn" at 379:16-379:18 (leading: Space)
-3977: Ident           "__lt" at 379:19-379:23 (leading: Space)
-3978: LParen          "(" at 379:23-379:24
-3979: Ident           "self" at 379:24-379:28
-3980: Colon           ":" at 379:28-379:29
-3981: Ident           "int16" at 379:30-379:35 (leading: Space)
-3982: Comma           "," at 379:35-379:36
-3983: Ident           "other" at 379:37-379:42 (leading: Space)
-3984: Colon           ":" at 379:42-379:43
-3985: Ident           "int16" at 379:44-379:49 (leading: Space)
-3986: RParen          ")" at 379:49-379:50
-3987: Arrow           "->" at 379:51-379:53 (leading: Space)
-3988: Ident           "bool" at 379:54-379:58 (leading: Space)
-3989: Semicolon       ";" at 379:58-379:59
-3990: At              "@" at 380:5-380:6 (leading: Newline, Space)
-3991: Ident           "intrinsic" at 380:6-380:15
-3992: KwFn            "fn" at 380:16-380:18 (leading: Space)
-3993: Ident           "__le" at 380:19-380:23 (leading: Space)
-3994: LParen          "(" at 380:23-380:24
-3995: Ident           "self" at 380:24-380:28
-3996: Colon           ":" at 380:28-380:29
-3997: Ident           "int16" at 380:30-380:35 (leading: Space)
-3998: Comma           "," at 380:35-380:36
-3999: Ident           "other" at 380:37-380:42 (leading: Space)
-4000: Colon           ":" at 380:42-380:43
-4001: Ident           "int16" at 380:44-380:49 (leading: Space)
-4002: RParen          ")" at 380:49-380:50
-4003: Arrow           "->" at 380:51-380:53 (leading: Space)
-4004: Ident           "bool" at 380:54-380:58 (leading: Space)
-4005: Semicolon       ";" at 380:58-380:59
-4006: At              "@" at 381:5-381:6 (leading: Newline, Space)
-4007: Ident           "intrinsic" at 381:6-381:15
-4008: KwFn            "fn" at 381:16-381:18 (leading: Space)
-4009: Ident           "__eq" at 381:19-381:23 (leading: Space)
-4010: LParen          "(" at 381:23-381:24
-4011: Ident           "self" at 381:24-381:28
-4012: Colon           ":" at 381:28-381:29
-4013: Ident           "int16" at 381:30-381:35 (leading: Space)
-4014: Comma           "," at 381:35-381:36
-4015: Ident           "other" at 381:37-381:42 (leading: Space)
-4016: Colon           ":" at 381:42-381:43
-4017: Ident           "int16" at 381:44-381:49 (leading: Space)
-4018: RParen          ")" at 381:49-381:50
-4019: Arrow           "->" at 381:51-381:53 (leading: Space)
-4020: Ident           "bool" at 381:54-381:58 (leading: Space)
-4021: Semicolon       ";" at 381:58-381:59
-4022: At              "@" at 382:5-382:6 (leading: Newline, Space)
-4023: Ident           "intrinsic" at 382:6-382:15
-4024: KwFn            "fn" at 382:16-382:18 (leading: Space)
-4025: Ident           "__ne" at 382:19-382:23 (leading: Space)
-4026: LParen          "(" at 382:23-382:24
-4027: Ident           "self" at 382:24-382:28
-4028: Colon           ":" at 382:28-382:29
-4029: Ident           "int16" at 382:30-382:35 (leading: Space)
-4030: Comma           "," at 382:35-382:36
-4031: Ident           "other" at 382:37-382:42 (leading: Space)
-4032: Colon           ":" at 382:42-382:43
-4033: Ident           "int16" at 382:44-382:49 (leading: Space)
-4034: RParen          ")" at 382:49-382:50
-4035: Arrow           "->" at 382:51-382:53 (leading: Space)
-4036: Ident           "bool" at 382:54-382:58 (leading: Space)
-4037: Semicolon       ";" at 382:58-382:59
-4038: At              "@" at 383:5-383:6 (leading: Newline, Space)
-4039: Ident           "intrinsic" at 383:6-383:15
-4040: KwFn            "fn" at 383:16-383:18 (leading: Space)
-4041: Ident           "__ge" at 383:19-383:23 (leading: Space)
-4042: LParen          "(" at 383:23-383:24
-4043: Ident           "self" at 383:24-383:28
-4044: Colon           ":" at 383:28-383:29
-4045: Ident           "int16" at 383:30-383:35 (leading: Space)
-4046: Comma           "," at 383:35-383:36
-4047: Ident           "other" at 383:37-383:42 (leading: Space)
-4048: Colon           ":" at 383:42-383:43
-4049: Ident           "int16" at 383:44-383:49 (leading: Space)
-4050: RParen          ")" at 383:49-383:50
-4051: Arrow           "->" at 383:51-383:53 (leading: Space)
-4052: Ident           "bool" at 383:54-383:58 (leading: Space)
-4053: Semicolon       ";" at 383:58-383:59
-4054: At              "@" at 384:5-384:6 (leading: Newline, Space)
-4055: Ident           "intrinsic" at 384:6-384:15
-4056: KwFn            "fn" at 384:16-384:18 (leading: Space)
-4057: Ident           "__gt" at 384:19-384:23 (leading: Space)
-4058: LParen          "(" at 384:23-384:24
-4059: Ident           "self" at 384:24-384:28
-4060: Colon           ":" at 384:28-384:29
-4061: Ident           "int16" at 384:30-384:35 (leading: Space)
-4062: Comma           "," at 384:35-384:36
-4063: Ident           "other" at 384:37-384:42 (leading: Space)
-4064: Colon           ":" at 384:42-384:43
-4065: Ident           "int16" at 384:44-384:49 (leading: Space)
-4066: RParen          ")" at 384:49-384:50
-4067: Arrow           "->" at 384:51-384:53 (leading: Space)
-4068: Ident           "bool" at 384:54-384:58 (leading: Space)
-4069: Semicolon       ";" at 384:58-384:59
-4070: At              "@" at 385:5-385:6 (leading: Newline, Space)
-4071: Ident           "intrinsic" at 385:6-385:15
-4072: KwFn            "fn" at 385:16-385:18 (leading: Space)
-4073: Ident           "__pos" at 385:19-385:24 (leading: Space)
-4074: LParen          "(" at 385:24-385:25
-4075: Ident           "self" at 385:25-385:29
-4076: Colon           ":" at 385:29-385:30
-4077: Ident           "int16" at 385:31-385:36 (leading: Space)
-4078: RParen          ")" at 385:36-385:37
-4079: Arrow           "->" at 385:38-385:40 (leading: Space)
-4080: Ident           "int16" at 385:41-385:46 (leading: Space)
-4081: Semicolon       ";" at 385:46-385:47
-4082: At              "@" at 386:5-386:6 (leading: Newline, Space)
-4083: Ident           "intrinsic" at 386:6-386:15
-4084: KwFn            "fn" at 386:16-386:18 (leading: Space)
-4085: Ident           "__neg" at 386:19-386:24 (leading: Space)
-4086: LParen          "(" at 386:24-386:25
-4087: Ident           "self" at 386:25-386:29
-4088: Colon           ":" at 386:29-386:30
-4089: Ident           "int16" at 386:31-386:36 (leading: Space)
-4090: RParen          ")" at 386:36-386:37
-4091: Arrow           "->" at 386:38-386:40 (leading: Space)
-4092: Ident           "int16" at 386:41-386:46 (leading: Space)
-4093: Semicolon       ";" at 386:46-386:47
-4094: At              "@" at 387:5-387:6 (leading: Newline, Space)
-4095: Ident           "intrinsic" at 387:6-387:15
-4096: KwFn            "fn" at 387:16-387:18 (leading: Space)
-4097: Ident           "__abs" at 387:19-387:24 (leading: Space)
-4098: LParen          "(" at 387:24-387:25
-4099: Ident           "self" at 387:25-387:29
-4100: Colon           ":" at 387:29-387:30
-4101: Ident           "int16" at 387:31-387:36 (leading: Space)
-4102: RParen          ")" at 387:36-387:37
-4103: Arrow           "->" at 387:38-387:40 (leading: Space)
-4104: Ident           "int16" at 387:41-387:46 (leading: Space)
-4105: Semicolon       ";" at 387:46-387:47
-4106: At              "@" at 388:5-388:6 (leading: Newline, Space)
-4107: Ident           "intrinsic" at 388:6-388:15
-4108: KwFn            "fn" at 388:16-388:18 (leading: Space)
-4109: Ident           "__to" at 388:19-388:23 (leading: Space)
-4110: LParen          "(" at 388:23-388:24
-4111: Ident           "self" at 388:24-388:28
-4112: Colon           ":" at 388:28-388:29
-4113: Ident           "int16" at 388:30-388:35 (leading: Space)
-4114: Comma           "," at 388:35-388:36
-4115: Ident           "target" at 388:37-388:43 (leading: Space)
-4116: Colon           ":" at 388:43-388:44
-4117: Ident           "int" at 388:45-388:48 (leading: Space)
-4118: RParen          ")" at 388:48-388:49
-4119: Arrow           "->" at 388:50-388:52 (leading: Space)
-4120: Ident           "int" at 388:53-388:56 (leading: Space)
-4121: Semicolon       ";" at 388:56-388:57
-4122: At              "@" at 389:5-389:6 (leading: Newline, Space)
-4123: Ident           "intrinsic" at 389:6-389:15
-4124: At              "@" at 389:16-389:17 (leading: Space)
-4125: Ident           "overload" at 389:17-389:25
-4126: KwFn            "fn" at 389:26-389:28 (leading: Space)
-4127: Ident           "__to" at 389:29-389:33 (leading: Space)
-4128: LParen          "(" at 389:33-389:34
-4129: Ident           "self" at 389:34-389:38
-4130: Colon           ":" at 389:38-389:39
-4131: Ident           "int16" at 389:40-389:45 (leading: Space)
-4132: Comma           "," at 389:45-389:46
-4133: Ident           "target" at 389:47-389:53 (leading: Space)
-4134: Colon           ":" at 389:53-389:54
-4135: Ident           "int8" at 389:55-389:59 (leading: Space)
-4136: RParen          ")" at 389:59-389:60
-4137: Arrow           "->" at 389:61-389:63 (leading: Space)
-4138: Ident           "int8" at 389:64-389:68 (leading: Space)
-4139: Semicolon       ";" at 389:68-389:69
-4140: At              "@" at 390:5-390:6 (leading: Newline, Space)
-4141: Ident           "intrinsic" at 390:6-390:15
-4142: At              "@" at 390:16-390:17 (leading: Space)
-4143: Ident           "overload" at 390:17-390:25
-4144: KwFn            "fn" at 390:26-390:28 (leading: Space)
-4145: Ident           "__to" at 390:29-390:33 (leading: Space)
-4146: LParen          "(" at 390:33-390:34
-4147: Ident           "self" at 390:34-390:38
-4148: Colon           ":" at 390:38-390:39
-4149: Ident           "int16" at 390:40-390:45 (leading: Space)
-4150: Comma           "," at 390:45-390:46
-4151: Ident           "target" at 390:47-390:53 (leading: Space)
-4152: Colon           ":" at 390:53-390:54
-4153: Ident           "int32" at 390:55-390:60 (leading: Space)
-4154: RParen          ")" at 390:60-390:61
-4155: Arrow           "->" at 390:62-390:64 (leading: Space)
-4156: Ident           "int32" at 390:65-390:70 (leading: Space)
-4157: Semicolon       ";" at 390:70-390:71
-4158: At              "@" at 391:5-391:6 (leading: Newline, Space)
-4159: Ident           "intrinsic" at 391:6-391:15
-4160: At              "@" at 391:16-391:17 (leading: Space)
-4161: Ident           "overload" at 391:17-391:25
-4162: KwFn            "fn" at 391:26-391:28 (leading: Space)
-4163: Ident           "__to" at 391:29-391:33 (leading: Space)
-4164: LParen          "(" at 391:33-391:34
-4165: Ident           "self" at 391:34-391:38
-4166: Colon           ":" at 391:38-391:39
-4167: Ident           "int16" at 391:40-391:45 (leading: Space)
-4168: Comma           "," at 391:45-391:46
-4169: Ident           "target" at 391:47-391:53 (leading: Space)
-4170: Colon           ":" at 391:53-391:54
-4171: Ident           "int64" at 391:55-391:60 (leading: Space)
-4172: RParen          ")" at 391:60-391:61
-4173: Arrow           "->" at 391:62-391:64 (leading: Space)
-4174: Ident           "int64" at 391:65-391:70 (leading: Space)
-4175: Semicolon       ";" at 391:70-391:71
-4176: At              "@" at 392:5-392:6 (leading: Newline, Space)
-4177: Ident           "intrinsic" at 392:6-392:15
-4178: KwPub           "pub" at 392:16-392:19 (leading: Space)
-4179: KwFn            "fn" at 392:20-392:22 (leading: Space)
-4180: Ident           "from_str" at 392:23-392:31 (leading: Space)
-4181: LParen          "(" at 392:31-392:32
-4182: Ident           "s" at 392:32-392:33
-4183: Colon           ":" at 392:33-392:34
-4184: Amp             "&" at 392:35-392:36 (leading: Space)
-4185: Ident           "string" at 392:36-392:42
-4186: RParen          ")" at 392:42-392:43
-4187: Arrow           "->" at 392:44-392:46 (leading: Space)
-4188: Ident           "Erring" at 392:47-392:53 (leading: Space)
-4189: Lt              "<" at 392:53-392:54
-4190: Ident           "int16" at 392:54-392:59
-4191: Comma           "," at 392:59-392:60
-4192: Ident           "Error" at 392:61-392:66 (leading: Space)
-4193: Gt              ">" at 392:66-392:67
-4194: Semicolon       ";" at 392:67-392:68
-4195: RBrace          "}" at 393:1-393:2 (leading: Newline)
-4196: KwExtern        "extern" at 395:1-395:7 (leading: Newline)
-4197: Lt              "<" at 395:7-395:8
-4198: Ident           "int32" at 395:8-395:13
-4199: Gt              ">" at 395:13-395:14
-4200: LBrace          "{" at 395:15-395:16 (leading: Space)
-4201: KwPub           "pub" at 396:5-396:8 (leading: Newline, Space)
-4202: KwFn            "fn" at 396:9-396:11 (leading: Space)
-4203: Ident           "__min_value" at 396:12-396:23 (leading: Space)
-4204: LParen          "(" at 396:23-396:24
-4205: RParen          ")" at 396:24-396:25
-4206: Arrow           "->" at 396:26-396:28 (leading: Space)
-4207: Ident           "int32" at 396:29-396:34 (leading: Space)
-4208: LBrace          "{" at 396:35-396:36 (leading: Space)
-4209: KwReturn        "return" at 396:37-396:43 (leading: Space)
-4210: LParen          "(" at 396:44-396:45 (leading: Space)
-4211: Minus           "-" at 396:45-396:46
-4212: IntLit          "2_147_483_648" at 396:46-396:59
-4213: RParen          ")" at 396:59-396:60
-4214: Colon           ":" at 396:60-396:61
-4215: Ident           "int32" at 396:61-396:66
-4216: Semicolon       ";" at 396:66-396:67
-4217: RBrace          "}" at 396:68-396:69 (leading: Space)
-4218: KwPub           "pub" at 397:5-397:8 (leading: Newline, Space)
-4219: KwFn            "fn" at 397:9-397:11 (leading: Space)
-4220: Ident           "__max_value" at 397:12-397:23 (leading: Space)
-4221: LParen          "(" at 397:23-397:24
-4222: RParen          ")" at 397:24-397:25
-4223: Arrow           "->" at 397:26-397:28 (leading: Space)
-4224: Ident           "int32" at 397:29-397:34 (leading: Space)
-4225: LBrace          "{" at 397:35-397:36 (leading: Space)
-4226: KwReturn        "return" at 397:37-397:43 (leading: Space)
-4227: LParen          "(" at 397:44-397:45 (leading: Space)
-4228: IntLit          "2_147_483_647" at 397:45-397:58
-4229: RParen          ")" at 397:58-397:59
-4230: Colon           ":" at 397:59-397:60
-4231: Ident           "int32" at 397:60-397:65
-4232: Semicolon       ";" at 397:65-397:66
-4233: RBrace          "}" at 397:67-397:68 (leading: Space)
-4234: At              "@" at 398:5-398:6 (leading: Newline, Space)
-4235: Ident           "intrinsic" at 398:6-398:15
-4236: KwFn            "fn" at 398:16-398:18 (leading: Space)
-4237: Ident           "__add" at 398:19-398:24 (leading: Space)
-4238: LParen          "(" at 398:24-398:25
-4239: Ident           "self" at 398:25-398:29
-4240: Colon           ":" at 398:29-398:30
-4241: Ident           "int32" at 398:31-398:36 (leading: Space)
-4242: Comma           "," at 398:36-398:37
-4243: Ident           "other" at 398:38-398:43 (leading: Space)
-4244: Colon           ":" at 398:43-398:44
-4245: Ident           "int32" at 398:45-398:50 (leading: Space)
-4246: RParen          ")" at 398:50-398:51
-4247: Arrow           "->" at 398:52-398:54 (leading: Space)
-4248: Ident           "int32" at 398:55-398:60 (leading: Space)
-4249: Semicolon       ";" at 398:60-398:61
-4250: At              "@" at 399:5-399:6 (leading: Newline, Space)
-4251: Ident           "intrinsic" at 399:6-399:15
-4252: KwFn            "fn" at 399:16-399:18 (leading: Space)
-4253: Ident           "__sub" at 399:19-399:24 (leading: Space)
-4254: LParen          "(" at 399:24-399:25
-4255: Ident           "self" at 399:25-399:29
-4256: Colon           ":" at 399:29-399:30
-4257: Ident           "int32" at 399:31-399:36 (leading: Space)
-4258: Comma           "," at 399:36-399:37
-4259: Ident           "other" at 399:38-399:43 (leading: Space)
-4260: Colon           ":" at 399:43-399:44
-4261: Ident           "int32" at 399:45-399:50 (leading: Space)
-4262: RParen          ")" at 399:50-399:51
-4263: Arrow           "->" at 399:52-399:54 (leading: Space)
-4264: Ident           "int32" at 399:55-399:60 (leading: Space)
-4265: Semicolon       ";" at 399:60-399:61
-4266: At              "@" at 400:5-400:6 (leading: Newline, Space)
-4267: Ident           "intrinsic" at 400:6-400:15
-4268: KwFn            "fn" at 400:16-400:18 (leading: Space)
-4269: Ident           "__mul" at 400:19-400:24 (leading: Space)
-4270: LParen          "(" at 400:24-400:25
-4271: Ident           "self" at 400:25-400:29
-4272: Colon           ":" at 400:29-400:30
-4273: Ident           "int32" at 400:31-400:36 (leading: Space)
-4274: Comma           "," at 400:36-400:37
-4275: Ident           "other" at 400:38-400:43 (leading: Space)
-4276: Colon           ":" at 400:43-400:44
-4277: Ident           "int32" at 400:45-400:50 (leading: Space)
-4278: RParen          ")" at 400:50-400:51
-4279: Arrow           "->" at 400:52-400:54 (leading: Space)
-4280: Ident           "int32" at 400:55-400:60 (leading: Space)
-4281: Semicolon       ";" at 400:60-400:61
-4282: At              "@" at 401:5-401:6 (leading: Newline, Space)
-4283: Ident           "intrinsic" at 401:6-401:15
-4284: KwFn            "fn" at 401:16-401:18 (leading: Space)
-4285: Ident           "__div" at 401:19-401:24 (leading: Space)
-4286: LParen          "(" at 401:24-401:25
-4287: Ident           "self" at 401:25-401:29
-4288: Colon           ":" at 401:29-401:30
-4289: Ident           "int32" at 401:31-401:36 (leading: Space)
-4290: Comma           "," at 401:36-401:37
-4291: Ident           "other" at 401:38-401:43 (leading: Space)
-4292: Colon           ":" at 401:43-401:44
-4293: Ident           "int32" at 401:45-401:50 (leading: Space)
-4294: RParen          ")" at 401:50-401:51
-4295: Arrow           "->" at 401:52-401:54 (leading: Space)
-4296: Ident           "int32" at 401:55-401:60 (leading: Space)
-4297: Semicolon       ";" at 401:60-401:61
-4298: At              "@" at 402:5-402:6 (leading: Newline, Space)
-4299: Ident           "intrinsic" at 402:6-402:15
-4300: KwFn            "fn" at 402:16-402:18 (leading: Space)
-4301: Ident           "__mod" at 402:19-402:24 (leading: Space)
-4302: LParen          "(" at 402:24-402:25
-4303: Ident           "self" at 402:25-402:29
-4304: Colon           ":" at 402:29-402:30
-4305: Ident           "int32" at 402:31-402:36 (leading: Space)
-4306: Comma           "," at 402:36-402:37
-4307: Ident           "other" at 402:38-402:43 (leading: Space)
-4308: Colon           ":" at 402:43-402:44
-4309: Ident           "int32" at 402:45-402:50 (leading: Space)
-4310: RParen          ")" at 402:50-402:51
-4311: Arrow           "->" at 402:52-402:54 (leading: Space)
-4312: Ident           "int32" at 402:55-402:60 (leading: Space)
-4313: Semicolon       ";" at 402:60-402:61
-4314: At              "@" at 403:5-403:6 (leading: Newline, Space)
-4315: Ident           "intrinsic" at 403:6-403:15
-4316: KwFn            "fn" at 403:16-403:18 (leading: Space)
-4317: Ident           "__bit_and" at 403:19-403:28 (leading: Space)
-4318: LParen          "(" at 403:28-403:29
-4319: Ident           "self" at 403:29-403:33
-4320: Colon           ":" at 403:33-403:34
-4321: Ident           "int32" at 403:35-403:40 (leading: Space)
-4322: Comma           "," at 403:40-403:41
-4323: Ident           "other" at 403:42-403:47 (leading: Space)
-4324: Colon           ":" at 403:47-403:48
-4325: Ident           "int32" at 403:49-403:54 (leading: Space)
-4326: RParen          ")" at 403:54-403:55
-4327: Arrow           "->" at 403:56-403:58 (leading: Space)
-4328: Ident           "int32" at 403:59-403:64 (leading: Space)
-4329: Semicolon       ";" at 403:64-403:65
-4330: At              "@" at 404:5-404:6 (leading: Newline, Space)
-4331: Ident           "intrinsic" at 404:6-404:15
-4332: KwFn            "fn" at 404:16-404:18 (leading: Space)
-4333: Ident           "__bit_or" at 404:19-404:27 (leading: Space)
-4334: LParen          "(" at 404:27-404:28
-4335: Ident           "self" at 404:28-404:32
-4336: Colon           ":" at 404:32-404:33
-4337: Ident           "int32" at 404:34-404:39 (leading: Space)
-4338: Comma           "," at 404:39-404:40
-4339: Ident           "other" at 404:41-404:46 (leading: Space)
-4340: Colon           ":" at 404:46-404:47
-4341: Ident           "int32" at 404:48-404:53 (leading: Space)
-4342: RParen          ")" at 404:53-404:54
-4343: Arrow           "->" at 404:55-404:57 (leading: Space)
-4344: Ident           "int32" at 404:58-404:63 (leading: Space)
-4345: Semicolon       ";" at 404:63-404:64
-4346: At              "@" at 405:5-405:6 (leading: Newline, Space)
-4347: Ident           "intrinsic" at 405:6-405:15
-4348: KwFn            "fn" at 405:16-405:18 (leading: Space)
-4349: Ident           "__bit_xor" at 405:19-405:28 (leading: Space)
-4350: LParen          "(" at 405:28-405:29
-4351: Ident           "self" at 405:29-405:33
-4352: Colon           ":" at 405:33-405:34
-4353: Ident           "int32" at 405:35-405:40 (leading: Space)
-4354: Comma           "," at 405:40-405:41
-4355: Ident           "other" at 405:42-405:47 (leading: Space)
-4356: Colon           ":" at 405:47-405:48
-4357: Ident           "int32" at 405:49-405:54 (leading: Space)
-4358: RParen          ")" at 405:54-405:55
-4359: Arrow           "->" at 405:56-405:58 (leading: Space)
-4360: Ident           "int32" at 405:59-405:64 (leading: Space)
-4361: Semicolon       ";" at 405:64-405:65
-4362: At              "@" at 406:5-406:6 (leading: Newline, Space)
-4363: Ident           "intrinsic" at 406:6-406:15
-4364: KwFn            "fn" at 406:16-406:18 (leading: Space)
-4365: Ident           "__shl" at 406:19-406:24 (leading: Space)
-4366: LParen          "(" at 406:24-406:25
-4367: Ident           "self" at 406:25-406:29
-4368: Colon           ":" at 406:29-406:30
-4369: Ident           "int32" at 406:31-406:36 (leading: Space)
-4370: Comma           "," at 406:36-406:37
-4371: Ident           "other" at 406:38-406:43 (leading: Space)
-4372: Colon           ":" at 406:43-406:44
-4373: Ident           "int32" at 406:45-406:50 (leading: Space)
-4374: RParen          ")" at 406:50-406:51
-4375: Arrow           "->" at 406:52-406:54 (leading: Space)
-4376: Ident           "int32" at 406:55-406:60 (leading: Space)
-4377: Semicolon       ";" at 406:60-406:61
-4378: At              "@" at 407:5-407:6 (leading: Newline, Space)
-4379: Ident           "intrinsic" at 407:6-407:15
-4380: KwFn            "fn" at 407:16-407:18 (leading: Space)
-4381: Ident           "__shr" at 407:19-407:24 (leading: Space)
-4382: LParen          "(" at 407:24-407:25
-4383: Ident           "self" at 407:25-407:29
-4384: Colon           ":" at 407:29-407:30
-4385: Ident           "int32" at 407:31-407:36 (leading: Space)
-4386: Comma           "," at 407:36-407:37
-4387: Ident           "other" at 407:38-407:43 (leading: Space)
-4388: Colon           ":" at 407:43-407:44
-4389: Ident           "int32" at 407:45-407:50 (leading: Space)
-4390: RParen          ")" at 407:50-407:51
-4391: Arrow           "->" at 407:52-407:54 (leading: Space)
-4392: Ident           "int32" at 407:55-407:60 (leading: Space)
-4393: Semicolon       ";" at 407:60-407:61
-4394: At              "@" at 408:5-408:6 (leading: Newline, Space)
-4395: Ident           "intrinsic" at 408:6-408:15
-4396: KwFn            "fn" at 408:16-408:18 (leading: Space)
-4397: Ident           "__lt" at 408:19-408:23 (leading: Space)
-4398: LParen          "(" at 408:23-408:24
-4399: Ident           "self" at 408:24-408:28
-4400: Colon           ":" at 408:28-408:29
-4401: Ident           "int32" at 408:30-408:35 (leading: Space)
-4402: Comma           "," at 408:35-408:36
-4403: Ident           "other" at 408:37-408:42 (leading: Space)
-4404: Colon           ":" at 408:42-408:43
-4405: Ident           "int32" at 408:44-408:49 (leading: Space)
-4406: RParen          ")" at 408:49-408:50
-4407: Arrow           "->" at 408:51-408:53 (leading: Space)
-4408: Ident           "bool" at 408:54-408:58 (leading: Space)
-4409: Semicolon       ";" at 408:58-408:59
-4410: At              "@" at 409:5-409:6 (leading: Newline, Space)
-4411: Ident           "intrinsic" at 409:6-409:15
-4412: KwFn            "fn" at 409:16-409:18 (leading: Space)
-4413: Ident           "__le" at 409:19-409:23 (leading: Space)
-4414: LParen          "(" at 409:23-409:24
-4415: Ident           "self" at 409:24-409:28
-4416: Colon           ":" at 409:28-409:29
-4417: Ident           "int32" at 409:30-409:35 (leading: Space)
-4418: Comma           "," at 409:35-409:36
-4419: Ident           "other" at 409:37-409:42 (leading: Space)
-4420: Colon           ":" at 409:42-409:43
-4421: Ident           "int32" at 409:44-409:49 (leading: Space)
-4422: RParen          ")" at 409:49-409:50
-4423: Arrow           "->" at 409:51-409:53 (leading: Space)
-4424: Ident           "bool" at 409:54-409:58 (leading: Space)
-4425: Semicolon       ";" at 409:58-409:59
-4426: At              "@" at 410:5-410:6 (leading: Newline, Space)
-4427: Ident           "intrinsic" at 410:6-410:15
-4428: KwFn            "fn" at 410:16-410:18 (leading: Space)
-4429: Ident           "__eq" at 410:19-410:23 (leading: Space)
-4430: LParen          "(" at 410:23-410:24
-4431: Ident           "self" at 410:24-410:28
-4432: Colon           ":" at 410:28-410:29
-4433: Ident           "int32" at 410:30-410:35 (leading: Space)
-4434: Comma           "," at 410:35-410:36
-4435: Ident           "other" at 410:37-410:42 (leading: Space)
-4436: Colon           ":" at 410:42-410:43
-4437: Ident           "int32" at 410:44-410:49 (leading: Space)
-4438: RParen          ")" at 410:49-410:50
-4439: Arrow           "->" at 410:51-410:53 (leading: Space)
-4440: Ident           "bool" at 410:54-410:58 (leading: Space)
-4441: Semicolon       ";" at 410:58-410:59
-4442: At              "@" at 411:5-411:6 (leading: Newline, Space)
-4443: Ident           "intrinsic" at 411:6-411:15
-4444: KwFn            "fn" at 411:16-411:18 (leading: Space)
-4445: Ident           "__ne" at 411:19-411:23 (leading: Space)
-4446: LParen          "(" at 411:23-411:24
-4447: Ident           "self" at 411:24-411:28
-4448: Colon           ":" at 411:28-411:29
-4449: Ident           "int32" at 411:30-411:35 (leading: Space)
-4450: Comma           "," at 411:35-411:36
-4451: Ident           "other" at 411:37-411:42 (leading: Space)
-4452: Colon           ":" at 411:42-411:43
-4453: Ident           "int32" at 411:44-411:49 (leading: Space)
-4454: RParen          ")" at 411:49-411:50
-4455: Arrow           "->" at 411:51-411:53 (leading: Space)
-4456: Ident           "bool" at 411:54-411:58 (leading: Space)
-4457: Semicolon       ";" at 411:58-411:59
-4458: At              "@" at 412:5-412:6 (leading: Newline, Space)
-4459: Ident           "intrinsic" at 412:6-412:15
-4460: KwFn            "fn" at 412:16-412:18 (leading: Space)
-4461: Ident           "__ge" at 412:19-412:23 (leading: Space)
-4462: LParen          "(" at 412:23-412:24
-4463: Ident           "self" at 412:24-412:28
-4464: Colon           ":" at 412:28-412:29
-4465: Ident           "int32" at 412:30-412:35 (leading: Space)
-4466: Comma           "," at 412:35-412:36
-4467: Ident           "other" at 412:37-412:42 (leading: Space)
-4468: Colon           ":" at 412:42-412:43
-4469: Ident           "int32" at 412:44-412:49 (leading: Space)
-4470: RParen          ")" at 412:49-412:50
-4471: Arrow           "->" at 412:51-412:53 (leading: Space)
-4472: Ident           "bool" at 412:54-412:58 (leading: Space)
-4473: Semicolon       ";" at 412:58-412:59
-4474: At              "@" at 413:5-413:6 (leading: Newline, Space)
-4475: Ident           "intrinsic" at 413:6-413:15
-4476: KwFn            "fn" at 413:16-413:18 (leading: Space)
-4477: Ident           "__gt" at 413:19-413:23 (leading: Space)
-4478: LParen          "(" at 413:23-413:24
-4479: Ident           "self" at 413:24-413:28
-4480: Colon           ":" at 413:28-413:29
-4481: Ident           "int32" at 413:30-413:35 (leading: Space)
-4482: Comma           "," at 413:35-413:36
-4483: Ident           "other" at 413:37-413:42 (leading: Space)
-4484: Colon           ":" at 413:42-413:43
-4485: Ident           "int32" at 413:44-413:49 (leading: Space)
-4486: RParen          ")" at 413:49-413:50
-4487: Arrow           "->" at 413:51-413:53 (leading: Space)
-4488: Ident           "bool" at 413:54-413:58 (leading: Space)
-4489: Semicolon       ";" at 413:58-413:59
-4490: At              "@" at 414:5-414:6 (leading: Newline, Space)
-4491: Ident           "intrinsic" at 414:6-414:15
-4492: KwFn            "fn" at 414:16-414:18 (leading: Space)
-4493: Ident           "__pos" at 414:19-414:24 (leading: Space)
-4494: LParen          "(" at 414:24-414:25
-4495: Ident           "self" at 414:25-414:29
-4496: Colon           ":" at 414:29-414:30
-4497: Ident           "int32" at 414:31-414:36 (leading: Space)
-4498: RParen          ")" at 414:36-414:37
-4499: Arrow           "->" at 414:38-414:40 (leading: Space)
-4500: Ident           "int32" at 414:41-414:46 (leading: Space)
-4501: Semicolon       ";" at 414:46-414:47
-4502: At              "@" at 415:5-415:6 (leading: Newline, Space)
-4503: Ident           "intrinsic" at 415:6-415:15
-4504: KwFn            "fn" at 415:16-415:18 (leading: Space)
-4505: Ident           "__neg" at 415:19-415:24 (leading: Space)
-4506: LParen          "(" at 415:24-415:25
-4507: Ident           "self" at 415:25-415:29
-4508: Colon           ":" at 415:29-415:30
-4509: Ident           "int32" at 415:31-415:36 (leading: Space)
-4510: RParen          ")" at 415:36-415:37
-4511: Arrow           "->" at 415:38-415:40 (leading: Space)
-4512: Ident           "int32" at 415:41-415:46 (leading: Space)
-4513: Semicolon       ";" at 415:46-415:47
-4514: At              "@" at 416:5-416:6 (leading: Newline, Space)
-4515: Ident           "intrinsic" at 416:6-416:15
-4516: KwFn            "fn" at 416:16-416:18 (leading: Space)
-4517: Ident           "__abs" at 416:19-416:24 (leading: Space)
-4518: LParen          "(" at 416:24-416:25
-4519: Ident           "self" at 416:25-416:29
-4520: Colon           ":" at 416:29-416:30
-4521: Ident           "int32" at 416:31-416:36 (leading: Space)
-4522: RParen          ")" at 416:36-416:37
-4523: Arrow           "->" at 416:38-416:40 (leading: Space)
-4524: Ident           "int32" at 416:41-416:46 (leading: Space)
-4525: Semicolon       ";" at 416:46-416:47
-4526: At              "@" at 417:5-417:6 (leading: Newline, Space)
-4527: Ident           "intrinsic" at 417:6-417:15
-4528: KwFn            "fn" at 417:16-417:18 (leading: Space)
-4529: Ident           "__to" at 417:19-417:23 (leading: Space)
-4530: LParen          "(" at 417:23-417:24
-4531: Ident           "self" at 417:24-417:28
-4532: Colon           ":" at 417:28-417:29
-4533: Ident           "int32" at 417:30-417:35 (leading: Space)
-4534: Comma           "," at 417:35-417:36
-4535: Ident           "target" at 417:37-417:43 (leading: Space)
-4536: Colon           ":" at 417:43-417:44
-4537: Ident           "int" at 417:45-417:48 (leading: Space)
-4538: RParen          ")" at 417:48-417:49
-4539: Arrow           "->" at 417:50-417:52 (leading: Space)
-4540: Ident           "int" at 417:53-417:56 (leading: Space)
-4541: Semicolon       ";" at 417:56-417:57
-4542: At              "@" at 418:5-418:6 (leading: Newline, Space)
-4543: Ident           "intrinsic" at 418:6-418:15
-4544: At              "@" at 418:16-418:17 (leading: Space)
-4545: Ident           "overload" at 418:17-418:25
-4546: KwFn            "fn" at 418:26-418:28 (leading: Space)
-4547: Ident           "__to" at 418:29-418:33 (leading: Space)
-4548: LParen          "(" at 418:33-418:34
-4549: Ident           "self" at 418:34-418:38
-4550: Colon           ":" at 418:38-418:39
-4551: Ident           "int32" at 418:40-418:45 (leading: Space)
-4552: Comma           "," at 418:45-418:46
-4553: Ident           "target" at 418:47-418:53 (leading: Space)
-4554: Colon           ":" at 418:53-418:54
-4555: Ident           "int8" at 418:55-418:59 (leading: Space)
-4556: RParen          ")" at 418:59-418:60
-4557: Arrow           "->" at 418:61-418:63 (leading: Space)
-4558: Ident           "int8" at 418:64-418:68 (leading: Space)
-4559: Semicolon       ";" at 418:68-418:69
-4560: At              "@" at 419:5-419:6 (leading: Newline, Space)
-4561: Ident           "intrinsic" at 419:6-419:15
-4562: At              "@" at 419:16-419:17 (leading: Space)
-4563: Ident           "overload" at 419:17-419:25
-4564: KwFn            "fn" at 419:26-419:28 (leading: Space)
-4565: Ident           "__to" at 419:29-419:33 (leading: Space)
-4566: LParen          "(" at 419:33-419:34
-4567: Ident           "self" at 419:34-419:38
-4568: Colon           ":" at 419:38-419:39
-4569: Ident           "int32" at 419:40-419:45 (leading: Space)
-4570: Comma           "," at 419:45-419:46
-4571: Ident           "target" at 419:47-419:53 (leading: Space)
-4572: Colon           ":" at 419:53-419:54
-4573: Ident           "int16" at 419:55-419:60 (leading: Space)
-4574: RParen          ")" at 419:60-419:61
-4575: Arrow           "->" at 419:62-419:64 (leading: Space)
-4576: Ident           "int16" at 419:65-419:70 (leading: Space)
-4577: Semicolon       ";" at 419:70-419:71
-4578: At              "@" at 420:5-420:6 (leading: Newline, Space)
-4579: Ident           "intrinsic" at 420:6-420:15
-4580: At              "@" at 420:16-420:17 (leading: Space)
-4581: Ident           "overload" at 420:17-420:25
-4582: KwFn            "fn" at 420:26-420:28 (leading: Space)
-4583: Ident           "__to" at 420:29-420:33 (leading: Space)
-4584: LParen          "(" at 420:33-420:34
-4585: Ident           "self" at 420:34-420:38
-4586: Colon           ":" at 420:38-420:39
-4587: Ident           "int32" at 420:40-420:45 (leading: Space)
-4588: Comma           "," at 420:45-420:46
-4589: Ident           "target" at 420:47-420:53 (leading: Space)
-4590: Colon           ":" at 420:53-420:54
-4591: Ident           "int64" at 420:55-420:60 (leading: Space)
-4592: RParen          ")" at 420:60-420:61
-4593: Arrow           "->" at 420:62-420:64 (leading: Space)
-4594: Ident           "int64" at 420:65-420:70 (leading: Space)
-4595: Semicolon       ";" at 420:70-420:71
-4596: At              "@" at 421:5-421:6 (leading: Newline, Space)
-4597: Ident           "intrinsic" at 421:6-421:15
-4598: KwPub           "pub" at 421:16-421:19 (leading: Space)
-4599: KwFn            "fn" at 421:20-421:22 (leading: Space)
-4600: Ident           "from_str" at 421:23-421:31 (leading: Space)
-4601: LParen          "(" at 421:31-421:32
-4602: Ident           "s" at 421:32-421:33
-4603: Colon           ":" at 421:33-421:34
-4604: Amp             "&" at 421:35-421:36 (leading: Space)
-4605: Ident           "string" at 421:36-421:42
-4606: RParen          ")" at 421:42-421:43
-4607: Arrow           "->" at 421:44-421:46 (leading: Space)
-4608: Ident           "Erring" at 421:47-421:53 (leading: Space)
-4609: Lt              "<" at 421:53-421:54
-4610: Ident           "int32" at 421:54-421:59
-4611: Comma           "," at 421:59-421:60
-4612: Ident           "Error" at 421:61-421:66 (leading: Space)
-4613: Gt              ">" at 421:66-421:67
-4614: Semicolon       ";" at 421:67-421:68
-4615: RBrace          "}" at 422:1-422:2 (leading: Newline)
-4616: KwExtern        "extern" at 424:1-424:7 (leading: Newline)
-4617: Lt              "<" at 424:7-424:8
-4618: Ident           "int64" at 424:8-424:13
-4619: Gt              ">" at 424:13-424:14
-4620: LBrace          "{" at 424:15-424:16 (leading: Space)
-4621: KwPub           "pub" at 425:5-425:8 (leading: Newline, Space)
-4622: KwFn            "fn" at 425:9-425:11 (leading: Space)
-4623: Ident           "__min_value" at 425:12-425:23 (leading: Space)
-4624: LParen          "(" at 425:23-425:24
-4625: RParen          ")" at 425:24-425:25
-4626: Arrow           "->" at 425:26-425:28 (leading: Space)
-4627: Ident           "int64" at 425:29-425:34 (leading: Space)
-4628: LBrace          "{" at 425:35-425:36 (leading: Space)
-4629: KwReturn        "return" at 425:37-425:43 (leading: Space)
-4630: LParen          "(" at 425:44-425:45 (leading: Space)
-4631: Minus           "-" at 425:45-425:46
-4632: IntLit          "9_223_372_036_854_775_808" at 425:46-425:71
-4633: RParen          ")" at 425:71-425:72
-4634: Colon           ":" at 425:72-425:73
-4635: Ident           "int64" at 425:73-425:78
-4636: Semicolon       ";" at 425:78-425:79
-4637: RBrace          "}" at 425:80-425:81 (leading: Space)
-4638: KwPub           "pub" at 426:5-426:8 (leading: Newline, Space)
-4639: KwFn            "fn" at 426:9-426:11 (leading: Space)
-4640: Ident           "__max_value" at 426:12-426:23 (leading: Space)
-4641: LParen          "(" at 426:23-426:24
-4642: RParen          ")" at 426:24-426:25
-4643: Arrow           "->" at 426:26-426:28 (leading: Space)
-4644: Ident           "int64" at 426:29-426:34 (leading: Space)
-4645: LBrace          "{" at 426:35-426:36 (leading: Space)
-4646: KwReturn        "return" at 426:37-426:43 (leading: Space)
-4647: LParen          "(" at 426:44-426:45 (leading: Space)
-4648: IntLit          "9_223_372_036_854_775_807" at 426:45-426:70
-4649: RParen          ")" at 426:70-426:71
-4650: Colon           ":" at 426:71-426:72
-4651: Ident           "int64" at 426:72-426:77
-4652: Semicolon       ";" at 426:77-426:78
-4653: RBrace          "}" at 426:79-426:80 (leading: Space)
-4654: At              "@" at 427:5-427:6 (leading: Newline, Space)
-4655: Ident           "intrinsic" at 427:6-427:15
-4656: KwFn            "fn" at 427:16-427:18 (leading: Space)
-4657: Ident           "__add" at 427:19-427:24 (leading: Space)
-4658: LParen          "(" at 427:24-427:25
-4659: Ident           "self" at 427:25-427:29
-4660: Colon           ":" at 427:29-427:30
-4661: Ident           "int64" at 427:31-427:36 (leading: Space)
-4662: Comma           "," at 427:36-427:37
-4663: Ident           "other" at 427:38-427:43 (leading: Space)
-4664: Colon           ":" at 427:43-427:44
-4665: Ident           "int64" at 427:45-427:50 (leading: Space)
-4666: RParen          ")" at 427:50-427:51
-4667: Arrow           "->" at 427:52-427:54 (leading: Space)
-4668: Ident           "int64" at 427:55-427:60 (leading: Space)
-4669: Semicolon       ";" at 427:60-427:61
-4670: At              "@" at 428:5-428:6 (leading: Newline, Space)
-4671: Ident           "intrinsic" at 428:6-428:15
-4672: KwFn            "fn" at 428:16-428:18 (leading: Space)
-4673: Ident           "__sub" at 428:19-428:24 (leading: Space)
-4674: LParen          "(" at 428:24-428:25
-4675: Ident           "self" at 428:25-428:29
-4676: Colon           ":" at 428:29-428:30
-4677: Ident           "int64" at 428:31-428:36 (leading: Space)
-4678: Comma           "," at 428:36-428:37
-4679: Ident           "other" at 428:38-428:43 (leading: Space)
-4680: Colon           ":" at 428:43-428:44
-4681: Ident           "int64" at 428:45-428:50 (leading: Space)
-4682: RParen          ")" at 428:50-428:51
-4683: Arrow           "->" at 428:52-428:54 (leading: Space)
-4684: Ident           "int64" at 428:55-428:60 (leading: Space)
-4685: Semicolon       ";" at 428:60-428:61
-4686: At              "@" at 429:5-429:6 (leading: Newline, Space)
-4687: Ident           "intrinsic" at 429:6-429:15
-4688: KwFn            "fn" at 429:16-429:18 (leading: Space)
-4689: Ident           "__mul" at 429:19-429:24 (leading: Space)
-4690: LParen          "(" at 429:24-429:25
-4691: Ident           "self" at 429:25-429:29
-4692: Colon           ":" at 429:29-429:30
-4693: Ident           "int64" at 429:31-429:36 (leading: Space)
-4694: Comma           "," at 429:36-429:37
-4695: Ident           "other" at 429:38-429:43 (leading: Space)
-4696: Colon           ":" at 429:43-429:44
-4697: Ident           "int64" at 429:45-429:50 (leading: Space)
-4698: RParen          ")" at 429:50-429:51
-4699: Arrow           "->" at 429:52-429:54 (leading: Space)
-4700: Ident           "int64" at 429:55-429:60 (leading: Space)
-4701: Semicolon       ";" at 429:60-429:61
-4702: At              "@" at 430:5-430:6 (leading: Newline, Space)
-4703: Ident           "intrinsic" at 430:6-430:15
-4704: KwFn            "fn" at 430:16-430:18 (leading: Space)
-4705: Ident           "__div" at 430:19-430:24 (leading: Space)
-4706: LParen          "(" at 430:24-430:25
-4707: Ident           "self" at 430:25-430:29
-4708: Colon           ":" at 430:29-430:30
-4709: Ident           "int64" at 430:31-430:36 (leading: Space)
-4710: Comma           "," at 430:36-430:37
-4711: Ident           "other" at 430:38-430:43 (leading: Space)
-4712: Colon           ":" at 430:43-430:44
-4713: Ident           "int64" at 430:45-430:50 (leading: Space)
-4714: RParen          ")" at 430:50-430:51
-4715: Arrow           "->" at 430:52-430:54 (leading: Space)
-4716: Ident           "int64" at 430:55-430:60 (leading: Space)
-4717: Semicolon       ";" at 430:60-430:61
-4718: At              "@" at 431:5-431:6 (leading: Newline, Space)
-4719: Ident           "intrinsic" at 431:6-431:15
-4720: KwFn            "fn" at 431:16-431:18 (leading: Space)
-4721: Ident           "__mod" at 431:19-431:24 (leading: Space)
-4722: LParen          "(" at 431:24-431:25
-4723: Ident           "self" at 431:25-431:29
-4724: Colon           ":" at 431:29-431:30
-4725: Ident           "int64" at 431:31-431:36 (leading: Space)
-4726: Comma           "," at 431:36-431:37
-4727: Ident           "other" at 431:38-431:43 (leading: Space)
-4728: Colon           ":" at 431:43-431:44
-4729: Ident           "int64" at 431:45-431:50 (leading: Space)
-4730: RParen          ")" at 431:50-431:51
-4731: Arrow           "->" at 431:52-431:54 (leading: Space)
-4732: Ident           "int64" at 431:55-431:60 (leading: Space)
-4733: Semicolon       ";" at 431:60-431:61
-4734: At              "@" at 432:5-432:6 (leading: Newline, Space)
-4735: Ident           "intrinsic" at 432:6-432:15
-4736: KwFn            "fn" at 432:16-432:18 (leading: Space)
-4737: Ident           "__bit_and" at 432:19-432:28 (leading: Space)
-4738: LParen          "(" at 432:28-432:29
-4739: Ident           "self" at 432:29-432:33
-4740: Colon           ":" at 432:33-432:34
-4741: Ident           "int64" at 432:35-432:40 (leading: Space)
-4742: Comma           "," at 432:40-432:41
-4743: Ident           "other" at 432:42-432:47 (leading: Space)
-4744: Colon           ":" at 432:47-432:48
-4745: Ident           "int64" at 432:49-432:54 (leading: Space)
-4746: RParen          ")" at 432:54-432:55
-4747: Arrow           "->" at 432:56-432:58 (leading: Space)
-4748: Ident           "int64" at 432:59-432:64 (leading: Space)
-4749: Semicolon       ";" at 432:64-432:65
-4750: At              "@" at 433:5-433:6 (leading: Newline, Space)
-4751: Ident           "intrinsic" at 433:6-433:15
-4752: KwFn            "fn" at 433:16-433:18 (leading: Space)
-4753: Ident           "__bit_or" at 433:19-433:27 (leading: Space)
-4754: LParen          "(" at 433:27-433:28
-4755: Ident           "self" at 433:28-433:32
-4756: Colon           ":" at 433:32-433:33
-4757: Ident           "int64" at 433:34-433:39 (leading: Space)
-4758: Comma           "," at 433:39-433:40
-4759: Ident           "other" at 433:41-433:46 (leading: Space)
-4760: Colon           ":" at 433:46-433:47
-4761: Ident           "int64" at 433:48-433:53 (leading: Space)
-4762: RParen          ")" at 433:53-433:54
-4763: Arrow           "->" at 433:55-433:57 (leading: Space)
-4764: Ident           "int64" at 433:58-433:63 (leading: Space)
-4765: Semicolon       ";" at 433:63-433:64
-4766: At              "@" at 434:5-434:6 (leading: Newline, Space)
-4767: Ident           "intrinsic" at 434:6-434:15
-4768: KwFn            "fn" at 434:16-434:18 (leading: Space)
-4769: Ident           "__bit_xor" at 434:19-434:28 (leading: Space)
-4770: LParen          "(" at 434:28-434:29
-4771: Ident           "self" at 434:29-434:33
-4772: Colon           ":" at 434:33-434:34
-4773: Ident           "int64" at 434:35-434:40 (leading: Space)
-4774: Comma           "," at 434:40-434:41
-4775: Ident           "other" at 434:42-434:47 (leading: Space)
-4776: Colon           ":" at 434:47-434:48
-4777: Ident           "int64" at 434:49-434:54 (leading: Space)
-4778: RParen          ")" at 434:54-434:55
-4779: Arrow           "->" at 434:56-434:58 (leading: Space)
-4780: Ident           "int64" at 434:59-434:64 (leading: Space)
-4781: Semicolon       ";" at 434:64-434:65
-4782: At              "@" at 435:5-435:6 (leading: Newline, Space)
-4783: Ident           "intrinsic" at 435:6-435:15
-4784: KwFn            "fn" at 435:16-435:18 (leading: Space)
-4785: Ident           "__shl" at 435:19-435:24 (leading: Space)
-4786: LParen          "(" at 435:24-435:25
-4787: Ident           "self" at 435:25-435:29
-4788: Colon           ":" at 435:29-435:30
-4789: Ident           "int64" at 435:31-435:36 (leading: Space)
-4790: Comma           "," at 435:36-435:37
-4791: Ident           "other" at 435:38-435:43 (leading: Space)
-4792: Colon           ":" at 435:43-435:44
-4793: Ident           "int64" at 435:45-435:50 (leading: Space)
-4794: RParen          ")" at 435:50-435:51
-4795: Arrow           "->" at 435:52-435:54 (leading: Space)
-4796: Ident           "int64" at 435:55-435:60 (leading: Space)
-4797: Semicolon       ";" at 435:60-435:61
-4798: At              "@" at 436:5-436:6 (leading: Newline, Space)
-4799: Ident           "intrinsic" at 436:6-436:15
-4800: KwFn            "fn" at 436:16-436:18 (leading: Space)
-4801: Ident           "__shr" at 436:19-436:24 (leading: Space)
-4802: LParen          "(" at 436:24-436:25
-4803: Ident           "self" at 436:25-436:29
-4804: Colon           ":" at 436:29-436:30
-4805: Ident           "int64" at 436:31-436:36 (leading: Space)
-4806: Comma           "," at 436:36-436:37
-4807: Ident           "other" at 436:38-436:43 (leading: Space)
-4808: Colon           ":" at 436:43-436:44
-4809: Ident           "int64" at 436:45-436:50 (leading: Space)
-4810: RParen          ")" at 436:50-436:51
-4811: Arrow           "->" at 436:52-436:54 (leading: Space)
-4812: Ident           "int64" at 436:55-436:60 (leading: Space)
-4813: Semicolon       ";" at 436:60-436:61
-4814: At              "@" at 437:5-437:6 (leading: Newline, Space)
-4815: Ident           "intrinsic" at 437:6-437:15
-4816: KwFn            "fn" at 437:16-437:18 (leading: Space)
-4817: Ident           "__lt" at 437:19-437:23 (leading: Space)
-4818: LParen          "(" at 437:23-437:24
-4819: Ident           "self" at 437:24-437:28
-4820: Colon           ":" at 437:28-437:29
-4821: Ident           "int64" at 437:30-437:35 (leading: Space)
-4822: Comma           "," at 437:35-437:36
-4823: Ident           "other" at 437:37-437:42 (leading: Space)
-4824: Colon           ":" at 437:42-437:43
-4825: Ident           "int64" at 437:44-437:49 (leading: Space)
-4826: RParen          ")" at 437:49-437:50
-4827: Arrow           "->" at 437:51-437:53 (leading: Space)
-4828: Ident           "bool" at 437:54-437:58 (leading: Space)
-4829: Semicolon       ";" at 437:58-437:59
-4830: At              "@" at 438:5-438:6 (leading: Newline, Space)
-4831: Ident           "intrinsic" at 438:6-438:15
-4832: KwFn            "fn" at 438:16-438:18 (leading: Space)
-4833: Ident           "__le" at 438:19-438:23 (leading: Space)
-4834: LParen          "(" at 438:23-438:24
-4835: Ident           "self" at 438:24-438:28
-4836: Colon           ":" at 438:28-438:29
-4837: Ident           "int64" at 438:30-438:35 (leading: Space)
-4838: Comma           "," at 438:35-438:36
-4839: Ident           "other" at 438:37-438:42 (leading: Space)
-4840: Colon           ":" at 438:42-438:43
-4841: Ident           "int64" at 438:44-438:49 (leading: Space)
-4842: RParen          ")" at 438:49-438:50
-4843: Arrow           "->" at 438:51-438:53 (leading: Space)
-4844: Ident           "bool" at 438:54-438:58 (leading: Space)
-4845: Semicolon       ";" at 438:58-438:59
-4846: At              "@" at 439:5-439:6 (leading: Newline, Space)
-4847: Ident           "intrinsic" at 439:6-439:15
-4848: KwFn            "fn" at 439:16-439:18 (leading: Space)
-4849: Ident           "__eq" at 439:19-439:23 (leading: Space)
-4850: LParen          "(" at 439:23-439:24
-4851: Ident           "self" at 439:24-439:28
-4852: Colon           ":" at 439:28-439:29
-4853: Ident           "int64" at 439:30-439:35 (leading: Space)
-4854: Comma           "," at 439:35-439:36
-4855: Ident           "other" at 439:37-439:42 (leading: Space)
-4856: Colon           ":" at 439:42-439:43
-4857: Ident           "int64" at 439:44-439:49 (leading: Space)
-4858: RParen          ")" at 439:49-439:50
-4859: Arrow           "->" at 439:51-439:53 (leading: Space)
-4860: Ident           "bool" at 439:54-439:58 (leading: Space)
-4861: Semicolon       ";" at 439:58-439:59
-4862: At              "@" at 440:5-440:6 (leading: Newline, Space)
-4863: Ident           "intrinsic" at 440:6-440:15
-4864: KwFn            "fn" at 440:16-440:18 (leading: Space)
-4865: Ident           "__ne" at 440:19-440:23 (leading: Space)
-4866: LParen          "(" at 440:23-440:24
-4867: Ident           "self" at 440:24-440:28
-4868: Colon           ":" at 440:28-440:29
-4869: Ident           "int64" at 440:30-440:35 (leading: Space)
-4870: Comma           "," at 440:35-440:36
-4871: Ident           "other" at 440:37-440:42 (leading: Space)
-4872: Colon           ":" at 440:42-440:43
-4873: Ident           "int64" at 440:44-440:49 (leading: Space)
-4874: RParen          ")" at 440:49-440:50
-4875: Arrow           "->" at 440:51-440:53 (leading: Space)
-4876: Ident           "bool" at 440:54-440:58 (leading: Space)
-4877: Semicolon       ";" at 440:58-440:59
-4878: At              "@" at 441:5-441:6 (leading: Newline, Space)
-4879: Ident           "intrinsic" at 441:6-441:15
-4880: KwFn            "fn" at 441:16-441:18 (leading: Space)
-4881: Ident           "__ge" at 441:19-441:23 (leading: Space)
-4882: LParen          "(" at 441:23-441:24
-4883: Ident           "self" at 441:24-441:28
-4884: Colon           ":" at 441:28-441:29
-4885: Ident           "int64" at 441:30-441:35 (leading: Space)
-4886: Comma           "," at 441:35-441:36
-4887: Ident           "other" at 441:37-441:42 (leading: Space)
-4888: Colon           ":" at 441:42-441:43
-4889: Ident           "int64" at 441:44-441:49 (leading: Space)
-4890: RParen          ")" at 441:49-441:50
-4891: Arrow           "->" at 441:51-441:53 (leading: Space)
-4892: Ident           "bool" at 441:54-441:58 (leading: Space)
-4893: Semicolon       ";" at 441:58-441:59
-4894: At              "@" at 442:5-442:6 (leading: Newline, Space)
-4895: Ident           "intrinsic" at 442:6-442:15
-4896: KwFn            "fn" at 442:16-442:18 (leading: Space)
-4897: Ident           "__gt" at 442:19-442:23 (leading: Space)
-4898: LParen          "(" at 442:23-442:24
-4899: Ident           "self" at 442:24-442:28
-4900: Colon           ":" at 442:28-442:29
-4901: Ident           "int64" at 442:30-442:35 (leading: Space)
-4902: Comma           "," at 442:35-442:36
-4903: Ident           "other" at 442:37-442:42 (leading: Space)
-4904: Colon           ":" at 442:42-442:43
-4905: Ident           "int64" at 442:44-442:49 (leading: Space)
-4906: RParen          ")" at 442:49-442:50
-4907: Arrow           "->" at 442:51-442:53 (leading: Space)
-4908: Ident           "bool" at 442:54-442:58 (leading: Space)
-4909: Semicolon       ";" at 442:58-442:59
-4910: At              "@" at 443:5-443:6 (leading: Newline, Space)
-4911: Ident           "intrinsic" at 443:6-443:15
-4912: KwFn            "fn" at 443:16-443:18 (leading: Space)
-4913: Ident           "__pos" at 443:19-443:24 (leading: Space)
-4914: LParen          "(" at 443:24-443:25
-4915: Ident           "self" at 443:25-443:29
-4916: Colon           ":" at 443:29-443:30
-4917: Ident           "int64" at 443:31-443:36 (leading: Space)
-4918: RParen          ")" at 443:36-443:37
-4919: Arrow           "->" at 443:38-443:40 (leading: Space)
-4920: Ident           "int64" at 443:41-443:46 (leading: Space)
-4921: Semicolon       ";" at 443:46-443:47
-4922: At              "@" at 444:5-444:6 (leading: Newline, Space)
-4923: Ident           "intrinsic" at 444:6-444:15
-4924: KwFn            "fn" at 444:16-444:18 (leading: Space)
-4925: Ident           "__neg" at 444:19-444:24 (leading: Space)
-4926: LParen          "(" at 444:24-444:25
-4927: Ident           "self" at 444:25-444:29
-4928: Colon           ":" at 444:29-444:30
-4929: Ident           "int64" at 444:31-444:36 (leading: Space)
-4930: RParen          ")" at 444:36-444:37
-4931: Arrow           "->" at 444:38-444:40 (leading: Space)
-4932: Ident           "int64" at 444:41-444:46 (leading: Space)
-4933: Semicolon       ";" at 444:46-444:47
-4934: At              "@" at 445:5-445:6 (leading: Newline, Space)
-4935: Ident           "intrinsic" at 445:6-445:15
-4936: KwFn            "fn" at 445:16-445:18 (leading: Space)
-4937: Ident           "__abs" at 445:19-445:24 (leading: Space)
-4938: LParen          "(" at 445:24-445:25
-4939: Ident           "self" at 445:25-445:29
-4940: Colon           ":" at 445:29-445:30
-4941: Ident           "int64" at 445:31-445:36 (leading: Space)
-4942: RParen          ")" at 445:36-445:37
-4943: Arrow           "->" at 445:38-445:40 (leading: Space)
-4944: Ident           "int64" at 445:41-445:46 (leading: Space)
-4945: Semicolon       ";" at 445:46-445:47
-4946: At              "@" at 446:5-446:6 (leading: Newline, Space)
-4947: Ident           "intrinsic" at 446:6-446:15
-4948: KwFn            "fn" at 446:16-446:18 (leading: Space)
-4949: Ident           "__to" at 446:19-446:23 (leading: Space)
-4950: LParen          "(" at 446:23-446:24
-4951: Ident           "self" at 446:24-446:28
-4952: Colon           ":" at 446:28-446:29
-4953: Ident           "int64" at 446:30-446:35 (leading: Space)
-4954: Comma           "," at 446:35-446:36
-4955: Ident           "target" at 446:37-446:43 (leading: Space)
-4956: Colon           ":" at 446:43-446:44
-4957: Ident           "int" at 446:45-446:48 (leading: Space)
-4958: RParen          ")" at 446:48-446:49
-4959: Arrow           "->" at 446:50-446:52 (leading: Space)
-4960: Ident           "int" at 446:53-446:56 (leading: Space)
-4961: Semicolon       ";" at 446:56-446:57
-4962: At              "@" at 447:5-447:6 (leading: Newline, Space)
-4963: Ident           "intrinsic" at 447:6-447:15
-4964: At              "@" at 447:16-447:17 (leading: Space)
-4965: Ident           "overload" at 447:17-447:25
-4966: KwFn            "fn" at 447:26-447:28 (leading: Space)
-4967: Ident           "__to" at 447:29-447:33 (leading: Space)
-4968: LParen          "(" at 447:33-447:34
-4969: Ident           "self" at 447:34-447:38
-4970: Colon           ":" at 447:38-447:39
-4971: Ident           "int64" at 447:40-447:45 (leading: Space)
-4972: Comma           "," at 447:45-447:46
-4973: Ident           "target" at 447:47-447:53 (leading: Space)
-4974: Colon           ":" at 447:53-447:54
-4975: Ident           "int8" at 447:55-447:59 (leading: Space)
-4976: RParen          ")" at 447:59-447:60
-4977: Arrow           "->" at 447:61-447:63 (leading: Space)
-4978: Ident           "int8" at 447:64-447:68 (leading: Space)
-4979: Semicolon       ";" at 447:68-447:69
-4980: At              "@" at 448:5-448:6 (leading: Newline, Space)
-4981: Ident           "intrinsic" at 448:6-448:15
-4982: At              "@" at 448:16-448:17 (leading: Space)
-4983: Ident           "overload" at 448:17-448:25
-4984: KwFn            "fn" at 448:26-448:28 (leading: Space)
-4985: Ident           "__to" at 448:29-448:33 (leading: Space)
-4986: LParen          "(" at 448:33-448:34
-4987: Ident           "self" at 448:34-448:38
-4988: Colon           ":" at 448:38-448:39
-4989: Ident           "int64" at 448:40-448:45 (leading: Space)
-4990: Comma           "," at 448:45-448:46
-4991: Ident           "target" at 448:47-448:53 (leading: Space)
-4992: Colon           ":" at 448:53-448:54
-4993: Ident           "int16" at 448:55-448:60 (leading: Space)
-4994: RParen          ")" at 448:60-448:61
-4995: Arrow           "->" at 448:62-448:64 (leading: Space)
-4996: Ident           "int16" at 448:65-448:70 (leading: Space)
-4997: Semicolon       ";" at 448:70-448:71
-4998: At              "@" at 449:5-449:6 (leading: Newline, Space)
-4999: Ident           "intrinsic" at 449:6-449:15
-5000: At              "@" at 449:16-449:17 (leading: Space)
-5001: Ident           "overload" at 449:17-449:25
-5002: KwFn            "fn" at 449:26-449:28 (leading: Space)
-5003: Ident           "__to" at 449:29-449:33 (leading: Space)
-5004: LParen          "(" at 449:33-449:34
-5005: Ident           "self" at 449:34-449:38
-5006: Colon           ":" at 449:38-449:39
-5007: Ident           "int64" at 449:40-449:45 (leading: Space)
-5008: Comma           "," at 449:45-449:46
-5009: Ident           "target" at 449:47-449:53 (leading: Space)
-5010: Colon           ":" at 449:53-449:54
-5011: Ident           "int32" at 449:55-449:60 (leading: Space)
-5012: RParen          ")" at 449:60-449:61
-5013: Arrow           "->" at 449:62-449:64 (leading: Space)
-5014: Ident           "int32" at 449:65-449:70 (leading: Space)
-5015: Semicolon       ";" at 449:70-449:71
-5016: At              "@" at 450:5-450:6 (leading: Newline, Space)
-5017: Ident           "intrinsic" at 450:6-450:15
-5018: KwPub           "pub" at 450:16-450:19 (leading: Space)
-5019: KwFn            "fn" at 450:20-450:22 (leading: Space)
-5020: Ident           "from_str" at 450:23-450:31 (leading: Space)
-5021: LParen          "(" at 450:31-450:32
-5022: Ident           "s" at 450:32-450:33
-5023: Colon           ":" at 450:33-450:34
-5024: Amp             "&" at 450:35-450:36 (leading: Space)
-5025: Ident           "string" at 450:36-450:42
-5026: RParen          ")" at 450:42-450:43
-5027: Arrow           "->" at 450:44-450:46 (leading: Space)
-5028: Ident           "Erring" at 450:47-450:53 (leading: Space)
-5029: Lt              "<" at 450:53-450:54
-5030: Ident           "int64" at 450:54-450:59
-5031: Comma           "," at 450:59-450:60
-5032: Ident           "Error" at 450:61-450:66 (leading: Space)
-5033: Gt              ">" at 450:66-450:67
-5034: Semicolon       ";" at 450:67-450:68
-5035: RBrace          "}" at 451:1-451:2 (leading: Newline)
-5036: KwExtern        "extern" at 453:1-453:7 (leading: Newline)
-5037: Lt              "<" at 453:7-453:8
-5038: Ident           "uint8" at 453:8-453:13
-5039: Gt              ">" at 453:13-453:14
-5040: LBrace          "{" at 453:15-453:16 (leading: Space)
-5041: KwPub           "pub" at 454:5-454:8 (leading: Newline, Space)
-5042: KwFn            "fn" at 454:9-454:11 (leading: Space)
-5043: Ident           "__min_value" at 454:12-454:23 (leading: Space)
-5044: LParen          "(" at 454:23-454:24
-5045: RParen          ")" at 454:24-454:25
-5046: Arrow           "->" at 454:26-454:28 (leading: Space)
-5047: Ident           "uint8" at 454:29-454:34 (leading: Space)
-5048: LBrace          "{" at 454:35-454:36 (leading: Space)
-5049: KwReturn        "return" at 454:37-454:43 (leading: Space)
-5050: LParen          "(" at 454:44-454:45 (leading: Space)
-5051: IntLit          "0" at 454:45-454:46
-5052: RParen          ")" at 454:46-454:47
-5053: Colon           ":" at 454:47-454:48
-5054: Ident           "uint8" at 454:48-454:53
-5055: Semicolon       ";" at 454:53-454:54
-5056: RBrace          "}" at 454:55-454:56 (leading: Space)
-5057: KwPub           "pub" at 455:5-455:8 (leading: Newline, Space)
-5058: KwFn            "fn" at 455:9-455:11 (leading: Space)
-5059: Ident           "__max_value" at 455:12-455:23 (leading: Space)
-5060: LParen          "(" at 455:23-455:24
-5061: RParen          ")" at 455:24-455:25
-5062: Arrow           "->" at 455:26-455:28 (leading: Space)
-5063: Ident           "uint8" at 455:29-455:34 (leading: Space)
-5064: LBrace          "{" at 455:35-455:36 (leading: Space)
-5065: KwReturn        "return" at 455:37-455:43 (leading: Space)
-5066: LParen          "(" at 455:44-455:45 (leading: Space)
-5067: IntLit          "255" at 455:45-455:48
-5068: RParen          ")" at 455:48-455:49
-5069: Colon           ":" at 455:49-455:50
-5070: Ident           "uint8" at 455:50-455:55
-5071: Semicolon       ";" at 455:55-455:56
-5072: RBrace          "}" at 455:57-455:58 (leading: Space)
-5073: At              "@" at 456:5-456:6 (leading: Newline, Space)
-5074: Ident           "intrinsic" at 456:6-456:15
-5075: KwFn            "fn" at 456:16-456:18 (leading: Space)
-5076: Ident           "__add" at 456:19-456:24 (leading: Space)
-5077: LParen          "(" at 456:24-456:25
-5078: Ident           "self" at 456:25-456:29
-5079: Colon           ":" at 456:29-456:30
-5080: Ident           "uint8" at 456:31-456:36 (leading: Space)
-5081: Comma           "," at 456:36-456:37
-5082: Ident           "other" at 456:38-456:43 (leading: Space)
-5083: Colon           ":" at 456:43-456:44
-5084: Ident           "uint8" at 456:45-456:50 (leading: Space)
-5085: RParen          ")" at 456:50-456:51
-5086: Arrow           "->" at 456:52-456:54 (leading: Space)
-5087: Ident           "uint8" at 456:55-456:60 (leading: Space)
-5088: Semicolon       ";" at 456:60-456:61
-5089: At              "@" at 457:5-457:6 (leading: Newline, Space)
-5090: Ident           "intrinsic" at 457:6-457:15
-5091: KwFn            "fn" at 457:16-457:18 (leading: Space)
-5092: Ident           "__sub" at 457:19-457:24 (leading: Space)
-5093: LParen          "(" at 457:24-457:25
-5094: Ident           "self" at 457:25-457:29
-5095: Colon           ":" at 457:29-457:30
-5096: Ident           "uint8" at 457:31-457:36 (leading: Space)
-5097: Comma           "," at 457:36-457:37
-5098: Ident           "other" at 457:38-457:43 (leading: Space)
-5099: Colon           ":" at 457:43-457:44
-5100: Ident           "uint8" at 457:45-457:50 (leading: Space)
-5101: RParen          ")" at 457:50-457:51
-5102: Arrow           "->" at 457:52-457:54 (leading: Space)
-5103: Ident           "uint8" at 457:55-457:60 (leading: Space)
-5104: Semicolon       ";" at 457:60-457:61
-5105: At              "@" at 458:5-458:6 (leading: Newline, Space)
-5106: Ident           "intrinsic" at 458:6-458:15
-5107: KwFn            "fn" at 458:16-458:18 (leading: Space)
-5108: Ident           "__mul" at 458:19-458:24 (leading: Space)
-5109: LParen          "(" at 458:24-458:25
-5110: Ident           "self" at 458:25-458:29
-5111: Colon           ":" at 458:29-458:30
-5112: Ident           "uint8" at 458:31-458:36 (leading: Space)
-5113: Comma           "," at 458:36-458:37
-5114: Ident           "other" at 458:38-458:43 (leading: Space)
-5115: Colon           ":" at 458:43-458:44
-5116: Ident           "uint8" at 458:45-458:50 (leading: Space)
-5117: RParen          ")" at 458:50-458:51
-5118: Arrow           "->" at 458:52-458:54 (leading: Space)
-5119: Ident           "uint8" at 458:55-458:60 (leading: Space)
-5120: Semicolon       ";" at 458:60-458:61
-5121: At              "@" at 459:5-459:6 (leading: Newline, Space)
-5122: Ident           "intrinsic" at 459:6-459:15
-5123: KwFn            "fn" at 459:16-459:18 (leading: Space)
-5124: Ident           "__div" at 459:19-459:24 (leading: Space)
-5125: LParen          "(" at 459:24-459:25
-5126: Ident           "self" at 459:25-459:29
-5127: Colon           ":" at 459:29-459:30
-5128: Ident           "uint8" at 459:31-459:36 (leading: Space)
-5129: Comma           "," at 459:36-459:37
-5130: Ident           "other" at 459:38-459:43 (leading: Space)
-5131: Colon           ":" at 459:43-459:44
-5132: Ident           "uint8" at 459:45-459:50 (leading: Space)
-5133: RParen          ")" at 459:50-459:51
-5134: Arrow           "->" at 459:52-459:54 (leading: Space)
-5135: Ident           "uint8" at 459:55-459:60 (leading: Space)
-5136: Semicolon       ";" at 459:60-459:61
-5137: At              "@" at 460:5-460:6 (leading: Newline, Space)
-5138: Ident           "intrinsic" at 460:6-460:15
-5139: KwFn            "fn" at 460:16-460:18 (leading: Space)
-5140: Ident           "__mod" at 460:19-460:24 (leading: Space)
-5141: LParen          "(" at 460:24-460:25
-5142: Ident           "self" at 460:25-460:29
-5143: Colon           ":" at 460:29-460:30
-5144: Ident           "uint8" at 460:31-460:36 (leading: Space)
-5145: Comma           "," at 460:36-460:37
-5146: Ident           "other" at 460:38-460:43 (leading: Space)
-5147: Colon           ":" at 460:43-460:44
-5148: Ident           "uint8" at 460:45-460:50 (leading: Space)
-5149: RParen          ")" at 460:50-460:51
-5150: Arrow           "->" at 460:52-460:54 (leading: Space)
-5151: Ident           "uint8" at 460:55-460:60 (leading: Space)
-5152: Semicolon       ";" at 460:60-460:61
-5153: At              "@" at 461:5-461:6 (leading: Newline, Space)
-5154: Ident           "intrinsic" at 461:6-461:15
-5155: KwFn            "fn" at 461:16-461:18 (leading: Space)
-5156: Ident           "__bit_and" at 461:19-461:28 (leading: Space)
-5157: LParen          "(" at 461:28-461:29
-5158: Ident           "self" at 461:29-461:33
-5159: Colon           ":" at 461:33-461:34
-5160: Ident           "uint8" at 461:35-461:40 (leading: Space)
-5161: Comma           "," at 461:40-461:41
-5162: Ident           "other" at 461:42-461:47 (leading: Space)
-5163: Colon           ":" at 461:47-461:48
-5164: Ident           "uint8" at 461:49-461:54 (leading: Space)
-5165: RParen          ")" at 461:54-461:55
-5166: Arrow           "->" at 461:56-461:58 (leading: Space)
-5167: Ident           "uint8" at 461:59-461:64 (leading: Space)
-5168: Semicolon       ";" at 461:64-461:65
-5169: At              "@" at 462:5-462:6 (leading: Newline, Space)
-5170: Ident           "intrinsic" at 462:6-462:15
-5171: KwFn            "fn" at 462:16-462:18 (leading: Space)
-5172: Ident           "__bit_or" at 462:19-462:27 (leading: Space)
-5173: LParen          "(" at 462:27-462:28
-5174: Ident           "self" at 462:28-462:32
-5175: Colon           ":" at 462:32-462:33
-5176: Ident           "uint8" at 462:34-462:39 (leading: Space)
-5177: Comma           "," at 462:39-462:40
-5178: Ident           "other" at 462:41-462:46 (leading: Space)
-5179: Colon           ":" at 462:46-462:47
-5180: Ident           "uint8" at 462:48-462:53 (leading: Space)
-5181: RParen          ")" at 462:53-462:54
-5182: Arrow           "->" at 462:55-462:57 (leading: Space)
-5183: Ident           "uint8" at 462:58-462:63 (leading: Space)
-5184: Semicolon       ";" at 462:63-462:64
-5185: At              "@" at 463:5-463:6 (leading: Newline, Space)
-5186: Ident           "intrinsic" at 463:6-463:15
-5187: KwFn            "fn" at 463:16-463:18 (leading: Space)
-5188: Ident           "__bit_xor" at 463:19-463:28 (leading: Space)
-5189: LParen          "(" at 463:28-463:29
-5190: Ident           "self" at 463:29-463:33
-5191: Colon           ":" at 463:33-463:34
-5192: Ident           "uint8" at 463:35-463:40 (leading: Space)
-5193: Comma           "," at 463:40-463:41
-5194: Ident           "other" at 463:42-463:47 (leading: Space)
-5195: Colon           ":" at 463:47-463:48
-5196: Ident           "uint8" at 463:49-463:54 (leading: Space)
-5197: RParen          ")" at 463:54-463:55
-5198: Arrow           "->" at 463:56-463:58 (leading: Space)
-5199: Ident           "uint8" at 463:59-463:64 (leading: Space)
-5200: Semicolon       ";" at 463:64-463:65
-5201: At              "@" at 464:5-464:6 (leading: Newline, Space)
-5202: Ident           "intrinsic" at 464:6-464:15
-5203: KwFn            "fn" at 464:16-464:18 (leading: Space)
-5204: Ident           "__shl" at 464:19-464:24 (leading: Space)
-5205: LParen          "(" at 464:24-464:25
-5206: Ident           "self" at 464:25-464:29
-5207: Colon           ":" at 464:29-464:30
-5208: Ident           "uint8" at 464:31-464:36 (leading: Space)
-5209: Comma           "," at 464:36-464:37
-5210: Ident           "other" at 464:38-464:43 (leading: Space)
-5211: Colon           ":" at 464:43-464:44
-5212: Ident           "uint8" at 464:45-464:50 (leading: Space)
-5213: RParen          ")" at 464:50-464:51
-5214: Arrow           "->" at 464:52-464:54 (leading: Space)
-5215: Ident           "uint8" at 464:55-464:60 (leading: Space)
-5216: Semicolon       ";" at 464:60-464:61
-5217: At              "@" at 465:5-465:6 (leading: Newline, Space)
-5218: Ident           "intrinsic" at 465:6-465:15
-5219: KwFn            "fn" at 465:16-465:18 (leading: Space)
-5220: Ident           "__shr" at 465:19-465:24 (leading: Space)
-5221: LParen          "(" at 465:24-465:25
-5222: Ident           "self" at 465:25-465:29
-5223: Colon           ":" at 465:29-465:30
-5224: Ident           "uint8" at 465:31-465:36 (leading: Space)
-5225: Comma           "," at 465:36-465:37
-5226: Ident           "other" at 465:38-465:43 (leading: Space)
-5227: Colon           ":" at 465:43-465:44
-5228: Ident           "uint8" at 465:45-465:50 (leading: Space)
-5229: RParen          ")" at 465:50-465:51
-5230: Arrow           "->" at 465:52-465:54 (leading: Space)
-5231: Ident           "uint8" at 465:55-465:60 (leading: Space)
-5232: Semicolon       ";" at 465:60-465:61
-5233: At              "@" at 466:5-466:6 (leading: Newline, Space)
-5234: Ident           "intrinsic" at 466:6-466:15
-5235: KwFn            "fn" at 466:16-466:18 (leading: Space)
-5236: Ident           "__lt" at 466:19-466:23 (leading: Space)
-5237: LParen          "(" at 466:23-466:24
-5238: Ident           "self" at 466:24-466:28
-5239: Colon           ":" at 466:28-466:29
-5240: Ident           "uint8" at 466:30-466:35 (leading: Space)
-5241: Comma           "," at 466:35-466:36
-5242: Ident           "other" at 466:37-466:42 (leading: Space)
-5243: Colon           ":" at 466:42-466:43
-5244: Ident           "uint8" at 466:44-466:49 (leading: Space)
-5245: RParen          ")" at 466:49-466:50
-5246: Arrow           "->" at 466:51-466:53 (leading: Space)
-5247: Ident           "bool" at 466:54-466:58 (leading: Space)
-5248: Semicolon       ";" at 466:58-466:59
-5249: At              "@" at 467:5-467:6 (leading: Newline, Space)
-5250: Ident           "intrinsic" at 467:6-467:15
-5251: KwFn            "fn" at 467:16-467:18 (leading: Space)
-5252: Ident           "__le" at 467:19-467:23 (leading: Space)
-5253: LParen          "(" at 467:23-467:24
-5254: Ident           "self" at 467:24-467:28
-5255: Colon           ":" at 467:28-467:29
-5256: Ident           "uint8" at 467:30-467:35 (leading: Space)
-5257: Comma           "," at 467:35-467:36
-5258: Ident           "other" at 467:37-467:42 (leading: Space)
-5259: Colon           ":" at 467:42-467:43
-5260: Ident           "uint8" at 467:44-467:49 (leading: Space)
-5261: RParen          ")" at 467:49-467:50
-5262: Arrow           "->" at 467:51-467:53 (leading: Space)
-5263: Ident           "bool" at 467:54-467:58 (leading: Space)
-5264: Semicolon       ";" at 467:58-467:59
-5265: At              "@" at 468:5-468:6 (leading: Newline, Space)
-5266: Ident           "intrinsic" at 468:6-468:15
-5267: KwFn            "fn" at 468:16-468:18 (leading: Space)
-5268: Ident           "__eq" at 468:19-468:23 (leading: Space)
-5269: LParen          "(" at 468:23-468:24
-5270: Ident           "self" at 468:24-468:28
-5271: Colon           ":" at 468:28-468:29
-5272: Ident           "uint8" at 468:30-468:35 (leading: Space)
-5273: Comma           "," at 468:35-468:36
-5274: Ident           "other" at 468:37-468:42 (leading: Space)
-5275: Colon           ":" at 468:42-468:43
-5276: Ident           "uint8" at 468:44-468:49 (leading: Space)
-5277: RParen          ")" at 468:49-468:50
-5278: Arrow           "->" at 468:51-468:53 (leading: Space)
-5279: Ident           "bool" at 468:54-468:58 (leading: Space)
-5280: Semicolon       ";" at 468:58-468:59
-5281: At              "@" at 469:5-469:6 (leading: Newline, Space)
-5282: Ident           "intrinsic" at 469:6-469:15
-5283: KwFn            "fn" at 469:16-469:18 (leading: Space)
-5284: Ident           "__ne" at 469:19-469:23 (leading: Space)
-5285: LParen          "(" at 469:23-469:24
-5286: Ident           "self" at 469:24-469:28
-5287: Colon           ":" at 469:28-469:29
-5288: Ident           "uint8" at 469:30-469:35 (leading: Space)
-5289: Comma           "," at 469:35-469:36
-5290: Ident           "other" at 469:37-469:42 (leading: Space)
-5291: Colon           ":" at 469:42-469:43
-5292: Ident           "uint8" at 469:44-469:49 (leading: Space)
-5293: RParen          ")" at 469:49-469:50
-5294: Arrow           "->" at 469:51-469:53 (leading: Space)
-5295: Ident           "bool" at 469:54-469:58 (leading: Space)
-5296: Semicolon       ";" at 469:58-469:59
-5297: At              "@" at 470:5-470:6 (leading: Newline, Space)
-5298: Ident           "intrinsic" at 470:6-470:15
-5299: KwFn            "fn" at 470:16-470:18 (leading: Space)
-5300: Ident           "__ge" at 470:19-470:23 (leading: Space)
-5301: LParen          "(" at 470:23-470:24
-5302: Ident           "self" at 470:24-470:28
-5303: Colon           ":" at 470:28-470:29
-5304: Ident           "uint8" at 470:30-470:35 (leading: Space)
-5305: Comma           "," at 470:35-470:36
-5306: Ident           "other" at 470:37-470:42 (leading: Space)
-5307: Colon           ":" at 470:42-470:43
-5308: Ident           "uint8" at 470:44-470:49 (leading: Space)
-5309: RParen          ")" at 470:49-470:50
-5310: Arrow           "->" at 470:51-470:53 (leading: Space)
-5311: Ident           "bool" at 470:54-470:58 (leading: Space)
-5312: Semicolon       ";" at 470:58-470:59
-5313: At              "@" at 471:5-471:6 (leading: Newline, Space)
-5314: Ident           "intrinsic" at 471:6-471:15
-5315: KwFn            "fn" at 471:16-471:18 (leading: Space)
-5316: Ident           "__gt" at 471:19-471:23 (leading: Space)
-5317: LParen          "(" at 471:23-471:24
-5318: Ident           "self" at 471:24-471:28
-5319: Colon           ":" at 471:28-471:29
-5320: Ident           "uint8" at 471:30-471:35 (leading: Space)
-5321: Comma           "," at 471:35-471:36
-5322: Ident           "other" at 471:37-471:42 (leading: Space)
-5323: Colon           ":" at 471:42-471:43
-5324: Ident           "uint8" at 471:44-471:49 (leading: Space)
-5325: RParen          ")" at 471:49-471:50
-5326: Arrow           "->" at 471:51-471:53 (leading: Space)
-5327: Ident           "bool" at 471:54-471:58 (leading: Space)
-5328: Semicolon       ";" at 471:58-471:59
-5329: At              "@" at 472:5-472:6 (leading: Newline, Space)
-5330: Ident           "intrinsic" at 472:6-472:15
-5331: KwFn            "fn" at 472:16-472:18 (leading: Space)
-5332: Ident           "__pos" at 472:19-472:24 (leading: Space)
-5333: LParen          "(" at 472:24-472:25
-5334: Ident           "self" at 472:25-472:29
-5335: Colon           ":" at 472:29-472:30
-5336: Ident           "uint8" at 472:31-472:36 (leading: Space)
-5337: RParen          ")" at 472:36-472:37
-5338: Arrow           "->" at 472:38-472:40 (leading: Space)
-5339: Ident           "uint8" at 472:41-472:46 (leading: Space)
-5340: Semicolon       ";" at 472:46-472:47
-5341: At              "@" at 473:5-473:6 (leading: Newline, Space)
-5342: Ident           "intrinsic" at 473:6-473:15
-5343: KwFn            "fn" at 473:16-473:18 (leading: Space)
-5344: Ident           "__abs" at 473:19-473:24 (leading: Space)
-5345: LParen          "(" at 473:24-473:25
-5346: Ident           "self" at 473:25-473:29
-5347: Colon           ":" at 473:29-473:30
-5348: Ident           "uint8" at 473:31-473:36 (leading: Space)
-5349: RParen          ")" at 473:36-473:37
-5350: Arrow           "->" at 473:38-473:40 (leading: Space)
-5351: Ident           "uint8" at 473:41-473:46 (leading: Space)
-5352: Semicolon       ";" at 473:46-473:47
-5353: At              "@" at 474:5-474:6 (leading: Newline, Space)
-5354: Ident           "intrinsic" at 474:6-474:15
-5355: KwFn            "fn" at 474:16-474:18 (leading: Space)
-5356: Ident           "__to" at 474:19-474:23 (leading: Space)
-5357: LParen          "(" at 474:23-474:24
-5358: Ident           "self" at 474:24-474:28
-5359: Colon           ":" at 474:28-474:29
-5360: Ident           "uint8" at 474:30-474:35 (leading: Space)
-5361: Comma           "," at 474:35-474:36
-5362: Ident           "target" at 474:37-474:43 (leading: Space)
-5363: Colon           ":" at 474:43-474:44
-5364: Ident           "uint" at 474:45-474:49 (leading: Space)
-5365: RParen          ")" at 474:49-474:50
-5366: Arrow           "->" at 474:51-474:53 (leading: Space)
-5367: Ident           "uint" at 474:54-474:58 (leading: Space)
-5368: Semicolon       ";" at 474:58-474:59
-5369: At              "@" at 475:5-475:6 (leading: Newline, Space)
-5370: Ident           "intrinsic" at 475:6-475:15
-5371: At              "@" at 475:16-475:17 (leading: Space)
-5372: Ident           "overload" at 475:17-475:25
-5373: KwFn            "fn" at 475:26-475:28 (leading: Space)
-5374: Ident           "__to" at 475:29-475:33 (leading: Space)
-5375: LParen          "(" at 475:33-475:34
-5376: Ident           "self" at 475:34-475:38
-5377: Colon           ":" at 475:38-475:39
-5378: Ident           "uint8" at 475:40-475:45 (leading: Space)
-5379: Comma           "," at 475:45-475:46
-5380: Ident           "target" at 475:47-475:53 (leading: Space)
-5381: Colon           ":" at 475:53-475:54
-5382: Ident           "uint16" at 475:55-475:61 (leading: Space)
-5383: RParen          ")" at 475:61-475:62
-5384: Arrow           "->" at 475:63-475:65 (leading: Space)
-5385: Ident           "uint16" at 475:66-475:72 (leading: Space)
-5386: Semicolon       ";" at 475:72-475:73
-5387: At              "@" at 476:5-476:6 (leading: Newline, Space)
-5388: Ident           "intrinsic" at 476:6-476:15
-5389: At              "@" at 476:16-476:17 (leading: Space)
-5390: Ident           "overload" at 476:17-476:25
-5391: KwFn            "fn" at 476:26-476:28 (leading: Space)
-5392: Ident           "__to" at 476:29-476:33 (leading: Space)
-5393: LParen          "(" at 476:33-476:34
-5394: Ident           "self" at 476:34-476:38
-5395: Colon           ":" at 476:38-476:39
-5396: Ident           "uint8" at 476:40-476:45 (leading: Space)
-5397: Comma           "," at 476:45-476:46
-5398: Ident           "target" at 476:47-476:53 (leading: Space)
-5399: Colon           ":" at 476:53-476:54
-5400: Ident           "uint32" at 476:55-476:61 (leading: Space)
-5401: RParen          ")" at 476:61-476:62
-5402: Arrow           "->" at 476:63-476:65 (leading: Space)
-5403: Ident           "uint32" at 476:66-476:72 (leading: Space)
-5404: Semicolon       ";" at 476:72-476:73
-5405: At              "@" at 477:5-477:6 (leading: Newline, Space)
-5406: Ident           "intrinsic" at 477:6-477:15
-5407: At              "@" at 477:16-477:17 (leading: Space)
-5408: Ident           "overload" at 477:17-477:25
-5409: KwFn            "fn" at 477:26-477:28 (leading: Space)
-5410: Ident           "__to" at 477:29-477:33 (leading: Space)
-5411: LParen          "(" at 477:33-477:34
-5412: Ident           "self" at 477:34-477:38
-5413: Colon           ":" at 477:38-477:39
-5414: Ident           "uint8" at 477:40-477:45 (leading: Space)
-5415: Comma           "," at 477:45-477:46
-5416: Ident           "target" at 477:47-477:53 (leading: Space)
-5417: Colon           ":" at 477:53-477:54
-5418: Ident           "uint64" at 477:55-477:61 (leading: Space)
-5419: RParen          ")" at 477:61-477:62
-5420: Arrow           "->" at 477:63-477:65 (leading: Space)
-5421: Ident           "uint64" at 477:66-477:72 (leading: Space)
-5422: Semicolon       ";" at 477:72-477:73
-5423: At              "@" at 478:5-478:6 (leading: Newline, Space)
-5424: Ident           "intrinsic" at 478:6-478:15
-5425: KwPub           "pub" at 478:16-478:19 (leading: Space)
-5426: KwFn            "fn" at 478:20-478:22 (leading: Space)
-5427: Ident           "from_str" at 478:23-478:31 (leading: Space)
-5428: LParen          "(" at 478:31-478:32
-5429: Ident           "s" at 478:32-478:33
-5430: Colon           ":" at 478:33-478:34
-5431: Amp             "&" at 478:35-478:36 (leading: Space)
-5432: Ident           "string" at 478:36-478:42
-5433: RParen          ")" at 478:42-478:43
-5434: Arrow           "->" at 478:44-478:46 (leading: Space)
-5435: Ident           "Erring" at 478:47-478:53 (leading: Space)
-5436: Lt              "<" at 478:53-478:54
-5437: Ident           "uint8" at 478:54-478:59
-5438: Comma           "," at 478:59-478:60
-5439: Ident           "Error" at 478:61-478:66 (leading: Space)
-5440: Gt              ">" at 478:66-478:67
-5441: Semicolon       ";" at 478:67-478:68
-5442: RBrace          "}" at 479:1-479:2 (leading: Newline)
-5443: KwExtern        "extern" at 481:1-481:7 (leading: Newline)
-5444: Lt              "<" at 481:7-481:8
-5445: Ident           "uint16" at 481:8-481:14
-5446: Gt              ">" at 481:14-481:15
-5447: LBrace          "{" at 481:16-481:17 (leading: Space)
-5448: KwPub           "pub" at 482:5-482:8 (leading: Newline, Space)
-5449: KwFn            "fn" at 482:9-482:11 (leading: Space)
-5450: Ident           "__min_value" at 482:12-482:23 (leading: Space)
-5451: LParen          "(" at 482:23-482:24
-5452: RParen          ")" at 482:24-482:25
-5453: Arrow           "->" at 482:26-482:28 (leading: Space)
-5454: Ident           "uint16" at 482:29-482:35 (leading: Space)
-5455: LBrace          "{" at 482:36-482:37 (leading: Space)
-5456: KwReturn        "return" at 482:38-482:44 (leading: Space)
-5457: LParen          "(" at 482:45-482:46 (leading: Space)
-5458: IntLit          "0" at 482:46-482:47
-5459: RParen          ")" at 482:47-482:48
-5460: Colon           ":" at 482:48-482:49
-5461: Ident           "uint16" at 482:49-482:55
-5462: Semicolon       ";" at 482:55-482:56
-5463: RBrace          "}" at 482:57-482:58 (leading: Space)
-5464: KwPub           "pub" at 483:5-483:8 (leading: Newline, Space)
-5465: KwFn            "fn" at 483:9-483:11 (leading: Space)
-5466: Ident           "__max_value" at 483:12-483:23 (leading: Space)
-5467: LParen          "(" at 483:23-483:24
-5468: RParen          ")" at 483:24-483:25
-5469: Arrow           "->" at 483:26-483:28 (leading: Space)
-5470: Ident           "uint16" at 483:29-483:35 (leading: Space)
-5471: LBrace          "{" at 483:36-483:37 (leading: Space)
-5472: KwReturn        "return" at 483:38-483:44 (leading: Space)
-5473: LParen          "(" at 483:45-483:46 (leading: Space)
-5474: IntLit          "65_535" at 483:46-483:52
-5475: RParen          ")" at 483:52-483:53
-5476: Colon           ":" at 483:53-483:54
-5477: Ident           "uint16" at 483:54-483:60
-5478: Semicolon       ";" at 483:60-483:61
-5479: RBrace          "}" at 483:62-483:63 (leading: Space)
-5480: At              "@" at 484:5-484:6 (leading: Newline, Space)
-5481: Ident           "intrinsic" at 484:6-484:15
-5482: KwFn            "fn" at 484:16-484:18 (leading: Space)
-5483: Ident           "__add" at 484:19-484:24 (leading: Space)
-5484: LParen          "(" at 484:24-484:25
-5485: Ident           "self" at 484:25-484:29
-5486: Colon           ":" at 484:29-484:30
-5487: Ident           "uint16" at 484:31-484:37 (leading: Space)
-5488: Comma           "," at 484:37-484:38
-5489: Ident           "other" at 484:39-484:44 (leading: Space)
-5490: Colon           ":" at 484:44-484:45
-5491: Ident           "uint16" at 484:46-484:52 (leading: Space)
-5492: RParen          ")" at 484:52-484:53
-5493: Arrow           "->" at 484:54-484:56 (leading: Space)
-5494: Ident           "uint16" at 484:57-484:63 (leading: Space)
-5495: Semicolon       ";" at 484:63-484:64
-5496: At              "@" at 485:5-485:6 (leading: Newline, Space)
-5497: Ident           "intrinsic" at 485:6-485:15
-5498: KwFn            "fn" at 485:16-485:18 (leading: Space)
-5499: Ident           "__sub" at 485:19-485:24 (leading: Space)
-5500: LParen          "(" at 485:24-485:25
-5501: Ident           "self" at 485:25-485:29
-5502: Colon           ":" at 485:29-485:30
-5503: Ident           "uint16" at 485:31-485:37 (leading: Space)
-5504: Comma           "," at 485:37-485:38
-5505: Ident           "other" at 485:39-485:44 (leading: Space)
-5506: Colon           ":" at 485:44-485:45
-5507: Ident           "uint16" at 485:46-485:52 (leading: Space)
-5508: RParen          ")" at 485:52-485:53
-5509: Arrow           "->" at 485:54-485:56 (leading: Space)
-5510: Ident           "uint16" at 485:57-485:63 (leading: Space)
-5511: Semicolon       ";" at 485:63-485:64
-5512: At              "@" at 486:5-486:6 (leading: Newline, Space)
-5513: Ident           "intrinsic" at 486:6-486:15
-5514: KwFn            "fn" at 486:16-486:18 (leading: Space)
-5515: Ident           "__mul" at 486:19-486:24 (leading: Space)
-5516: LParen          "(" at 486:24-486:25
-5517: Ident           "self" at 486:25-486:29
-5518: Colon           ":" at 486:29-486:30
-5519: Ident           "uint16" at 486:31-486:37 (leading: Space)
-5520: Comma           "," at 486:37-486:38
-5521: Ident           "other" at 486:39-486:44 (leading: Space)
-5522: Colon           ":" at 486:44-486:45
-5523: Ident           "uint16" at 486:46-486:52 (leading: Space)
-5524: RParen          ")" at 486:52-486:53
-5525: Arrow           "->" at 486:54-486:56 (leading: Space)
-5526: Ident           "uint16" at 486:57-486:63 (leading: Space)
-5527: Semicolon       ";" at 486:63-486:64
-5528: At              "@" at 487:5-487:6 (leading: Newline, Space)
-5529: Ident           "intrinsic" at 487:6-487:15
-5530: KwFn            "fn" at 487:16-487:18 (leading: Space)
-5531: Ident           "__div" at 487:19-487:24 (leading: Space)
-5532: LParen          "(" at 487:24-487:25
-5533: Ident           "self" at 487:25-487:29
-5534: Colon           ":" at 487:29-487:30
-5535: Ident           "uint16" at 487:31-487:37 (leading: Space)
-5536: Comma           "," at 487:37-487:38
-5537: Ident           "other" at 487:39-487:44 (leading: Space)
-5538: Colon           ":" at 487:44-487:45
-5539: Ident           "uint16" at 487:46-487:52 (leading: Space)
-5540: RParen          ")" at 487:52-487:53
-5541: Arrow           "->" at 487:54-487:56 (leading: Space)
-5542: Ident           "uint16" at 487:57-487:63 (leading: Space)
-5543: Semicolon       ";" at 487:63-487:64
-5544: At              "@" at 488:5-488:6 (leading: Newline, Space)
-5545: Ident           "intrinsic" at 488:6-488:15
-5546: KwFn            "fn" at 488:16-488:18 (leading: Space)
-5547: Ident           "__mod" at 488:19-488:24 (leading: Space)
-5548: LParen          "(" at 488:24-488:25
-5549: Ident           "self" at 488:25-488:29
-5550: Colon           ":" at 488:29-488:30
-5551: Ident           "uint16" at 488:31-488:37 (leading: Space)
-5552: Comma           "," at 488:37-488:38
-5553: Ident           "other" at 488:39-488:44 (leading: Space)
-5554: Colon           ":" at 488:44-488:45
-5555: Ident           "uint16" at 488:46-488:52 (leading: Space)
-5556: RParen          ")" at 488:52-488:53
-5557: Arrow           "->" at 488:54-488:56 (leading: Space)
-5558: Ident           "uint16" at 488:57-488:63 (leading: Space)
-5559: Semicolon       ";" at 488:63-488:64
-5560: At              "@" at 489:5-489:6 (leading: Newline, Space)
-5561: Ident           "intrinsic" at 489:6-489:15
-5562: KwFn            "fn" at 489:16-489:18 (leading: Space)
-5563: Ident           "__bit_and" at 489:19-489:28 (leading: Space)
-5564: LParen          "(" at 489:28-489:29
-5565: Ident           "self" at 489:29-489:33
-5566: Colon           ":" at 489:33-489:34
-5567: Ident           "uint16" at 489:35-489:41 (leading: Space)
-5568: Comma           "," at 489:41-489:42
-5569: Ident           "other" at 489:43-489:48 (leading: Space)
-5570: Colon           ":" at 489:48-489:49
-5571: Ident           "uint16" at 489:50-489:56 (leading: Space)
-5572: RParen          ")" at 489:56-489:57
-5573: Arrow           "->" at 489:58-489:60 (leading: Space)
-5574: Ident           "uint16" at 489:61-489:67 (leading: Space)
-5575: Semicolon       ";" at 489:67-489:68
-5576: At              "@" at 490:5-490:6 (leading: Newline, Space)
-5577: Ident           "intrinsic" at 490:6-490:15
-5578: KwFn            "fn" at 490:16-490:18 (leading: Space)
-5579: Ident           "__bit_or" at 490:19-490:27 (leading: Space)
-5580: LParen          "(" at 490:27-490:28
-5581: Ident           "self" at 490:28-490:32
-5582: Colon           ":" at 490:32-490:33
-5583: Ident           "uint16" at 490:34-490:40 (leading: Space)
-5584: Comma           "," at 490:40-490:41
-5585: Ident           "other" at 490:42-490:47 (leading: Space)
-5586: Colon           ":" at 490:47-490:48
-5587: Ident           "uint16" at 490:49-490:55 (leading: Space)
-5588: RParen          ")" at 490:55-490:56
-5589: Arrow           "->" at 490:57-490:59 (leading: Space)
-5590: Ident           "uint16" at 490:60-490:66 (leading: Space)
-5591: Semicolon       ";" at 490:66-490:67
-5592: At              "@" at 491:5-491:6 (leading: Newline, Space)
-5593: Ident           "intrinsic" at 491:6-491:15
-5594: KwFn            "fn" at 491:16-491:18 (leading: Space)
-5595: Ident           "__bit_xor" at 491:19-491:28 (leading: Space)
-5596: LParen          "(" at 491:28-491:29
-5597: Ident           "self" at 491:29-491:33
-5598: Colon           ":" at 491:33-491:34
-5599: Ident           "uint16" at 491:35-491:41 (leading: Space)
-5600: Comma           "," at 491:41-491:42
-5601: Ident           "other" at 491:43-491:48 (leading: Space)
-5602: Colon           ":" at 491:48-491:49
-5603: Ident           "uint16" at 491:50-491:56 (leading: Space)
-5604: RParen          ")" at 491:56-491:57
-5605: Arrow           "->" at 491:58-491:60 (leading: Space)
-5606: Ident           "uint16" at 491:61-491:67 (leading: Space)
-5607: Semicolon       ";" at 491:67-491:68
-5608: At              "@" at 492:5-492:6 (leading: Newline, Space)
-5609: Ident           "intrinsic" at 492:6-492:15
-5610: KwFn            "fn" at 492:16-492:18 (leading: Space)
-5611: Ident           "__shl" at 492:19-492:24 (leading: Space)
-5612: LParen          "(" at 492:24-492:25
-5613: Ident           "self" at 492:25-492:29
-5614: Colon           ":" at 492:29-492:30
-5615: Ident           "uint16" at 492:31-492:37 (leading: Space)
-5616: Comma           "," at 492:37-492:38
-5617: Ident           "other" at 492:39-492:44 (leading: Space)
-5618: Colon           ":" at 492:44-492:45
-5619: Ident           "uint16" at 492:46-492:52 (leading: Space)
-5620: RParen          ")" at 492:52-492:53
-5621: Arrow           "->" at 492:54-492:56 (leading: Space)
-5622: Ident           "uint16" at 492:57-492:63 (leading: Space)
-5623: Semicolon       ";" at 492:63-492:64
-5624: At              "@" at 493:5-493:6 (leading: Newline, Space)
-5625: Ident           "intrinsic" at 493:6-493:15
-5626: KwFn            "fn" at 493:16-493:18 (leading: Space)
-5627: Ident           "__shr" at 493:19-493:24 (leading: Space)
-5628: LParen          "(" at 493:24-493:25
-5629: Ident           "self" at 493:25-493:29
-5630: Colon           ":" at 493:29-493:30
-5631: Ident           "uint16" at 493:31-493:37 (leading: Space)
-5632: Comma           "," at 493:37-493:38
-5633: Ident           "other" at 493:39-493:44 (leading: Space)
-5634: Colon           ":" at 493:44-493:45
-5635: Ident           "uint16" at 493:46-493:52 (leading: Space)
-5636: RParen          ")" at 493:52-493:53
-5637: Arrow           "->" at 493:54-493:56 (leading: Space)
-5638: Ident           "uint16" at 493:57-493:63 (leading: Space)
-5639: Semicolon       ";" at 493:63-493:64
-5640: At              "@" at 494:5-494:6 (leading: Newline, Space)
-5641: Ident           "intrinsic" at 494:6-494:15
-5642: KwFn            "fn" at 494:16-494:18 (leading: Space)
-5643: Ident           "__lt" at 494:19-494:23 (leading: Space)
-5644: LParen          "(" at 494:23-494:24
-5645: Ident           "self" at 494:24-494:28
-5646: Colon           ":" at 494:28-494:29
-5647: Ident           "uint16" at 494:30-494:36 (leading: Space)
-5648: Comma           "," at 494:36-494:37
-5649: Ident           "other" at 494:38-494:43 (leading: Space)
-5650: Colon           ":" at 494:43-494:44
-5651: Ident           "uint16" at 494:45-494:51 (leading: Space)
-5652: RParen          ")" at 494:51-494:52
-5653: Arrow           "->" at 494:53-494:55 (leading: Space)
-5654: Ident           "bool" at 494:56-494:60 (leading: Space)
-5655: Semicolon       ";" at 494:60-494:61
-5656: At              "@" at 495:5-495:6 (leading: Newline, Space)
-5657: Ident           "intrinsic" at 495:6-495:15
-5658: KwFn            "fn" at 495:16-495:18 (leading: Space)
-5659: Ident           "__le" at 495:19-495:23 (leading: Space)
-5660: LParen          "(" at 495:23-495:24
-5661: Ident           "self" at 495:24-495:28
-5662: Colon           ":" at 495:28-495:29
-5663: Ident           "uint16" at 495:30-495:36 (leading: Space)
-5664: Comma           "," at 495:36-495:37
-5665: Ident           "other" at 495:38-495:43 (leading: Space)
-5666: Colon           ":" at 495:43-495:44
-5667: Ident           "uint16" at 495:45-495:51 (leading: Space)
-5668: RParen          ")" at 495:51-495:52
-5669: Arrow           "->" at 495:53-495:55 (leading: Space)
-5670: Ident           "bool" at 495:56-495:60 (leading: Space)
-5671: Semicolon       ";" at 495:60-495:61
-5672: At              "@" at 496:5-496:6 (leading: Newline, Space)
-5673: Ident           "intrinsic" at 496:6-496:15
-5674: KwFn            "fn" at 496:16-496:18 (leading: Space)
-5675: Ident           "__eq" at 496:19-496:23 (leading: Space)
-5676: LParen          "(" at 496:23-496:24
-5677: Ident           "self" at 496:24-496:28
-5678: Colon           ":" at 496:28-496:29
-5679: Ident           "uint16" at 496:30-496:36 (leading: Space)
-5680: Comma           "," at 496:36-496:37
-5681: Ident           "other" at 496:38-496:43 (leading: Space)
-5682: Colon           ":" at 496:43-496:44
-5683: Ident           "uint16" at 496:45-496:51 (leading: Space)
-5684: RParen          ")" at 496:51-496:52
-5685: Arrow           "->" at 496:53-496:55 (leading: Space)
-5686: Ident           "bool" at 496:56-496:60 (leading: Space)
-5687: Semicolon       ";" at 496:60-496:61
-5688: At              "@" at 497:5-497:6 (leading: Newline, Space)
-5689: Ident           "intrinsic" at 497:6-497:15
-5690: KwFn            "fn" at 497:16-497:18 (leading: Space)
-5691: Ident           "__ne" at 497:19-497:23 (leading: Space)
-5692: LParen          "(" at 497:23-497:24
-5693: Ident           "self" at 497:24-497:28
-5694: Colon           ":" at 497:28-497:29
-5695: Ident           "uint16" at 497:30-497:36 (leading: Space)
-5696: Comma           "," at 497:36-497:37
-5697: Ident           "other" at 497:38-497:43 (leading: Space)
-5698: Colon           ":" at 497:43-497:44
-5699: Ident           "uint16" at 497:45-497:51 (leading: Space)
-5700: RParen          ")" at 497:51-497:52
-5701: Arrow           "->" at 497:53-497:55 (leading: Space)
-5702: Ident           "bool" at 497:56-497:60 (leading: Space)
-5703: Semicolon       ";" at 497:60-497:61
-5704: At              "@" at 498:5-498:6 (leading: Newline, Space)
-5705: Ident           "intrinsic" at 498:6-498:15
-5706: KwFn            "fn" at 498:16-498:18 (leading: Space)
-5707: Ident           "__ge" at 498:19-498:23 (leading: Space)
-5708: LParen          "(" at 498:23-498:24
-5709: Ident           "self" at 498:24-498:28
-5710: Colon           ":" at 498:28-498:29
-5711: Ident           "uint16" at 498:30-498:36 (leading: Space)
-5712: Comma           "," at 498:36-498:37
-5713: Ident           "other" at 498:38-498:43 (leading: Space)
-5714: Colon           ":" at 498:43-498:44
-5715: Ident           "uint16" at 498:45-498:51 (leading: Space)
-5716: RParen          ")" at 498:51-498:52
-5717: Arrow           "->" at 498:53-498:55 (leading: Space)
-5718: Ident           "bool" at 498:56-498:60 (leading: Space)
-5719: Semicolon       ";" at 498:60-498:61
-5720: At              "@" at 499:5-499:6 (leading: Newline, Space)
-5721: Ident           "intrinsic" at 499:6-499:15
-5722: KwFn            "fn" at 499:16-499:18 (leading: Space)
-5723: Ident           "__gt" at 499:19-499:23 (leading: Space)
-5724: LParen          "(" at 499:23-499:24
-5725: Ident           "self" at 499:24-499:28
-5726: Colon           ":" at 499:28-499:29
-5727: Ident           "uint16" at 499:30-499:36 (leading: Space)
-5728: Comma           "," at 499:36-499:37
-5729: Ident           "other" at 499:38-499:43 (leading: Space)
-5730: Colon           ":" at 499:43-499:44
-5731: Ident           "uint16" at 499:45-499:51 (leading: Space)
-5732: RParen          ")" at 499:51-499:52
-5733: Arrow           "->" at 499:53-499:55 (leading: Space)
-5734: Ident           "bool" at 499:56-499:60 (leading: Space)
-5735: Semicolon       ";" at 499:60-499:61
-5736: At              "@" at 500:5-500:6 (leading: Newline, Space)
-5737: Ident           "intrinsic" at 500:6-500:15
-5738: KwFn            "fn" at 500:16-500:18 (leading: Space)
-5739: Ident           "__pos" at 500:19-500:24 (leading: Space)
-5740: LParen          "(" at 500:24-500:25
-5741: Ident           "self" at 500:25-500:29
-5742: Colon           ":" at 500:29-500:30
-5743: Ident           "uint16" at 500:31-500:37 (leading: Space)
-5744: RParen          ")" at 500:37-500:38
-5745: Arrow           "->" at 500:39-500:41 (leading: Space)
-5746: Ident           "uint16" at 500:42-500:48 (leading: Space)
-5747: Semicolon       ";" at 500:48-500:49
-5748: At              "@" at 501:5-501:6 (leading: Newline, Space)
-5749: Ident           "intrinsic" at 501:6-501:15
-5750: KwFn            "fn" at 501:16-501:18 (leading: Space)
-5751: Ident           "__abs" at 501:19-501:24 (leading: Space)
-5752: LParen          "(" at 501:24-501:25
-5753: Ident           "self" at 501:25-501:29
-5754: Colon           ":" at 501:29-501:30
-5755: Ident           "uint16" at 501:31-501:37 (leading: Space)
-5756: RParen          ")" at 501:37-501:38
-5757: Arrow           "->" at 501:39-501:41 (leading: Space)
-5758: Ident           "uint16" at 501:42-501:48 (leading: Space)
-5759: Semicolon       ";" at 501:48-501:49
-5760: At              "@" at 502:5-502:6 (leading: Newline, Space)
-5761: Ident           "intrinsic" at 502:6-502:15
-5762: KwFn            "fn" at 502:16-502:18 (leading: Space)
-5763: Ident           "__to" at 502:19-502:23 (leading: Space)
-5764: LParen          "(" at 502:23-502:24
-5765: Ident           "self" at 502:24-502:28
-5766: Colon           ":" at 502:28-502:29
-5767: Ident           "uint16" at 502:30-502:36 (leading: Space)
-5768: Comma           "," at 502:36-502:37
-5769: Ident           "target" at 502:38-502:44 (leading: Space)
-5770: Colon           ":" at 502:44-502:45
-5771: Ident           "uint" at 502:46-502:50 (leading: Space)
-5772: RParen          ")" at 502:50-502:51
-5773: Arrow           "->" at 502:52-502:54 (leading: Space)
-5774: Ident           "uint" at 502:55-502:59 (leading: Space)
-5775: Semicolon       ";" at 502:59-502:60
-5776: At              "@" at 503:5-503:6 (leading: Newline, Space)
-5777: Ident           "intrinsic" at 503:6-503:15
-5778: At              "@" at 503:16-503:17 (leading: Space)
-5779: Ident           "overload" at 503:17-503:25
-5780: KwFn            "fn" at 503:26-503:28 (leading: Space)
-5781: Ident           "__to" at 503:29-503:33 (leading: Space)
-5782: LParen          "(" at 503:33-503:34
-5783: Ident           "self" at 503:34-503:38
-5784: Colon           ":" at 503:38-503:39
-5785: Ident           "uint16" at 503:40-503:46 (leading: Space)
-5786: Comma           "," at 503:46-503:47
-5787: Ident           "target" at 503:48-503:54 (leading: Space)
-5788: Colon           ":" at 503:54-503:55
-5789: Ident           "uint8" at 503:56-503:61 (leading: Space)
-5790: RParen          ")" at 503:61-503:62
-5791: Arrow           "->" at 503:63-503:65 (leading: Space)
-5792: Ident           "uint8" at 503:66-503:71 (leading: Space)
-5793: Semicolon       ";" at 503:71-503:72
-5794: At              "@" at 504:5-504:6 (leading: Newline, Space)
-5795: Ident           "intrinsic" at 504:6-504:15
-5796: At              "@" at 504:16-504:17 (leading: Space)
-5797: Ident           "overload" at 504:17-504:25
-5798: KwFn            "fn" at 504:26-504:28 (leading: Space)
-5799: Ident           "__to" at 504:29-504:33 (leading: Space)
-5800: LParen          "(" at 504:33-504:34
-5801: Ident           "self" at 504:34-504:38
-5802: Colon           ":" at 504:38-504:39
-5803: Ident           "uint16" at 504:40-504:46 (leading: Space)
-5804: Comma           "," at 504:46-504:47
-5805: Ident           "target" at 504:48-504:54 (leading: Space)
-5806: Colon           ":" at 504:54-504:55
-5807: Ident           "uint32" at 504:56-504:62 (leading: Space)
-5808: RParen          ")" at 504:62-504:63
-5809: Arrow           "->" at 504:64-504:66 (leading: Space)
-5810: Ident           "uint32" at 504:67-504:73 (leading: Space)
-5811: Semicolon       ";" at 504:73-504:74
-5812: At              "@" at 505:5-505:6 (leading: Newline, Space)
-5813: Ident           "intrinsic" at 505:6-505:15
-5814: At              "@" at 505:16-505:17 (leading: Space)
-5815: Ident           "overload" at 505:17-505:25
-5816: KwFn            "fn" at 505:26-505:28 (leading: Space)
-5817: Ident           "__to" at 505:29-505:33 (leading: Space)
-5818: LParen          "(" at 505:33-505:34
-5819: Ident           "self" at 505:34-505:38
-5820: Colon           ":" at 505:38-505:39
-5821: Ident           "uint16" at 505:40-505:46 (leading: Space)
-5822: Comma           "," at 505:46-505:47
-5823: Ident           "target" at 505:48-505:54 (leading: Space)
-5824: Colon           ":" at 505:54-505:55
-5825: Ident           "uint64" at 505:56-505:62 (leading: Space)
-5826: RParen          ")" at 505:62-505:63
-5827: Arrow           "->" at 505:64-505:66 (leading: Space)
-5828: Ident           "uint64" at 505:67-505:73 (leading: Space)
-5829: Semicolon       ";" at 505:73-505:74
-5830: At              "@" at 506:5-506:6 (leading: Newline, Space)
-5831: Ident           "intrinsic" at 506:6-506:15
-5832: KwPub           "pub" at 506:16-506:19 (leading: Space)
-5833: KwFn            "fn" at 506:20-506:22 (leading: Space)
-5834: Ident           "from_str" at 506:23-506:31 (leading: Space)
-5835: LParen          "(" at 506:31-506:32
-5836: Ident           "s" at 506:32-506:33
-5837: Colon           ":" at 506:33-506:34
-5838: Amp             "&" at 506:35-506:36 (leading: Space)
-5839: Ident           "string" at 506:36-506:42
-5840: RParen          ")" at 506:42-506:43
-5841: Arrow           "->" at 506:44-506:46 (leading: Space)
-5842: Ident           "Erring" at 506:47-506:53 (leading: Space)
-5843: Lt              "<" at 506:53-506:54
-5844: Ident           "uint16" at 506:54-506:60
-5845: Comma           "," at 506:60-506:61
-5846: Ident           "Error" at 506:62-506:67 (leading: Space)
-5847: Gt              ">" at 506:67-506:68
-5848: Semicolon       ";" at 506:68-506:69
-5849: RBrace          "}" at 507:1-507:2 (leading: Newline)
-5850: KwExtern        "extern" at 509:1-509:7 (leading: Newline)
-5851: Lt              "<" at 509:7-509:8
-5852: Ident           "uint32" at 509:8-509:14
-5853: Gt              ">" at 509:14-509:15
-5854: LBrace          "{" at 509:16-509:17 (leading: Space)
-5855: KwPub           "pub" at 510:5-510:8 (leading: Newline, Space)
-5856: KwFn            "fn" at 510:9-510:11 (leading: Space)
-5857: Ident           "__min_value" at 510:12-510:23 (leading: Space)
-5858: LParen          "(" at 510:23-510:24
-5859: RParen          ")" at 510:24-510:25
-5860: Arrow           "->" at 510:26-510:28 (leading: Space)
-5861: Ident           "uint32" at 510:29-510:35 (leading: Space)
-5862: LBrace          "{" at 510:36-510:37 (leading: Space)
-5863: KwReturn        "return" at 510:38-510:44 (leading: Space)
-5864: LParen          "(" at 510:45-510:46 (leading: Space)
-5865: IntLit          "0" at 510:46-510:47
-5866: RParen          ")" at 510:47-510:48
-5867: Colon           ":" at 510:48-510:49
-5868: Ident           "uint32" at 510:49-510:55
-5869: Semicolon       ";" at 510:55-510:56
-5870: RBrace          "}" at 510:57-510:58 (leading: Space)
-5871: KwPub           "pub" at 511:5-511:8 (leading: Newline, Space)
-5872: KwFn            "fn" at 511:9-511:11 (leading: Space)
-5873: Ident           "__max_value" at 511:12-511:23 (leading: Space)
-5874: LParen          "(" at 511:23-511:24
-5875: RParen          ")" at 511:24-511:25
-5876: Arrow           "->" at 511:26-511:28 (leading: Space)
-5877: Ident           "uint32" at 511:29-511:35 (leading: Space)
-5878: LBrace          "{" at 511:36-511:37 (leading: Space)
-5879: KwReturn        "return" at 511:38-511:44 (leading: Space)
-5880: LParen          "(" at 511:45-511:46 (leading: Space)
-5881: IntLit          "4_294_967_295" at 511:46-511:59
-5882: RParen          ")" at 511:59-511:60
-5883: Colon           ":" at 511:60-511:61
-5884: Ident           "uint32" at 511:61-511:67
-5885: Semicolon       ";" at 511:67-511:68
-5886: RBrace          "}" at 511:69-511:70 (leading: Space)
-5887: At              "@" at 512:5-512:6 (leading: Newline, Space)
-5888: Ident           "intrinsic" at 512:6-512:15
-5889: KwFn            "fn" at 512:16-512:18 (leading: Space)
-5890: Ident           "__add" at 512:19-512:24 (leading: Space)
-5891: LParen          "(" at 512:24-512:25
-5892: Ident           "self" at 512:25-512:29
-5893: Colon           ":" at 512:29-512:30
-5894: Ident           "uint32" at 512:31-512:37 (leading: Space)
-5895: Comma           "," at 512:37-512:38
-5896: Ident           "other" at 512:39-512:44 (leading: Space)
-5897: Colon           ":" at 512:44-512:45
-5898: Ident           "uint32" at 512:46-512:52 (leading: Space)
-5899: RParen          ")" at 512:52-512:53
-5900: Arrow           "->" at 512:54-512:56 (leading: Space)
-5901: Ident           "uint32" at 512:57-512:63 (leading: Space)
-5902: Semicolon       ";" at 512:63-512:64
-5903: At              "@" at 513:5-513:6 (leading: Newline, Space)
-5904: Ident           "intrinsic" at 513:6-513:15
-5905: KwFn            "fn" at 513:16-513:18 (leading: Space)
-5906: Ident           "__sub" at 513:19-513:24 (leading: Space)
-5907: LParen          "(" at 513:24-513:25
-5908: Ident           "self" at 513:25-513:29
-5909: Colon           ":" at 513:29-513:30
-5910: Ident           "uint32" at 513:31-513:37 (leading: Space)
-5911: Comma           "," at 513:37-513:38
-5912: Ident           "other" at 513:39-513:44 (leading: Space)
-5913: Colon           ":" at 513:44-513:45
-5914: Ident           "uint32" at 513:46-513:52 (leading: Space)
-5915: RParen          ")" at 513:52-513:53
-5916: Arrow           "->" at 513:54-513:56 (leading: Space)
-5917: Ident           "uint32" at 513:57-513:63 (leading: Space)
-5918: Semicolon       ";" at 513:63-513:64
-5919: At              "@" at 514:5-514:6 (leading: Newline, Space)
-5920: Ident           "intrinsic" at 514:6-514:15
-5921: KwFn            "fn" at 514:16-514:18 (leading: Space)
-5922: Ident           "__mul" at 514:19-514:24 (leading: Space)
-5923: LParen          "(" at 514:24-514:25
-5924: Ident           "self" at 514:25-514:29
-5925: Colon           ":" at 514:29-514:30
-5926: Ident           "uint32" at 514:31-514:37 (leading: Space)
-5927: Comma           "," at 514:37-514:38
-5928: Ident           "other" at 514:39-514:44 (leading: Space)
-5929: Colon           ":" at 514:44-514:45
-5930: Ident           "uint32" at 514:46-514:52 (leading: Space)
-5931: RParen          ")" at 514:52-514:53
-5932: Arrow           "->" at 514:54-514:56 (leading: Space)
-5933: Ident           "uint32" at 514:57-514:63 (leading: Space)
-5934: Semicolon       ";" at 514:63-514:64
-5935: At              "@" at 515:5-515:6 (leading: Newline, Space)
-5936: Ident           "intrinsic" at 515:6-515:15
-5937: KwFn            "fn" at 515:16-515:18 (leading: Space)
-5938: Ident           "__div" at 515:19-515:24 (leading: Space)
-5939: LParen          "(" at 515:24-515:25
-5940: Ident           "self" at 515:25-515:29
-5941: Colon           ":" at 515:29-515:30
-5942: Ident           "uint32" at 515:31-515:37 (leading: Space)
-5943: Comma           "," at 515:37-515:38
-5944: Ident           "other" at 515:39-515:44 (leading: Space)
-5945: Colon           ":" at 515:44-515:45
-5946: Ident           "uint32" at 515:46-515:52 (leading: Space)
-5947: RParen          ")" at 515:52-515:53
-5948: Arrow           "->" at 515:54-515:56 (leading: Space)
-5949: Ident           "uint32" at 515:57-515:63 (leading: Space)
-5950: Semicolon       ";" at 515:63-515:64
-5951: At              "@" at 516:5-516:6 (leading: Newline, Space)
-5952: Ident           "intrinsic" at 516:6-516:15
-5953: KwFn            "fn" at 516:16-516:18 (leading: Space)
-5954: Ident           "__mod" at 516:19-516:24 (leading: Space)
-5955: LParen          "(" at 516:24-516:25
-5956: Ident           "self" at 516:25-516:29
-5957: Colon           ":" at 516:29-516:30
-5958: Ident           "uint32" at 516:31-516:37 (leading: Space)
-5959: Comma           "," at 516:37-516:38
-5960: Ident           "other" at 516:39-516:44 (leading: Space)
-5961: Colon           ":" at 516:44-516:45
-5962: Ident           "uint32" at 516:46-516:52 (leading: Space)
-5963: RParen          ")" at 516:52-516:53
-5964: Arrow           "->" at 516:54-516:56 (leading: Space)
-5965: Ident           "uint32" at 516:57-516:63 (leading: Space)
-5966: Semicolon       ";" at 516:63-516:64
-5967: At              "@" at 517:5-517:6 (leading: Newline, Space)
-5968: Ident           "intrinsic" at 517:6-517:15
-5969: KwFn            "fn" at 517:16-517:18 (leading: Space)
-5970: Ident           "__bit_and" at 517:19-517:28 (leading: Space)
-5971: LParen          "(" at 517:28-517:29
-5972: Ident           "self" at 517:29-517:33
-5973: Colon           ":" at 517:33-517:34
-5974: Ident           "uint32" at 517:35-517:41 (leading: Space)
-5975: Comma           "," at 517:41-517:42
-5976: Ident           "other" at 517:43-517:48 (leading: Space)
-5977: Colon           ":" at 517:48-517:49
-5978: Ident           "uint32" at 517:50-517:56 (leading: Space)
-5979: RParen          ")" at 517:56-517:57
-5980: Arrow           "->" at 517:58-517:60 (leading: Space)
-5981: Ident           "uint32" at 517:61-517:67 (leading: Space)
-5982: Semicolon       ";" at 517:67-517:68
-5983: At              "@" at 518:5-518:6 (leading: Newline, Space)
-5984: Ident           "intrinsic" at 518:6-518:15
-5985: KwFn            "fn" at 518:16-518:18 (leading: Space)
-5986: Ident           "__bit_or" at 518:19-518:27 (leading: Space)
-5987: LParen          "(" at 518:27-518:28
-5988: Ident           "self" at 518:28-518:32
-5989: Colon           ":" at 518:32-518:33
-5990: Ident           "uint32" at 518:34-518:40 (leading: Space)
-5991: Comma           "," at 518:40-518:41
-5992: Ident           "other" at 518:42-518:47 (leading: Space)
-5993: Colon           ":" at 518:47-518:48
-5994: Ident           "uint32" at 518:49-518:55 (leading: Space)
-5995: RParen          ")" at 518:55-518:56
-5996: Arrow           "->" at 518:57-518:59 (leading: Space)
-5997: Ident           "uint32" at 518:60-518:66 (leading: Space)
-5998: Semicolon       ";" at 518:66-518:67
-5999: At              "@" at 519:5-519:6 (leading: Newline, Space)
-6000: Ident           "intrinsic" at 519:6-519:15
-6001: KwFn            "fn" at 519:16-519:18 (leading: Space)
-6002: Ident           "__bit_xor" at 519:19-519:28 (leading: Space)
-6003: LParen          "(" at 519:28-519:29
-6004: Ident           "self" at 519:29-519:33
-6005: Colon           ":" at 519:33-519:34
-6006: Ident           "uint32" at 519:35-519:41 (leading: Space)
-6007: Comma           "," at 519:41-519:42
-6008: Ident           "other" at 519:43-519:48 (leading: Space)
-6009: Colon           ":" at 519:48-519:49
-6010: Ident           "uint32" at 519:50-519:56 (leading: Space)
-6011: RParen          ")" at 519:56-519:57
-6012: Arrow           "->" at 519:58-519:60 (leading: Space)
-6013: Ident           "uint32" at 519:61-519:67 (leading: Space)
-6014: Semicolon       ";" at 519:67-519:68
-6015: At              "@" at 520:5-520:6 (leading: Newline, Space)
-6016: Ident           "intrinsic" at 520:6-520:15
-6017: KwFn            "fn" at 520:16-520:18 (leading: Space)
-6018: Ident           "__shl" at 520:19-520:24 (leading: Space)
-6019: LParen          "(" at 520:24-520:25
-6020: Ident           "self" at 520:25-520:29
-6021: Colon           ":" at 520:29-520:30
-6022: Ident           "uint32" at 520:31-520:37 (leading: Space)
-6023: Comma           "," at 520:37-520:38
-6024: Ident           "other" at 520:39-520:44 (leading: Space)
-6025: Colon           ":" at 520:44-520:45
-6026: Ident           "uint32" at 520:46-520:52 (leading: Space)
-6027: RParen          ")" at 520:52-520:53
-6028: Arrow           "->" at 520:54-520:56 (leading: Space)
-6029: Ident           "uint32" at 520:57-520:63 (leading: Space)
-6030: Semicolon       ";" at 520:63-520:64
-6031: At              "@" at 521:5-521:6 (leading: Newline, Space)
-6032: Ident           "intrinsic" at 521:6-521:15
-6033: KwFn            "fn" at 521:16-521:18 (leading: Space)
-6034: Ident           "__shr" at 521:19-521:24 (leading: Space)
-6035: LParen          "(" at 521:24-521:25
-6036: Ident           "self" at 521:25-521:29
-6037: Colon           ":" at 521:29-521:30
-6038: Ident           "uint32" at 521:31-521:37 (leading: Space)
-6039: Comma           "," at 521:37-521:38
-6040: Ident           "other" at 521:39-521:44 (leading: Space)
-6041: Colon           ":" at 521:44-521:45
-6042: Ident           "uint32" at 521:46-521:52 (leading: Space)
-6043: RParen          ")" at 521:52-521:53
-6044: Arrow           "->" at 521:54-521:56 (leading: Space)
-6045: Ident           "uint32" at 521:57-521:63 (leading: Space)
-6046: Semicolon       ";" at 521:63-521:64
-6047: At              "@" at 522:5-522:6 (leading: Newline, Space)
-6048: Ident           "intrinsic" at 522:6-522:15
-6049: KwFn            "fn" at 522:16-522:18 (leading: Space)
-6050: Ident           "__lt" at 522:19-522:23 (leading: Space)
-6051: LParen          "(" at 522:23-522:24
-6052: Ident           "self" at 522:24-522:28
-6053: Colon           ":" at 522:28-522:29
-6054: Ident           "uint32" at 522:30-522:36 (leading: Space)
-6055: Comma           "," at 522:36-522:37
-6056: Ident           "other" at 522:38-522:43 (leading: Space)
-6057: Colon           ":" at 522:43-522:44
-6058: Ident           "uint32" at 522:45-522:51 (leading: Space)
-6059: RParen          ")" at 522:51-522:52
-6060: Arrow           "->" at 522:53-522:55 (leading: Space)
-6061: Ident           "bool" at 522:56-522:60 (leading: Space)
-6062: Semicolon       ";" at 522:60-522:61
-6063: At              "@" at 523:5-523:6 (leading: Newline, Space)
-6064: Ident           "intrinsic" at 523:6-523:15
-6065: KwFn            "fn" at 523:16-523:18 (leading: Space)
-6066: Ident           "__le" at 523:19-523:23 (leading: Space)
-6067: LParen          "(" at 523:23-523:24
-6068: Ident           "self" at 523:24-523:28
-6069: Colon           ":" at 523:28-523:29
-6070: Ident           "uint32" at 523:30-523:36 (leading: Space)
-6071: Comma           "," at 523:36-523:37
-6072: Ident           "other" at 523:38-523:43 (leading: Space)
-6073: Colon           ":" at 523:43-523:44
-6074: Ident           "uint32" at 523:45-523:51 (leading: Space)
-6075: RParen          ")" at 523:51-523:52
-6076: Arrow           "->" at 523:53-523:55 (leading: Space)
-6077: Ident           "bool" at 523:56-523:60 (leading: Space)
-6078: Semicolon       ";" at 523:60-523:61
-6079: At              "@" at 524:5-524:6 (leading: Newline, Space)
-6080: Ident           "intrinsic" at 524:6-524:15
-6081: KwFn            "fn" at 524:16-524:18 (leading: Space)
-6082: Ident           "__eq" at 524:19-524:23 (leading: Space)
-6083: LParen          "(" at 524:23-524:24
-6084: Ident           "self" at 524:24-524:28
-6085: Colon           ":" at 524:28-524:29
-6086: Ident           "uint32" at 524:30-524:36 (leading: Space)
-6087: Comma           "," at 524:36-524:37
-6088: Ident           "other" at 524:38-524:43 (leading: Space)
-6089: Colon           ":" at 524:43-524:44
-6090: Ident           "uint32" at 524:45-524:51 (leading: Space)
-6091: RParen          ")" at 524:51-524:52
-6092: Arrow           "->" at 524:53-524:55 (leading: Space)
-6093: Ident           "bool" at 524:56-524:60 (leading: Space)
-6094: Semicolon       ";" at 524:60-524:61
-6095: At              "@" at 525:5-525:6 (leading: Newline, Space)
-6096: Ident           "intrinsic" at 525:6-525:15
-6097: KwFn            "fn" at 525:16-525:18 (leading: Space)
-6098: Ident           "__ne" at 525:19-525:23 (leading: Space)
-6099: LParen          "(" at 525:23-525:24
-6100: Ident           "self" at 525:24-525:28
-6101: Colon           ":" at 525:28-525:29
-6102: Ident           "uint32" at 525:30-525:36 (leading: Space)
-6103: Comma           "," at 525:36-525:37
-6104: Ident           "other" at 525:38-525:43 (leading: Space)
-6105: Colon           ":" at 525:43-525:44
-6106: Ident           "uint32" at 525:45-525:51 (leading: Space)
-6107: RParen          ")" at 525:51-525:52
-6108: Arrow           "->" at 525:53-525:55 (leading: Space)
-6109: Ident           "bool" at 525:56-525:60 (leading: Space)
-6110: Semicolon       ";" at 525:60-525:61
-6111: At              "@" at 526:5-526:6 (leading: Newline, Space)
-6112: Ident           "intrinsic" at 526:6-526:15
-6113: KwFn            "fn" at 526:16-526:18 (leading: Space)
-6114: Ident           "__ge" at 526:19-526:23 (leading: Space)
-6115: LParen          "(" at 526:23-526:24
-6116: Ident           "self" at 526:24-526:28
-6117: Colon           ":" at 526:28-526:29
-6118: Ident           "uint32" at 526:30-526:36 (leading: Space)
-6119: Comma           "," at 526:36-526:37
-6120: Ident           "other" at 526:38-526:43 (leading: Space)
-6121: Colon           ":" at 526:43-526:44
-6122: Ident           "uint32" at 526:45-526:51 (leading: Space)
-6123: RParen          ")" at 526:51-526:52
-6124: Arrow           "->" at 526:53-526:55 (leading: Space)
-6125: Ident           "bool" at 526:56-526:60 (leading: Space)
-6126: Semicolon       ";" at 526:60-526:61
-6127: At              "@" at 527:5-527:6 (leading: Newline, Space)
-6128: Ident           "intrinsic" at 527:6-527:15
-6129: KwFn            "fn" at 527:16-527:18 (leading: Space)
-6130: Ident           "__gt" at 527:19-527:23 (leading: Space)
-6131: LParen          "(" at 527:23-527:24
-6132: Ident           "self" at 527:24-527:28
-6133: Colon           ":" at 527:28-527:29
-6134: Ident           "uint32" at 527:30-527:36 (leading: Space)
-6135: Comma           "," at 527:36-527:37
-6136: Ident           "other" at 527:38-527:43 (leading: Space)
-6137: Colon           ":" at 527:43-527:44
-6138: Ident           "uint32" at 527:45-527:51 (leading: Space)
-6139: RParen          ")" at 527:51-527:52
-6140: Arrow           "->" at 527:53-527:55 (leading: Space)
-6141: Ident           "bool" at 527:56-527:60 (leading: Space)
-6142: Semicolon       ";" at 527:60-527:61
-6143: At              "@" at 528:5-528:6 (leading: Newline, Space)
-6144: Ident           "intrinsic" at 528:6-528:15
-6145: KwFn            "fn" at 528:16-528:18 (leading: Space)
-6146: Ident           "__pos" at 528:19-528:24 (leading: Space)
-6147: LParen          "(" at 528:24-528:25
-6148: Ident           "self" at 528:25-528:29
-6149: Colon           ":" at 528:29-528:30
-6150: Ident           "uint32" at 528:31-528:37 (leading: Space)
-6151: RParen          ")" at 528:37-528:38
-6152: Arrow           "->" at 528:39-528:41 (leading: Space)
-6153: Ident           "uint32" at 528:42-528:48 (leading: Space)
-6154: Semicolon       ";" at 528:48-528:49
-6155: At              "@" at 529:5-529:6 (leading: Newline, Space)
-6156: Ident           "intrinsic" at 529:6-529:15
-6157: KwFn            "fn" at 529:16-529:18 (leading: Space)
-6158: Ident           "__abs" at 529:19-529:24 (leading: Space)
-6159: LParen          "(" at 529:24-529:25
-6160: Ident           "self" at 529:25-529:29
-6161: Colon           ":" at 529:29-529:30
-6162: Ident           "uint32" at 529:31-529:37 (leading: Space)
-6163: RParen          ")" at 529:37-529:38
-6164: Arrow           "->" at 529:39-529:41 (leading: Space)
-6165: Ident           "uint32" at 529:42-529:48 (leading: Space)
-6166: Semicolon       ";" at 529:48-529:49
-6167: At              "@" at 530:5-530:6 (leading: Newline, Space)
-6168: Ident           "intrinsic" at 530:6-530:15
-6169: KwFn            "fn" at 530:16-530:18 (leading: Space)
-6170: Ident           "__to" at 530:19-530:23 (leading: Space)
-6171: LParen          "(" at 530:23-530:24
-6172: Ident           "self" at 530:24-530:28
-6173: Colon           ":" at 530:28-530:29
-6174: Ident           "uint32" at 530:30-530:36 (leading: Space)
-6175: Comma           "," at 530:36-530:37
-6176: Ident           "target" at 530:38-530:44 (leading: Space)
-6177: Colon           ":" at 530:44-530:45
-6178: Ident           "uint" at 530:46-530:50 (leading: Space)
-6179: RParen          ")" at 530:50-530:51
-6180: Arrow           "->" at 530:52-530:54 (leading: Space)
-6181: Ident           "uint" at 530:55-530:59 (leading: Space)
-6182: Semicolon       ";" at 530:59-530:60
-6183: At              "@" at 531:5-531:6 (leading: Newline, Space)
-6184: Ident           "intrinsic" at 531:6-531:15
-6185: At              "@" at 531:16-531:17 (leading: Space)
-6186: Ident           "overload" at 531:17-531:25
-6187: KwFn            "fn" at 531:26-531:28 (leading: Space)
-6188: Ident           "__to" at 531:29-531:33 (leading: Space)
-6189: LParen          "(" at 531:33-531:34
-6190: Ident           "self" at 531:34-531:38
-6191: Colon           ":" at 531:38-531:39
-6192: Ident           "uint32" at 531:40-531:46 (leading: Space)
-6193: Comma           "," at 531:46-531:47
-6194: Ident           "target" at 531:48-531:54 (leading: Space)
-6195: Colon           ":" at 531:54-531:55
-6196: Ident           "uint8" at 531:56-531:61 (leading: Space)
-6197: RParen          ")" at 531:61-531:62
-6198: Arrow           "->" at 531:63-531:65 (leading: Space)
-6199: Ident           "uint8" at 531:66-531:71 (leading: Space)
-6200: Semicolon       ";" at 531:71-531:72
-6201: At              "@" at 532:5-532:6 (leading: Newline, Space)
-6202: Ident           "intrinsic" at 532:6-532:15
-6203: At              "@" at 532:16-532:17 (leading: Space)
-6204: Ident           "overload" at 532:17-532:25
-6205: KwFn            "fn" at 532:26-532:28 (leading: Space)
-6206: Ident           "__to" at 532:29-532:33 (leading: Space)
-6207: LParen          "(" at 532:33-532:34
-6208: Ident           "self" at 532:34-532:38
-6209: Colon           ":" at 532:38-532:39
-6210: Ident           "uint32" at 532:40-532:46 (leading: Space)
-6211: Comma           "," at 532:46-532:47
-6212: Ident           "target" at 532:48-532:54 (leading: Space)
-6213: Colon           ":" at 532:54-532:55
-6214: Ident           "uint16" at 532:56-532:62 (leading: Space)
-6215: RParen          ")" at 532:62-532:63
-6216: Arrow           "->" at 532:64-532:66 (leading: Space)
-6217: Ident           "uint16" at 532:67-532:73 (leading: Space)
-6218: Semicolon       ";" at 532:73-532:74
-6219: At              "@" at 533:5-533:6 (leading: Newline, Space)
-6220: Ident           "intrinsic" at 533:6-533:15
-6221: At              "@" at 533:16-533:17 (leading: Space)
-6222: Ident           "overload" at 533:17-533:25
-6223: KwFn            "fn" at 533:26-533:28 (leading: Space)
-6224: Ident           "__to" at 533:29-533:33 (leading: Space)
-6225: LParen          "(" at 533:33-533:34
-6226: Ident           "self" at 533:34-533:38
-6227: Colon           ":" at 533:38-533:39
-6228: Ident           "uint32" at 533:40-533:46 (leading: Space)
-6229: Comma           "," at 533:46-533:47
-6230: Ident           "target" at 533:48-533:54 (leading: Space)
-6231: Colon           ":" at 533:54-533:55
-6232: Ident           "uint64" at 533:56-533:62 (leading: Space)
-6233: RParen          ")" at 533:62-533:63
-6234: Arrow           "->" at 533:64-533:66 (leading: Space)
-6235: Ident           "uint64" at 533:67-533:73 (leading: Space)
-6236: Semicolon       ";" at 533:73-533:74
-6237: At              "@" at 534:5-534:6 (leading: Newline, Space)
-6238: Ident           "intrinsic" at 534:6-534:15
-6239: KwPub           "pub" at 534:16-534:19 (leading: Space)
-6240: KwFn            "fn" at 534:20-534:22 (leading: Space)
-6241: Ident           "from_str" at 534:23-534:31 (leading: Space)
-6242: LParen          "(" at 534:31-534:32
-6243: Ident           "s" at 534:32-534:33
-6244: Colon           ":" at 534:33-534:34
-6245: Amp             "&" at 534:35-534:36 (leading: Space)
-6246: Ident           "string" at 534:36-534:42
-6247: RParen          ")" at 534:42-534:43
-6248: Arrow           "->" at 534:44-534:46 (leading: Space)
-6249: Ident           "Erring" at 534:47-534:53 (leading: Space)
-6250: Lt              "<" at 534:53-534:54
-6251: Ident           "uint32" at 534:54-534:60
-6252: Comma           "," at 534:60-534:61
-6253: Ident           "Error" at 534:62-534:67 (leading: Space)
-6254: Gt              ">" at 534:67-534:68
-6255: Semicolon       ";" at 534:68-534:69
-6256: RBrace          "}" at 535:1-535:2 (leading: Newline)
-6257: KwExtern        "extern" at 537:1-537:7 (leading: Newline)
-6258: Lt              "<" at 537:7-537:8
-6259: Ident           "uint64" at 537:8-537:14
-6260: Gt              ">" at 537:14-537:15
-6261: LBrace          "{" at 537:16-537:17 (leading: Space)
-6262: KwPub           "pub" at 538:5-538:8 (leading: Newline, Space)
-6263: KwFn            "fn" at 538:9-538:11 (leading: Space)
-6264: Ident           "__min_value" at 538:12-538:23 (leading: Space)
-6265: LParen          "(" at 538:23-538:24
-6266: RParen          ")" at 538:24-538:25
-6267: Arrow           "->" at 538:26-538:28 (leading: Space)
-6268: Ident           "uint64" at 538:29-538:35 (leading: Space)
-6269: LBrace          "{" at 538:36-538:37 (leading: Space)
-6270: KwReturn        "return" at 538:38-538:44 (leading: Space)
-6271: LParen          "(" at 538:45-538:46 (leading: Space)
-6272: IntLit          "0" at 538:46-538:47
-6273: RParen          ")" at 538:47-538:48
-6274: Colon           ":" at 538:48-538:49
-6275: Ident           "uint64" at 538:49-538:55
-6276: Semicolon       ";" at 538:55-538:56
-6277: RBrace          "}" at 538:57-538:58 (leading: Space)
-6278: KwPub           "pub" at 539:5-539:8 (leading: Newline, Space)
-6279: KwFn            "fn" at 539:9-539:11 (leading: Space)
-6280: Ident           "__max_value" at 539:12-539:23 (leading: Space)
-6281: LParen          "(" at 539:23-539:24
-6282: RParen          ")" at 539:24-539:25
-6283: Arrow           "->" at 539:26-539:28 (leading: Space)
-6284: Ident           "uint64" at 539:29-539:35 (leading: Space)
-6285: LBrace          "{" at 539:36-539:37 (leading: Space)
-6286: KwReturn        "return" at 539:38-539:44 (leading: Space)
-6287: LParen          "(" at 539:45-539:46 (leading: Space)
-6288: IntLit          "18_446_744_073_709_551_615" at 539:46-539:72
-6289: RParen          ")" at 539:72-539:73
-6290: Colon           ":" at 539:73-539:74
-6291: Ident           "uint64" at 539:74-539:80
-6292: Semicolon       ";" at 539:80-539:81
-6293: RBrace          "}" at 539:82-539:83 (leading: Space)
-6294: At              "@" at 540:5-540:6 (leading: Newline, Space)
-6295: Ident           "intrinsic" at 540:6-540:15
-6296: KwFn            "fn" at 540:16-540:18 (leading: Space)
-6297: Ident           "__add" at 540:19-540:24 (leading: Space)
-6298: LParen          "(" at 540:24-540:25
-6299: Ident           "self" at 540:25-540:29
-6300: Colon           ":" at 540:29-540:30
-6301: Ident           "uint64" at 540:31-540:37 (leading: Space)
-6302: Comma           "," at 540:37-540:38
-6303: Ident           "other" at 540:39-540:44 (leading: Space)
-6304: Colon           ":" at 540:44-540:45
-6305: Ident           "uint64" at 540:46-540:52 (leading: Space)
-6306: RParen          ")" at 540:52-540:53
-6307: Arrow           "->" at 540:54-540:56 (leading: Space)
-6308: Ident           "uint64" at 540:57-540:63 (leading: Space)
-6309: Semicolon       ";" at 540:63-540:64
-6310: At              "@" at 541:5-541:6 (leading: Newline, Space)
-6311: Ident           "intrinsic" at 541:6-541:15
-6312: KwFn            "fn" at 541:16-541:18 (leading: Space)
-6313: Ident           "__sub" at 541:19-541:24 (leading: Space)
-6314: LParen          "(" at 541:24-541:25
-6315: Ident           "self" at 541:25-541:29
-6316: Colon           ":" at 541:29-541:30
-6317: Ident           "uint64" at 541:31-541:37 (leading: Space)
-6318: Comma           "," at 541:37-541:38
-6319: Ident           "other" at 541:39-541:44 (leading: Space)
-6320: Colon           ":" at 541:44-541:45
-6321: Ident           "uint64" at 541:46-541:52 (leading: Space)
-6322: RParen          ")" at 541:52-541:53
-6323: Arrow           "->" at 541:54-541:56 (leading: Space)
-6324: Ident           "uint64" at 541:57-541:63 (leading: Space)
-6325: Semicolon       ";" at 541:63-541:64
-6326: At              "@" at 542:5-542:6 (leading: Newline, Space)
-6327: Ident           "intrinsic" at 542:6-542:15
-6328: KwFn            "fn" at 542:16-542:18 (leading: Space)
-6329: Ident           "__mul" at 542:19-542:24 (leading: Space)
-6330: LParen          "(" at 542:24-542:25
-6331: Ident           "self" at 542:25-542:29
-6332: Colon           ":" at 542:29-542:30
-6333: Ident           "uint64" at 542:31-542:37 (leading: Space)
-6334: Comma           "," at 542:37-542:38
-6335: Ident           "other" at 542:39-542:44 (leading: Space)
-6336: Colon           ":" at 542:44-542:45
-6337: Ident           "uint64" at 542:46-542:52 (leading: Space)
-6338: RParen          ")" at 542:52-542:53
-6339: Arrow           "->" at 542:54-542:56 (leading: Space)
-6340: Ident           "uint64" at 542:57-542:63 (leading: Space)
-6341: Semicolon       ";" at 542:63-542:64
-6342: At              "@" at 543:5-543:6 (leading: Newline, Space)
-6343: Ident           "intrinsic" at 543:6-543:15
-6344: KwFn            "fn" at 543:16-543:18 (leading: Space)
-6345: Ident           "__div" at 543:19-543:24 (leading: Space)
-6346: LParen          "(" at 543:24-543:25
-6347: Ident           "self" at 543:25-543:29
-6348: Colon           ":" at 543:29-543:30
-6349: Ident           "uint64" at 543:31-543:37 (leading: Space)
-6350: Comma           "," at 543:37-543:38
-6351: Ident           "other" at 543:39-543:44 (leading: Space)
-6352: Colon           ":" at 543:44-543:45
-6353: Ident           "uint64" at 543:46-543:52 (leading: Space)
-6354: RParen          ")" at 543:52-543:53
-6355: Arrow           "->" at 543:54-543:56 (leading: Space)
-6356: Ident           "uint64" at 543:57-543:63 (leading: Space)
-6357: Semicolon       ";" at 543:63-543:64
-6358: At              "@" at 544:5-544:6 (leading: Newline, Space)
-6359: Ident           "intrinsic" at 544:6-544:15
-6360: KwFn            "fn" at 544:16-544:18 (leading: Space)
-6361: Ident           "__mod" at 544:19-544:24 (leading: Space)
-6362: LParen          "(" at 544:24-544:25
-6363: Ident           "self" at 544:25-544:29
-6364: Colon           ":" at 544:29-544:30
-6365: Ident           "uint64" at 544:31-544:37 (leading: Space)
-6366: Comma           "," at 544:37-544:38
-6367: Ident           "other" at 544:39-544:44 (leading: Space)
-6368: Colon           ":" at 544:44-544:45
-6369: Ident           "uint64" at 544:46-544:52 (leading: Space)
-6370: RParen          ")" at 544:52-544:53
-6371: Arrow           "->" at 544:54-544:56 (leading: Space)
-6372: Ident           "uint64" at 544:57-544:63 (leading: Space)
-6373: Semicolon       ";" at 544:63-544:64
-6374: At              "@" at 545:5-545:6 (leading: Newline, Space)
-6375: Ident           "intrinsic" at 545:6-545:15
-6376: KwFn            "fn" at 545:16-545:18 (leading: Space)
-6377: Ident           "__bit_and" at 545:19-545:28 (leading: Space)
-6378: LParen          "(" at 545:28-545:29
-6379: Ident           "self" at 545:29-545:33
-6380: Colon           ":" at 545:33-545:34
-6381: Ident           "uint64" at 545:35-545:41 (leading: Space)
-6382: Comma           "," at 545:41-545:42
-6383: Ident           "other" at 545:43-545:48 (leading: Space)
-6384: Colon           ":" at 545:48-545:49
-6385: Ident           "uint64" at 545:50-545:56 (leading: Space)
-6386: RParen          ")" at 545:56-545:57
-6387: Arrow           "->" at 545:58-545:60 (leading: Space)
-6388: Ident           "uint64" at 545:61-545:67 (leading: Space)
-6389: Semicolon       ";" at 545:67-545:68
-6390: At              "@" at 546:5-546:6 (leading: Newline, Space)
-6391: Ident           "intrinsic" at 546:6-546:15
-6392: KwFn            "fn" at 546:16-546:18 (leading: Space)
-6393: Ident           "__bit_or" at 546:19-546:27 (leading: Space)
-6394: LParen          "(" at 546:27-546:28
-6395: Ident           "self" at 546:28-546:32
-6396: Colon           ":" at 546:32-546:33
-6397: Ident           "uint64" at 546:34-546:40 (leading: Space)
-6398: Comma           "," at 546:40-546:41
-6399: Ident           "other" at 546:42-546:47 (leading: Space)
-6400: Colon           ":" at 546:47-546:48
-6401: Ident           "uint64" at 546:49-546:55 (leading: Space)
-6402: RParen          ")" at 546:55-546:56
-6403: Arrow           "->" at 546:57-546:59 (leading: Space)
-6404: Ident           "uint64" at 546:60-546:66 (leading: Space)
-6405: Semicolon       ";" at 546:66-546:67
-6406: At              "@" at 547:5-547:6 (leading: Newline, Space)
-6407: Ident           "intrinsic" at 547:6-547:15
-6408: KwFn            "fn" at 547:16-547:18 (leading: Space)
-6409: Ident           "__bit_xor" at 547:19-547:28 (leading: Space)
-6410: LParen          "(" at 547:28-547:29
-6411: Ident           "self" at 547:29-547:33
-6412: Colon           ":" at 547:33-547:34
-6413: Ident           "uint64" at 547:35-547:41 (leading: Space)
-6414: Comma           "," at 547:41-547:42
-6415: Ident           "other" at 547:43-547:48 (leading: Space)
-6416: Colon           ":" at 547:48-547:49
-6417: Ident           "uint64" at 547:50-547:56 (leading: Space)
-6418: RParen          ")" at 547:56-547:57
-6419: Arrow           "->" at 547:58-547:60 (leading: Space)
-6420: Ident           "uint64" at 547:61-547:67 (leading: Space)
-6421: Semicolon       ";" at 547:67-547:68
-6422: At              "@" at 548:5-548:6 (leading: Newline, Space)
-6423: Ident           "intrinsic" at 548:6-548:15
-6424: KwFn            "fn" at 548:16-548:18 (leading: Space)
-6425: Ident           "__shl" at 548:19-548:24 (leading: Space)
-6426: LParen          "(" at 548:24-548:25
-6427: Ident           "self" at 548:25-548:29
-6428: Colon           ":" at 548:29-548:30
-6429: Ident           "uint64" at 548:31-548:37 (leading: Space)
-6430: Comma           "," at 548:37-548:38
-6431: Ident           "other" at 548:39-548:44 (leading: Space)
-6432: Colon           ":" at 548:44-548:45
-6433: Ident           "uint64" at 548:46-548:52 (leading: Space)
-6434: RParen          ")" at 548:52-548:53
-6435: Arrow           "->" at 548:54-548:56 (leading: Space)
-6436: Ident           "uint64" at 548:57-548:63 (leading: Space)
-6437: Semicolon       ";" at 548:63-548:64
-6438: At              "@" at 549:5-549:6 (leading: Newline, Space)
-6439: Ident           "intrinsic" at 549:6-549:15
-6440: KwFn            "fn" at 549:16-549:18 (leading: Space)
-6441: Ident           "__shr" at 549:19-549:24 (leading: Space)
-6442: LParen          "(" at 549:24-549:25
-6443: Ident           "self" at 549:25-549:29
-6444: Colon           ":" at 549:29-549:30
-6445: Ident           "uint64" at 549:31-549:37 (leading: Space)
-6446: Comma           "," at 549:37-549:38
-6447: Ident           "other" at 549:39-549:44 (leading: Space)
-6448: Colon           ":" at 549:44-549:45
-6449: Ident           "uint64" at 549:46-549:52 (leading: Space)
-6450: RParen          ")" at 549:52-549:53
-6451: Arrow           "->" at 549:54-549:56 (leading: Space)
-6452: Ident           "uint64" at 549:57-549:63 (leading: Space)
-6453: Semicolon       ";" at 549:63-549:64
-6454: At              "@" at 550:5-550:6 (leading: Newline, Space)
-6455: Ident           "intrinsic" at 550:6-550:15
-6456: KwFn            "fn" at 550:16-550:18 (leading: Space)
-6457: Ident           "__lt" at 550:19-550:23 (leading: Space)
-6458: LParen          "(" at 550:23-550:24
-6459: Ident           "self" at 550:24-550:28
-6460: Colon           ":" at 550:28-550:29
-6461: Ident           "uint64" at 550:30-550:36 (leading: Space)
-6462: Comma           "," at 550:36-550:37
-6463: Ident           "other" at 550:38-550:43 (leading: Space)
-6464: Colon           ":" at 550:43-550:44
-6465: Ident           "uint64" at 550:45-550:51 (leading: Space)
-6466: RParen          ")" at 550:51-550:52
-6467: Arrow           "->" at 550:53-550:55 (leading: Space)
-6468: Ident           "bool" at 550:56-550:60 (leading: Space)
-6469: Semicolon       ";" at 550:60-550:61
-6470: At              "@" at 551:5-551:6 (leading: Newline, Space)
-6471: Ident           "intrinsic" at 551:6-551:15
-6472: KwFn            "fn" at 551:16-551:18 (leading: Space)
-6473: Ident           "__le" at 551:19-551:23 (leading: Space)
-6474: LParen          "(" at 551:23-551:24
-6475: Ident           "self" at 551:24-551:28
-6476: Colon           ":" at 551:28-551:29
-6477: Ident           "uint64" at 551:30-551:36 (leading: Space)
-6478: Comma           "," at 551:36-551:37
-6479: Ident           "other" at 551:38-551:43 (leading: Space)
-6480: Colon           ":" at 551:43-551:44
-6481: Ident           "uint64" at 551:45-551:51 (leading: Space)
-6482: RParen          ")" at 551:51-551:52
-6483: Arrow           "->" at 551:53-551:55 (leading: Space)
-6484: Ident           "bool" at 551:56-551:60 (leading: Space)
-6485: Semicolon       ";" at 551:60-551:61
-6486: At              "@" at 552:5-552:6 (leading: Newline, Space)
-6487: Ident           "intrinsic" at 552:6-552:15
-6488: KwFn            "fn" at 552:16-552:18 (leading: Space)
-6489: Ident           "__eq" at 552:19-552:23 (leading: Space)
-6490: LParen          "(" at 552:23-552:24
-6491: Ident           "self" at 552:24-552:28
-6492: Colon           ":" at 552:28-552:29
-6493: Ident           "uint64" at 552:30-552:36 (leading: Space)
-6494: Comma           "," at 552:36-552:37
-6495: Ident           "other" at 552:38-552:43 (leading: Space)
-6496: Colon           ":" at 552:43-552:44
-6497: Ident           "uint64" at 552:45-552:51 (leading: Space)
-6498: RParen          ")" at 552:51-552:52
-6499: Arrow           "->" at 552:53-552:55 (leading: Space)
-6500: Ident           "bool" at 552:56-552:60 (leading: Space)
-6501: Semicolon       ";" at 552:60-552:61
-6502: At              "@" at 553:5-553:6 (leading: Newline, Space)
-6503: Ident           "intrinsic" at 553:6-553:15
-6504: KwFn            "fn" at 553:16-553:18 (leading: Space)
-6505: Ident           "__ne" at 553:19-553:23 (leading: Space)
-6506: LParen          "(" at 553:23-553:24
-6507: Ident           "self" at 553:24-553:28
-6508: Colon           ":" at 553:28-553:29
-6509: Ident           "uint64" at 553:30-553:36 (leading: Space)
-6510: Comma           "," at 553:36-553:37
-6511: Ident           "other" at 553:38-553:43 (leading: Space)
-6512: Colon           ":" at 553:43-553:44
-6513: Ident           "uint64" at 553:45-553:51 (leading: Space)
-6514: RParen          ")" at 553:51-553:52
-6515: Arrow           "->" at 553:53-553:55 (leading: Space)
-6516: Ident           "bool" at 553:56-553:60 (leading: Space)
-6517: Semicolon       ";" at 553:60-553:61
-6518: At              "@" at 554:5-554:6 (leading: Newline, Space)
-6519: Ident           "intrinsic" at 554:6-554:15
-6520: KwFn            "fn" at 554:16-554:18 (leading: Space)
-6521: Ident           "__ge" at 554:19-554:23 (leading: Space)
-6522: LParen          "(" at 554:23-554:24
-6523: Ident           "self" at 554:24-554:28
-6524: Colon           ":" at 554:28-554:29
-6525: Ident           "uint64" at 554:30-554:36 (leading: Space)
-6526: Comma           "," at 554:36-554:37
-6527: Ident           "other" at 554:38-554:43 (leading: Space)
-6528: Colon           ":" at 554:43-554:44
-6529: Ident           "uint64" at 554:45-554:51 (leading: Space)
-6530: RParen          ")" at 554:51-554:52
-6531: Arrow           "->" at 554:53-554:55 (leading: Space)
-6532: Ident           "bool" at 554:56-554:60 (leading: Space)
-6533: Semicolon       ";" at 554:60-554:61
-6534: At              "@" at 555:5-555:6 (leading: Newline, Space)
-6535: Ident           "intrinsic" at 555:6-555:15
-6536: KwFn            "fn" at 555:16-555:18 (leading: Space)
-6537: Ident           "__gt" at 555:19-555:23 (leading: Space)
-6538: LParen          "(" at 555:23-555:24
-6539: Ident           "self" at 555:24-555:28
-6540: Colon           ":" at 555:28-555:29
-6541: Ident           "uint64" at 555:30-555:36 (leading: Space)
-6542: Comma           "," at 555:36-555:37
-6543: Ident           "other" at 555:38-555:43 (leading: Space)
-6544: Colon           ":" at 555:43-555:44
-6545: Ident           "uint64" at 555:45-555:51 (leading: Space)
-6546: RParen          ")" at 555:51-555:52
-6547: Arrow           "->" at 555:53-555:55 (leading: Space)
-6548: Ident           "bool" at 555:56-555:60 (leading: Space)
-6549: Semicolon       ";" at 555:60-555:61
-6550: At              "@" at 556:5-556:6 (leading: Newline, Space)
-6551: Ident           "intrinsic" at 556:6-556:15
-6552: KwFn            "fn" at 556:16-556:18 (leading: Space)
-6553: Ident           "__pos" at 556:19-556:24 (leading: Space)
-6554: LParen          "(" at 556:24-556:25
-6555: Ident           "self" at 556:25-556:29
-6556: Colon           ":" at 556:29-556:30
-6557: Ident           "uint64" at 556:31-556:37 (leading: Space)
-6558: RParen          ")" at 556:37-556:38
-6559: Arrow           "->" at 556:39-556:41 (leading: Space)
-6560: Ident           "uint64" at 556:42-556:48 (leading: Space)
-6561: Semicolon       ";" at 556:48-556:49
-6562: At              "@" at 557:5-557:6 (leading: Newline, Space)
-6563: Ident           "intrinsic" at 557:6-557:15
-6564: KwFn            "fn" at 557:16-557:18 (leading: Space)
-6565: Ident           "__abs" at 557:19-557:24 (leading: Space)
-6566: LParen          "(" at 557:24-557:25
-6567: Ident           "self" at 557:25-557:29
-6568: Colon           ":" at 557:29-557:30
-6569: Ident           "uint64" at 557:31-557:37 (leading: Space)
-6570: RParen          ")" at 557:37-557:38
-6571: Arrow           "->" at 557:39-557:41 (leading: Space)
-6572: Ident           "uint64" at 557:42-557:48 (leading: Space)
-6573: Semicolon       ";" at 557:48-557:49
-6574: At              "@" at 558:5-558:6 (leading: Newline, Space)
-6575: Ident           "intrinsic" at 558:6-558:15
-6576: KwFn            "fn" at 558:16-558:18 (leading: Space)
-6577: Ident           "__to" at 558:19-558:23 (leading: Space)
-6578: LParen          "(" at 558:23-558:24
-6579: Ident           "self" at 558:24-558:28
-6580: Colon           ":" at 558:28-558:29
-6581: Ident           "uint64" at 558:30-558:36 (leading: Space)
-6582: Comma           "," at 558:36-558:37
-6583: Ident           "target" at 558:38-558:44 (leading: Space)
-6584: Colon           ":" at 558:44-558:45
-6585: Ident           "uint" at 558:46-558:50 (leading: Space)
-6586: RParen          ")" at 558:50-558:51
-6587: Arrow           "->" at 558:52-558:54 (leading: Space)
-6588: Ident           "uint" at 558:55-558:59 (leading: Space)
-6589: Semicolon       ";" at 558:59-558:60
-6590: At              "@" at 559:5-559:6 (leading: Newline, Space)
-6591: Ident           "intrinsic" at 559:6-559:15
-6592: At              "@" at 559:16-559:17 (leading: Space)
-6593: Ident           "overload" at 559:17-559:25
-6594: KwFn            "fn" at 559:26-559:28 (leading: Space)
-6595: Ident           "__to" at 559:29-559:33 (leading: Space)
-6596: LParen          "(" at 559:33-559:34
-6597: Ident           "self" at 559:34-559:38
-6598: Colon           ":" at 559:38-559:39
-6599: Ident           "uint64" at 559:40-559:46 (leading: Space)
-6600: Comma           "," at 559:46-559:47
-6601: Ident           "target" at 559:48-559:54 (leading: Space)
-6602: Colon           ":" at 559:54-559:55
-6603: Ident           "uint8" at 559:56-559:61 (leading: Space)
-6604: RParen          ")" at 559:61-559:62
-6605: Arrow           "->" at 559:63-559:65 (leading: Space)
-6606: Ident           "uint8" at 559:66-559:71 (leading: Space)
-6607: Semicolon       ";" at 559:71-559:72
-6608: At              "@" at 560:5-560:6 (leading: Newline, Space)
-6609: Ident           "intrinsic" at 560:6-560:15
-6610: At              "@" at 560:16-560:17 (leading: Space)
-6611: Ident           "overload" at 560:17-560:25
-6612: KwFn            "fn" at 560:26-560:28 (leading: Space)
-6613: Ident           "__to" at 560:29-560:33 (leading: Space)
-6614: LParen          "(" at 560:33-560:34
-6615: Ident           "self" at 560:34-560:38
-6616: Colon           ":" at 560:38-560:39
-6617: Ident           "uint64" at 560:40-560:46 (leading: Space)
-6618: Comma           "," at 560:46-560:47
-6619: Ident           "target" at 560:48-560:54 (leading: Space)
-6620: Colon           ":" at 560:54-560:55
-6621: Ident           "uint16" at 560:56-560:62 (leading: Space)
-6622: RParen          ")" at 560:62-560:63
-6623: Arrow           "->" at 560:64-560:66 (leading: Space)
-6624: Ident           "uint16" at 560:67-560:73 (leading: Space)
-6625: Semicolon       ";" at 560:73-560:74
-6626: At              "@" at 561:5-561:6 (leading: Newline, Space)
-6627: Ident           "intrinsic" at 561:6-561:15
-6628: At              "@" at 561:16-561:17 (leading: Space)
-6629: Ident           "overload" at 561:17-561:25
-6630: KwFn            "fn" at 561:26-561:28 (leading: Space)
-6631: Ident           "__to" at 561:29-561:33 (leading: Space)
-6632: LParen          "(" at 561:33-561:34
-6633: Ident           "self" at 561:34-561:38
-6634: Colon           ":" at 561:38-561:39
-6635: Ident           "uint64" at 561:40-561:46 (leading: Space)
-6636: Comma           "," at 561:46-561:47
-6637: Ident           "target" at 561:48-561:54 (leading: Space)
-6638: Colon           ":" at 561:54-561:55
-6639: Ident           "uint32" at 561:56-561:62 (leading: Space)
-6640: RParen          ")" at 561:62-561:63
-6641: Arrow           "->" at 561:64-561:66 (leading: Space)
-6642: Ident           "uint32" at 561:67-561:73 (leading: Space)
-6643: Semicolon       ";" at 561:73-561:74
-6644: At              "@" at 562:5-562:6 (leading: Newline, Space)
-6645: Ident           "intrinsic" at 562:6-562:15
-6646: KwPub           "pub" at 562:16-562:19 (leading: Space)
-6647: KwFn            "fn" at 562:20-562:22 (leading: Space)
-6648: Ident           "from_str" at 562:23-562:31 (leading: Space)
-6649: LParen          "(" at 562:31-562:32
-6650: Ident           "s" at 562:32-562:33
-6651: Colon           ":" at 562:33-562:34
-6652: Amp             "&" at 562:35-562:36 (leading: Space)
-6653: Ident           "string" at 562:36-562:42
-6654: RParen          ")" at 562:42-562:43
-6655: Arrow           "->" at 562:44-562:46 (leading: Space)
-6656: Ident           "Erring" at 562:47-562:53 (leading: Space)
-6657: Lt              "<" at 562:53-562:54
-6658: Ident           "uint64" at 562:54-562:60
-6659: Comma           "," at 562:60-562:61
-6660: Ident           "Error" at 562:62-562:67 (leading: Space)
-6661: Gt              ">" at 562:67-562:68
-6662: Semicolon       ";" at 562:68-562:69
-6663: RBrace          "}" at 563:1-563:2 (leading: Newline)
-6664: KwExtern        "extern" at 565:1-565:7 (leading: Newline)
-6665: Lt              "<" at 565:7-565:8
-6666: Ident           "float16" at 565:8-565:15
-6667: Gt              ">" at 565:15-565:16
-6668: LBrace          "{" at 565:17-565:18 (leading: Space)
-6669: KwPub           "pub" at 566:5-566:8 (leading: Newline, Space)
-6670: KwFn            "fn" at 566:9-566:11 (leading: Space)
-6671: Ident           "__min_value" at 566:12-566:23 (leading: Space)
-6672: LParen          "(" at 566:23-566:24
-6673: RParen          ")" at 566:24-566:25
-6674: Arrow           "->" at 566:26-566:28 (leading: Space)
-6675: Ident           "float16" at 566:29-566:36 (leading: Space)
-6676: LBrace          "{" at 566:37-566:38 (leading: Space)
-6677: KwReturn        "return" at 566:39-566:45 (leading: Space)
-6678: LParen          "(" at 566:46-566:47 (leading: Space)
-6679: Minus           "-" at 566:47-566:48
-6680: FloatLit        "65504.0" at 566:48-566:55
-6681: RParen          ")" at 566:55-566:56
-6682: Colon           ":" at 566:56-566:57
-6683: Ident           "float16" at 566:57-566:64
-6684: Semicolon       ";" at 566:64-566:65
-6685: RBrace          "}" at 566:66-566:67 (leading: Space)
-6686: KwPub           "pub" at 567:5-567:8 (leading: Newline, Space)
-6687: KwFn            "fn" at 567:9-567:11 (leading: Space)
-6688: Ident           "__max_value" at 567:12-567:23 (leading: Space)
-6689: LParen          "(" at 567:23-567:24
-6690: RParen          ")" at 567:24-567:25
-6691: Arrow           "->" at 567:26-567:28 (leading: Space)
-6692: Ident           "float16" at 567:29-567:36 (leading: Space)
-6693: LBrace          "{" at 567:37-567:38 (leading: Space)
-6694: KwReturn        "return" at 567:39-567:45 (leading: Space)
-6695: LParen          "(" at 567:46-567:47 (leading: Space)
-6696: FloatLit        "65504.0" at 567:47-567:54
-6697: RParen          ")" at 567:54-567:55
-6698: Colon           ":" at 567:55-567:56
-6699: Ident           "float16" at 567:56-567:63
-6700: Semicolon       ";" at 567:63-567:64
-6701: RBrace          "}" at 567:65-567:66 (leading: Space)
-6702: At              "@" at 568:5-568:6 (leading: Newline, Space)
-6703: Ident           "intrinsic" at 568:6-568:15
-6704: KwFn            "fn" at 568:16-568:18 (leading: Space)
-6705: Ident           "__add" at 568:19-568:24 (leading: Space)
-6706: LParen          "(" at 568:24-568:25
-6707: Ident           "self" at 568:25-568:29
-6708: Colon           ":" at 568:29-568:30
-6709: Ident           "float16" at 568:31-568:38 (leading: Space)
-6710: Comma           "," at 568:38-568:39
-6711: Ident           "other" at 568:40-568:45 (leading: Space)
-6712: Colon           ":" at 568:45-568:46
-6713: Ident           "float16" at 568:47-568:54 (leading: Space)
-6714: RParen          ")" at 568:54-568:55
-6715: Arrow           "->" at 568:56-568:58 (leading: Space)
-6716: Ident           "float16" at 568:59-568:66 (leading: Space)
-6717: Semicolon       ";" at 568:66-568:67
-6718: At              "@" at 569:5-569:6 (leading: Newline, Space)
-6719: Ident           "intrinsic" at 569:6-569:15
-6720: KwFn            "fn" at 569:16-569:18 (leading: Space)
-6721: Ident           "__sub" at 569:19-569:24 (leading: Space)
-6722: LParen          "(" at 569:24-569:25
-6723: Ident           "self" at 569:25-569:29
-6724: Colon           ":" at 569:29-569:30
-6725: Ident           "float16" at 569:31-569:38 (leading: Space)
-6726: Comma           "," at 569:38-569:39
-6727: Ident           "other" at 569:40-569:45 (leading: Space)
-6728: Colon           ":" at 569:45-569:46
-6729: Ident           "float16" at 569:47-569:54 (leading: Space)
-6730: RParen          ")" at 569:54-569:55
-6731: Arrow           "->" at 569:56-569:58 (leading: Space)
-6732: Ident           "float16" at 569:59-569:66 (leading: Space)
-6733: Semicolon       ";" at 569:66-569:67
-6734: At              "@" at 570:5-570:6 (leading: Newline, Space)
-6735: Ident           "intrinsic" at 570:6-570:15
-6736: KwFn            "fn" at 570:16-570:18 (leading: Space)
-6737: Ident           "__mul" at 570:19-570:24 (leading: Space)
-6738: LParen          "(" at 570:24-570:25
-6739: Ident           "self" at 570:25-570:29
-6740: Colon           ":" at 570:29-570:30
-6741: Ident           "float16" at 570:31-570:38 (leading: Space)
-6742: Comma           "," at 570:38-570:39
-6743: Ident           "other" at 570:40-570:45 (leading: Space)
-6744: Colon           ":" at 570:45-570:46
-6745: Ident           "float16" at 570:47-570:54 (leading: Space)
-6746: RParen          ")" at 570:54-570:55
-6747: Arrow           "->" at 570:56-570:58 (leading: Space)
-6748: Ident           "float16" at 570:59-570:66 (leading: Space)
-6749: Semicolon       ";" at 570:66-570:67
-6750: At              "@" at 571:5-571:6 (leading: Newline, Space)
-6751: Ident           "intrinsic" at 571:6-571:15
-6752: KwFn            "fn" at 571:16-571:18 (leading: Space)
-6753: Ident           "__div" at 571:19-571:24 (leading: Space)
-6754: LParen          "(" at 571:24-571:25
-6755: Ident           "self" at 571:25-571:29
-6756: Colon           ":" at 571:29-571:30
-6757: Ident           "float16" at 571:31-571:38 (leading: Space)
-6758: Comma           "," at 571:38-571:39
-6759: Ident           "other" at 571:40-571:45 (leading: Space)
-6760: Colon           ":" at 571:45-571:46
-6761: Ident           "float16" at 571:47-571:54 (leading: Space)
-6762: RParen          ")" at 571:54-571:55
-6763: Arrow           "->" at 571:56-571:58 (leading: Space)
-6764: Ident           "float16" at 571:59-571:66 (leading: Space)
-6765: Semicolon       ";" at 571:66-571:67
-6766: At              "@" at 572:5-572:6 (leading: Newline, Space)
-6767: Ident           "intrinsic" at 572:6-572:15
-6768: KwFn            "fn" at 572:16-572:18 (leading: Space)
-6769: Ident           "__mod" at 572:19-572:24 (leading: Space)
-6770: LParen          "(" at 572:24-572:25
-6771: Ident           "self" at 572:25-572:29
-6772: Colon           ":" at 572:29-572:30
-6773: Ident           "float16" at 572:31-572:38 (leading: Space)
-6774: Comma           "," at 572:38-572:39
-6775: Ident           "other" at 572:40-572:45 (leading: Space)
-6776: Colon           ":" at 572:45-572:46
-6777: Ident           "float16" at 572:47-572:54 (leading: Space)
-6778: RParen          ")" at 572:54-572:55
-6779: Arrow           "->" at 572:56-572:58 (leading: Space)
-6780: Ident           "float16" at 572:59-572:66 (leading: Space)
-6781: Semicolon       ";" at 572:66-572:67
-6782: At              "@" at 573:5-573:6 (leading: Newline, Space)
-6783: Ident           "intrinsic" at 573:6-573:15
-6784: KwFn            "fn" at 573:16-573:18 (leading: Space)
-6785: Ident           "__lt" at 573:19-573:23 (leading: Space)
-6786: LParen          "(" at 573:23-573:24
-6787: Ident           "self" at 573:24-573:28
-6788: Colon           ":" at 573:28-573:29
-6789: Ident           "float16" at 573:30-573:37 (leading: Space)
-6790: Comma           "," at 573:37-573:38
-6791: Ident           "other" at 573:39-573:44 (leading: Space)
-6792: Colon           ":" at 573:44-573:45
-6793: Ident           "float16" at 573:46-573:53 (leading: Space)
-6794: RParen          ")" at 573:53-573:54
-6795: Arrow           "->" at 573:55-573:57 (leading: Space)
-6796: Ident           "bool" at 573:58-573:62 (leading: Space)
-6797: Semicolon       ";" at 573:62-573:63
-6798: At              "@" at 574:5-574:6 (leading: Newline, Space)
-6799: Ident           "intrinsic" at 574:6-574:15
-6800: KwFn            "fn" at 574:16-574:18 (leading: Space)
-6801: Ident           "__le" at 574:19-574:23 (leading: Space)
-6802: LParen          "(" at 574:23-574:24
-6803: Ident           "self" at 574:24-574:28
-6804: Colon           ":" at 574:28-574:29
-6805: Ident           "float16" at 574:30-574:37 (leading: Space)
-6806: Comma           "," at 574:37-574:38
-6807: Ident           "other" at 574:39-574:44 (leading: Space)
-6808: Colon           ":" at 574:44-574:45
-6809: Ident           "float16" at 574:46-574:53 (leading: Space)
-6810: RParen          ")" at 574:53-574:54
-6811: Arrow           "->" at 574:55-574:57 (leading: Space)
-6812: Ident           "bool" at 574:58-574:62 (leading: Space)
-6813: Semicolon       ";" at 574:62-574:63
-6814: At              "@" at 575:5-575:6 (leading: Newline, Space)
-6815: Ident           "intrinsic" at 575:6-575:15
-6816: KwFn            "fn" at 575:16-575:18 (leading: Space)
-6817: Ident           "__eq" at 575:19-575:23 (leading: Space)
-6818: LParen          "(" at 575:23-575:24
-6819: Ident           "self" at 575:24-575:28
-6820: Colon           ":" at 575:28-575:29
-6821: Ident           "float16" at 575:30-575:37 (leading: Space)
-6822: Comma           "," at 575:37-575:38
-6823: Ident           "other" at 575:39-575:44 (leading: Space)
-6824: Colon           ":" at 575:44-575:45
-6825: Ident           "float16" at 575:46-575:53 (leading: Space)
-6826: RParen          ")" at 575:53-575:54
-6827: Arrow           "->" at 575:55-575:57 (leading: Space)
-6828: Ident           "bool" at 575:58-575:62 (leading: Space)
-6829: Semicolon       ";" at 575:62-575:63
-6830: At              "@" at 576:5-576:6 (leading: Newline, Space)
-6831: Ident           "intrinsic" at 576:6-576:15
-6832: KwFn            "fn" at 576:16-576:18 (leading: Space)
-6833: Ident           "__ne" at 576:19-576:23 (leading: Space)
-6834: LParen          "(" at 576:23-576:24
-6835: Ident           "self" at 576:24-576:28
-6836: Colon           ":" at 576:28-576:29
-6837: Ident           "float16" at 576:30-576:37 (leading: Space)
-6838: Comma           "," at 576:37-576:38
-6839: Ident           "other" at 576:39-576:44 (leading: Space)
-6840: Colon           ":" at 576:44-576:45
-6841: Ident           "float16" at 576:46-576:53 (leading: Space)
-6842: RParen          ")" at 576:53-576:54
-6843: Arrow           "->" at 576:55-576:57 (leading: Space)
-6844: Ident           "bool" at 576:58-576:62 (leading: Space)
-6845: Semicolon       ";" at 576:62-576:63
-6846: At              "@" at 577:5-577:6 (leading: Newline, Space)
-6847: Ident           "intrinsic" at 577:6-577:15
-6848: KwFn            "fn" at 577:16-577:18 (leading: Space)
-6849: Ident           "__ge" at 577:19-577:23 (leading: Space)
-6850: LParen          "(" at 577:23-577:24
-6851: Ident           "self" at 577:24-577:28
-6852: Colon           ":" at 577:28-577:29
-6853: Ident           "float16" at 577:30-577:37 (leading: Space)
-6854: Comma           "," at 577:37-577:38
-6855: Ident           "other" at 577:39-577:44 (leading: Space)
-6856: Colon           ":" at 577:44-577:45
-6857: Ident           "float16" at 577:46-577:53 (leading: Space)
-6858: RParen          ")" at 577:53-577:54
-6859: Arrow           "->" at 577:55-577:57 (leading: Space)
-6860: Ident           "bool" at 577:58-577:62 (leading: Space)
-6861: Semicolon       ";" at 577:62-577:63
-6862: At              "@" at 578:5-578:6 (leading: Newline, Space)
-6863: Ident           "intrinsic" at 578:6-578:15
-6864: KwFn            "fn" at 578:16-578:18 (leading: Space)
-6865: Ident           "__gt" at 578:19-578:23 (leading: Space)
-6866: LParen          "(" at 578:23-578:24
-6867: Ident           "self" at 578:24-578:28
-6868: Colon           ":" at 578:28-578:29
-6869: Ident           "float16" at 578:30-578:37 (leading: Space)
-6870: Comma           "," at 578:37-578:38
-6871: Ident           "other" at 578:39-578:44 (leading: Space)
-6872: Colon           ":" at 578:44-578:45
-6873: Ident           "float16" at 578:46-578:53 (leading: Space)
-6874: RParen          ")" at 578:53-578:54
-6875: Arrow           "->" at 578:55-578:57 (leading: Space)
-6876: Ident           "bool" at 578:58-578:62 (leading: Space)
-6877: Semicolon       ";" at 578:62-578:63
-6878: At              "@" at 579:5-579:6 (leading: Newline, Space)
-6879: Ident           "intrinsic" at 579:6-579:15
-6880: KwFn            "fn" at 579:16-579:18 (leading: Space)
-6881: Ident           "__pos" at 579:19-579:24 (leading: Space)
-6882: LParen          "(" at 579:24-579:25
-6883: Ident           "self" at 579:25-579:29
-6884: Colon           ":" at 579:29-579:30
-6885: Ident           "float16" at 579:31-579:38 (leading: Space)
-6886: RParen          ")" at 579:38-579:39
-6887: Arrow           "->" at 579:40-579:42 (leading: Space)
-6888: Ident           "float16" at 579:43-579:50 (leading: Space)
-6889: Semicolon       ";" at 579:50-579:51
-6890: At              "@" at 580:5-580:6 (leading: Newline, Space)
-6891: Ident           "intrinsic" at 580:6-580:15
-6892: KwFn            "fn" at 580:16-580:18 (leading: Space)
-6893: Ident           "__neg" at 580:19-580:24 (leading: Space)
-6894: LParen          "(" at 580:24-580:25
-6895: Ident           "self" at 580:25-580:29
-6896: Colon           ":" at 580:29-580:30
-6897: Ident           "float16" at 580:31-580:38 (leading: Space)
-6898: RParen          ")" at 580:38-580:39
-6899: Arrow           "->" at 580:40-580:42 (leading: Space)
-6900: Ident           "float16" at 580:43-580:50 (leading: Space)
-6901: Semicolon       ";" at 580:50-580:51
-6902: At              "@" at 581:5-581:6 (leading: Newline, Space)
-6903: Ident           "intrinsic" at 581:6-581:15
-6904: KwFn            "fn" at 581:16-581:18 (leading: Space)
-6905: Ident           "__abs" at 581:19-581:24 (leading: Space)
-6906: LParen          "(" at 581:24-581:25
-6907: Ident           "self" at 581:25-581:29
-6908: Colon           ":" at 581:29-581:30
-6909: Ident           "float16" at 581:31-581:38 (leading: Space)
-6910: RParen          ")" at 581:38-581:39
-6911: Arrow           "->" at 581:40-581:42 (leading: Space)
-6912: Ident           "float16" at 581:43-581:50 (leading: Space)
-6913: Semicolon       ";" at 581:50-581:51
-6914: At              "@" at 582:5-582:6 (leading: Newline, Space)
-6915: Ident           "intrinsic" at 582:6-582:15
-6916: KwFn            "fn" at 582:16-582:18 (leading: Space)
-6917: Ident           "__to" at 582:19-582:23 (leading: Space)
-6918: LParen          "(" at 582:23-582:24
-6919: Ident           "self" at 582:24-582:28
-6920: Colon           ":" at 582:28-582:29
-6921: Ident           "float16" at 582:30-582:37 (leading: Space)
-6922: Comma           "," at 582:37-582:38
-6923: Ident           "target" at 582:39-582:45 (leading: Space)
-6924: Colon           ":" at 582:45-582:46
-6925: Ident           "float" at 582:47-582:52 (leading: Space)
-6926: RParen          ")" at 582:52-582:53
-6927: Arrow           "->" at 582:54-582:56 (leading: Space)
-6928: Ident           "float" at 582:57-582:62 (leading: Space)
-6929: Semicolon       ";" at 582:62-582:63
-6930: At              "@" at 583:5-583:6 (leading: Newline, Space)
-6931: Ident           "intrinsic" at 583:6-583:15
-6932: At              "@" at 583:16-583:17 (leading: Space)
-6933: Ident           "overload" at 583:17-583:25
-6934: KwFn            "fn" at 583:26-583:28 (leading: Space)
-6935: Ident           "__to" at 583:29-583:33 (leading: Space)
-6936: LParen          "(" at 583:33-583:34
-6937: Ident           "self" at 583:34-583:38
-6938: Colon           ":" at 583:38-583:39
-6939: Ident           "float16" at 583:40-583:47 (leading: Space)
-6940: Comma           "," at 583:47-583:48
-6941: Ident           "target" at 583:49-583:55 (leading: Space)
-6942: Colon           ":" at 583:55-583:56
-6943: Ident           "float32" at 583:57-583:64 (leading: Space)
-6944: RParen          ")" at 583:64-583:65
-6945: Arrow           "->" at 583:66-583:68 (leading: Space)
-6946: Ident           "float32" at 583:69-583:76 (leading: Space)
-6947: Semicolon       ";" at 583:76-583:77
-6948: At              "@" at 584:5-584:6 (leading: Newline, Space)
-6949: Ident           "intrinsic" at 584:6-584:15
-6950: At              "@" at 584:16-584:17 (leading: Space)
-6951: Ident           "overload" at 584:17-584:25
-6952: KwFn            "fn" at 584:26-584:28 (leading: Space)
-6953: Ident           "__to" at 584:29-584:33 (leading: Space)
-6954: LParen          "(" at 584:33-584:34
-6955: Ident           "self" at 584:34-584:38
-6956: Colon           ":" at 584:38-584:39
-6957: Ident           "float16" at 584:40-584:47 (leading: Space)
-6958: Comma           "," at 584:47-584:48
-6959: Ident           "target" at 584:49-584:55 (leading: Space)
-6960: Colon           ":" at 584:55-584:56
-6961: Ident           "float64" at 584:57-584:64 (leading: Space)
-6962: RParen          ")" at 584:64-584:65
-6963: Arrow           "->" at 584:66-584:68 (leading: Space)
-6964: Ident           "float64" at 584:69-584:76 (leading: Space)
-6965: Semicolon       ";" at 584:76-584:77
-6966: At              "@" at 585:5-585:6 (leading: Newline, Space)
-6967: Ident           "intrinsic" at 585:6-585:15
-6968: KwPub           "pub" at 585:16-585:19 (leading: Space)
-6969: KwFn            "fn" at 585:20-585:22 (leading: Space)
-6970: Ident           "from_str" at 585:23-585:31 (leading: Space)
-6971: LParen          "(" at 585:31-585:32
-6972: Ident           "s" at 585:32-585:33
-6973: Colon           ":" at 585:33-585:34
-6974: Amp             "&" at 585:35-585:36 (leading: Space)
-6975: Ident           "string" at 585:36-585:42
-6976: RParen          ")" at 585:42-585:43
-6977: Arrow           "->" at 585:44-585:46 (leading: Space)
-6978: Ident           "Erring" at 585:47-585:53 (leading: Space)
-6979: Lt              "<" at 585:53-585:54
-6980: Ident           "float16" at 585:54-585:61
-6981: Comma           "," at 585:61-585:62
-6982: Ident           "Error" at 585:63-585:68 (leading: Space)
-6983: Gt              ">" at 585:68-585:69
-6984: Semicolon       ";" at 585:69-585:70
-6985: RBrace          "}" at 586:1-586:2 (leading: Newline)
-6986: KwExtern        "extern" at 588:1-588:7 (leading: Newline)
-6987: Lt              "<" at 588:7-588:8
-6988: Ident           "float32" at 588:8-588:15
-6989: Gt              ">" at 588:15-588:16
-6990: LBrace          "{" at 588:17-588:18 (leading: Space)
-6991: KwPub           "pub" at 589:5-589:8 (leading: Newline, Space)
-6992: KwFn            "fn" at 589:9-589:11 (leading: Space)
-6993: Ident           "__min_value" at 589:12-589:23 (leading: Space)
-6994: LParen          "(" at 589:23-589:24
-6995: RParen          ")" at 589:24-589:25
-6996: Arrow           "->" at 589:26-589:28 (leading: Space)
-6997: Ident           "float32" at 589:29-589:36 (leading: Space)
-6998: LBrace          "{" at 589:37-589:38 (leading: Space)
-6999: KwReturn        "return" at 589:39-589:45 (leading: Space)
-7000: LParen          "(" at 589:46-589:47 (leading: Space)
-7001: Minus           "-" at 589:47-589:48
-7002: FloatLit        "3.402_823_466_385_2886e+38" at 589:48-589:74
-7003: RParen          ")" at 589:74-589:75
-7004: Colon           ":" at 589:75-589:76
-7005: Ident           "float32" at 589:76-589:83
-7006: Semicolon       ";" at 589:83-589:84
-7007: RBrace          "}" at 589:85-589:86 (leading: Space)
-7008: KwPub           "pub" at 590:5-590:8 (leading: Newline, Space)
-7009: KwFn            "fn" at 590:9-590:11 (leading: Space)
-7010: Ident           "__max_value" at 590:12-590:23 (leading: Space)
-7011: LParen          "(" at 590:23-590:24
-7012: RParen          ")" at 590:24-590:25
-7013: Arrow           "->" at 590:26-590:28 (leading: Space)
-7014: Ident           "float32" at 590:29-590:36 (leading: Space)
-7015: LBrace          "{" at 590:37-590:38 (leading: Space)
-7016: KwReturn        "return" at 590:39-590:45 (leading: Space)
-7017: LParen          "(" at 590:46-590:47 (leading: Space)
-7018: FloatLit        "3.402_823_466_385_2886e+38" at 590:47-590:73
-7019: RParen          ")" at 590:73-590:74
-7020: Colon           ":" at 590:74-590:75
-7021: Ident           "float32" at 590:75-590:82
-7022: Semicolon       ";" at 590:82-590:83
-7023: RBrace          "}" at 590:84-590:85 (leading: Space)
-7024: At              "@" at 591:5-591:6 (leading: Newline, Space)
-7025: Ident           "intrinsic" at 591:6-591:15
-7026: KwFn            "fn" at 591:16-591:18 (leading: Space)
-7027: Ident           "__add" at 591:19-591:24 (leading: Space)
-7028: LParen          "(" at 591:24-591:25
-7029: Ident           "self" at 591:25-591:29
-7030: Colon           ":" at 591:29-591:30
-7031: Ident           "float32" at 591:31-591:38 (leading: Space)
-7032: Comma           "," at 591:38-591:39
-7033: Ident           "other" at 591:40-591:45 (leading: Space)
-7034: Colon           ":" at 591:45-591:46
-7035: Ident           "float32" at 591:47-591:54 (leading: Space)
-7036: RParen          ")" at 591:54-591:55
-7037: Arrow           "->" at 591:56-591:58 (leading: Space)
-7038: Ident           "float32" at 591:59-591:66 (leading: Space)
-7039: Semicolon       ";" at 591:66-591:67
-7040: At              "@" at 592:5-592:6 (leading: Newline, Space)
-7041: Ident           "intrinsic" at 592:6-592:15
-7042: KwFn            "fn" at 592:16-592:18 (leading: Space)
-7043: Ident           "__sub" at 592:19-592:24 (leading: Space)
-7044: LParen          "(" at 592:24-592:25
-7045: Ident           "self" at 592:25-592:29
-7046: Colon           ":" at 592:29-592:30
-7047: Ident           "float32" at 592:31-592:38 (leading: Space)
-7048: Comma           "," at 592:38-592:39
-7049: Ident           "other" at 592:40-592:45 (leading: Space)
-7050: Colon           ":" at 592:45-592:46
-7051: Ident           "float32" at 592:47-592:54 (leading: Space)
-7052: RParen          ")" at 592:54-592:55
-7053: Arrow           "->" at 592:56-592:58 (leading: Space)
-7054: Ident           "float32" at 592:59-592:66 (leading: Space)
-7055: Semicolon       ";" at 592:66-592:67
-7056: At              "@" at 593:5-593:6 (leading: Newline, Space)
-7057: Ident           "intrinsic" at 593:6-593:15
-7058: KwFn            "fn" at 593:16-593:18 (leading: Space)
-7059: Ident           "__mul" at 593:19-593:24 (leading: Space)
-7060: LParen          "(" at 593:24-593:25
-7061: Ident           "self" at 593:25-593:29
-7062: Colon           ":" at 593:29-593:30
-7063: Ident           "float32" at 593:31-593:38 (leading: Space)
-7064: Comma           "," at 593:38-593:39
-7065: Ident           "other" at 593:40-593:45 (leading: Space)
-7066: Colon           ":" at 593:45-593:46
-7067: Ident           "float32" at 593:47-593:54 (leading: Space)
-7068: RParen          ")" at 593:54-593:55
-7069: Arrow           "->" at 593:56-593:58 (leading: Space)
-7070: Ident           "float32" at 593:59-593:66 (leading: Space)
-7071: Semicolon       ";" at 593:66-593:67
-7072: At              "@" at 594:5-594:6 (leading: Newline, Space)
-7073: Ident           "intrinsic" at 594:6-594:15
-7074: KwFn            "fn" at 594:16-594:18 (leading: Space)
-7075: Ident           "__div" at 594:19-594:24 (leading: Space)
-7076: LParen          "(" at 594:24-594:25
-7077: Ident           "self" at 594:25-594:29
-7078: Colon           ":" at 594:29-594:30
-7079: Ident           "float32" at 594:31-594:38 (leading: Space)
-7080: Comma           "," at 594:38-594:39
-7081: Ident           "other" at 594:40-594:45 (leading: Space)
-7082: Colon           ":" at 594:45-594:46
-7083: Ident           "float32" at 594:47-594:54 (leading: Space)
-7084: RParen          ")" at 594:54-594:55
-7085: Arrow           "->" at 594:56-594:58 (leading: Space)
-7086: Ident           "float32" at 594:59-594:66 (leading: Space)
-7087: Semicolon       ";" at 594:66-594:67
-7088: At              "@" at 595:5-595:6 (leading: Newline, Space)
-7089: Ident           "intrinsic" at 595:6-595:15
-7090: KwFn            "fn" at 595:16-595:18 (leading: Space)
-7091: Ident           "__mod" at 595:19-595:24 (leading: Space)
-7092: LParen          "(" at 595:24-595:25
-7093: Ident           "self" at 595:25-595:29
-7094: Colon           ":" at 595:29-595:30
-7095: Ident           "float32" at 595:31-595:38 (leading: Space)
-7096: Comma           "," at 595:38-595:39
-7097: Ident           "other" at 595:40-595:45 (leading: Space)
-7098: Colon           ":" at 595:45-595:46
-7099: Ident           "float32" at 595:47-595:54 (leading: Space)
-7100: RParen          ")" at 595:54-595:55
-7101: Arrow           "->" at 595:56-595:58 (leading: Space)
-7102: Ident           "float32" at 595:59-595:66 (leading: Space)
-7103: Semicolon       ";" at 595:66-595:67
-7104: At              "@" at 596:5-596:6 (leading: Newline, Space)
-7105: Ident           "intrinsic" at 596:6-596:15
-7106: KwFn            "fn" at 596:16-596:18 (leading: Space)
-7107: Ident           "__lt" at 596:19-596:23 (leading: Space)
-7108: LParen          "(" at 596:23-596:24
-7109: Ident           "self" at 596:24-596:28
-7110: Colon           ":" at 596:28-596:29
-7111: Ident           "float32" at 596:30-596:37 (leading: Space)
-7112: Comma           "," at 596:37-596:38
-7113: Ident           "other" at 596:39-596:44 (leading: Space)
-7114: Colon           ":" at 596:44-596:45
-7115: Ident           "float32" at 596:46-596:53 (leading: Space)
-7116: RParen          ")" at 596:53-596:54
-7117: Arrow           "->" at 596:55-596:57 (leading: Space)
-7118: Ident           "bool" at 596:58-596:62 (leading: Space)
-7119: Semicolon       ";" at 596:62-596:63
-7120: At              "@" at 597:5-597:6 (leading: Newline, Space)
-7121: Ident           "intrinsic" at 597:6-597:15
-7122: KwFn            "fn" at 597:16-597:18 (leading: Space)
-7123: Ident           "__le" at 597:19-597:23 (leading: Space)
-7124: LParen          "(" at 597:23-597:24
-7125: Ident           "self" at 597:24-597:28
-7126: Colon           ":" at 597:28-597:29
-7127: Ident           "float32" at 597:30-597:37 (leading: Space)
-7128: Comma           "," at 597:37-597:38
-7129: Ident           "other" at 597:39-597:44 (leading: Space)
-7130: Colon           ":" at 597:44-597:45
-7131: Ident           "float32" at 597:46-597:53 (leading: Space)
-7132: RParen          ")" at 597:53-597:54
-7133: Arrow           "->" at 597:55-597:57 (leading: Space)
-7134: Ident           "bool" at 597:58-597:62 (leading: Space)
-7135: Semicolon       ";" at 597:62-597:63
-7136: At              "@" at 598:5-598:6 (leading: Newline, Space)
-7137: Ident           "intrinsic" at 598:6-598:15
-7138: KwFn            "fn" at 598:16-598:18 (leading: Space)
-7139: Ident           "__eq" at 598:19-598:23 (leading: Space)
-7140: LParen          "(" at 598:23-598:24
-7141: Ident           "self" at 598:24-598:28
-7142: Colon           ":" at 598:28-598:29
-7143: Ident           "float32" at 598:30-598:37 (leading: Space)
-7144: Comma           "," at 598:37-598:38
-7145: Ident           "other" at 598:39-598:44 (leading: Space)
-7146: Colon           ":" at 598:44-598:45
-7147: Ident           "float32" at 598:46-598:53 (leading: Space)
-7148: RParen          ")" at 598:53-598:54
-7149: Arrow           "->" at 598:55-598:57 (leading: Space)
-7150: Ident           "bool" at 598:58-598:62 (leading: Space)
-7151: Semicolon       ";" at 598:62-598:63
-7152: At              "@" at 599:5-599:6 (leading: Newline, Space)
-7153: Ident           "intrinsic" at 599:6-599:15
-7154: KwFn            "fn" at 599:16-599:18 (leading: Space)
-7155: Ident           "__ne" at 599:19-599:23 (leading: Space)
-7156: LParen          "(" at 599:23-599:24
-7157: Ident           "self" at 599:24-599:28
-7158: Colon           ":" at 599:28-599:29
-7159: Ident           "float32" at 599:30-599:37 (leading: Space)
-7160: Comma           "," at 599:37-599:38
-7161: Ident           "other" at 599:39-599:44 (leading: Space)
-7162: Colon           ":" at 599:44-599:45
-7163: Ident           "float32" at 599:46-599:53 (leading: Space)
-7164: RParen          ")" at 599:53-599:54
-7165: Arrow           "->" at 599:55-599:57 (leading: Space)
-7166: Ident           "bool" at 599:58-599:62 (leading: Space)
-7167: Semicolon       ";" at 599:62-599:63
-7168: At              "@" at 600:5-600:6 (leading: Newline, Space)
-7169: Ident           "intrinsic" at 600:6-600:15
-7170: KwFn            "fn" at 600:16-600:18 (leading: Space)
-7171: Ident           "__ge" at 600:19-600:23 (leading: Space)
-7172: LParen          "(" at 600:23-600:24
-7173: Ident           "self" at 600:24-600:28
-7174: Colon           ":" at 600:28-600:29
-7175: Ident           "float32" at 600:30-600:37 (leading: Space)
-7176: Comma           "," at 600:37-600:38
-7177: Ident           "other" at 600:39-600:44 (leading: Space)
-7178: Colon           ":" at 600:44-600:45
-7179: Ident           "float32" at 600:46-600:53 (leading: Space)
-7180: RParen          ")" at 600:53-600:54
-7181: Arrow           "->" at 600:55-600:57 (leading: Space)
-7182: Ident           "bool" at 600:58-600:62 (leading: Space)
-7183: Semicolon       ";" at 600:62-600:63
-7184: At              "@" at 601:5-601:6 (leading: Newline, Space)
-7185: Ident           "intrinsic" at 601:6-601:15
-7186: KwFn            "fn" at 601:16-601:18 (leading: Space)
-7187: Ident           "__gt" at 601:19-601:23 (leading: Space)
-7188: LParen          "(" at 601:23-601:24
-7189: Ident           "self" at 601:24-601:28
-7190: Colon           ":" at 601:28-601:29
-7191: Ident           "float32" at 601:30-601:37 (leading: Space)
-7192: Comma           "," at 601:37-601:38
-7193: Ident           "other" at 601:39-601:44 (leading: Space)
-7194: Colon           ":" at 601:44-601:45
-7195: Ident           "float32" at 601:46-601:53 (leading: Space)
-7196: RParen          ")" at 601:53-601:54
-7197: Arrow           "->" at 601:55-601:57 (leading: Space)
-7198: Ident           "bool" at 601:58-601:62 (leading: Space)
-7199: Semicolon       ";" at 601:62-601:63
-7200: At              "@" at 602:5-602:6 (leading: Newline, Space)
-7201: Ident           "intrinsic" at 602:6-602:15
-7202: KwFn            "fn" at 602:16-602:18 (leading: Space)
-7203: Ident           "__pos" at 602:19-602:24 (leading: Space)
-7204: LParen          "(" at 602:24-602:25
-7205: Ident           "self" at 602:25-602:29
-7206: Colon           ":" at 602:29-602:30
-7207: Ident           "float32" at 602:31-602:38 (leading: Space)
-7208: RParen          ")" at 602:38-602:39
-7209: Arrow           "->" at 602:40-602:42 (leading: Space)
-7210: Ident           "float32" at 602:43-602:50 (leading: Space)
-7211: Semicolon       ";" at 602:50-602:51
-7212: At              "@" at 603:5-603:6 (leading: Newline, Space)
-7213: Ident           "intrinsic" at 603:6-603:15
-7214: KwFn            "fn" at 603:16-603:18 (leading: Space)
-7215: Ident           "__neg" at 603:19-603:24 (leading: Space)
-7216: LParen          "(" at 603:24-603:25
-7217: Ident           "self" at 603:25-603:29
-7218: Colon           ":" at 603:29-603:30
-7219: Ident           "float32" at 603:31-603:38 (leading: Space)
-7220: RParen          ")" at 603:38-603:39
-7221: Arrow           "->" at 603:40-603:42 (leading: Space)
-7222: Ident           "float32" at 603:43-603:50 (leading: Space)
-7223: Semicolon       ";" at 603:50-603:51
-7224: At              "@" at 604:5-604:6 (leading: Newline, Space)
-7225: Ident           "intrinsic" at 604:6-604:15
-7226: KwFn            "fn" at 604:16-604:18 (leading: Space)
-7227: Ident           "__abs" at 604:19-604:24 (leading: Space)
-7228: LParen          "(" at 604:24-604:25
-7229: Ident           "self" at 604:25-604:29
-7230: Colon           ":" at 604:29-604:30
-7231: Ident           "float32" at 604:31-604:38 (leading: Space)
-7232: RParen          ")" at 604:38-604:39
-7233: Arrow           "->" at 604:40-604:42 (leading: Space)
-7234: Ident           "float32" at 604:43-604:50 (leading: Space)
-7235: Semicolon       ";" at 604:50-604:51
-7236: At              "@" at 605:5-605:6 (leading: Newline, Space)
-7237: Ident           "intrinsic" at 605:6-605:15
-7238: KwFn            "fn" at 605:16-605:18 (leading: Space)
-7239: Ident           "__to" at 605:19-605:23 (leading: Space)
-7240: LParen          "(" at 605:23-605:24
-7241: Ident           "self" at 605:24-605:28
-7242: Colon           ":" at 605:28-605:29
-7243: Ident           "float32" at 605:30-605:37 (leading: Space)
-7244: Comma           "," at 605:37-605:38
-7245: Ident           "target" at 605:39-605:45 (leading: Space)
-7246: Colon           ":" at 605:45-605:46
-7247: Ident           "float" at 605:47-605:52 (leading: Space)
-7248: RParen          ")" at 605:52-605:53
-7249: Arrow           "->" at 605:54-605:56 (leading: Space)
-7250: Ident           "float" at 605:57-605:62 (leading: Space)
-7251: Semicolon       ";" at 605:62-605:63
-7252: At              "@" at 606:5-606:6 (leading: Newline, Space)
-7253: Ident           "intrinsic" at 606:6-606:15
-7254: At              "@" at 606:16-606:17 (leading: Space)
-7255: Ident           "overload" at 606:17-606:25
-7256: KwFn            "fn" at 606:26-606:28 (leading: Space)
-7257: Ident           "__to" at 606:29-606:33 (leading: Space)
-7258: LParen          "(" at 606:33-606:34
-7259: Ident           "self" at 606:34-606:38
-7260: Colon           ":" at 606:38-606:39
-7261: Ident           "float32" at 606:40-606:47 (leading: Space)
-7262: Comma           "," at 606:47-606:48
-7263: Ident           "target" at 606:49-606:55 (leading: Space)
-7264: Colon           ":" at 606:55-606:56
-7265: Ident           "float16" at 606:57-606:64 (leading: Space)
-7266: RParen          ")" at 606:64-606:65
-7267: Arrow           "->" at 606:66-606:68 (leading: Space)
-7268: Ident           "float16" at 606:69-606:76 (leading: Space)
-7269: Semicolon       ";" at 606:76-606:77
-7270: At              "@" at 607:5-607:6 (leading: Newline, Space)
-7271: Ident           "intrinsic" at 607:6-607:15
-7272: At              "@" at 607:16-607:17 (leading: Space)
-7273: Ident           "overload" at 607:17-607:25
-7274: KwFn            "fn" at 607:26-607:28 (leading: Space)
-7275: Ident           "__to" at 607:29-607:33 (leading: Space)
-7276: LParen          "(" at 607:33-607:34
-7277: Ident           "self" at 607:34-607:38
-7278: Colon           ":" at 607:38-607:39
-7279: Ident           "float32" at 607:40-607:47 (leading: Space)
-7280: Comma           "," at 607:47-607:48
-7281: Ident           "target" at 607:49-607:55 (leading: Space)
-7282: Colon           ":" at 607:55-607:56
-7283: Ident           "float64" at 607:57-607:64 (leading: Space)
-7284: RParen          ")" at 607:64-607:65
-7285: Arrow           "->" at 607:66-607:68 (leading: Space)
-7286: Ident           "float64" at 607:69-607:76 (leading: Space)
-7287: Semicolon       ";" at 607:76-607:77
-7288: At              "@" at 608:5-608:6 (leading: Newline, Space)
-7289: Ident           "intrinsic" at 608:6-608:15
-7290: KwPub           "pub" at 608:16-608:19 (leading: Space)
-7291: KwFn            "fn" at 608:20-608:22 (leading: Space)
-7292: Ident           "from_str" at 608:23-608:31 (leading: Space)
-7293: LParen          "(" at 608:31-608:32
-7294: Ident           "s" at 608:32-608:33
-7295: Colon           ":" at 608:33-608:34
-7296: Amp             "&" at 608:35-608:36 (leading: Space)
-7297: Ident           "string" at 608:36-608:42
-7298: RParen          ")" at 608:42-608:43
-7299: Arrow           "->" at 608:44-608:46 (leading: Space)
-7300: Ident           "Erring" at 608:47-608:53 (leading: Space)
-7301: Lt              "<" at 608:53-608:54
-7302: Ident           "float32" at 608:54-608:61
-7303: Comma           "," at 608:61-608:62
-7304: Ident           "Error" at 608:63-608:68 (leading: Space)
-7305: Gt              ">" at 608:68-608:69
-7306: Semicolon       ";" at 608:69-608:70
-7307: RBrace          "}" at 609:1-609:2 (leading: Newline)
-7308: KwExtern        "extern" at 611:1-611:7 (leading: Newline)
-7309: Lt              "<" at 611:7-611:8
-7310: Ident           "float64" at 611:8-611:15
-7311: Gt              ">" at 611:15-611:16
-7312: LBrace          "{" at 611:17-611:18 (leading: Space)
-7313: KwPub           "pub" at 612:5-612:8 (leading: Newline, Space)
-7314: KwFn            "fn" at 612:9-612:11 (leading: Space)
-7315: Ident           "__min_value" at 612:12-612:23 (leading: Space)
-7316: LParen          "(" at 612:23-612:24
-7317: RParen          ")" at 612:24-612:25
-7318: Arrow           "->" at 612:26-612:28 (leading: Space)
-7319: Ident           "float64" at 612:29-612:36 (leading: Space)
-7320: LBrace          "{" at 612:37-612:38 (leading: Space)
-7321: KwReturn        "return" at 612:39-612:45 (leading: Space)
-7322: LParen          "(" at 612:46-612:47 (leading: Space)
-7323: Minus           "-" at 612:47-612:48
-7324: FloatLit        "1.797_693_134_862_3157e+308" at 612:48-612:75
-7325: RParen          ")" at 612:75-612:76
-7326: Colon           ":" at 612:76-612:77
-7327: Ident           "float64" at 612:77-612:84
-7328: Semicolon       ";" at 612:84-612:85
-7329: RBrace          "}" at 612:86-612:87 (leading: Space)
-7330: KwPub           "pub" at 613:5-613:8 (leading: Newline, Space)
-7331: KwFn            "fn" at 613:9-613:11 (leading: Space)
-7332: Ident           "__max_value" at 613:12-613:23 (leading: Space)
-7333: LParen          "(" at 613:23-613:24
-7334: RParen          ")" at 613:24-613:25
-7335: Arrow           "->" at 613:26-613:28 (leading: Space)
-7336: Ident           "float64" at 613:29-613:36 (leading: Space)
-7337: LBrace          "{" at 613:37-613:38 (leading: Space)
-7338: KwReturn        "return" at 613:39-613:45 (leading: Space)
-7339: LParen          "(" at 613:46-613:47 (leading: Space)
-7340: FloatLit        "1.797_693_134_862_3157e+308" at 613:47-613:74
-7341: RParen          ")" at 613:74-613:75
-7342: Colon           ":" at 613:75-613:76
-7343: Ident           "float64" at 613:76-613:83
-7344: Semicolon       ";" at 613:83-613:84
-7345: RBrace          "}" at 613:85-613:86 (leading: Space)
-7346: At              "@" at 614:5-614:6 (leading: Newline, Space)
-7347: Ident           "intrinsic" at 614:6-614:15
-7348: KwFn            "fn" at 614:16-614:18 (leading: Space)
-7349: Ident           "__add" at 614:19-614:24 (leading: Space)
-7350: LParen          "(" at 614:24-614:25
-7351: Ident           "self" at 614:25-614:29
-7352: Colon           ":" at 614:29-614:30
-7353: Ident           "float64" at 614:31-614:38 (leading: Space)
-7354: Comma           "," at 614:38-614:39
-7355: Ident           "other" at 614:40-614:45 (leading: Space)
-7356: Colon           ":" at 614:45-614:46
-7357: Ident           "float64" at 614:47-614:54 (leading: Space)
-7358: RParen          ")" at 614:54-614:55
-7359: Arrow           "->" at 614:56-614:58 (leading: Space)
-7360: Ident           "float64" at 614:59-614:66 (leading: Space)
-7361: Semicolon       ";" at 614:66-614:67
-7362: At              "@" at 615:5-615:6 (leading: Newline, Space)
-7363: Ident           "intrinsic" at 615:6-615:15
-7364: KwFn            "fn" at 615:16-615:18 (leading: Space)
-7365: Ident           "__sub" at 615:19-615:24 (leading: Space)
-7366: LParen          "(" at 615:24-615:25
-7367: Ident           "self" at 615:25-615:29
-7368: Colon           ":" at 615:29-615:30
-7369: Ident           "float64" at 615:31-615:38 (leading: Space)
-7370: Comma           "," at 615:38-615:39
-7371: Ident           "other" at 615:40-615:45 (leading: Space)
-7372: Colon           ":" at 615:45-615:46
-7373: Ident           "float64" at 615:47-615:54 (leading: Space)
-7374: RParen          ")" at 615:54-615:55
-7375: Arrow           "->" at 615:56-615:58 (leading: Space)
-7376: Ident           "float64" at 615:59-615:66 (leading: Space)
-7377: Semicolon       ";" at 615:66-615:67
-7378: At              "@" at 616:5-616:6 (leading: Newline, Space)
-7379: Ident           "intrinsic" at 616:6-616:15
-7380: KwFn            "fn" at 616:16-616:18 (leading: Space)
-7381: Ident           "__mul" at 616:19-616:24 (leading: Space)
-7382: LParen          "(" at 616:24-616:25
-7383: Ident           "self" at 616:25-616:29
-7384: Colon           ":" at 616:29-616:30
-7385: Ident           "float64" at 616:31-616:38 (leading: Space)
-7386: Comma           "," at 616:38-616:39
-7387: Ident           "other" at 616:40-616:45 (leading: Space)
-7388: Colon           ":" at 616:45-616:46
-7389: Ident           "float64" at 616:47-616:54 (leading: Space)
-7390: RParen          ")" at 616:54-616:55
-7391: Arrow           "->" at 616:56-616:58 (leading: Space)
-7392: Ident           "float64" at 616:59-616:66 (leading: Space)
-7393: Semicolon       ";" at 616:66-616:67
-7394: At              "@" at 617:5-617:6 (leading: Newline, Space)
-7395: Ident           "intrinsic" at 617:6-617:15
-7396: KwFn            "fn" at 617:16-617:18 (leading: Space)
-7397: Ident           "__div" at 617:19-617:24 (leading: Space)
-7398: LParen          "(" at 617:24-617:25
-7399: Ident           "self" at 617:25-617:29
-7400: Colon           ":" at 617:29-617:30
-7401: Ident           "float64" at 617:31-617:38 (leading: Space)
-7402: Comma           "," at 617:38-617:39
-7403: Ident           "other" at 617:40-617:45 (leading: Space)
-7404: Colon           ":" at 617:45-617:46
-7405: Ident           "float64" at 617:47-617:54 (leading: Space)
-7406: RParen          ")" at 617:54-617:55
-7407: Arrow           "->" at 617:56-617:58 (leading: Space)
-7408: Ident           "float64" at 617:59-617:66 (leading: Space)
-7409: Semicolon       ";" at 617:66-617:67
-7410: At              "@" at 618:5-618:6 (leading: Newline, Space)
-7411: Ident           "intrinsic" at 618:6-618:15
-7412: KwFn            "fn" at 618:16-618:18 (leading: Space)
-7413: Ident           "__mod" at 618:19-618:24 (leading: Space)
-7414: LParen          "(" at 618:24-618:25
-7415: Ident           "self" at 618:25-618:29
-7416: Colon           ":" at 618:29-618:30
-7417: Ident           "float64" at 618:31-618:38 (leading: Space)
-7418: Comma           "," at 618:38-618:39
-7419: Ident           "other" at 618:40-618:45 (leading: Space)
-7420: Colon           ":" at 618:45-618:46
-7421: Ident           "float64" at 618:47-618:54 (leading: Space)
-7422: RParen          ")" at 618:54-618:55
-7423: Arrow           "->" at 618:56-618:58 (leading: Space)
-7424: Ident           "float64" at 618:59-618:66 (leading: Space)
-7425: Semicolon       ";" at 618:66-618:67
-7426: At              "@" at 619:5-619:6 (leading: Newline, Space)
-7427: Ident           "intrinsic" at 619:6-619:15
-7428: KwFn            "fn" at 619:16-619:18 (leading: Space)
-7429: Ident           "__lt" at 619:19-619:23 (leading: Space)
-7430: LParen          "(" at 619:23-619:24
-7431: Ident           "self" at 619:24-619:28
-7432: Colon           ":" at 619:28-619:29
-7433: Ident           "float64" at 619:30-619:37 (leading: Space)
-7434: Comma           "," at 619:37-619:38
-7435: Ident           "other" at 619:39-619:44 (leading: Space)
-7436: Colon           ":" at 619:44-619:45
-7437: Ident           "float64" at 619:46-619:53 (leading: Space)
-7438: RParen          ")" at 619:53-619:54
-7439: Arrow           "->" at 619:55-619:57 (leading: Space)
-7440: Ident           "bool" at 619:58-619:62 (leading: Space)
-7441: Semicolon       ";" at 619:62-619:63
-7442: At              "@" at 620:5-620:6 (leading: Newline, Space)
-7443: Ident           "intrinsic" at 620:6-620:15
-7444: KwFn            "fn" at 620:16-620:18 (leading: Space)
-7445: Ident           "__le" at 620:19-620:23 (leading: Space)
-7446: LParen          "(" at 620:23-620:24
-7447: Ident           "self" at 620:24-620:28
-7448: Colon           ":" at 620:28-620:29
-7449: Ident           "float64" at 620:30-620:37 (leading: Space)
-7450: Comma           "," at 620:37-620:38
-7451: Ident           "other" at 620:39-620:44 (leading: Space)
-7452: Colon           ":" at 620:44-620:45
-7453: Ident           "float64" at 620:46-620:53 (leading: Space)
-7454: RParen          ")" at 620:53-620:54
-7455: Arrow           "->" at 620:55-620:57 (leading: Space)
-7456: Ident           "bool" at 620:58-620:62 (leading: Space)
-7457: Semicolon       ";" at 620:62-620:63
-7458: At              "@" at 621:5-621:6 (leading: Newline, Space)
-7459: Ident           "intrinsic" at 621:6-621:15
-7460: KwFn            "fn" at 621:16-621:18 (leading: Space)
-7461: Ident           "__eq" at 621:19-621:23 (leading: Space)
-7462: LParen          "(" at 621:23-621:24
-7463: Ident           "self" at 621:24-621:28
-7464: Colon           ":" at 621:28-621:29
-7465: Ident           "float64" at 621:30-621:37 (leading: Space)
-7466: Comma           "," at 621:37-621:38
-7467: Ident           "other" at 621:39-621:44 (leading: Space)
-7468: Colon           ":" at 621:44-621:45
-7469: Ident           "float64" at 621:46-621:53 (leading: Space)
-7470: RParen          ")" at 621:53-621:54
-7471: Arrow           "->" at 621:55-621:57 (leading: Space)
-7472: Ident           "bool" at 621:58-621:62 (leading: Space)
-7473: Semicolon       ";" at 621:62-621:63
-7474: At              "@" at 622:5-622:6 (leading: Newline, Space)
-7475: Ident           "intrinsic" at 622:6-622:15
-7476: KwFn            "fn" at 622:16-622:18 (leading: Space)
-7477: Ident           "__ne" at 622:19-622:23 (leading: Space)
-7478: LParen          "(" at 622:23-622:24
-7479: Ident           "self" at 622:24-622:28
-7480: Colon           ":" at 622:28-622:29
-7481: Ident           "float64" at 622:30-622:37 (leading: Space)
-7482: Comma           "," at 622:37-622:38
-7483: Ident           "other" at 622:39-622:44 (leading: Space)
-7484: Colon           ":" at 622:44-622:45
-7485: Ident           "float64" at 622:46-622:53 (leading: Space)
-7486: RParen          ")" at 622:53-622:54
-7487: Arrow           "->" at 622:55-622:57 (leading: Space)
-7488: Ident           "bool" at 622:58-622:62 (leading: Space)
-7489: Semicolon       ";" at 622:62-622:63
-7490: At              "@" at 623:5-623:6 (leading: Newline, Space)
-7491: Ident           "intrinsic" at 623:6-623:15
-7492: KwFn            "fn" at 623:16-623:18 (leading: Space)
-7493: Ident           "__ge" at 623:19-623:23 (leading: Space)
-7494: LParen          "(" at 623:23-623:24
-7495: Ident           "self" at 623:24-623:28
-7496: Colon           ":" at 623:28-623:29
-7497: Ident           "float64" at 623:30-623:37 (leading: Space)
-7498: Comma           "," at 623:37-623:38
-7499: Ident           "other" at 623:39-623:44 (leading: Space)
-7500: Colon           ":" at 623:44-623:45
-7501: Ident           "float64" at 623:46-623:53 (leading: Space)
-7502: RParen          ")" at 623:53-623:54
-7503: Arrow           "->" at 623:55-623:57 (leading: Space)
-7504: Ident           "bool" at 623:58-623:62 (leading: Space)
-7505: Semicolon       ";" at 623:62-623:63
-7506: At              "@" at 624:5-624:6 (leading: Newline, Space)
-7507: Ident           "intrinsic" at 624:6-624:15
-7508: KwFn            "fn" at 624:16-624:18 (leading: Space)
-7509: Ident           "__gt" at 624:19-624:23 (leading: Space)
-7510: LParen          "(" at 624:23-624:24
-7511: Ident           "self" at 624:24-624:28
-7512: Colon           ":" at 624:28-624:29
-7513: Ident           "float64" at 624:30-624:37 (leading: Space)
-7514: Comma           "," at 624:37-624:38
-7515: Ident           "other" at 624:39-624:44 (leading: Space)
-7516: Colon           ":" at 624:44-624:45
-7517: Ident           "float64" at 624:46-624:53 (leading: Space)
-7518: RParen          ")" at 624:53-624:54
-7519: Arrow           "->" at 624:55-624:57 (leading: Space)
-7520: Ident           "bool" at 624:58-624:62 (leading: Space)
-7521: Semicolon       ";" at 624:62-624:63
-7522: At              "@" at 625:5-625:6 (leading: Newline, Space)
-7523: Ident           "intrinsic" at 625:6-625:15
-7524: KwFn            "fn" at 625:16-625:18 (leading: Space)
-7525: Ident           "__pos" at 625:19-625:24 (leading: Space)
-7526: LParen          "(" at 625:24-625:25
-7527: Ident           "self" at 625:25-625:29
-7528: Colon           ":" at 625:29-625:30
-7529: Ident           "float64" at 625:31-625:38 (leading: Space)
-7530: RParen          ")" at 625:38-625:39
-7531: Arrow           "->" at 625:40-625:42 (leading: Space)
-7532: Ident           "float64" at 625:43-625:50 (leading: Space)
-7533: Semicolon       ";" at 625:50-625:51
-7534: At              "@" at 626:5-626:6 (leading: Newline, Space)
-7535: Ident           "intrinsic" at 626:6-626:15
-7536: KwFn            "fn" at 626:16-626:18 (leading: Space)
-7537: Ident           "__neg" at 626:19-626:24 (leading: Space)
-7538: LParen          "(" at 626:24-626:25
-7539: Ident           "self" at 626:25-626:29
-7540: Colon           ":" at 626:29-626:30
-7541: Ident           "float64" at 626:31-626:38 (leading: Space)
-7542: RParen          ")" at 626:38-626:39
-7543: Arrow           "->" at 626:40-626:42 (leading: Space)
-7544: Ident           "float64" at 626:43-626:50 (leading: Space)
-7545: Semicolon       ";" at 626:50-626:51
-7546: At              "@" at 627:5-627:6 (leading: Newline, Space)
-7547: Ident           "intrinsic" at 627:6-627:15
-7548: KwFn            "fn" at 627:16-627:18 (leading: Space)
-7549: Ident           "__abs" at 627:19-627:24 (leading: Space)
-7550: LParen          "(" at 627:24-627:25
-7551: Ident           "self" at 627:25-627:29
-7552: Colon           ":" at 627:29-627:30
-7553: Ident           "float64" at 627:31-627:38 (leading: Space)
-7554: RParen          ")" at 627:38-627:39
-7555: Arrow           "->" at 627:40-627:42 (leading: Space)
-7556: Ident           "float64" at 627:43-627:50 (leading: Space)
-7557: Semicolon       ";" at 627:50-627:51
-7558: At              "@" at 628:5-628:6 (leading: Newline, Space)
-7559: Ident           "intrinsic" at 628:6-628:15
-7560: KwFn            "fn" at 628:16-628:18 (leading: Space)
-7561: Ident           "__to" at 628:19-628:23 (leading: Space)
-7562: LParen          "(" at 628:23-628:24
-7563: Ident           "self" at 628:24-628:28
-7564: Colon           ":" at 628:28-628:29
-7565: Ident           "float64" at 628:30-628:37 (leading: Space)
-7566: Comma           "," at 628:37-628:38
-7567: Ident           "target" at 628:39-628:45 (leading: Space)
-7568: Colon           ":" at 628:45-628:46
-7569: Ident           "float" at 628:47-628:52 (leading: Space)
-7570: RParen          ")" at 628:52-628:53
-7571: Arrow           "->" at 628:54-628:56 (leading: Space)
-7572: Ident           "float" at 628:57-628:62 (leading: Space)
-7573: Semicolon       ";" at 628:62-628:63
-7574: At              "@" at 629:5-629:6 (leading: Newline, Space)
-7575: Ident           "intrinsic" at 629:6-629:15
-7576: At              "@" at 629:16-629:17 (leading: Space)
-7577: Ident           "overload" at 629:17-629:25
-7578: KwFn            "fn" at 629:26-629:28 (leading: Space)
-7579: Ident           "__to" at 629:29-629:33 (leading: Space)
-7580: LParen          "(" at 629:33-629:34
-7581: Ident           "self" at 629:34-629:38
-7582: Colon           ":" at 629:38-629:39
-7583: Ident           "float64" at 629:40-629:47 (leading: Space)
-7584: Comma           "," at 629:47-629:48
-7585: Ident           "target" at 629:49-629:55 (leading: Space)
-7586: Colon           ":" at 629:55-629:56
-7587: Ident           "float16" at 629:57-629:64 (leading: Space)
-7588: RParen          ")" at 629:64-629:65
-7589: Arrow           "->" at 629:66-629:68 (leading: Space)
-7590: Ident           "float16" at 629:69-629:76 (leading: Space)
-7591: Semicolon       ";" at 629:76-629:77
-7592: At              "@" at 630:5-630:6 (leading: Newline, Space)
-7593: Ident           "intrinsic" at 630:6-630:15
-7594: At              "@" at 630:16-630:17 (leading: Space)
-7595: Ident           "overload" at 630:17-630:25
-7596: KwFn            "fn" at 630:26-630:28 (leading: Space)
-7597: Ident           "__to" at 630:29-630:33 (leading: Space)
-7598: LParen          "(" at 630:33-630:34
-7599: Ident           "self" at 630:34-630:38
-7600: Colon           ":" at 630:38-630:39
-7601: Ident           "float64" at 630:40-630:47 (leading: Space)
-7602: Comma           "," at 630:47-630:48
-7603: Ident           "target" at 630:49-630:55 (leading: Space)
-7604: Colon           ":" at 630:55-630:56
-7605: Ident           "float32" at 630:57-630:64 (leading: Space)
-7606: RParen          ")" at 630:64-630:65
-7607: Arrow           "->" at 630:66-630:68 (leading: Space)
-7608: Ident           "float32" at 630:69-630:76 (leading: Space)
-7609: Semicolon       ";" at 630:76-630:77
-7610: At              "@" at 631:5-631:6 (leading: Newline, Space)
-7611: Ident           "intrinsic" at 631:6-631:15
-7612: KwPub           "pub" at 631:16-631:19 (leading: Space)
-7613: KwFn            "fn" at 631:20-631:22 (leading: Space)
-7614: Ident           "from_str" at 631:23-631:31 (leading: Space)
-7615: LParen          "(" at 631:31-631:32
-7616: Ident           "s" at 631:32-631:33
-7617: Colon           ":" at 631:33-631:34
-7618: Amp             "&" at 631:35-631:36 (leading: Space)
-7619: Ident           "string" at 631:36-631:42
-7620: RParen          ")" at 631:42-631:43
-7621: Arrow           "->" at 631:44-631:46 (leading: Space)
-7622: Ident           "Erring" at 631:47-631:53 (leading: Space)
-7623: Lt              "<" at 631:53-631:54
-7624: Ident           "float64" at 631:54-631:61
-7625: Comma           "," at 631:61-631:62
-7626: Ident           "Error" at 631:63-631:68 (leading: Space)
-7627: Gt              ">" at 631:68-631:69
-7628: Semicolon       ";" at 631:69-631:70
-7629: RBrace          "}" at 632:1-632:2 (leading: Newline)
-7630: KwExtern        "extern" at 634:1-634:7 (leading: Newline)
-7631: Lt              "<" at 634:7-634:8
-7632: Ident           "float" at 634:8-634:13
-7633: Gt              ">" at 634:13-634:14
-7634: LBrace          "{" at 634:15-634:16 (leading: Space)
-7635: At              "@" at 635:5-635:6 (leading: Newline, Space)
-7636: Ident           "intrinsic" at 635:6-635:15
-7637: KwFn            "fn" at 635:16-635:18 (leading: Space)
-7638: Ident           "__add" at 635:19-635:24 (leading: Space)
-7639: LParen          "(" at 635:24-635:25
-7640: Ident           "self" at 635:25-635:29
-7641: Colon           ":" at 635:29-635:30
-7642: Ident           "float" at 635:31-635:36 (leading: Space)
-7643: Comma           "," at 635:36-635:37
-7644: Ident           "other" at 635:38-635:43 (leading: Space)
-7645: Colon           ":" at 635:43-635:44
-7646: Ident           "float" at 635:45-635:50 (leading: Space)
-7647: RParen          ")" at 635:50-635:51
-7648: Arrow           "->" at 635:52-635:54 (leading: Space)
-7649: Ident           "float" at 635:55-635:60 (leading: Space)
-7650: Semicolon       ";" at 635:60-635:61
-7651: At              "@" at 636:5-636:6 (leading: Newline, Space)
-7652: Ident           "intrinsic" at 636:6-636:15
-7653: KwFn            "fn" at 636:16-636:18 (leading: Space)
-7654: Ident           "__sub" at 636:19-636:24 (leading: Space)
-7655: LParen          "(" at 636:24-636:25
-7656: Ident           "self" at 636:25-636:29
-7657: Colon           ":" at 636:29-636:30
-7658: Ident           "float" at 636:31-636:36 (leading: Space)
-7659: Comma           "," at 636:36-636:37
-7660: Ident           "other" at 636:38-636:43 (leading: Space)
-7661: Colon           ":" at 636:43-636:44
-7662: Ident           "float" at 636:45-636:50 (leading: Space)
-7663: RParen          ")" at 636:50-636:51
-7664: Arrow           "->" at 636:52-636:54 (leading: Space)
-7665: Ident           "float" at 636:55-636:60 (leading: Space)
-7666: Semicolon       ";" at 636:60-636:61
-7667: At              "@" at 637:5-637:6 (leading: Newline, Space)
-7668: Ident           "intrinsic" at 637:6-637:15
-7669: KwFn            "fn" at 637:16-637:18 (leading: Space)
-7670: Ident           "__mul" at 637:19-637:24 (leading: Space)
-7671: LParen          "(" at 637:24-637:25
-7672: Ident           "self" at 637:25-637:29
-7673: Colon           ":" at 637:29-637:30
-7674: Ident           "float" at 637:31-637:36 (leading: Space)
-7675: Comma           "," at 637:36-637:37
-7676: Ident           "other" at 637:38-637:43 (leading: Space)
-7677: Colon           ":" at 637:43-637:44
-7678: Ident           "float" at 637:45-637:50 (leading: Space)
-7679: RParen          ")" at 637:50-637:51
-7680: Arrow           "->" at 637:52-637:54 (leading: Space)
-7681: Ident           "float" at 637:55-637:60 (leading: Space)
-7682: Semicolon       ";" at 637:60-637:61
-7683: At              "@" at 638:5-638:6 (leading: Newline, Space)
-7684: Ident           "intrinsic" at 638:6-638:15
-7685: KwFn            "fn" at 638:16-638:18 (leading: Space)
-7686: Ident           "__div" at 638:19-638:24 (leading: Space)
-7687: LParen          "(" at 638:24-638:25
-7688: Ident           "self" at 638:25-638:29
-7689: Colon           ":" at 638:29-638:30
-7690: Ident           "float" at 638:31-638:36 (leading: Space)
-7691: Comma           "," at 638:36-638:37
-7692: Ident           "other" at 638:38-638:43 (leading: Space)
-7693: Colon           ":" at 638:43-638:44
-7694: Ident           "float" at 638:45-638:50 (leading: Space)
-7695: RParen          ")" at 638:50-638:51
-7696: Arrow           "->" at 638:52-638:54 (leading: Space)
-7697: Ident           "float" at 638:55-638:60 (leading: Space)
-7698: Semicolon       ";" at 638:60-638:61
-7699: At              "@" at 639:5-639:6 (leading: Newline, Space)
-7700: Ident           "intrinsic" at 639:6-639:15
-7701: KwFn            "fn" at 639:16-639:18 (leading: Space)
-7702: Ident           "__mod" at 639:19-639:24 (leading: Space)
-7703: LParen          "(" at 639:24-639:25
-7704: Ident           "self" at 639:25-639:29
-7705: Colon           ":" at 639:29-639:30
-7706: Ident           "float" at 639:31-639:36 (leading: Space)
-7707: Comma           "," at 639:36-639:37
-7708: Ident           "other" at 639:38-639:43 (leading: Space)
-7709: Colon           ":" at 639:43-639:44
-7710: Ident           "float" at 639:45-639:50 (leading: Space)
-7711: RParen          ")" at 639:50-639:51
-7712: Arrow           "->" at 639:52-639:54 (leading: Space)
-7713: Ident           "float" at 639:55-639:60 (leading: Space)
-7714: Semicolon       ";" at 639:60-639:61
-7715: At              "@" at 640:5-640:6 (leading: Newline, Space)
-7716: Ident           "intrinsic" at 640:6-640:15
-7717: KwFn            "fn" at 640:16-640:18 (leading: Space)
-7718: Ident           "__lt" at 640:19-640:23 (leading: Space)
-7719: LParen          "(" at 640:23-640:24
-7720: Ident           "self" at 640:24-640:28
-7721: Colon           ":" at 640:28-640:29
-7722: Ident           "float" at 640:30-640:35 (leading: Space)
-7723: Comma           "," at 640:35-640:36
-7724: Ident           "other" at 640:37-640:42 (leading: Space)
-7725: Colon           ":" at 640:42-640:43
-7726: Ident           "float" at 640:44-640:49 (leading: Space)
-7727: RParen          ")" at 640:49-640:50
-7728: Arrow           "->" at 640:51-640:53 (leading: Space)
-7729: Ident           "bool" at 640:54-640:58 (leading: Space)
-7730: Semicolon       ";" at 640:58-640:59
-7731: At              "@" at 641:5-641:6 (leading: Newline, Space)
-7732: Ident           "intrinsic" at 641:6-641:15
-7733: KwFn            "fn" at 641:16-641:18 (leading: Space)
-7734: Ident           "__le" at 641:19-641:23 (leading: Space)
-7735: LParen          "(" at 641:23-641:24
-7736: Ident           "self" at 641:24-641:28
-7737: Colon           ":" at 641:28-641:29
-7738: Ident           "float" at 641:30-641:35 (leading: Space)
-7739: Comma           "," at 641:35-641:36
-7740: Ident           "other" at 641:37-641:42 (leading: Space)
-7741: Colon           ":" at 641:42-641:43
-7742: Ident           "float" at 641:44-641:49 (leading: Space)
-7743: RParen          ")" at 641:49-641:50
-7744: Arrow           "->" at 641:51-641:53 (leading: Space)
-7745: Ident           "bool" at 641:54-641:58 (leading: Space)
-7746: Semicolon       ";" at 641:58-641:59
-7747: At              "@" at 642:5-642:6 (leading: Newline, Space)
-7748: Ident           "intrinsic" at 642:6-642:15
-7749: KwFn            "fn" at 642:16-642:18 (leading: Space)
-7750: Ident           "__eq" at 642:19-642:23 (leading: Space)
-7751: LParen          "(" at 642:23-642:24
-7752: Ident           "self" at 642:24-642:28
-7753: Colon           ":" at 642:28-642:29
-7754: Ident           "float" at 642:30-642:35 (leading: Space)
-7755: Comma           "," at 642:35-642:36
-7756: Ident           "other" at 642:37-642:42 (leading: Space)
-7757: Colon           ":" at 642:42-642:43
-7758: Ident           "float" at 642:44-642:49 (leading: Space)
-7759: RParen          ")" at 642:49-642:50
-7760: Arrow           "->" at 642:51-642:53 (leading: Space)
-7761: Ident           "bool" at 642:54-642:58 (leading: Space)
-7762: Semicolon       ";" at 642:58-642:59
-7763: At              "@" at 643:5-643:6 (leading: Newline, Space)
-7764: Ident           "intrinsic" at 643:6-643:15
-7765: KwFn            "fn" at 643:16-643:18 (leading: Space)
-7766: Ident           "__ne" at 643:19-643:23 (leading: Space)
-7767: LParen          "(" at 643:23-643:24
-7768: Ident           "self" at 643:24-643:28
-7769: Colon           ":" at 643:28-643:29
-7770: Ident           "float" at 643:30-643:35 (leading: Space)
-7771: Comma           "," at 643:35-643:36
-7772: Ident           "other" at 643:37-643:42 (leading: Space)
-7773: Colon           ":" at 643:42-643:43
-7774: Ident           "float" at 643:44-643:49 (leading: Space)
-7775: RParen          ")" at 643:49-643:50
-7776: Arrow           "->" at 643:51-643:53 (leading: Space)
-7777: Ident           "bool" at 643:54-643:58 (leading: Space)
-7778: Semicolon       ";" at 643:58-643:59
-7779: At              "@" at 644:5-644:6 (leading: Newline, Space)
-7780: Ident           "intrinsic" at 644:6-644:15
-7781: KwFn            "fn" at 644:16-644:18 (leading: Space)
-7782: Ident           "__ge" at 644:19-644:23 (leading: Space)
-7783: LParen          "(" at 644:23-644:24
-7784: Ident           "self" at 644:24-644:28
-7785: Colon           ":" at 644:28-644:29
-7786: Ident           "float" at 644:30-644:35 (leading: Space)
-7787: Comma           "," at 644:35-644:36
-7788: Ident           "other" at 644:37-644:42 (leading: Space)
-7789: Colon           ":" at 644:42-644:43
-7790: Ident           "float" at 644:44-644:49 (leading: Space)
-7791: RParen          ")" at 644:49-644:50
-7792: Arrow           "->" at 644:51-644:53 (leading: Space)
-7793: Ident           "bool" at 644:54-644:58 (leading: Space)
-7794: Semicolon       ";" at 644:58-644:59
-7795: At              "@" at 645:5-645:6 (leading: Newline, Space)
-7796: Ident           "intrinsic" at 645:6-645:15
-7797: KwFn            "fn" at 645:16-645:18 (leading: Space)
-7798: Ident           "__gt" at 645:19-645:23 (leading: Space)
-7799: LParen          "(" at 645:23-645:24
-7800: Ident           "self" at 645:24-645:28
-7801: Colon           ":" at 645:28-645:29
-7802: Ident           "float" at 645:30-645:35 (leading: Space)
-7803: Comma           "," at 645:35-645:36
-7804: Ident           "other" at 645:37-645:42 (leading: Space)
-7805: Colon           ":" at 645:42-645:43
-7806: Ident           "float" at 645:44-645:49 (leading: Space)
-7807: RParen          ")" at 645:49-645:50
-7808: Arrow           "->" at 645:51-645:53 (leading: Space)
-7809: Ident           "bool" at 645:54-645:58 (leading: Space)
-7810: Semicolon       ";" at 645:58-645:59
-7811: At              "@" at 646:5-646:6 (leading: Newline, Space)
-7812: Ident           "intrinsic" at 646:6-646:15
-7813: KwFn            "fn" at 646:16-646:18 (leading: Space)
-7814: Ident           "__pos" at 646:19-646:24 (leading: Space)
-7815: LParen          "(" at 646:24-646:25
-7816: Ident           "self" at 646:25-646:29
-7817: Colon           ":" at 646:29-646:30
-7818: Ident           "float" at 646:31-646:36 (leading: Space)
-7819: RParen          ")" at 646:36-646:37
-7820: Arrow           "->" at 646:38-646:40 (leading: Space)
-7821: Ident           "float" at 646:41-646:46 (leading: Space)
-7822: Semicolon       ";" at 646:46-646:47
-7823: At              "@" at 647:5-647:6 (leading: Newline, Space)
-7824: Ident           "intrinsic" at 647:6-647:15
-7825: KwFn            "fn" at 647:16-647:18 (leading: Space)
-7826: Ident           "__neg" at 647:19-647:24 (leading: Space)
-7827: LParen          "(" at 647:24-647:25
-7828: Ident           "self" at 647:25-647:29
-7829: Colon           ":" at 647:29-647:30
-7830: Ident           "float" at 647:31-647:36 (leading: Space)
-7831: RParen          ")" at 647:36-647:37
-7832: Arrow           "->" at 647:38-647:40 (leading: Space)
-7833: Ident           "float" at 647:41-647:46 (leading: Space)
-7834: Semicolon       ";" at 647:46-647:47
-7835: At              "@" at 648:5-648:6 (leading: Newline, Space)
-7836: Ident           "intrinsic" at 648:6-648:15
-7837: KwFn            "fn" at 648:16-648:18 (leading: Space)
-7838: Ident           "__abs" at 648:19-648:24 (leading: Space)
-7839: LParen          "(" at 648:24-648:25
-7840: Ident           "self" at 648:25-648:29
-7841: Colon           ":" at 648:29-648:30
-7842: Ident           "float" at 648:31-648:36 (leading: Space)
-7843: RParen          ")" at 648:36-648:37
-7844: Arrow           "->" at 648:38-648:40 (leading: Space)
-7845: Ident           "float" at 648:41-648:46 (leading: Space)
-7846: Semicolon       ";" at 648:46-648:47
-7847: At              "@" at 649:5-649:6 (leading: Newline, Space)
-7848: Ident           "intrinsic" at 649:6-649:15
-7849: KwFn            "fn" at 649:16-649:18 (leading: Space)
-7850: Ident           "__to" at 649:19-649:23 (leading: Space)
-7851: LParen          "(" at 649:23-649:24
-7852: Ident           "self" at 649:24-649:28
-7853: Colon           ":" at 649:28-649:29
-7854: Ident           "float" at 649:30-649:35 (leading: Space)
-7855: Comma           "," at 649:35-649:36
-7856: Ident           "target" at 649:37-649:43 (leading: Space)
-7857: Colon           ":" at 649:43-649:44
-7858: Ident           "string" at 649:45-649:51 (leading: Space)
-7859: RParen          ")" at 649:51-649:52
-7860: Arrow           "->" at 649:53-649:55 (leading: Space)
-7861: Ident           "string" at 649:56-649:62 (leading: Space)
-7862: Semicolon       ";" at 649:62-649:63
-7863: At              "@" at 650:5-650:6 (leading: Newline, Space)
-7864: Ident           "overload" at 650:6-650:14
-7865: KwPub           "pub" at 650:15-650:18 (leading: Space)
-7866: KwFn            "fn" at 650:19-650:21 (leading: Space)
-7867: Ident           "__to" at 650:22-650:26 (leading: Space)
-7868: LParen          "(" at 650:26-650:27
-7869: Ident           "self" at 650:27-650:31
-7870: Colon           ":" at 650:31-650:32
-7871: Amp             "&" at 650:33-650:34 (leading: Space)
-7872: Ident           "float" at 650:34-650:39
-7873: Comma           "," at 650:39-650:40
-7874: Underscore      "_" at 650:41-650:42 (leading: Space)
-7875: Colon           ":" at 650:42-650:43
-7876: Ident           "string" at 650:44-650:50 (leading: Space)
-7877: RParen          ")" at 650:50-650:51
-7878: Arrow           "->" at 650:52-650:54 (leading: Space)
-7879: Ident           "string" at 650:55-650:61 (leading: Space)
-7880: LBrace          "{" at 650:62-650:63 (leading: Space)
-7881: KwReturn        "return" at 651:9-651:15 (leading: Newline, Space)
-7882: LParen          "(" at 651:16-651:17 (leading: Space)
-7883: Star            "*" at 651:17-651:18
-7884: Ident           "self" at 651:18-651:22
-7885: RParen          ")" at 651:22-651:23
-7886: KwTo            "to" at 651:24-651:26 (leading: Space)
-7887: Ident           "string" at 651:27-651:33 (leading: Space)
-7888: Semicolon       ";" at 651:33-651:34
-7889: RBrace          "}" at 652:5-652:6 (leading: Newline, Space)
-7890: At              "@" at 653:5-653:6 (leading: Newline, Space)
-7891: Ident           "intrinsic" at 653:6-653:15
-7892: At              "@" at 653:16-653:17 (leading: Space)
-7893: Ident           "overload" at 653:17-653:25
-7894: KwFn            "fn" at 653:26-653:28 (leading: Space)
-7895: Ident           "__to" at 653:29-653:33 (leading: Space)
-7896: LParen          "(" at 653:33-653:34
-7897: Ident           "self" at 653:34-653:38
-7898: Colon           ":" at 653:38-653:39
-7899: Ident           "float" at 653:40-653:45 (leading: Space)
-7900: Comma           "," at 653:45-653:46
-7901: Ident           "target" at 653:47-653:53 (leading: Space)
-7902: Colon           ":" at 653:53-653:54
-7903: Ident           "int" at 653:55-653:58 (leading: Space)
-7904: RParen          ")" at 653:58-653:59
-7905: Arrow           "->" at 653:60-653:62 (leading: Space)
-7906: Ident           "int" at 653:63-653:66 (leading: Space)
-7907: Semicolon       ";" at 653:66-653:67
-7908: At              "@" at 654:5-654:6 (leading: Newline, Space)
-7909: Ident           "intrinsic" at 654:6-654:15
-7910: At              "@" at 654:16-654:17 (leading: Space)
-7911: Ident           "overload" at 654:17-654:25
-7912: KwFn            "fn" at 654:26-654:28 (leading: Space)
-7913: Ident           "__to" at 654:29-654:33 (leading: Space)
-7914: LParen          "(" at 654:33-654:34
-7915: Ident           "self" at 654:34-654:38
-7916: Colon           ":" at 654:38-654:39
-7917: Ident           "float" at 654:40-654:45 (leading: Space)
-7918: Comma           "," at 654:45-654:46
-7919: Ident           "target" at 654:47-654:53 (leading: Space)
-7920: Colon           ":" at 654:53-654:54
-7921: Ident           "uint" at 654:55-654:59 (leading: Space)
-7922: RParen          ")" at 654:59-654:60
-7923: Arrow           "->" at 654:61-654:63 (leading: Space)
-7924: Ident           "uint" at 654:64-654:68 (leading: Space)
-7925: Semicolon       ";" at 654:68-654:69
-7926: At              "@" at 655:5-655:6 (leading: Newline, Space)
-7927: Ident           "intrinsic" at 655:6-655:15
-7928: At              "@" at 655:16-655:17 (leading: Space)
-7929: Ident           "overload" at 655:17-655:25
-7930: KwFn            "fn" at 655:26-655:28 (leading: Space)
-7931: Ident           "__to" at 655:29-655:33 (leading: Space)
-7932: LParen          "(" at 655:33-655:34
-7933: Ident           "self" at 655:34-655:38
-7934: Colon           ":" at 655:38-655:39
-7935: Ident           "float" at 655:40-655:45 (leading: Space)
-7936: Comma           "," at 655:45-655:46
-7937: Ident           "target" at 655:47-655:53 (leading: Space)
-7938: Colon           ":" at 655:53-655:54
-7939: Ident           "int8" at 655:55-655:59 (leading: Space)
-7940: RParen          ")" at 655:59-655:60
-7941: Arrow           "->" at 655:61-655:63 (leading: Space)
-7942: Ident           "int8" at 655:64-655:68 (leading: Space)
-7943: Semicolon       ";" at 655:68-655:69
-7944: At              "@" at 656:5-656:6 (leading: Newline, Space)
-7945: Ident           "intrinsic" at 656:6-656:15
-7946: At              "@" at 656:16-656:17 (leading: Space)
-7947: Ident           "overload" at 656:17-656:25
-7948: KwFn            "fn" at 656:26-656:28 (leading: Space)
-7949: Ident           "__to" at 656:29-656:33 (leading: Space)
-7950: LParen          "(" at 656:33-656:34
-7951: Ident           "self" at 656:34-656:38
-7952: Colon           ":" at 656:38-656:39
-7953: Ident           "float" at 656:40-656:45 (leading: Space)
-7954: Comma           "," at 656:45-656:46
-7955: Ident           "target" at 656:47-656:53 (leading: Space)
-7956: Colon           ":" at 656:53-656:54
-7957: Ident           "int16" at 656:55-656:60 (leading: Space)
-7958: RParen          ")" at 656:60-656:61
-7959: Arrow           "->" at 656:62-656:64 (leading: Space)
-7960: Ident           "int16" at 656:65-656:70 (leading: Space)
-7961: Semicolon       ";" at 656:70-656:71
-7962: At              "@" at 657:5-657:6 (leading: Newline, Space)
-7963: Ident           "intrinsic" at 657:6-657:15
-7964: At              "@" at 657:16-657:17 (leading: Space)
-7965: Ident           "overload" at 657:17-657:25
-7966: KwFn            "fn" at 657:26-657:28 (leading: Space)
-7967: Ident           "__to" at 657:29-657:33 (leading: Space)
-7968: LParen          "(" at 657:33-657:34
-7969: Ident           "self" at 657:34-657:38
-7970: Colon           ":" at 657:38-657:39
-7971: Ident           "float" at 657:40-657:45 (leading: Space)
-7972: Comma           "," at 657:45-657:46
-7973: Ident           "target" at 657:47-657:53 (leading: Space)
-7974: Colon           ":" at 657:53-657:54
-7975: Ident           "int32" at 657:55-657:60 (leading: Space)
-7976: RParen          ")" at 657:60-657:61
-7977: Arrow           "->" at 657:62-657:64 (leading: Space)
-7978: Ident           "int32" at 657:65-657:70 (leading: Space)
-7979: Semicolon       ";" at 657:70-657:71
-7980: At              "@" at 658:5-658:6 (leading: Newline, Space)
-7981: Ident           "intrinsic" at 658:6-658:15
-7982: At              "@" at 658:16-658:17 (leading: Space)
-7983: Ident           "overload" at 658:17-658:25
-7984: KwFn            "fn" at 658:26-658:28 (leading: Space)
-7985: Ident           "__to" at 658:29-658:33 (leading: Space)
-7986: LParen          "(" at 658:33-658:34
-7987: Ident           "self" at 658:34-658:38
-7988: Colon           ":" at 658:38-658:39
-7989: Ident           "float" at 658:40-658:45 (leading: Space)
-7990: Comma           "," at 658:45-658:46
-7991: Ident           "target" at 658:47-658:53 (leading: Space)
-7992: Colon           ":" at 658:53-658:54
-7993: Ident           "int64" at 658:55-658:60 (leading: Space)
-7994: RParen          ")" at 658:60-658:61
-7995: Arrow           "->" at 658:62-658:64 (leading: Space)
-7996: Ident           "int64" at 658:65-658:70 (leading: Space)
-7997: Semicolon       ";" at 658:70-658:71
-7998: At              "@" at 659:5-659:6 (leading: Newline, Space)
-7999: Ident           "intrinsic" at 659:6-659:15
-8000: At              "@" at 659:16-659:17 (leading: Space)
-8001: Ident           "overload" at 659:17-659:25
-8002: KwFn            "fn" at 659:26-659:28 (leading: Space)
-8003: Ident           "__to" at 659:29-659:33 (leading: Space)
-8004: LParen          "(" at 659:33-659:34
-8005: Ident           "self" at 659:34-659:38
-8006: Colon           ":" at 659:38-659:39
-8007: Ident           "float" at 659:40-659:45 (leading: Space)
-8008: Comma           "," at 659:45-659:46
-8009: Ident           "target" at 659:47-659:53 (leading: Space)
-8010: Colon           ":" at 659:53-659:54
-8011: Ident           "uint8" at 659:55-659:60 (leading: Space)
-8012: RParen          ")" at 659:60-659:61
-8013: Arrow           "->" at 659:62-659:64 (leading: Space)
-8014: Ident           "uint8" at 659:65-659:70 (leading: Space)
-8015: Semicolon       ";" at 659:70-659:71
-8016: At              "@" at 660:5-660:6 (leading: Newline, Space)
-8017: Ident           "intrinsic" at 660:6-660:15
-8018: At              "@" at 660:16-660:17 (leading: Space)
-8019: Ident           "overload" at 660:17-660:25
-8020: KwFn            "fn" at 660:26-660:28 (leading: Space)
-8021: Ident           "__to" at 660:29-660:33 (leading: Space)
-8022: LParen          "(" at 660:33-660:34
-8023: Ident           "self" at 660:34-660:38
-8024: Colon           ":" at 660:38-660:39
-8025: Ident           "float" at 660:40-660:45 (leading: Space)
-8026: Comma           "," at 660:45-660:46
-8027: Ident           "target" at 660:47-660:53 (leading: Space)
-8028: Colon           ":" at 660:53-660:54
-8029: Ident           "uint16" at 660:55-660:61 (leading: Space)
-8030: RParen          ")" at 660:61-660:62
-8031: Arrow           "->" at 660:63-660:65 (leading: Space)
-8032: Ident           "uint16" at 660:66-660:72 (leading: Space)
-8033: Semicolon       ";" at 660:72-660:73
-8034: At              "@" at 661:5-661:6 (leading: Newline, Space)
-8035: Ident           "intrinsic" at 661:6-661:15
-8036: At              "@" at 661:16-661:17 (leading: Space)
-8037: Ident           "overload" at 661:17-661:25
-8038: KwFn            "fn" at 661:26-661:28 (leading: Space)
-8039: Ident           "__to" at 661:29-661:33 (leading: Space)
-8040: LParen          "(" at 661:33-661:34
-8041: Ident           "self" at 661:34-661:38
-8042: Colon           ":" at 661:38-661:39
-8043: Ident           "float" at 661:40-661:45 (leading: Space)
-8044: Comma           "," at 661:45-661:46
-8045: Ident           "target" at 661:47-661:53 (leading: Space)
-8046: Colon           ":" at 661:53-661:54
-8047: Ident           "uint32" at 661:55-661:61 (leading: Space)
-8048: RParen          ")" at 661:61-661:62
-8049: Arrow           "->" at 661:63-661:65 (leading: Space)
-8050: Ident           "uint32" at 661:66-661:72 (leading: Space)
-8051: Semicolon       ";" at 661:72-661:73
-8052: At              "@" at 662:5-662:6 (leading: Newline, Space)
-8053: Ident           "intrinsic" at 662:6-662:15
-8054: At              "@" at 662:16-662:17 (leading: Space)
-8055: Ident           "overload" at 662:17-662:25
-8056: KwFn            "fn" at 662:26-662:28 (leading: Space)
-8057: Ident           "__to" at 662:29-662:33 (leading: Space)
-8058: LParen          "(" at 662:33-662:34
-8059: Ident           "self" at 662:34-662:38
-8060: Colon           ":" at 662:38-662:39
-8061: Ident           "float" at 662:40-662:45 (leading: Space)
-8062: Comma           "," at 662:45-662:46
-8063: Ident           "target" at 662:47-662:53 (leading: Space)
-8064: Colon           ":" at 662:53-662:54
-8065: Ident           "uint64" at 662:55-662:61 (leading: Space)
-8066: RParen          ")" at 662:61-662:62
-8067: Arrow           "->" at 662:63-662:65 (leading: Space)
-8068: Ident           "uint64" at 662:66-662:72 (leading: Space)
-8069: Semicolon       ";" at 662:72-662:73
-8070: At              "@" at 663:5-663:6 (leading: Newline, Space)
-8071: Ident           "intrinsic" at 663:6-663:15
-8072: At              "@" at 663:16-663:17 (leading: Space)
-8073: Ident           "overload" at 663:17-663:25
-8074: KwFn            "fn" at 663:26-663:28 (leading: Space)
-8075: Ident           "__to" at 663:29-663:33 (leading: Space)
-8076: LParen          "(" at 663:33-663:34
-8077: Ident           "self" at 663:34-663:38
-8078: Colon           ":" at 663:38-663:39
-8079: Ident           "float" at 663:40-663:45 (leading: Space)
-8080: Comma           "," at 663:45-663:46
-8081: Ident           "target" at 663:47-663:53 (leading: Space)
-8082: Colon           ":" at 663:53-663:54
-8083: Ident           "float16" at 663:55-663:62 (leading: Space)
-8084: RParen          ")" at 663:62-663:63
-8085: Arrow           "->" at 663:64-663:66 (leading: Space)
-8086: Ident           "float16" at 663:67-663:74 (leading: Space)
-8087: Semicolon       ";" at 663:74-663:75
-8088: At              "@" at 664:5-664:6 (leading: Newline, Space)
-8089: Ident           "intrinsic" at 664:6-664:15
-8090: At              "@" at 664:16-664:17 (leading: Space)
-8091: Ident           "overload" at 664:17-664:25
-8092: KwFn            "fn" at 664:26-664:28 (leading: Space)
-8093: Ident           "__to" at 664:29-664:33 (leading: Space)
-8094: LParen          "(" at 664:33-664:34
-8095: Ident           "self" at 664:34-664:38
-8096: Colon           ":" at 664:38-664:39
-8097: Ident           "float" at 664:40-664:45 (leading: Space)
-8098: Comma           "," at 664:45-664:46
-8099: Ident           "target" at 664:47-664:53 (leading: Space)
-8100: Colon           ":" at 664:53-664:54
-8101: Ident           "float32" at 664:55-664:62 (leading: Space)
-8102: RParen          ")" at 664:62-664:63
-8103: Arrow           "->" at 664:64-664:66 (leading: Space)
-8104: Ident           "float32" at 664:67-664:74 (leading: Space)
-8105: Semicolon       ";" at 664:74-664:75
-8106: At              "@" at 665:5-665:6 (leading: Newline, Space)
-8107: Ident           "intrinsic" at 665:6-665:15
-8108: At              "@" at 665:16-665:17 (leading: Space)
-8109: Ident           "overload" at 665:17-665:25
-8110: KwFn            "fn" at 665:26-665:28 (leading: Space)
-8111: Ident           "__to" at 665:29-665:33 (leading: Space)
-8112: LParen          "(" at 665:33-665:34
-8113: Ident           "self" at 665:34-665:38
-8114: Colon           ":" at 665:38-665:39
-8115: Ident           "float" at 665:40-665:45 (leading: Space)
-8116: Comma           "," at 665:45-665:46
-8117: Ident           "target" at 665:47-665:53 (leading: Space)
-8118: Colon           ":" at 665:53-665:54
-8119: Ident           "float64" at 665:55-665:62 (leading: Space)
-8120: RParen          ")" at 665:62-665:63
-8121: Arrow           "->" at 665:64-665:66 (leading: Space)
-8122: Ident           "float64" at 665:67-665:74 (leading: Space)
-8123: Semicolon       ";" at 665:74-665:75
-8124: At              "@" at 667:5-667:6 (leading: Newline, Space, LineComment, Newline, Space)
-8125: Ident           "intrinsic" at 667:6-667:15
-8126: KwPub           "pub" at 667:16-667:19 (leading: Space)
-8127: KwFn            "fn" at 667:20-667:22 (leading: Space)
-8128: Ident           "from_str" at 667:23-667:31 (leading: Space)
-8129: LParen          "(" at 667:31-667:32
-8130: Ident           "s" at 667:32-667:33
-8131: Colon           ":" at 667:33-667:34
-8132: Amp             "&" at 667:35-667:36 (leading: Space)
-8133: Ident           "string" at 667:36-667:42
-8134: RParen          ")" at 667:42-667:43
-8135: Arrow           "->" at 667:44-667:46 (leading: Space)
-8136: Ident           "Erring" at 667:47-667:53 (leading: Space)
-8137: Lt              "<" at 667:53-667:54
-8138: Ident           "float" at 667:54-667:59
-8139: Comma           "," at 667:59-667:60
-8140: Ident           "Error" at 667:61-667:66 (leading: Space)
-8141: Gt              ">" at 667:66-667:67
-8142: Semicolon       ";" at 667:67-667:68
-8143: RBrace          "}" at 668:1-668:2 (leading: Newline)
-8144: KwExtern        "extern" at 670:1-670:7 (leading: Newline)
-8145: Lt              "<" at 670:7-670:8
-8146: Ident           "string" at 670:8-670:14
-8147: Gt              ">" at 670:14-670:15
-8148: LBrace          "{" at 670:16-670:17 (leading: Space)
-8149: At              "@" at 671:5-671:6 (leading: Newline, Space)
-8150: Ident           "intrinsic" at 671:6-671:15
-8151: KwFn            "fn" at 671:16-671:18 (leading: Space)
-8152: Ident           "__add" at 671:19-671:24 (leading: Space)
-8153: LParen          "(" at 671:24-671:25
-8154: Ident           "self" at 671:25-671:29
-8155: Colon           ":" at 671:29-671:30
-8156: Amp             "&" at 671:31-671:32 (leading: Space)
-8157: Ident           "string" at 671:32-671:38
-8158: Comma           "," at 671:38-671:39
-8159: Ident           "other" at 671:40-671:45 (leading: Space)
-8160: Colon           ":" at 671:45-671:46
-8161: Amp             "&" at 671:47-671:48 (leading: Space)
-8162: Ident           "string" at 671:48-671:54
-8163: RParen          ")" at 671:54-671:55
-8164: Arrow           "->" at 671:56-671:58 (leading: Space)
-8165: Ident           "string" at 671:59-671:65 (leading: Space)
-8166: Semicolon       ";" at 671:65-671:66
-8167: At              "@" at 672:5-672:6 (leading: Newline, Space)
-8168: Ident           "intrinsic" at 672:6-672:15
-8169: KwFn            "fn" at 672:16-672:18 (leading: Space)
-8170: Ident           "__mul" at 672:19-672:24 (leading: Space)
-8171: LParen          "(" at 672:24-672:25
-8172: Ident           "self" at 672:25-672:29
-8173: Colon           ":" at 672:29-672:30
-8174: Amp             "&" at 672:31-672:32 (leading: Space)
-8175: Ident           "string" at 672:32-672:38
-8176: Comma           "," at 672:38-672:39
-8177: Ident           "other" at 672:40-672:45 (leading: Space)
-8178: Colon           ":" at 672:45-672:46
-8179: Ident           "int" at 672:47-672:50 (leading: Space)
-8180: RParen          ")" at 672:50-672:51
-8181: Arrow           "->" at 672:52-672:54 (leading: Space)
-8182: Ident           "string" at 672:55-672:61 (leading: Space)
-8183: Semicolon       ";" at 672:61-672:62
-8184: At              "@" at 673:5-673:6 (leading: Newline, Space)
-8185: Ident           "overload" at 673:6-673:14
-8186: KwPub           "pub" at 673:15-673:18 (leading: Space)
-8187: KwFn            "fn" at 673:19-673:21 (leading: Space)
-8188: Ident           "__mul" at 673:22-673:27 (leading: Space)
-8189: LParen          "(" at 673:27-673:28
-8190: Ident           "self" at 673:28-673:32
-8191: Colon           ":" at 673:32-673:33
-8192: Amp             "&" at 673:34-673:35 (leading: Space)
-8193: Ident           "string" at 673:35-673:41
-8194: Comma           "," at 673:41-673:42
-8195: Ident           "other" at 673:43-673:48 (leading: Space)
-8196: Colon           ":" at 673:48-673:49
-8197: Ident           "uint" at 673:50-673:54 (leading: Space)
-8198: RParen          ")" at 673:54-673:55
-8199: Arrow           "->" at 673:56-673:58 (leading: Space)
-8200: Ident           "string" at 673:59-673:65 (leading: Space)
-8201: LBrace          "{" at 673:66-673:67 (leading: Space)
-8202: KwReturn        "return" at 674:9-674:15 (leading: Newline, Space)
-8203: Ident           "self" at 674:16-674:20 (leading: Space)
-8204: Star            "*" at 674:21-674:22 (leading: Space)
-8205: LParen          "(" at 674:23-674:24 (leading: Space)
-8206: Ident           "other" at 674:24-674:29
-8207: KwTo            "to" at 674:30-674:32 (leading: Space)
-8208: Ident           "int" at 674:33-674:36 (leading: Space)
-8209: RParen          ")" at 674:36-674:37
-8210: Semicolon       ";" at 674:37-674:38
-8211: RBrace          "}" at 675:5-675:6 (leading: Newline, Space)
-8212: At              "@" at 676:5-676:6 (leading: Newline, Space)
-8213: Ident           "intrinsic" at 676:6-676:15
-8214: KwFn            "fn" at 676:16-676:18 (leading: Space)
-8215: Ident           "__eq" at 676:19-676:23 (leading: Space)
-8216: LParen          "(" at 676:23-676:24
-8217: Ident           "self" at 676:24-676:28
-8218: Colon           ":" at 676:28-676:29
-8219: Amp             "&" at 676:30-676:31 (leading: Space)
-8220: Ident           "string" at 676:31-676:37
-8221: Comma           "," at 676:37-676:38
-8222: Ident           "other" at 676:39-676:44 (leading: Space)
-8223: Colon           ":" at 676:44-676:45
-8224: Amp             "&" at 676:46-676:47 (leading: Space)
-8225: Ident           "string" at 676:47-676:53
-8226: RParen          ")" at 676:53-676:54
-8227: Arrow           "->" at 676:55-676:57 (leading: Space)
-8228: Ident           "bool" at 676:58-676:62 (leading: Space)
-8229: Semicolon       ";" at 676:62-676:63
-8230: At              "@" at 677:5-677:6 (leading: Newline, Space)
-8231: Ident           "intrinsic" at 677:6-677:15
-8232: KwFn            "fn" at 677:16-677:18 (leading: Space)
-8233: Ident           "__ne" at 677:19-677:23 (leading: Space)
-8234: LParen          "(" at 677:23-677:24
-8235: Ident           "self" at 677:24-677:28
-8236: Colon           ":" at 677:28-677:29
-8237: Amp             "&" at 677:30-677:31 (leading: Space)
-8238: Ident           "string" at 677:31-677:37
-8239: Comma           "," at 677:37-677:38
-8240: Ident           "other" at 677:39-677:44 (leading: Space)
-8241: Colon           ":" at 677:44-677:45
-8242: Amp             "&" at 677:46-677:47 (leading: Space)
-8243: Ident           "string" at 677:47-677:53
-8244: RParen          ")" at 677:53-677:54
-8245: Arrow           "->" at 677:55-677:57 (leading: Space)
-8246: Ident           "bool" at 677:58-677:62 (leading: Space)
-8247: Semicolon       ";" at 677:62-677:63
-8248: At              "@" at 678:5-678:6 (leading: Newline, Space)
-8249: Ident           "intrinsic" at 678:6-678:15
-8250: KwFn            "fn" at 678:16-678:18 (leading: Space)
-8251: Ident           "__to" at 678:19-678:23 (leading: Space)
-8252: LParen          "(" at 678:23-678:24
-8253: Ident           "self" at 678:24-678:28
-8254: Colon           ":" at 678:28-678:29
-8255: Amp             "&" at 678:30-678:31 (leading: Space)
-8256: Ident           "string" at 678:31-678:37
-8257: Comma           "," at 678:37-678:38
-8258: Ident           "target" at 678:39-678:45 (leading: Space)
-8259: Colon           ":" at 678:45-678:46
-8260: Ident           "int" at 678:47-678:50 (leading: Space)
-8261: RParen          ")" at 678:50-678:51
-8262: Arrow           "->" at 678:52-678:54 (leading: Space)
-8263: Ident           "int" at 678:55-678:58 (leading: Space)
-8264: Semicolon       ";" at 678:58-678:59
-8265: At              "@" at 679:5-679:6 (leading: Newline, Space)
-8266: Ident           "intrinsic" at 679:6-679:15
-8267: At              "@" at 679:16-679:17 (leading: Space)
-8268: Ident           "overload" at 679:17-679:25
-8269: KwFn            "fn" at 679:26-679:28 (leading: Space)
-8270: Ident           "__to" at 679:29-679:33 (leading: Space)
-8271: LParen          "(" at 679:33-679:34
-8272: Ident           "self" at 679:34-679:38
-8273: Colon           ":" at 679:38-679:39
-8274: Amp             "&" at 679:40-679:41 (leading: Space)
-8275: Ident           "string" at 679:41-679:47
-8276: Comma           "," at 679:47-679:48
-8277: Ident           "target" at 679:49-679:55 (leading: Space)
-8278: Colon           ":" at 679:55-679:56
-8279: Ident           "uint" at 679:57-679:61 (leading: Space)
-8280: RParen          ")" at 679:61-679:62
-8281: Arrow           "->" at 679:63-679:65 (leading: Space)
-8282: Ident           "uint" at 679:66-679:70 (leading: Space)
-8283: Semicolon       ";" at 679:70-679:71
-8284: At              "@" at 680:5-680:6 (leading: Newline, Space)
-8285: Ident           "intrinsic" at 680:6-680:15
-8286: At              "@" at 680:16-680:17 (leading: Space)
-8287: Ident           "overload" at 680:17-680:25
-8288: KwFn            "fn" at 680:26-680:28 (leading: Space)
-8289: Ident           "__to" at 680:29-680:33 (leading: Space)
-8290: LParen          "(" at 680:33-680:34
-8291: Ident           "self" at 680:34-680:38
-8292: Colon           ":" at 680:38-680:39
-8293: Amp             "&" at 680:40-680:41 (leading: Space)
-8294: Ident           "string" at 680:41-680:47
-8295: Comma           "," at 680:47-680:48
-8296: Ident           "target" at 680:49-680:55 (leading: Space)
-8297: Colon           ":" at 680:55-680:56
-8298: Ident           "float" at 680:57-680:62 (leading: Space)
-8299: RParen          ")" at 680:62-680:63
-8300: Arrow           "->" at 680:64-680:66 (leading: Space)
-8301: Ident           "float" at 680:67-680:72 (leading: Space)
-8302: Semicolon       ";" at 680:72-680:73
-8303: At              "@" at 681:5-681:6 (leading: Newline, Space)
-8304: Ident           "overload" at 681:6-681:14
-8305: KwPub           "pub" at 681:15-681:18 (leading: Space)
-8306: KwFn            "fn" at 681:19-681:21 (leading: Space)
-8307: Ident           "__to" at 681:22-681:26 (leading: Space)
-8308: LParen          "(" at 681:26-681:27
-8309: Ident           "self" at 681:27-681:31
-8310: Colon           ":" at 681:31-681:32
-8311: Amp             "&" at 681:33-681:34 (leading: Space)
-8312: Ident           "string" at 681:34-681:40
-8313: Comma           "," at 681:40-681:41
-8314: Underscore      "_" at 681:42-681:43 (leading: Space)
-8315: Colon           ":" at 681:43-681:44
-8316: Ident           "string" at 681:45-681:51 (leading: Space)
-8317: RParen          ")" at 681:51-681:52
-8318: Arrow           "->" at 681:53-681:55 (leading: Space)
-8319: Ident           "string" at 681:56-681:62 (leading: Space)
-8320: LBrace          "{" at 681:63-681:64 (leading: Space)
-8321: KwReturn        "return" at 682:9-682:15 (leading: Newline, Space)
-8322: Ident           "self" at 682:16-682:20 (leading: Space)
-8323: Dot             "." at 682:20-682:21
-8324: Ident           "__clone" at 682:21-682:28
-8325: LParen          "(" at 682:28-682:29
-8326: RParen          ")" at 682:29-682:30
-8327: Semicolon       ";" at 682:30-682:31
-8328: RBrace          "}" at 683:5-683:6 (leading: Newline, Space)
-8329: At              "@" at 684:5-684:6 (leading: Newline, Space)
-8330: Ident           "overload" at 684:6-684:14
-8331: KwPub           "pub" at 685:5-685:8 (leading: Newline, Space)
-8332: KwFn            "fn" at 685:9-685:11 (leading: Space)
-8333: Ident           "__to" at 685:12-685:16 (leading: Space)
-8334: LParen          "(" at 685:16-685:17
-8335: Ident           "self" at 685:17-685:21
-8336: Colon           ":" at 685:21-685:22
-8337: Amp             "&" at 685:23-685:24 (leading: Space)
-8338: Ident           "string" at 685:24-685:30
-8339: Comma           "," at 685:30-685:31
-8340: Underscore      "_" at 685:32-685:33 (leading: Space)
-8341: Colon           ":" at 685:33-685:34
-8342: Ident           "byte" at 685:35-685:39 (leading: Space)
-8343: LBracket        "[" at 685:39-685:40
-8344: RBracket        "]" at 685:40-685:41
-8345: RParen          ")" at 685:41-685:42
-8346: Arrow           "->" at 685:43-685:45 (leading: Space)
-8347: Ident           "byte" at 685:46-685:50 (leading: Space)
-8348: LBracket        "[" at 685:50-685:51
-8349: RBracket        "]" at 685:51-685:52
-8350: LBrace          "{" at 685:53-685:54 (leading: Space)
-8351: KwLet           "let" at 686:9-686:12 (leading: Newline, Space)
-8352: Ident           "view" at 686:13-686:17 (leading: Space)
-8353: Assign          "=" at 686:18-686:19 (leading: Space)
-8354: Ident           "self" at 686:20-686:24 (leading: Space)
-8355: Dot             "." at 686:24-686:25
-8356: Ident           "bytes" at 686:25-686:30
-8357: LParen          "(" at 686:30-686:31
-8358: RParen          ")" at 686:31-686:32
-8359: Semicolon       ";" at 686:32-686:33
-8360: KwLet           "let" at 687:9-687:12 (leading: Newline, Space)
-8361: Ident           "length" at 687:13-687:19 (leading: Space)
-8362: Colon           ":" at 687:19-687:20
-8363: Ident           "uint" at 687:21-687:25 (leading: Space)
-8364: Assign          "=" at 687:26-687:27 (leading: Space)
-8365: Ident           "view" at 687:28-687:32 (leading: Space)
-8366: Dot             "." at 687:32-687:33
-8367: Ident           "__len" at 687:33-687:38
-8368: LParen          "(" at 687:38-687:39
-8369: RParen          ")" at 687:39-687:40
-8370: Semicolon       ";" at 687:40-687:41
-8371: KwLet           "let" at 688:9-688:12 (leading: Newline, Space)
-8372: KwMut           "mut" at 688:13-688:16 (leading: Space)
-8373: Ident           "out" at 688:17-688:20 (leading: Space)
-8374: Colon           ":" at 688:20-688:21
-8375: Ident           "byte" at 688:22-688:26 (leading: Space)
-8376: LBracket        "[" at 688:26-688:27
-8377: RBracket        "]" at 688:27-688:28
-8378: Assign          "=" at 688:29-688:30 (leading: Space)
-8379: LBracket        "[" at 688:31-688:32 (leading: Space)
-8380: RBracket        "]" at 688:32-688:33
-8381: Semicolon       ";" at 688:33-688:34
-8382: Ident           "out" at 689:9-689:12 (leading: Newline, Space)
-8383: Dot             "." at 689:12-689:13
-8384: Ident           "reserve" at 689:13-689:20
-8385: LParen          "(" at 689:20-689:21
-8386: Ident           "length" at 689:21-689:27
-8387: RParen          ")" at 689:27-689:28
-8388: Semicolon       ";" at 689:28-689:29
-8389: KwLet           "let" at 690:9-690:12 (leading: Newline, Space)
-8390: Ident           "len_i" at 690:13-690:18 (leading: Space)
-8391: Colon           ":" at 690:18-690:19
-8392: Ident           "int" at 690:20-690:23 (leading: Space)
-8393: Assign          "=" at 690:24-690:25 (leading: Space)
-8394: Ident           "length" at 690:26-690:32 (leading: Space)
-8395: KwTo            "to" at 690:33-690:35 (leading: Space)
-8396: Ident           "int" at 690:36-690:39 (leading: Space)
-8397: Semicolon       ";" at 690:39-690:40
-8398: KwLet           "let" at 691:9-691:12 (leading: Newline, Space)
-8399: KwMut           "mut" at 691:13-691:16 (leading: Space)
-8400: Ident           "i" at 691:17-691:18 (leading: Space)
-8401: Colon           ":" at 691:18-691:19
-8402: Ident           "int" at 691:20-691:23 (leading: Space)
-8403: Assign          "=" at 691:24-691:25 (leading: Space)
-8404: IntLit          "0" at 691:26-691:27 (leading: Space)
-8405: Semicolon       ";" at 691:27-691:28
-8406: KwWhile         "while" at 692:9-692:14 (leading: Newline, Space)
-8407: Ident           "i" at 692:15-692:16 (leading: Space)
-8408: Lt              "<" at 692:17-692:18 (leading: Space)
-8409: Ident           "len_i" at 692:19-692:24 (leading: Space)
-8410: LBrace          "{" at 692:25-692:26 (leading: Space)
-8411: KwLet           "let" at 693:13-693:16 (leading: Newline, Space)
-8412: Ident           "b" at 693:17-693:18 (leading: Space)
-8413: Colon           ":" at 693:18-693:19
-8414: Ident           "byte" at 693:20-693:24 (leading: Space)
-8415: Assign          "=" at 693:25-693:26 (leading: Space)
-8416: Ident           "view" at 693:27-693:31 (leading: Space)
-8417: LBracket        "[" at 693:31-693:32
-8418: Ident           "i" at 693:32-693:33
-8419: RBracket        "]" at 693:33-693:34
-8420: Semicolon       ";" at 693:34-693:35
-8421: Ident           "out" at 694:13-694:16 (leading: Newline, Space)
-8422: Dot             "." at 694:16-694:17
-8423: Ident           "push" at 694:17-694:21
-8424: LParen          "(" at 694:21-694:22
-8425: Ident           "b" at 694:22-694:23
-8426: RParen          ")" at 694:23-694:24
-8427: Semicolon       ";" at 694:24-694:25
-8428: Ident           "i" at 695:13-695:14 (leading: Newline, Space)
-8429: Assign          "=" at 695:15-695:16 (leading: Space)
-8430: Ident           "i" at 695:17-695:18 (leading: Space)
-8431: Plus            "+" at 695:19-695:20 (leading: Space)
-8432: IntLit          "1" at 695:21-695:22 (leading: Space)
-8433: Semicolon       ";" at 695:22-695:23
-8434: RBrace          "}" at 696:9-696:10 (leading: Newline, Space)
-8435: KwReturn        "return" at 697:9-697:15 (leading: Newline, Space)
-8436: Ident           "out" at 697:16-697:19 (leading: Space)
-8437: Semicolon       ";" at 697:19-697:20
-8438: RBrace          "}" at 698:5-698:6 (leading: Newline, Space)
-8439: At              "@" at 699:5-699:6 (leading: Newline, Space)
-8440: Ident           "intrinsic" at 699:6-699:15
-8441: KwFn            "fn" at 699:16-699:18 (leading: Space)
-8442: Ident           "__len" at 699:19-699:24 (leading: Space)
-8443: LParen          "(" at 699:24-699:25
-8444: Ident           "self" at 699:25-699:29
-8445: Colon           ":" at 699:29-699:30
-8446: Amp             "&" at 699:31-699:32 (leading: Space)
-8447: Ident           "string" at 699:32-699:38
-8448: RParen          ")" at 699:38-699:39
-8449: Arrow           "->" at 699:40-699:42 (leading: Space)
-8450: Ident           "uint" at 699:43-699:47 (leading: Space)
-8451: Semicolon       ";" at 699:47-699:48
-8452: At              "@" at 700:5-700:6 (leading: Newline, Space)
-8453: Ident           "intrinsic" at 700:6-700:15
-8454: KwFn            "fn" at 700:16-700:18 (leading: Space)
-8455: Ident           "__clone" at 700:19-700:26 (leading: Space)
-8456: LParen          "(" at 700:26-700:27
-8457: Ident           "self" at 700:27-700:31
-8458: Colon           ":" at 700:31-700:32
-8459: Amp             "&" at 700:33-700:34 (leading: Space)
-8460: Ident           "string" at 700:34-700:40
-8461: RParen          ")" at 700:40-700:41
-8462: Arrow           "->" at 700:42-700:44 (leading: Space)
-8463: Ident           "string" at 700:45-700:51 (leading: Space)
-8464: Semicolon       ";" at 700:51-700:52
-8465: At              "@" at 701:5-701:6 (leading: Newline, Space)
-8466: Ident           "intrinsic" at 701:6-701:15
-8467: At              "@" at 701:16-701:17 (leading: Space)
-8468: Ident           "overload" at 701:17-701:25
-8469: KwFn            "fn" at 701:26-701:28 (leading: Space)
-8470: Ident           "__index" at 701:29-701:36 (leading: Space)
-8471: LParen          "(" at 701:36-701:37
-8472: Ident           "self" at 701:37-701:41
-8473: Colon           ":" at 701:41-701:42
-8474: Amp             "&" at 701:43-701:44 (leading: Space)
-8475: Ident           "string" at 701:44-701:50
-8476: Comma           "," at 701:50-701:51
-8477: Ident           "index" at 701:52-701:57 (leading: Space)
-8478: Colon           ":" at 701:57-701:58
-8479: Ident           "int" at 701:59-701:62 (leading: Space)
-8480: RParen          ")" at 701:62-701:63
-8481: Arrow           "->" at 701:64-701:66 (leading: Space)
-8482: Ident           "uint32" at 701:67-701:73 (leading: Space)
-8483: Semicolon       ";" at 701:73-701:74
-8484: At              "@" at 702:5-702:6 (leading: Newline, Space)
-8485: Ident           "intrinsic" at 702:6-702:15
-8486: At              "@" at 702:16-702:17 (leading: Space)
-8487: Ident           "overload" at 702:17-702:25
-8488: KwFn            "fn" at 702:26-702:28 (leading: Space)
-8489: Ident           "__index" at 702:29-702:36 (leading: Space)
-8490: LParen          "(" at 702:36-702:37
-8491: Ident           "self" at 702:37-702:41
-8492: Colon           ":" at 702:41-702:42
-8493: Amp             "&" at 702:43-702:44 (leading: Space)
-8494: Ident           "string" at 702:44-702:50
-8495: Comma           "," at 702:50-702:51
-8496: Ident           "index" at 702:52-702:57 (leading: Space)
-8497: Colon           ":" at 702:57-702:58
-8498: Ident           "Range" at 702:59-702:64 (leading: Space)
-8499: Lt              "<" at 702:64-702:65
-8500: Ident           "int" at 702:65-702:68
-8501: Gt              ">" at 702:68-702:69
-8502: RParen          ")" at 702:69-702:70
-8503: Arrow           "->" at 702:71-702:73 (leading: Space)
-8504: Ident           "string" at 702:74-702:80 (leading: Space)
-8505: Semicolon       ";" at 702:80-702:81
-8506: RBrace          "}" at 703:1-703:2 (leading: Newline)
-8507: At              "@" at 705:1-705:2 (leading: Newline)
-8508: Ident           "intrinsic" at 705:2-705:11
-8509: KwPub           "pub" at 706:1-706:4 (leading: Newline)
-8510: KwType          "type" at 706:5-706:9 (leading: Space)
-8511: Ident           "BytesView" at 706:10-706:19 (leading: Space)
-8512: Assign          "=" at 706:20-706:21 (leading: Space)
-8513: LBrace          "{" at 706:22-706:23 (leading: Space)
-8514: Ident           "owner" at 707:5-707:10 (leading: Newline, Space)
-8515: Colon           ":" at 707:10-707:11
-8516: Ident           "string" at 707:12-707:18 (leading: Space)
-8517: Comma           "," at 707:18-707:19
-8518: Ident           "ptr" at 708:5-708:8 (leading: Newline, Space)
-8519: Colon           ":" at 708:8-708:9
-8520: Star            "*" at 708:10-708:11 (leading: Space)
-8521: Ident           "byte" at 708:11-708:15
-8522: Comma           "," at 708:15-708:16
-8523: Ident           "len" at 709:5-709:8 (leading: Newline, Space)
-8524: Colon           ":" at 709:8-709:9
-8525: Ident           "uint" at 709:10-709:14 (leading: Space)
-8526: Comma           "," at 709:14-709:15
-8527: RBrace          "}" at 710:1-710:2 (leading: Newline)
-8528: Semicolon       ";" at 710:2-710:3
-8529: KwExtern        "extern" at 712:1-712:7 (leading: Newline)
-8530: Lt              "<" at 712:7-712:8
-8531: Ident           "BytesView" at 712:8-712:17
-8532: Gt              ">" at 712:17-712:18
-8533: LBrace          "{" at 712:19-712:20 (leading: Space)
-8534: At              "@" at 713:5-713:6 (leading: Newline, Space)
-8535: Ident           "intrinsic" at 713:6-713:15
-8536: KwFn            "fn" at 713:16-713:18 (leading: Space)
-8537: Ident           "__len" at 713:19-713:24 (leading: Space)
-8538: LParen          "(" at 713:24-713:25
-8539: Ident           "self" at 713:25-713:29
-8540: Colon           ":" at 713:29-713:30
-8541: Amp             "&" at 713:31-713:32 (leading: Space)
-8542: Ident           "BytesView" at 713:32-713:41
-8543: RParen          ")" at 713:41-713:42
-8544: Arrow           "->" at 713:43-713:45 (leading: Space)
-8545: Ident           "uint" at 713:46-713:50 (leading: Space)
-8546: Semicolon       ";" at 713:50-713:51
-8547: At              "@" at 714:5-714:6 (leading: Newline, Space)
-8548: Ident           "intrinsic" at 714:6-714:15
-8549: KwFn            "fn" at 714:16-714:18 (leading: Space)
-8550: Ident           "__index" at 714:19-714:26 (leading: Space)
-8551: LParen          "(" at 714:26-714:27
-8552: Ident           "self" at 714:27-714:31
-8553: Colon           ":" at 714:31-714:32
-8554: Amp             "&" at 714:33-714:34 (leading: Space)
-8555: Ident           "BytesView" at 714:34-714:43
-8556: Comma           "," at 714:43-714:44
-8557: Ident           "index" at 714:45-714:50 (leading: Space)
-8558: Colon           ":" at 714:50-714:51
-8559: Ident           "int" at 714:52-714:55 (leading: Space)
-8560: RParen          ")" at 714:55-714:56
-8561: Arrow           "->" at 714:57-714:59 (leading: Space)
-8562: Ident           "uint8" at 714:60-714:65 (leading: Space)
-8563: Semicolon       ";" at 714:65-714:66
-8564: RBrace          "}" at 715:1-715:2 (leading: Newline)
-8565: KwExtern        "extern" at 717:1-717:7 (leading: Newline)
-8566: Lt              "<" at 717:7-717:8
-8567: Ident           "bool" at 717:8-717:12
-8568: Gt              ">" at 717:12-717:13
-8569: LBrace          "{" at 717:14-717:15 (leading: Space)
-8570: At              "@" at 718:5-718:6 (leading: Newline, Space)
-8571: Ident           "intrinsic" at 718:6-718:15
-8572: KwFn            "fn" at 718:16-718:18 (leading: Space)
-8573: Ident           "__eq" at 718:19-718:23 (leading: Space)
-8574: LParen          "(" at 718:23-718:24
-8575: Ident           "self" at 718:24-718:28
-8576: Colon           ":" at 718:28-718:29
-8577: Ident           "bool" at 718:30-718:34 (leading: Space)
-8578: Comma           "," at 718:34-718:35
-8579: Ident           "other" at 718:36-718:41 (leading: Space)
-8580: Colon           ":" at 718:41-718:42
-8581: Ident           "bool" at 718:43-718:47 (leading: Space)
-8582: RParen          ")" at 718:47-718:48
-8583: Arrow           "->" at 718:49-718:51 (leading: Space)
-8584: Ident           "bool" at 718:52-718:56 (leading: Space)
-8585: Semicolon       ";" at 718:56-718:57
-8586: At              "@" at 719:5-719:6 (leading: Newline, Space)
-8587: Ident           "intrinsic" at 719:6-719:15
-8588: KwFn            "fn" at 719:16-719:18 (leading: Space)
-8589: Ident           "__ne" at 719:19-719:23 (leading: Space)
-8590: LParen          "(" at 719:23-719:24
-8591: Ident           "self" at 719:24-719:28
-8592: Colon           ":" at 719:28-719:29
-8593: Ident           "bool" at 719:30-719:34 (leading: Space)
-8594: Comma           "," at 719:34-719:35
-8595: Ident           "other" at 719:36-719:41 (leading: Space)
-8596: Colon           ":" at 719:41-719:42
-8597: Ident           "bool" at 719:43-719:47 (leading: Space)
-8598: RParen          ")" at 719:47-719:48
-8599: Arrow           "->" at 719:49-719:51 (leading: Space)
-8600: Ident           "bool" at 719:52-719:56 (leading: Space)
-8601: Semicolon       ";" at 719:56-719:57
-8602: At              "@" at 720:5-720:6 (leading: Newline, Space)
-8603: Ident           "intrinsic" at 720:6-720:15
-8604: KwFn            "fn" at 720:16-720:18 (leading: Space)
-8605: Ident           "__not" at 720:19-720:24 (leading: Space)
-8606: LParen          "(" at 720:24-720:25
-8607: Ident           "self" at 720:25-720:29
-8608: Colon           ":" at 720:29-720:30
-8609: Ident           "bool" at 720:31-720:35 (leading: Space)
-8610: RParen          ")" at 720:35-720:36
-8611: Arrow           "->" at 720:37-720:39 (leading: Space)
-8612: Ident           "bool" at 720:40-720:44 (leading: Space)
-8613: Semicolon       ";" at 720:44-720:45
-8614: At              "@" at 721:5-721:6 (leading: Newline, Space)
-8615: Ident           "intrinsic" at 721:6-721:15
-8616: KwFn            "fn" at 721:16-721:18 (leading: Space)
-8617: Ident           "__to" at 721:19-721:23 (leading: Space)
-8618: LParen          "(" at 721:23-721:24
-8619: Ident           "self" at 721:24-721:28
-8620: Colon           ":" at 721:28-721:29
-8621: Ident           "bool" at 721:30-721:34 (leading: Space)
-8622: Comma           "," at 721:34-721:35
-8623: Ident           "target" at 721:36-721:42 (leading: Space)
-8624: Colon           ":" at 721:42-721:43
-8625: Ident           "string" at 721:44-721:50 (leading: Space)
-8626: RParen          ")" at 721:50-721:51
-8627: Arrow           "->" at 721:52-721:54 (leading: Space)
-8628: Ident           "string" at 721:55-721:61 (leading: Space)
-8629: Semicolon       ";" at 721:61-721:62
-8630: At              "@" at 722:5-722:6 (leading: Newline, Space)
-8631: Ident           "overload" at 722:6-722:14
-8632: KwPub           "pub" at 722:15-722:18 (leading: Space)
-8633: KwFn            "fn" at 722:19-722:21 (leading: Space)
-8634: Ident           "__to" at 722:22-722:26 (leading: Space)
-8635: LParen          "(" at 722:26-722:27
-8636: Ident           "self" at 722:27-722:31
-8637: Colon           ":" at 722:31-722:32
-8638: Amp             "&" at 722:33-722:34 (leading: Space)
-8639: Ident           "bool" at 722:34-722:38
-8640: Comma           "," at 722:38-722:39
-8641: Underscore      "_" at 722:40-722:41 (leading: Space)
-8642: Colon           ":" at 722:41-722:42
-8643: Ident           "string" at 722:43-722:49 (leading: Space)
-8644: RParen          ")" at 722:49-722:50
-8645: Arrow           "->" at 722:51-722:53 (leading: Space)
-8646: Ident           "string" at 722:54-722:60 (leading: Space)
-8647: LBrace          "{" at 722:61-722:62 (leading: Space)
-8648: KwReturn        "return" at 723:9-723:15 (leading: Newline, Space)
-8649: LParen          "(" at 723:16-723:17 (leading: Space)
-8650: Star            "*" at 723:17-723:18
-8651: Ident           "self" at 723:18-723:22
-8652: RParen          ")" at 723:22-723:23
-8653: KwTo            "to" at 723:24-723:26 (leading: Space)
-8654: Ident           "string" at 723:27-723:33 (leading: Space)
-8655: Semicolon       ";" at 723:33-723:34
-8656: RBrace          "}" at 724:5-724:6 (leading: Newline, Space)
-8657: At              "@" at 725:5-725:6 (leading: Newline, Space)
-8658: Ident           "intrinsic" at 725:6-725:15
-8659: At              "@" at 725:16-725:17 (leading: Space)
-8660: Ident           "overload" at 725:17-725:25
-8661: KwFn            "fn" at 725:26-725:28 (leading: Space)
-8662: Ident           "__to" at 725:29-725:33 (leading: Space)
-8663: LParen          "(" at 725:33-725:34
-8664: Ident           "self" at 725:34-725:38
-8665: Colon           ":" at 725:38-725:39
-8666: Ident           "bool" at 725:40-725:44 (leading: Space)
-8667: Comma           "," at 725:44-725:45
-8668: Ident           "target" at 725:46-725:52 (leading: Space)
-8669: Colon           ":" at 725:52-725:53
-8670: Ident           "int" at 725:54-725:57 (leading: Space)
-8671: RParen          ")" at 725:57-725:58
-8672: Arrow           "->" at 725:59-725:61 (leading: Space)
-8673: Ident           "int" at 725:62-725:65 (leading: Space)
-8674: Semicolon       ";" at 725:65-725:66
-8675: At              "@" at 727:5-727:6 (leading: Newline, Space, LineComment, Newline, Space)
-8676: Ident           "intrinsic" at 727:6-727:15
-8677: KwPub           "pub" at 727:16-727:19 (leading: Space)
-8678: KwFn            "fn" at 727:20-727:22 (leading: Space)
-8679: Ident           "from_str" at 727:23-727:31 (leading: Space)
-8680: LParen          "(" at 727:31-727:32
-8681: Ident           "s" at 727:32-727:33
-8682: Colon           ":" at 727:33-727:34
-8683: Amp             "&" at 727:35-727:36 (leading: Space)
-8684: Ident           "string" at 727:36-727:42
-8685: RParen          ")" at 727:42-727:43
-8686: Arrow           "->" at 727:44-727:46 (leading: Space)
-8687: Ident           "Erring" at 727:47-727:53 (leading: Space)
-8688: Lt              "<" at 727:53-727:54
-8689: Ident           "bool" at 727:54-727:58
-8690: Comma           "," at 727:58-727:59
-8691: Ident           "Error" at 727:60-727:65 (leading: Space)
-8692: Gt              ">" at 727:65-727:66
-8693: Semicolon       ";" at 727:66-727:67
-8694: RBrace          "}" at 728:1-728:2 (leading: Newline)
-8695: KwExtern        "extern" at 730:1-730:7 (leading: Newline)
-8696: Lt              "<" at 730:7-730:8
-8697: Ident           "Array" at 730:8-730:13
-8698: Lt              "<" at 730:13-730:14
-8699: Ident           "T" at 730:14-730:15
-8700: Shr             ">>" at 730:15-730:17
-8701: LBrace          "{" at 730:18-730:19 (leading: Space)
-8702: At              "@" at 731:5-731:6 (leading: Newline, Space)
-8703: Ident           "intrinsic" at 731:6-731:15
-8704: KwFn            "fn" at 731:16-731:18 (leading: Space)
-8705: Ident           "__add" at 731:19-731:24 (leading: Space)
-8706: LParen          "(" at 731:24-731:25
-8707: Ident           "self" at 731:25-731:29
-8708: Colon           ":" at 731:29-731:30
-8709: Amp             "&" at 731:31-731:32 (leading: Space)
-8710: Ident           "Array" at 731:32-731:37
-8711: Lt              "<" at 731:37-731:38
-8712: Ident           "T" at 731:38-731:39
-8713: Gt              ">" at 731:39-731:40
-8714: Comma           "," at 731:40-731:41
-8715: Ident           "other" at 731:42-731:47 (leading: Space)
-8716: Colon           ":" at 731:47-731:48
-8717: Amp             "&" at 731:49-731:50 (leading: Space)
-8718: Ident           "Array" at 731:50-731:55
-8719: Lt              "<" at 731:55-731:56
-8720: Ident           "T" at 731:56-731:57
-8721: Gt              ">" at 731:57-731:58
-8722: RParen          ")" at 731:58-731:59
-8723: Arrow           "->" at 731:60-731:62 (leading: Space)
-8724: Ident           "Array" at 731:63-731:68 (leading: Space)
-8725: Lt              "<" at 731:68-731:69
-8726: Ident           "T" at 731:69-731:70
-8727: Gt              ">" at 731:70-731:71
-8728: Semicolon       ";" at 731:71-731:72
-8729: At              "@" at 732:5-732:6 (leading: Newline, Space)
-8730: Ident           "intrinsic" at 732:6-732:15
-8731: KwFn            "fn" at 732:16-732:18 (leading: Space)
-8732: Ident           "__index" at 732:19-732:26 (leading: Space)
-8733: LParen          "(" at 732:26-732:27
-8734: Ident           "self" at 732:27-732:31
-8735: Colon           ":" at 732:31-732:32
-8736: Amp             "&" at 732:33-732:34 (leading: Space)
-8737: Ident           "Array" at 732:34-732:39
-8738: Lt              "<" at 732:39-732:40
-8739: Ident           "T" at 732:40-732:41
-8740: Gt              ">" at 732:41-732:42
-8741: Comma           "," at 732:42-732:43
-8742: Ident           "index" at 732:44-732:49 (leading: Space)
-8743: Colon           ":" at 732:49-732:50
-8744: Ident           "int" at 732:51-732:54 (leading: Space)
-8745: RParen          ")" at 732:54-732:55
-8746: Arrow           "->" at 732:56-732:58 (leading: Space)
-8747: Amp             "&" at 732:59-732:60 (leading: Space)
-8748: Ident           "T" at 732:60-732:61
-8749: Semicolon       ";" at 732:61-732:62
-8750: At              "@" at 733:5-733:6 (leading: Newline, Space)
-8751: Ident           "intrinsic" at 733:6-733:15
-8752: At              "@" at 733:16-733:17 (leading: Space)
-8753: Ident           "overload" at 733:17-733:25
-8754: KwFn            "fn" at 733:26-733:28 (leading: Space)
-8755: Ident           "__index" at 733:29-733:36 (leading: Space)
-8756: LParen          "(" at 733:36-733:37
-8757: Ident           "self" at 733:37-733:41
-8758: Colon           ":" at 733:41-733:42
-8759: Amp             "&" at 733:43-733:44 (leading: Space)
-8760: Ident           "Array" at 733:44-733:49
-8761: Lt              "<" at 733:49-733:50
-8762: Ident           "T" at 733:50-733:51
-8763: Gt              ">" at 733:51-733:52
-8764: Comma           "," at 733:52-733:53
-8765: Ident           "index" at 733:54-733:59 (leading: Space)
-8766: Colon           ":" at 733:59-733:60
-8767: Ident           "Range" at 733:61-733:66 (leading: Space)
-8768: Lt              "<" at 733:66-733:67
-8769: Ident           "int" at 733:67-733:70
-8770: Gt              ">" at 733:70-733:71
-8771: RParen          ")" at 733:71-733:72
-8772: Arrow           "->" at 733:73-733:75 (leading: Space)
-8773: Ident           "Array" at 733:76-733:81 (leading: Space)
-8774: Lt              "<" at 733:81-733:82
-8775: Ident           "T" at 733:82-733:83
-8776: Gt              ">" at 733:83-733:84
-8777: Semicolon       ";" at 733:84-733:85
-8778: At              "@" at 734:5-734:6 (leading: Newline, Space)
-8779: Ident           "intrinsic" at 734:6-734:15
-8780: KwFn            "fn" at 734:16-734:18 (leading: Space)
-8781: Ident           "__index_set" at 734:19-734:30 (leading: Space)
-8782: LParen          "(" at 734:30-734:31
-8783: Ident           "self" at 734:31-734:35
-8784: Colon           ":" at 734:35-734:36
-8785: Amp             "&" at 734:37-734:38 (leading: Space)
-8786: KwMut           "mut" at 734:38-734:41
-8787: Ident           "Array" at 734:42-734:47 (leading: Space)
-8788: Lt              "<" at 734:47-734:48
-8789: Ident           "T" at 734:48-734:49
-8790: Gt              ">" at 734:49-734:50
-8791: Comma           "," at 734:50-734:51
-8792: Ident           "index" at 734:52-734:57 (leading: Space)
-8793: Colon           ":" at 734:57-734:58
-8794: Ident           "int" at 734:59-734:62 (leading: Space)
-8795: Comma           "," at 734:62-734:63
-8796: Ident           "value" at 734:64-734:69 (leading: Space)
-8797: Colon           ":" at 734:69-734:70
-8798: Ident           "T" at 734:71-734:72 (leading: Space)
-8799: RParen          ")" at 734:72-734:73
-8800: Arrow           "->" at 734:74-734:76 (leading: Space)
-8801: NothingLit      "nothing" at 734:77-734:84 (leading: Space)
-8802: Semicolon       ";" at 734:84-734:85
+882: At              "@" at 98:1-98:2 (leading: Newline)
+883: Ident           "intrinsic" at 98:2-98:11
+884: KwFn            "fn" at 98:12-98:14 (leading: Space)
+885: Ident           "rt_net_read_bytes" at 98:15-98:32 (leading: Space)
+886: LParen          "(" at 98:32-98:33
+887: Ident           "c" at 98:33-98:34
+888: Colon           ":" at 98:34-98:35
+889: Amp             "&" at 98:36-98:37 (leading: Space)
+890: Ident           "TcpConn" at 98:37-98:44
+891: Comma           "," at 98:44-98:45
+892: Ident           "cap" at 98:46-98:49 (leading: Space)
+893: Colon           ":" at 98:49-98:50
+894: Ident           "uint" at 98:51-98:55 (leading: Space)
+895: RParen          ")" at 98:55-98:56
+896: Arrow           "->" at 98:57-98:59 (leading: Space)
+897: Ident           "NetResult" at 98:60-98:69 (leading: Space)
+898: Lt              "<" at 98:69-98:70
+899: Ident           "byte" at 98:70-98:74
+900: LBracket        "[" at 98:74-98:75
+901: RBracket        "]" at 98:75-98:76
+902: Gt              ">" at 98:76-98:77
+903: Semicolon       ";" at 98:77-98:78
+904: At              "@" at 99:1-99:2 (leading: Newline)
+905: Ident           "intrinsic" at 99:2-99:11
+906: KwFn            "fn" at 99:12-99:14 (leading: Space)
+907: Ident           "rt_net_write_bytes" at 99:15-99:33 (leading: Space)
+908: LParen          "(" at 99:33-99:34
+909: Ident           "c" at 99:34-99:35
+910: Colon           ":" at 99:35-99:36
+911: Amp             "&" at 99:37-99:38 (leading: Space)
+912: Ident           "TcpConn" at 99:38-99:45
+913: Comma           "," at 99:45-99:46
+914: Ident           "data" at 99:47-99:51 (leading: Space)
+915: Colon           ":" at 99:51-99:52
+916: Amp             "&" at 99:53-99:54 (leading: Space)
+917: Ident           "byte" at 99:54-99:58
+918: LBracket        "[" at 99:58-99:59
+919: RBracket        "]" at 99:59-99:60
+920: Comma           "," at 99:60-99:61
+921: Ident           "offset" at 99:62-99:68 (leading: Space)
+922: Colon           ":" at 99:68-99:69
+923: Ident           "uint" at 99:70-99:74 (leading: Space)
+924: Comma           "," at 99:74-99:75
+925: Ident           "length" at 99:76-99:82 (leading: Space)
+926: Colon           ":" at 99:82-99:83
+927: Ident           "uint" at 99:84-99:88 (leading: Space)
+928: RParen          ")" at 99:88-99:89
+929: Arrow           "->" at 99:90-99:92 (leading: Space)
+930: Ident           "NetResult" at 99:93-99:102 (leading: Space)
+931: Lt              "<" at 99:102-99:103
+932: Ident           "uint" at 99:103-99:107
+933: Gt              ">" at 99:107-99:108
+934: Semicolon       ";" at 99:108-99:109
+935: At              "@" at 101:1-101:2 (leading: Newline)
+936: Ident           "intrinsic" at 101:2-101:11
+937: KwFn            "fn" at 101:12-101:14 (leading: Space)
+938: Ident           "rt_net_wait_accept" at 101:15-101:33 (leading: Space)
+939: LParen          "(" at 101:33-101:34
+940: Ident           "l" at 101:34-101:35
+941: Colon           ":" at 101:35-101:36
+942: Amp             "&" at 101:37-101:38 (leading: Space)
+943: Ident           "TcpListener" at 101:38-101:49
+944: RParen          ")" at 101:49-101:50
+945: Arrow           "->" at 101:51-101:53 (leading: Space)
+946: Ident           "Task" at 101:54-101:58 (leading: Space)
+947: Lt              "<" at 101:58-101:59
+948: NothingLit      "nothing" at 101:59-101:66
+949: Gt              ">" at 101:66-101:67
+950: Semicolon       ";" at 101:67-101:68
+951: At              "@" at 102:1-102:2 (leading: Newline)
+952: Ident           "intrinsic" at 102:2-102:11
+953: KwFn            "fn" at 102:12-102:14 (leading: Space)
+954: Ident           "rt_net_wait_readable" at 102:15-102:35 (leading: Space)
+955: LParen          "(" at 102:35-102:36
+956: Ident           "c" at 102:36-102:37
+957: Colon           ":" at 102:37-102:38
+958: Amp             "&" at 102:39-102:40 (leading: Space)
+959: Ident           "TcpConn" at 102:40-102:47
+960: RParen          ")" at 102:47-102:48
+961: Arrow           "->" at 102:49-102:51 (leading: Space)
+962: Ident           "Task" at 102:52-102:56 (leading: Space)
+963: Lt              "<" at 102:56-102:57
+964: NothingLit      "nothing" at 102:57-102:64
+965: Gt              ">" at 102:64-102:65
+966: Semicolon       ";" at 102:65-102:66
+967: At              "@" at 103:1-103:2 (leading: Newline)
+968: Ident           "intrinsic" at 103:2-103:11
+969: KwFn            "fn" at 103:12-103:14 (leading: Space)
+970: Ident           "rt_net_wait_writable" at 103:15-103:35 (leading: Space)
+971: LParen          "(" at 103:35-103:36
+972: Ident           "c" at 103:36-103:37
+973: Colon           ":" at 103:37-103:38
+974: Amp             "&" at 103:39-103:40 (leading: Space)
+975: Ident           "TcpConn" at 103:40-103:47
+976: RParen          ")" at 103:47-103:48
+977: Arrow           "->" at 103:49-103:51 (leading: Space)
+978: Ident           "Task" at 103:52-103:56 (leading: Space)
+979: Lt              "<" at 103:56-103:57
+980: NothingLit      "nothing" at 103:57-103:64
+981: Gt              ">" at 103:64-103:65
+982: Semicolon       ";" at 103:65-103:66
+983: KwExtern        "extern" at 105:1-105:7 (leading: Newline)
+984: Lt              "<" at 105:7-105:8
+985: Ident           "TcpConn" at 105:8-105:15
+986: Gt              ">" at 105:15-105:16
+987: LBrace          "{" at 105:17-105:18 (leading: Space)
+988: KwPub           "pub" at 106:5-106:8 (leading: Newline, Space)
+989: KwFn            "fn" at 106:9-106:11 (leading: Space)
+990: Ident           "new" at 106:12-106:15 (leading: Space)
+991: LParen          "(" at 106:15-106:16
+992: RParen          ")" at 106:16-106:17
+993: Arrow           "->" at 106:18-106:20 (leading: Space)
+994: Ident           "TcpConn" at 106:21-106:28 (leading: Space)
+995: LBrace          "{" at 106:29-106:30 (leading: Space)
+996: KwReturn        "return" at 107:9-107:15 (leading: Newline, Space)
+997: LBrace          "{" at 107:16-107:17 (leading: Space)
+998: Ident           "__opaque" at 107:18-107:26 (leading: Space)
+999: Colon           ":" at 107:26-107:27
+1000: IntLit          "0" at 107:28-107:29 (leading: Space)
+1001: RBrace          "}" at 107:30-107:31 (leading: Space)
+1002: Semicolon       ";" at 107:31-107:32
+1003: RBrace          "}" at 108:5-108:6 (leading: Newline, Space)
+1004: RBrace          "}" at 109:1-109:2 (leading: Newline)
+1005: At              "@" at 112:1-112:2 (leading: Newline, LineComment, Newline)
+1006: Ident           "intrinsic" at 112:2-112:11
+1007: KwFn            "fn" at 112:12-112:14 (leading: Space)
+1008: Ident           "rt_string_ptr" at 112:15-112:28 (leading: Space)
+1009: LParen          "(" at 112:28-112:29
+1010: Ident           "s" at 112:29-112:30
+1011: Colon           ":" at 112:30-112:31
+1012: Amp             "&" at 112:32-112:33 (leading: Space)
+1013: Ident           "string" at 112:33-112:39
+1014: RParen          ")" at 112:39-112:40
+1015: Arrow           "->" at 112:41-112:43 (leading: Space)
+1016: Star            "*" at 112:44-112:45 (leading: Space)
+1017: Ident           "byte" at 112:45-112:49
+1018: Semicolon       ";" at 112:49-112:50
+1019: At              "@" at 114:1-114:2 (leading: Newline, LineComment, Newline)
+1020: Ident           "intrinsic" at 114:2-114:11
+1021: KwFn            "fn" at 114:12-114:14 (leading: Space)
+1022: Ident           "rt_string_len" at 114:15-114:28 (leading: Space)
+1023: LParen          "(" at 114:28-114:29
+1024: Ident           "s" at 114:29-114:30
+1025: Colon           ":" at 114:30-114:31
+1026: Amp             "&" at 114:32-114:33 (leading: Space)
+1027: Ident           "string" at 114:33-114:39
+1028: RParen          ")" at 114:39-114:40
+1029: Arrow           "->" at 114:41-114:43 (leading: Space)
+1030: Ident           "uint" at 114:44-114:48 (leading: Space)
+1031: Semicolon       ";" at 114:48-114:49
+1032: At              "@" at 115:1-115:2 (leading: Newline)
+1033: Ident           "intrinsic" at 115:2-115:11
+1034: KwFn            "fn" at 115:12-115:14 (leading: Space)
+1035: Ident           "rt_string_len_bytes" at 115:15-115:34 (leading: Space)
+1036: LParen          "(" at 115:34-115:35
+1037: Ident           "s" at 115:35-115:36
+1038: Colon           ":" at 115:36-115:37
+1039: Amp             "&" at 115:38-115:39 (leading: Space)
+1040: Ident           "string" at 115:39-115:45
+1041: RParen          ")" at 115:45-115:46
+1042: Arrow           "->" at 115:47-115:49 (leading: Space)
+1043: Ident           "uint" at 115:50-115:54 (leading: Space)
+1044: Semicolon       ";" at 115:54-115:55
+1045: At              "@" at 116:1-116:2 (leading: Newline)
+1046: Ident           "intrinsic" at 116:2-116:11
+1047: KwFn            "fn" at 116:12-116:14 (leading: Space)
+1048: Ident           "rt_string_from_bytes" at 116:15-116:35 (leading: Space)
+1049: LParen          "(" at 116:35-116:36
+1050: Ident           "ptr" at 116:36-116:39
+1051: Colon           ":" at 116:39-116:40
+1052: Star            "*" at 116:41-116:42 (leading: Space)
+1053: Ident           "byte" at 116:42-116:46
+1054: Comma           "," at 116:46-116:47
+1055: Ident           "length" at 116:48-116:54 (leading: Space)
+1056: Colon           ":" at 116:54-116:55
+1057: Ident           "uint" at 116:56-116:60 (leading: Space)
+1058: RParen          ")" at 116:60-116:61
+1059: Arrow           "->" at 116:62-116:64 (leading: Space)
+1060: Ident           "string" at 116:65-116:71 (leading: Space)
+1061: Semicolon       ";" at 116:71-116:72
+1062: At              "@" at 117:1-117:2 (leading: Newline)
+1063: Ident           "intrinsic" at 117:2-117:11
+1064: KwFn            "fn" at 117:12-117:14 (leading: Space)
+1065: Ident           "rt_string_from_utf16" at 117:15-117:35 (leading: Space)
+1066: LParen          "(" at 117:35-117:36
+1067: Ident           "ptr" at 117:36-117:39
+1068: Colon           ":" at 117:39-117:40
+1069: Star            "*" at 117:41-117:42 (leading: Space)
+1070: Ident           "uint16" at 117:42-117:48
+1071: Comma           "," at 117:48-117:49
+1072: Ident           "length" at 117:50-117:56 (leading: Space)
+1073: Colon           ":" at 117:56-117:57
+1074: Ident           "uint" at 117:58-117:62 (leading: Space)
+1075: RParen          ")" at 117:62-117:63
+1076: Arrow           "->" at 117:64-117:66 (leading: Space)
+1077: Ident           "string" at 117:67-117:73 (leading: Space)
+1078: Semicolon       ";" at 117:73-117:74
+1079: At              "@" at 118:1-118:2 (leading: Newline)
+1080: Ident           "intrinsic" at 118:2-118:11
+1081: KwFn            "fn" at 118:12-118:14 (leading: Space)
+1082: Ident           "rt_string_index" at 118:15-118:30 (leading: Space)
+1083: LParen          "(" at 118:30-118:31
+1084: Ident           "s" at 118:31-118:32
+1085: Colon           ":" at 118:32-118:33
+1086: Amp             "&" at 118:34-118:35 (leading: Space)
+1087: Ident           "string" at 118:35-118:41
+1088: Comma           "," at 118:41-118:42
+1089: Ident           "index" at 118:43-118:48 (leading: Space)
+1090: Colon           ":" at 118:48-118:49
+1091: Ident           "int" at 118:50-118:53 (leading: Space)
+1092: RParen          ")" at 118:53-118:54
+1093: Arrow           "->" at 118:55-118:57 (leading: Space)
+1094: Ident           "uint32" at 118:58-118:64 (leading: Space)
+1095: Semicolon       ";" at 118:64-118:65
+1096: At              "@" at 119:1-119:2 (leading: Newline)
+1097: Ident           "intrinsic" at 119:2-119:11
+1098: KwFn            "fn" at 119:12-119:14 (leading: Space)
+1099: Ident           "rt_string_slice" at 119:15-119:30 (leading: Space)
+1100: LParen          "(" at 119:30-119:31
+1101: Ident           "s" at 119:31-119:32
+1102: Colon           ":" at 119:32-119:33
+1103: Amp             "&" at 119:34-119:35 (leading: Space)
+1104: Ident           "string" at 119:35-119:41
+1105: Comma           "," at 119:41-119:42
+1106: Ident           "r" at 119:43-119:44 (leading: Space)
+1107: Colon           ":" at 119:44-119:45
+1108: Ident           "Range" at 119:46-119:51 (leading: Space)
+1109: Lt              "<" at 119:51-119:52
+1110: Ident           "int" at 119:52-119:55
+1111: Gt              ">" at 119:55-119:56
+1112: RParen          ")" at 119:56-119:57
+1113: Arrow           "->" at 119:58-119:60 (leading: Space)
+1114: Ident           "string" at 119:61-119:67 (leading: Space)
+1115: Semicolon       ";" at 119:67-119:68
+1116: At              "@" at 120:1-120:2 (leading: Newline)
+1117: Ident           "intrinsic" at 120:2-120:11
+1118: KwFn            "fn" at 120:12-120:14 (leading: Space)
+1119: Ident           "rt_string_concat" at 120:15-120:31 (leading: Space)
+1120: LParen          "(" at 120:31-120:32
+1121: Ident           "a" at 120:32-120:33
+1122: Colon           ":" at 120:33-120:34
+1123: Amp             "&" at 120:35-120:36 (leading: Space)
+1124: Ident           "string" at 120:36-120:42
+1125: Comma           "," at 120:42-120:43
+1126: Ident           "b" at 120:44-120:45 (leading: Space)
+1127: Colon           ":" at 120:45-120:46
+1128: Amp             "&" at 120:47-120:48 (leading: Space)
+1129: Ident           "string" at 120:48-120:54
+1130: RParen          ")" at 120:54-120:55
+1131: Arrow           "->" at 120:56-120:58 (leading: Space)
+1132: Ident           "string" at 120:59-120:65 (leading: Space)
+1133: Semicolon       ";" at 120:65-120:66
+1134: At              "@" at 121:1-121:2 (leading: Newline)
+1135: Ident           "intrinsic" at 121:2-121:11
+1136: KwFn            "fn" at 121:12-121:14 (leading: Space)
+1137: Ident           "rt_string_eq" at 121:15-121:27 (leading: Space)
+1138: LParen          "(" at 121:27-121:28
+1139: Ident           "a" at 121:28-121:29
+1140: Colon           ":" at 121:29-121:30
+1141: Amp             "&" at 121:31-121:32 (leading: Space)
+1142: Ident           "string" at 121:32-121:38
+1143: Comma           "," at 121:38-121:39
+1144: Ident           "b" at 121:40-121:41 (leading: Space)
+1145: Colon           ":" at 121:41-121:42
+1146: Amp             "&" at 121:43-121:44 (leading: Space)
+1147: Ident           "string" at 121:44-121:50
+1148: RParen          ")" at 121:50-121:51
+1149: Arrow           "->" at 121:52-121:54 (leading: Space)
+1150: Ident           "bool" at 121:55-121:59 (leading: Space)
+1151: Semicolon       ";" at 121:59-121:60
+1152: At              "@" at 122:1-122:2 (leading: Newline)
+1153: Ident           "intrinsic" at 122:2-122:11
+1154: KwFn            "fn" at 122:12-122:14 (leading: Space)
+1155: Ident           "rt_string_bytes_view" at 122:15-122:35 (leading: Space)
+1156: LParen          "(" at 122:35-122:36
+1157: Ident           "s" at 122:36-122:37
+1158: Colon           ":" at 122:37-122:38
+1159: Amp             "&" at 122:39-122:40 (leading: Space)
+1160: Ident           "string" at 122:40-122:46
+1161: RParen          ")" at 122:46-122:47
+1162: Arrow           "->" at 122:48-122:50 (leading: Space)
+1163: Ident           "BytesView" at 122:51-122:60 (leading: Space)
+1164: Semicolon       ";" at 122:60-122:61
+1165: At              "@" at 124:1-124:2 (leading: Newline, LineComment, Newline)
+1166: Ident           "intrinsic" at 124:2-124:11
+1167: KwFn            "fn" at 124:12-124:14 (leading: Space)
+1168: Ident           "rt_string_force_flatten" at 124:15-124:38 (leading: Space)
+1169: LParen          "(" at 124:38-124:39
+1170: Ident           "s" at 124:39-124:40
+1171: Colon           ":" at 124:40-124:41
+1172: Amp             "&" at 124:42-124:43 (leading: Space)
+1173: Ident           "string" at 124:43-124:49
+1174: RParen          ")" at 124:49-124:50
+1175: Arrow           "->" at 124:51-124:53 (leading: Space)
+1176: NothingLit      "nothing" at 124:54-124:61 (leading: Space)
+1177: Semicolon       ";" at 124:61-124:62
+1178: At              "@" at 127:1-127:2 (leading: Newline, LineComment, Newline)
+1179: Ident           "intrinsic" at 127:2-127:11
+1180: KwFn            "fn" at 127:12-127:14 (leading: Space)
+1181: Ident           "rt_array_reserve" at 127:15-127:31 (leading: Space)
+1182: Lt              "<" at 127:31-127:32
+1183: Ident           "T" at 127:32-127:33
+1184: Gt              ">" at 127:33-127:34
+1185: LParen          "(" at 127:34-127:35
+1186: Ident           "a" at 127:35-127:36
+1187: Colon           ":" at 127:36-127:37
+1188: Amp             "&" at 127:38-127:39 (leading: Space)
+1189: KwMut           "mut" at 127:39-127:42
+1190: Ident           "Array" at 127:43-127:48 (leading: Space)
+1191: Lt              "<" at 127:48-127:49
+1192: Ident           "T" at 127:49-127:50
+1193: Gt              ">" at 127:50-127:51
+1194: Comma           "," at 127:51-127:52
+1195: Ident           "new_cap" at 127:53-127:60 (leading: Space)
+1196: Colon           ":" at 127:60-127:61
+1197: Ident           "uint" at 127:62-127:66 (leading: Space)
+1198: RParen          ")" at 127:66-127:67
+1199: Arrow           "->" at 127:68-127:70 (leading: Space)
+1200: NothingLit      "nothing" at 127:71-127:78 (leading: Space)
+1201: Semicolon       ";" at 127:78-127:79
+1202: At              "@" at 128:1-128:2 (leading: Newline)
+1203: Ident           "intrinsic" at 128:2-128:11
+1204: KwFn            "fn" at 128:12-128:14 (leading: Space)
+1205: Ident           "rt_array_push" at 128:15-128:28 (leading: Space)
+1206: Lt              "<" at 128:28-128:29
+1207: Ident           "T" at 128:29-128:30
+1208: Gt              ">" at 128:30-128:31
+1209: LParen          "(" at 128:31-128:32
+1210: Ident           "a" at 128:32-128:33
+1211: Colon           ":" at 128:33-128:34
+1212: Amp             "&" at 128:35-128:36 (leading: Space)
+1213: KwMut           "mut" at 128:36-128:39
+1214: Ident           "Array" at 128:40-128:45 (leading: Space)
+1215: Lt              "<" at 128:45-128:46
+1216: Ident           "T" at 128:46-128:47
+1217: Gt              ">" at 128:47-128:48
+1218: Comma           "," at 128:48-128:49
+1219: Ident           "value" at 128:50-128:55 (leading: Space)
+1220: Colon           ":" at 128:55-128:56
+1221: Ident           "T" at 128:57-128:58 (leading: Space)
+1222: RParen          ")" at 128:58-128:59
+1223: Arrow           "->" at 128:60-128:62 (leading: Space)
+1224: NothingLit      "nothing" at 128:63-128:70 (leading: Space)
+1225: Semicolon       ";" at 128:70-128:71
+1226: At              "@" at 129:1-129:2 (leading: Newline)
+1227: Ident           "intrinsic" at 129:2-129:11
+1228: KwFn            "fn" at 129:12-129:14 (leading: Space)
+1229: Ident           "rt_array_pop" at 129:15-129:27 (leading: Space)
+1230: Lt              "<" at 129:27-129:28
+1231: Ident           "T" at 129:28-129:29
+1232: Gt              ">" at 129:29-129:30
+1233: LParen          "(" at 129:30-129:31
+1234: Ident           "a" at 129:31-129:32
+1235: Colon           ":" at 129:32-129:33
+1236: Amp             "&" at 129:34-129:35 (leading: Space)
+1237: KwMut           "mut" at 129:35-129:38
+1238: Ident           "Array" at 129:39-129:44 (leading: Space)
+1239: Lt              "<" at 129:44-129:45
+1240: Ident           "T" at 129:45-129:46
+1241: Gt              ">" at 129:46-129:47
+1242: RParen          ")" at 129:47-129:48
+1243: Arrow           "->" at 129:49-129:51 (leading: Space)
+1244: Ident           "Option" at 129:52-129:58 (leading: Space)
+1245: Lt              "<" at 129:58-129:59
+1246: Ident           "T" at 129:59-129:60
+1247: Gt              ">" at 129:60-129:61
+1248: Semicolon       ";" at 129:61-129:62
+1249: At              "@" at 130:1-130:2 (leading: Newline)
+1250: Ident           "intrinsic" at 130:2-130:11
+1251: KwFn            "fn" at 130:12-130:14 (leading: Space)
+1252: Ident           "rt_array_get_mut" at 130:15-130:31 (leading: Space)
+1253: Lt              "<" at 130:31-130:32
+1254: Ident           "T" at 130:32-130:33
+1255: Gt              ">" at 130:33-130:34
+1256: LParen          "(" at 130:34-130:35
+1257: Ident           "a" at 130:35-130:36
+1258: Colon           ":" at 130:36-130:37
+1259: Amp             "&" at 130:38-130:39 (leading: Space)
+1260: KwMut           "mut" at 130:39-130:42
+1261: Ident           "Array" at 130:43-130:48 (leading: Space)
+1262: Lt              "<" at 130:48-130:49
+1263: Ident           "T" at 130:49-130:50
+1264: Gt              ">" at 130:50-130:51
+1265: Comma           "," at 130:51-130:52
+1266: Ident           "index" at 130:53-130:58 (leading: Space)
+1267: Colon           ":" at 130:58-130:59
+1268: Ident           "int" at 130:60-130:63 (leading: Space)
+1269: RParen          ")" at 130:63-130:64
+1270: Arrow           "->" at 130:65-130:67 (leading: Space)
+1271: Amp             "&" at 130:68-130:69 (leading: Space)
+1272: KwMut           "mut" at 130:69-130:72
+1273: Ident           "T" at 130:73-130:74 (leading: Space)
+1274: Semicolon       ";" at 130:74-130:75
+1275: At              "@" at 131:1-131:2 (leading: Newline)
+1276: Ident           "intrinsic" at 131:2-131:11
+1277: At              "@" at 131:12-131:13 (leading: Space)
+1278: Ident           "overload" at 131:13-131:21
+1279: KwFn            "fn" at 131:22-131:24 (leading: Space)
+1280: Ident           "rt_array_get_mut" at 131:25-131:41 (leading: Space)
+1281: Lt              "<" at 131:41-131:42
+1282: Ident           "T" at 131:42-131:43
+1283: Comma           "," at 131:43-131:44
+1284: KwConst         "const" at 131:45-131:50 (leading: Space)
+1285: Ident           "N" at 131:51-131:52 (leading: Space)
+1286: Colon           ":" at 131:52-131:53
+1287: Ident           "int" at 131:53-131:56
+1288: Gt              ">" at 131:56-131:57
+1289: LParen          "(" at 131:57-131:58
+1290: Ident           "a" at 131:58-131:59
+1291: Colon           ":" at 131:59-131:60
+1292: Amp             "&" at 131:61-131:62 (leading: Space)
+1293: KwMut           "mut" at 131:62-131:65
+1294: Ident           "ArrayFixed" at 131:66-131:76 (leading: Space)
+1295: Lt              "<" at 131:76-131:77
+1296: Ident           "T" at 131:77-131:78
+1297: Comma           "," at 131:78-131:79
+1298: Ident           "N" at 131:80-131:81 (leading: Space)
+1299: Gt              ">" at 131:81-131:82
+1300: Comma           "," at 131:82-131:83
+1301: Ident           "index" at 131:84-131:89 (leading: Space)
+1302: Colon           ":" at 131:89-131:90
+1303: Ident           "int" at 131:91-131:94 (leading: Space)
+1304: RParen          ")" at 131:94-131:95
+1305: Arrow           "->" at 131:96-131:98 (leading: Space)
+1306: Amp             "&" at 131:99-131:100 (leading: Space)
+1307: KwMut           "mut" at 131:100-131:103
+1308: Ident           "T" at 131:104-131:105 (leading: Space)
+1309: Semicolon       ";" at 131:105-131:106
+1310: At              "@" at 134:1-134:2 (leading: Newline, LineComment, Newline)
+1311: Ident           "intrinsic" at 134:2-134:11
+1312: KwFn            "fn" at 134:12-134:14 (leading: Space)
+1313: Ident           "rt_map_new" at 134:15-134:25 (leading: Space)
+1314: Lt              "<" at 134:25-134:26
+1315: Ident           "K" at 134:26-134:27
+1316: Comma           "," at 134:27-134:28
+1317: Ident           "V" at 134:29-134:30 (leading: Space)
+1318: Gt              ">" at 134:30-134:31
+1319: LParen          "(" at 134:31-134:32
+1320: RParen          ")" at 134:32-134:33
+1321: Arrow           "->" at 134:34-134:36 (leading: Space)
+1322: Ident           "Map" at 134:37-134:40 (leading: Space)
+1323: Lt              "<" at 134:40-134:41
+1324: Ident           "K" at 134:41-134:42
+1325: Comma           "," at 134:42-134:43
+1326: Ident           "V" at 134:44-134:45 (leading: Space)
+1327: Gt              ">" at 134:45-134:46
+1328: Semicolon       ";" at 134:46-134:47
+1329: At              "@" at 135:1-135:2 (leading: Newline)
+1330: Ident           "intrinsic" at 135:2-135:11
+1331: KwFn            "fn" at 135:12-135:14 (leading: Space)
+1332: Ident           "rt_map_len" at 135:15-135:25 (leading: Space)
+1333: Lt              "<" at 135:25-135:26
+1334: Ident           "K" at 135:26-135:27
+1335: Comma           "," at 135:27-135:28
+1336: Ident           "V" at 135:29-135:30 (leading: Space)
+1337: Gt              ">" at 135:30-135:31
+1338: LParen          "(" at 135:31-135:32
+1339: Ident           "m" at 135:32-135:33
+1340: Colon           ":" at 135:33-135:34
+1341: Amp             "&" at 135:35-135:36 (leading: Space)
+1342: Ident           "Map" at 135:36-135:39
+1343: Lt              "<" at 135:39-135:40
+1344: Ident           "K" at 135:40-135:41
+1345: Comma           "," at 135:41-135:42
+1346: Ident           "V" at 135:43-135:44 (leading: Space)
+1347: Gt              ">" at 135:44-135:45
+1348: RParen          ")" at 135:45-135:46
+1349: Arrow           "->" at 135:47-135:49 (leading: Space)
+1350: Ident           "uint" at 135:50-135:54 (leading: Space)
+1351: Semicolon       ";" at 135:54-135:55
+1352: At              "@" at 136:1-136:2 (leading: Newline)
+1353: Ident           "intrinsic" at 136:2-136:11
+1354: KwFn            "fn" at 136:12-136:14 (leading: Space)
+1355: Ident           "rt_map_contains" at 136:15-136:30 (leading: Space)
+1356: Lt              "<" at 136:30-136:31
+1357: Ident           "K" at 136:31-136:32
+1358: Comma           "," at 136:32-136:33
+1359: Ident           "V" at 136:34-136:35 (leading: Space)
+1360: Gt              ">" at 136:35-136:36
+1361: LParen          "(" at 136:36-136:37
+1362: Ident           "m" at 136:37-136:38
+1363: Colon           ":" at 136:38-136:39
+1364: Amp             "&" at 136:40-136:41 (leading: Space)
+1365: Ident           "Map" at 136:41-136:44
+1366: Lt              "<" at 136:44-136:45
+1367: Ident           "K" at 136:45-136:46
+1368: Comma           "," at 136:46-136:47
+1369: Ident           "V" at 136:48-136:49 (leading: Space)
+1370: Gt              ">" at 136:49-136:50
+1371: Comma           "," at 136:50-136:51
+1372: Ident           "key" at 136:52-136:55 (leading: Space)
+1373: Colon           ":" at 136:55-136:56
+1374: Amp             "&" at 136:57-136:58 (leading: Space)
+1375: Ident           "K" at 136:58-136:59
+1376: RParen          ")" at 136:59-136:60
+1377: Arrow           "->" at 136:61-136:63 (leading: Space)
+1378: Ident           "bool" at 136:64-136:68 (leading: Space)
+1379: Semicolon       ";" at 136:68-136:69
+1380: At              "@" at 137:1-137:2 (leading: Newline)
+1381: Ident           "intrinsic" at 137:2-137:11
+1382: KwFn            "fn" at 137:12-137:14 (leading: Space)
+1383: Ident           "rt_map_get_ref" at 137:15-137:29 (leading: Space)
+1384: Lt              "<" at 137:29-137:30
+1385: Ident           "K" at 137:30-137:31
+1386: Comma           "," at 137:31-137:32
+1387: Ident           "V" at 137:33-137:34 (leading: Space)
+1388: Gt              ">" at 137:34-137:35
+1389: LParen          "(" at 137:35-137:36
+1390: Ident           "m" at 137:36-137:37
+1391: Colon           ":" at 137:37-137:38
+1392: Amp             "&" at 137:39-137:40 (leading: Space)
+1393: Ident           "Map" at 137:40-137:43
+1394: Lt              "<" at 137:43-137:44
+1395: Ident           "K" at 137:44-137:45
+1396: Comma           "," at 137:45-137:46
+1397: Ident           "V" at 137:47-137:48 (leading: Space)
+1398: Gt              ">" at 137:48-137:49
+1399: Comma           "," at 137:49-137:50
+1400: Ident           "key" at 137:51-137:54 (leading: Space)
+1401: Colon           ":" at 137:54-137:55
+1402: Amp             "&" at 137:56-137:57 (leading: Space)
+1403: Ident           "K" at 137:57-137:58
+1404: RParen          ")" at 137:58-137:59
+1405: Arrow           "->" at 137:60-137:62 (leading: Space)
+1406: Ident           "Option" at 137:63-137:69 (leading: Space)
+1407: Lt              "<" at 137:69-137:70
+1408: Amp             "&" at 137:70-137:71
+1409: Ident           "V" at 137:71-137:72
+1410: Gt              ">" at 137:72-137:73
+1411: Semicolon       ";" at 137:73-137:74
+1412: At              "@" at 138:1-138:2 (leading: Newline)
+1413: Ident           "intrinsic" at 138:2-138:11
+1414: KwFn            "fn" at 138:12-138:14 (leading: Space)
+1415: Ident           "rt_map_get_mut" at 138:15-138:29 (leading: Space)
+1416: Lt              "<" at 138:29-138:30
+1417: Ident           "K" at 138:30-138:31
+1418: Comma           "," at 138:31-138:32
+1419: Ident           "V" at 138:33-138:34 (leading: Space)
+1420: Gt              ">" at 138:34-138:35
+1421: LParen          "(" at 138:35-138:36
+1422: Ident           "m" at 138:36-138:37
+1423: Colon           ":" at 138:37-138:38
+1424: Amp             "&" at 138:39-138:40 (leading: Space)
+1425: KwMut           "mut" at 138:40-138:43
+1426: Ident           "Map" at 138:44-138:47 (leading: Space)
+1427: Lt              "<" at 138:47-138:48
+1428: Ident           "K" at 138:48-138:49
+1429: Comma           "," at 138:49-138:50
+1430: Ident           "V" at 138:51-138:52 (leading: Space)
+1431: Gt              ">" at 138:52-138:53
+1432: Comma           "," at 138:53-138:54
+1433: Ident           "key" at 138:55-138:58 (leading: Space)
+1434: Colon           ":" at 138:58-138:59
+1435: Amp             "&" at 138:60-138:61 (leading: Space)
+1436: Ident           "K" at 138:61-138:62
+1437: RParen          ")" at 138:62-138:63
+1438: Arrow           "->" at 138:64-138:66 (leading: Space)
+1439: Ident           "Option" at 138:67-138:73 (leading: Space)
+1440: Lt              "<" at 138:73-138:74
+1441: Amp             "&" at 138:74-138:75
+1442: KwMut           "mut" at 138:75-138:78
+1443: Ident           "V" at 138:79-138:80 (leading: Space)
+1444: Gt              ">" at 138:80-138:81
+1445: Semicolon       ";" at 138:81-138:82
+1446: At              "@" at 139:1-139:2 (leading: Newline)
+1447: Ident           "intrinsic" at 139:2-139:11
+1448: KwFn            "fn" at 139:12-139:14 (leading: Space)
+1449: Ident           "rt_map_insert" at 139:15-139:28 (leading: Space)
+1450: Lt              "<" at 139:28-139:29
+1451: Ident           "K" at 139:29-139:30
+1452: Comma           "," at 139:30-139:31
+1453: Ident           "V" at 139:32-139:33 (leading: Space)
+1454: Gt              ">" at 139:33-139:34
+1455: LParen          "(" at 139:34-139:35
+1456: Ident           "m" at 139:35-139:36
+1457: Colon           ":" at 139:36-139:37
+1458: Amp             "&" at 139:38-139:39 (leading: Space)
+1459: KwMut           "mut" at 139:39-139:42
+1460: Ident           "Map" at 139:43-139:46 (leading: Space)
+1461: Lt              "<" at 139:46-139:47
+1462: Ident           "K" at 139:47-139:48
+1463: Comma           "," at 139:48-139:49
+1464: Ident           "V" at 139:50-139:51 (leading: Space)
+1465: Gt              ">" at 139:51-139:52
+1466: Comma           "," at 139:52-139:53
+1467: Ident           "key" at 139:54-139:57 (leading: Space)
+1468: Colon           ":" at 139:57-139:58
+1469: Ident           "K" at 139:59-139:60 (leading: Space)
+1470: Comma           "," at 139:60-139:61
+1471: Ident           "value" at 139:62-139:67 (leading: Space)
+1472: Colon           ":" at 139:67-139:68
+1473: Ident           "V" at 139:69-139:70 (leading: Space)
+1474: RParen          ")" at 139:70-139:71
+1475: Arrow           "->" at 139:72-139:74 (leading: Space)
+1476: Ident           "Option" at 139:75-139:81 (leading: Space)
+1477: Lt              "<" at 139:81-139:82
+1478: Ident           "V" at 139:82-139:83
+1479: Gt              ">" at 139:83-139:84
+1480: Semicolon       ";" at 139:84-139:85
+1481: At              "@" at 140:1-140:2 (leading: Newline)
+1482: Ident           "intrinsic" at 140:2-140:11
+1483: KwFn            "fn" at 140:12-140:14 (leading: Space)
+1484: Ident           "rt_map_remove" at 140:15-140:28 (leading: Space)
+1485: Lt              "<" at 140:28-140:29
+1486: Ident           "K" at 140:29-140:30
+1487: Comma           "," at 140:30-140:31
+1488: Ident           "V" at 140:32-140:33 (leading: Space)
+1489: Gt              ">" at 140:33-140:34
+1490: LParen          "(" at 140:34-140:35
+1491: Ident           "m" at 140:35-140:36
+1492: Colon           ":" at 140:36-140:37
+1493: Amp             "&" at 140:38-140:39 (leading: Space)
+1494: KwMut           "mut" at 140:39-140:42
+1495: Ident           "Map" at 140:43-140:46 (leading: Space)
+1496: Lt              "<" at 140:46-140:47
+1497: Ident           "K" at 140:47-140:48
+1498: Comma           "," at 140:48-140:49
+1499: Ident           "V" at 140:50-140:51 (leading: Space)
+1500: Gt              ">" at 140:51-140:52
+1501: Comma           "," at 140:52-140:53
+1502: Ident           "key" at 140:54-140:57 (leading: Space)
+1503: Colon           ":" at 140:57-140:58
+1504: Amp             "&" at 140:59-140:60 (leading: Space)
+1505: Ident           "K" at 140:60-140:61
+1506: RParen          ")" at 140:61-140:62
+1507: Arrow           "->" at 140:63-140:65 (leading: Space)
+1508: Ident           "Option" at 140:66-140:72 (leading: Space)
+1509: Lt              "<" at 140:72-140:73
+1510: Ident           "V" at 140:73-140:74
+1511: Gt              ">" at 140:74-140:75
+1512: Semicolon       ";" at 140:75-140:76
+1513: At              "@" at 141:1-141:2 (leading: Newline)
+1514: Ident           "intrinsic" at 141:2-141:11
+1515: KwFn            "fn" at 141:12-141:14 (leading: Space)
+1516: Ident           "rt_map_keys" at 141:15-141:26 (leading: Space)
+1517: Lt              "<" at 141:26-141:27
+1518: Ident           "K" at 141:27-141:28
+1519: Comma           "," at 141:28-141:29
+1520: Ident           "V" at 141:30-141:31 (leading: Space)
+1521: Gt              ">" at 141:31-141:32
+1522: LParen          "(" at 141:32-141:33
+1523: Ident           "m" at 141:33-141:34
+1524: Colon           ":" at 141:34-141:35
+1525: Amp             "&" at 141:36-141:37 (leading: Space)
+1526: Ident           "Map" at 141:37-141:40
+1527: Lt              "<" at 141:40-141:41
+1528: Ident           "K" at 141:41-141:42
+1529: Comma           "," at 141:42-141:43
+1530: Ident           "V" at 141:44-141:45 (leading: Space)
+1531: Gt              ">" at 141:45-141:46
+1532: RParen          ")" at 141:46-141:47
+1533: Arrow           "->" at 141:48-141:50 (leading: Space)
+1534: Ident           "K" at 141:51-141:52 (leading: Space)
+1535: LBracket        "[" at 141:52-141:53
+1536: RBracket        "]" at 141:53-141:54
+1537: Semicolon       ";" at 141:54-141:55
+1538: At              "@" at 144:1-144:2 (leading: Newline, LineComment, Newline)
+1539: Ident           "intrinsic" at 144:2-144:11
+1540: KwPub           "pub" at 145:1-145:4 (leading: Newline)
+1541: KwFn            "fn" at 145:5-145:7 (leading: Space)
+1542: Ident           "readline" at 145:8-145:16 (leading: Space)
+1543: LParen          "(" at 145:16-145:17
+1544: RParen          ")" at 145:17-145:18
+1545: Arrow           "->" at 145:19-145:21 (leading: Space)
+1546: Ident           "string" at 145:22-145:28 (leading: Space)
+1547: Semicolon       ";" at 145:28-145:29
+1548: At              "@" at 147:1-147:2 (leading: Newline)
+1549: Ident           "intrinsic" at 147:2-147:11
+1550: KwPub           "pub" at 148:1-148:4 (leading: Newline)
+1551: KwType          "type" at 148:5-148:9 (leading: Space)
+1552: Ident           "Range" at 148:10-148:15 (leading: Space)
+1553: Lt              "<" at 148:15-148:16
+1554: Ident           "T" at 148:16-148:17
+1555: Gt              ">" at 148:17-148:18
+1556: Assign          "=" at 148:19-148:20 (leading: Space)
+1557: LBrace          "{" at 148:21-148:22 (leading: Space)
+1558: Ident           "__state" at 149:5-149:12 (leading: Newline, Space)
+1559: Colon           ":" at 149:12-149:13
+1560: Star            "*" at 149:14-149:15 (leading: Space)
+1561: Ident           "byte" at 149:15-149:19
+1562: Comma           "," at 149:19-149:20
+1563: RBrace          "}" at 150:1-150:2 (leading: Newline)
+1564: Semicolon       ";" at 150:2-150:3
+1565: At              "@" at 153:1-153:2 (leading: Newline, LineComment, Newline)
+1566: Ident           "intrinsic" at 153:2-153:11
+1567: KwPub           "pub" at 153:12-153:15 (leading: Space)
+1568: KwFn            "fn" at 153:16-153:18 (leading: Space)
+1569: Ident           "rt_range_int_new" at 153:19-153:35 (leading: Space)
+1570: LParen          "(" at 153:35-153:36
+1571: Ident           "start" at 153:36-153:41
+1572: Colon           ":" at 153:41-153:42
+1573: Ident           "int" at 153:43-153:46 (leading: Space)
+1574: Comma           "," at 153:46-153:47
+1575: Ident           "end" at 153:48-153:51 (leading: Space)
+1576: Colon           ":" at 153:51-153:52
+1577: Ident           "int" at 153:53-153:56 (leading: Space)
+1578: Comma           "," at 153:56-153:57
+1579: Ident           "inclusive" at 153:58-153:67 (leading: Space)
+1580: Colon           ":" at 153:67-153:68
+1581: Ident           "bool" at 153:69-153:73 (leading: Space)
+1582: RParen          ")" at 153:73-153:74
+1583: Arrow           "->" at 153:75-153:77 (leading: Space)
+1584: Ident           "Range" at 153:78-153:83 (leading: Space)
+1585: Lt              "<" at 153:83-153:84
+1586: Ident           "int" at 153:84-153:87
+1587: Gt              ">" at 153:87-153:88
+1588: Semicolon       ";" at 153:88-153:89
+1589: At              "@" at 154:1-154:2 (leading: Newline)
+1590: Ident           "intrinsic" at 154:2-154:11
+1591: KwPub           "pub" at 154:12-154:15 (leading: Space)
+1592: KwFn            "fn" at 154:16-154:18 (leading: Space)
+1593: Ident           "rt_range_int_from_start" at 154:19-154:42 (leading: Space)
+1594: LParen          "(" at 154:42-154:43
+1595: Ident           "start" at 154:43-154:48
+1596: Colon           ":" at 154:48-154:49
+1597: Ident           "int" at 154:50-154:53 (leading: Space)
+1598: Comma           "," at 154:53-154:54
+1599: Ident           "inclusive" at 154:55-154:64 (leading: Space)
+1600: Colon           ":" at 154:64-154:65
+1601: Ident           "bool" at 154:66-154:70 (leading: Space)
+1602: RParen          ")" at 154:70-154:71
+1603: Arrow           "->" at 154:72-154:74 (leading: Space)
+1604: Ident           "Range" at 154:75-154:80 (leading: Space)
+1605: Lt              "<" at 154:80-154:81
+1606: Ident           "int" at 154:81-154:84
+1607: Gt              ">" at 154:84-154:85
+1608: Semicolon       ";" at 154:85-154:86
+1609: At              "@" at 155:1-155:2 (leading: Newline)
+1610: Ident           "intrinsic" at 155:2-155:11
+1611: KwPub           "pub" at 155:12-155:15 (leading: Space)
+1612: KwFn            "fn" at 155:16-155:18 (leading: Space)
+1613: Ident           "rt_range_int_to_end" at 155:19-155:38 (leading: Space)
+1614: LParen          "(" at 155:38-155:39
+1615: Ident           "end" at 155:39-155:42
+1616: Colon           ":" at 155:42-155:43
+1617: Ident           "int" at 155:44-155:47 (leading: Space)
+1618: Comma           "," at 155:47-155:48
+1619: Ident           "inclusive" at 155:49-155:58 (leading: Space)
+1620: Colon           ":" at 155:58-155:59
+1621: Ident           "bool" at 155:60-155:64 (leading: Space)
+1622: RParen          ")" at 155:64-155:65
+1623: Arrow           "->" at 155:66-155:68 (leading: Space)
+1624: Ident           "Range" at 155:69-155:74 (leading: Space)
+1625: Lt              "<" at 155:74-155:75
+1626: Ident           "int" at 155:75-155:78
+1627: Gt              ">" at 155:78-155:79
+1628: Semicolon       ";" at 155:79-155:80
+1629: At              "@" at 156:1-156:2 (leading: Newline)
+1630: Ident           "intrinsic" at 156:2-156:11
+1631: KwPub           "pub" at 156:12-156:15 (leading: Space)
+1632: KwFn            "fn" at 156:16-156:18 (leading: Space)
+1633: Ident           "rt_range_int_full" at 156:19-156:36 (leading: Space)
+1634: LParen          "(" at 156:36-156:37
+1635: Ident           "inclusive" at 156:37-156:46
+1636: Colon           ":" at 156:46-156:47
+1637: Ident           "bool" at 156:48-156:52 (leading: Space)
+1638: RParen          ")" at 156:52-156:53
+1639: Arrow           "->" at 156:54-156:56 (leading: Space)
+1640: Ident           "Range" at 156:57-156:62 (leading: Space)
+1641: Lt              "<" at 156:62-156:63
+1642: Ident           "int" at 156:63-156:66
+1643: Gt              ">" at 156:66-156:67
+1644: Semicolon       ";" at 156:67-156:68
+1645: KwExtern        "extern" at 158:1-158:7 (leading: Newline)
+1646: Lt              "<" at 158:7-158:8
+1647: Ident           "Range" at 158:8-158:13
+1648: Lt              "<" at 158:13-158:14
+1649: Ident           "T" at 158:14-158:15
+1650: Shr             ">>" at 158:15-158:17
+1651: LBrace          "{" at 158:18-158:19 (leading: Space)
+1652: At              "@" at 159:5-159:6 (leading: Newline, Space)
+1653: Ident           "intrinsic" at 159:6-159:15
+1654: KwPub           "pub" at 159:16-159:19 (leading: Space)
+1655: KwFn            "fn" at 159:20-159:22 (leading: Space)
+1656: Ident           "next" at 159:23-159:27 (leading: Space)
+1657: LParen          "(" at 159:27-159:28
+1658: Ident           "self" at 159:28-159:32
+1659: Colon           ":" at 159:32-159:33
+1660: Amp             "&" at 159:34-159:35 (leading: Space)
+1661: KwMut           "mut" at 159:35-159:38
+1662: Ident           "Range" at 159:39-159:44 (leading: Space)
+1663: Lt              "<" at 159:44-159:45
+1664: Ident           "T" at 159:45-159:46
+1665: Gt              ">" at 159:46-159:47
+1666: RParen          ")" at 159:47-159:48
+1667: Arrow           "->" at 159:49-159:51 (leading: Space)
+1668: Ident           "Option" at 159:52-159:58 (leading: Space)
+1669: Lt              "<" at 159:58-159:59
+1670: Ident           "T" at 159:59-159:60
+1671: Gt              ">" at 159:60-159:61
+1672: Semicolon       ";" at 159:61-159:62
+1673: RBrace          "}" at 160:1-160:2 (leading: Newline)
+1674: KwPub           "pub" at 162:1-162:4 (leading: Newline)
+1675: KwType          "type" at 162:5-162:9 (leading: Space)
+1676: Ident           "HeapStats" at 162:10-162:19 (leading: Space)
+1677: Assign          "=" at 162:20-162:21 (leading: Space)
+1678: LBrace          "{" at 162:22-162:23 (leading: Space)
+1679: Ident           "alloc_count" at 163:5-163:16 (leading: Newline, Space)
+1680: Colon           ":" at 163:16-163:17
+1681: Ident           "uint" at 163:18-163:22 (leading: Space)
+1682: Comma           "," at 163:22-163:23
+1683: Ident           "free_count" at 164:5-164:15 (leading: Newline, Space)
+1684: Colon           ":" at 164:15-164:16
+1685: Ident           "uint" at 164:17-164:21 (leading: Space)
+1686: Comma           "," at 164:21-164:22
+1687: Ident           "live_blocks" at 165:5-165:16 (leading: Newline, Space)
+1688: Colon           ":" at 165:16-165:17
+1689: Ident           "uint" at 165:18-165:22 (leading: Space)
+1690: Comma           "," at 165:22-165:23
+1691: Ident           "live_bytes" at 166:5-166:15 (leading: Newline, Space)
+1692: Colon           ":" at 166:15-166:16
+1693: Ident           "uint" at 166:17-166:21 (leading: Space)
+1694: Comma           "," at 166:21-166:22
+1695: Ident           "rc_increments" at 167:5-167:18 (leading: Newline, Space)
+1696: Colon           ":" at 167:18-167:19
+1697: Ident           "uint" at 167:20-167:24 (leading: Space)
+1698: Comma           "," at 167:24-167:25
+1699: Ident           "rc_decrements" at 168:5-168:18 (leading: Newline, Space)
+1700: Colon           ":" at 168:18-168:19
+1701: Ident           "uint" at 168:20-168:24 (leading: Space)
+1702: Comma           "," at 168:24-168:25
+1703: RBrace          "}" at 169:1-169:2 (leading: Newline)
+1704: Semicolon       ";" at 169:2-169:3
+1705: At              "@" at 175:1-175:2 (leading: Newline, LineComment, Newline, LineComment, Newline, LineComment, Newline, LineComment, Newline)
+1706: Ident           "intrinsic" at 175:2-175:11
+1707: KwPub           "pub" at 175:12-175:15 (leading: Space)
+1708: KwFn            "fn" at 175:16-175:18 (leading: Space)
+1709: Ident           "rt_heap_stats" at 175:19-175:32 (leading: Space)
+1710: LParen          "(" at 175:32-175:33
+1711: RParen          ")" at 175:33-175:34
+1712: Arrow           "->" at 175:35-175:37 (leading: Space)
+1713: Ident           "HeapStats" at 175:38-175:47 (leading: Space)
+1714: Semicolon       ";" at 175:47-175:48
+1715: At              "@" at 177:1-177:2 (leading: Newline, LineComment, Newline)
+1716: Ident           "intrinsic" at 177:2-177:11
+1717: KwPub           "pub" at 177:12-177:15 (leading: Space)
+1718: KwFn            "fn" at 177:16-177:18 (leading: Space)
+1719: Ident           "rt_heap_dump" at 177:19-177:31 (leading: Space)
+1720: LParen          "(" at 177:31-177:32
+1721: RParen          ")" at 177:32-177:33
+1722: Arrow           "->" at 177:34-177:36 (leading: Space)
+1723: Ident           "string" at 177:37-177:43 (leading: Space)
+1724: Semicolon       ";" at 177:43-177:44
+1725: At              "@" at 179:1-179:2 (leading: Newline, LineComment, Newline)
+1726: Ident           "intrinsic" at 179:2-179:11
+1727: KwPub           "pub" at 179:12-179:15 (leading: Space)
+1728: KwFn            "fn" at 179:16-179:18 (leading: Space)
+1729: Ident           "rt_worker_count" at 179:19-179:34 (leading: Space)
+1730: LParen          "(" at 179:34-179:35
+1731: RParen          ")" at 179:35-179:36
+1732: Arrow           "->" at 179:37-179:39 (leading: Space)
+1733: Ident           "uint" at 179:40-179:44 (leading: Space)
+1734: Semicolon       ";" at 179:44-179:45
+1735: KwPub           "pub" at 181:1-181:4 (leading: Newline)
+1736: KwType          "type" at 181:5-181:9 (leading: Space)
+1737: Ident           "Task" at 181:10-181:14 (leading: Space)
+1738: Lt              "<" at 181:14-181:15
+1739: Ident           "T" at 181:15-181:16
+1740: Gt              ">" at 181:16-181:17
+1741: Assign          "=" at 181:18-181:19 (leading: Space)
+1742: LBrace          "{" at 181:20-181:21 (leading: Space)
+1743: Ident           "__opaque" at 182:5-182:13 (leading: Newline, Space)
+1744: Colon           ":" at 182:13-182:14
+1745: Ident           "int" at 182:15-182:18 (leading: Space)
+1746: Comma           "," at 182:18-182:19
+1747: RBrace          "}" at 183:1-183:2 (leading: Newline)
+1748: Semicolon       ";" at 183:2-183:3
+1749: KwPub           "pub" at 185:1-185:4 (leading: Newline)
+1750: KwTag           "tag" at 185:5-185:8 (leading: Space)
+1751: Ident           "Cancelled" at 185:9-185:18 (leading: Space)
+1752: LParen          "(" at 185:18-185:19
+1753: RParen          ")" at 185:19-185:20
+1754: Semicolon       ";" at 185:20-185:21
+1755: KwPub           "pub" at 186:1-186:4 (leading: Newline)
+1756: KwType          "type" at 186:5-186:9 (leading: Space)
+1757: Ident           "TaskResult" at 186:10-186:20 (leading: Space)
+1758: Lt              "<" at 186:20-186:21
+1759: Ident           "T" at 186:21-186:22
+1760: Gt              ">" at 186:22-186:23
+1761: Assign          "=" at 186:24-186:25 (leading: Space)
+1762: Ident           "Success" at 186:26-186:33 (leading: Space)
+1763: LParen          "(" at 186:33-186:34
+1764: Ident           "T" at 186:34-186:35
+1765: RParen          ")" at 186:35-186:36
+1766: Pipe            "|" at 186:37-186:38 (leading: Space)
+1767: Ident           "Cancelled" at 186:39-186:48 (leading: Space)
+1768: Semicolon       ";" at 186:48-186:49
+1769: At              "@" at 188:1-188:2 (leading: Newline)
+1770: Ident           "intrinsic" at 188:2-188:11
+1771: KwFn            "fn" at 188:12-188:14 (leading: Space)
+1772: Ident           "rt_scope_enter" at 188:15-188:29 (leading: Space)
+1773: LParen          "(" at 188:29-188:30
+1774: Ident           "failfast" at 188:30-188:38
+1775: Colon           ":" at 188:38-188:39
+1776: Ident           "bool" at 188:40-188:44 (leading: Space)
+1777: RParen          ")" at 188:44-188:45
+1778: Arrow           "->" at 188:46-188:48 (leading: Space)
+1779: Ident           "uint" at 188:49-188:53 (leading: Space)
+1780: Semicolon       ";" at 188:53-188:54
+1781: At              "@" at 189:1-189:2 (leading: Newline)
+1782: Ident           "intrinsic" at 189:2-189:11
+1783: KwFn            "fn" at 189:12-189:14 (leading: Space)
+1784: Ident           "rt_scope_register_child" at 189:15-189:38 (leading: Space)
+1785: Lt              "<" at 189:38-189:39
+1786: Ident           "T" at 189:39-189:40
+1787: Gt              ">" at 189:40-189:41
+1788: LParen          "(" at 189:41-189:42
+1789: Ident           "scope" at 189:42-189:47
+1790: Colon           ":" at 189:47-189:48
+1791: Ident           "uint" at 189:49-189:53 (leading: Space)
+1792: Comma           "," at 189:53-189:54
+1793: Ident           "child" at 189:55-189:60 (leading: Space)
+1794: Colon           ":" at 189:60-189:61
+1795: Ident           "Task" at 189:62-189:66 (leading: Space)
+1796: Lt              "<" at 189:66-189:67
+1797: Ident           "T" at 189:67-189:68
+1798: Gt              ">" at 189:68-189:69
+1799: RParen          ")" at 189:69-189:70
+1800: Arrow           "->" at 189:71-189:73 (leading: Space)
+1801: NothingLit      "nothing" at 189:74-189:81 (leading: Space)
+1802: Semicolon       ";" at 189:81-189:82
+1803: At              "@" at 190:1-190:2 (leading: Newline)
+1804: Ident           "intrinsic" at 190:2-190:11
+1805: KwFn            "fn" at 190:12-190:14 (leading: Space)
+1806: Ident           "rt_scope_cancel_all" at 190:15-190:34 (leading: Space)
+1807: LParen          "(" at 190:34-190:35
+1808: Ident           "scope" at 190:35-190:40
+1809: Colon           ":" at 190:40-190:41
+1810: Ident           "uint" at 190:42-190:46 (leading: Space)
+1811: RParen          ")" at 190:46-190:47
+1812: Arrow           "->" at 190:48-190:50 (leading: Space)
+1813: NothingLit      "nothing" at 190:51-190:58 (leading: Space)
+1814: Semicolon       ";" at 190:58-190:59
+1815: At              "@" at 191:1-191:2 (leading: Newline)
+1816: Ident           "intrinsic" at 191:2-191:11
+1817: KwFn            "fn" at 191:12-191:14 (leading: Space)
+1818: Ident           "rt_scope_join_all" at 191:15-191:32 (leading: Space)
+1819: LParen          "(" at 191:32-191:33
+1820: Ident           "scope" at 191:33-191:38
+1821: Colon           ":" at 191:38-191:39
+1822: Ident           "uint" at 191:40-191:44 (leading: Space)
+1823: RParen          ")" at 191:44-191:45
+1824: Arrow           "->" at 191:46-191:48 (leading: Space)
+1825: Ident           "bool" at 191:49-191:53 (leading: Space)
+1826: Semicolon       ";" at 191:53-191:54
+1827: At              "@" at 192:1-192:2 (leading: Newline)
+1828: Ident           "intrinsic" at 192:2-192:11
+1829: KwFn            "fn" at 192:12-192:14 (leading: Space)
+1830: Ident           "rt_scope_exit" at 192:15-192:28 (leading: Space)
+1831: LParen          "(" at 192:28-192:29
+1832: Ident           "scope" at 192:29-192:34
+1833: Colon           ":" at 192:34-192:35
+1834: Ident           "uint" at 192:36-192:40 (leading: Space)
+1835: RParen          ")" at 192:40-192:41
+1836: Arrow           "->" at 192:42-192:44 (leading: Space)
+1837: NothingLit      "nothing" at 192:45-192:52 (leading: Space)
+1838: Semicolon       ";" at 192:52-192:53
+1839: KwExtern        "extern" at 194:1-194:7 (leading: Newline)
+1840: Lt              "<" at 194:7-194:8
+1841: Ident           "Task" at 194:8-194:12
+1842: Lt              "<" at 194:12-194:13
+1843: Ident           "T" at 194:13-194:14
+1844: Shr             ">>" at 194:14-194:16
+1845: LBrace          "{" at 194:17-194:18 (leading: Space)
+1846: At              "@" at 195:5-195:6 (leading: Newline, Space)
+1847: Ident           "intrinsic" at 195:6-195:15
+1848: KwPub           "pub" at 195:16-195:19 (leading: Space)
+1849: KwFn            "fn" at 195:20-195:22 (leading: Space)
+1850: Ident           "clone" at 195:23-195:28 (leading: Space)
+1851: LParen          "(" at 195:28-195:29
+1852: Ident           "self" at 195:29-195:33
+1853: Colon           ":" at 195:33-195:34
+1854: Amp             "&" at 195:35-195:36 (leading: Space)
+1855: Ident           "Task" at 195:36-195:40
+1856: Lt              "<" at 195:40-195:41
+1857: Ident           "T" at 195:41-195:42
+1858: Gt              ">" at 195:42-195:43
+1859: RParen          ")" at 195:43-195:44
+1860: Arrow           "->" at 195:45-195:47 (leading: Space)
+1861: Ident           "Task" at 195:48-195:52 (leading: Space)
+1862: Lt              "<" at 195:52-195:53
+1863: Ident           "T" at 195:53-195:54
+1864: Gt              ">" at 195:54-195:55
+1865: Semicolon       ";" at 195:55-195:56
+1866: At              "@" at 196:5-196:6 (leading: Newline, Space)
+1867: Ident           "intrinsic" at 196:6-196:15
+1868: KwPub           "pub" at 196:16-196:19 (leading: Space)
+1869: KwFn            "fn" at 196:20-196:22 (leading: Space)
+1870: Ident           "cancel" at 196:23-196:29 (leading: Space)
+1871: LParen          "(" at 196:29-196:30
+1872: Ident           "self" at 196:30-196:34
+1873: Colon           ":" at 196:34-196:35
+1874: Amp             "&" at 196:36-196:37 (leading: Space)
+1875: Ident           "Task" at 196:37-196:41
+1876: Lt              "<" at 196:41-196:42
+1877: Ident           "T" at 196:42-196:43
+1878: Gt              ">" at 196:43-196:44
+1879: RParen          ")" at 196:44-196:45
+1880: Arrow           "->" at 196:46-196:48 (leading: Space)
+1881: NothingLit      "nothing" at 196:49-196:56 (leading: Space)
+1882: Semicolon       ";" at 196:56-196:57
+1883: At              "@" at 197:5-197:6 (leading: Newline, Space)
+1884: Ident           "intrinsic" at 197:6-197:15
+1885: KwPub           "pub" at 197:16-197:19 (leading: Space)
+1886: KwFn            "fn" at 197:20-197:22 (leading: Space)
+1887: Ident           "await" at 197:23-197:28 (leading: Space)
+1888: LParen          "(" at 197:28-197:29
+1889: Ident           "self" at 197:29-197:33
+1890: Colon           ":" at 197:33-197:34
+1891: KwOwn           "own" at 197:35-197:38 (leading: Space)
+1892: Ident           "Task" at 197:39-197:43 (leading: Space)
+1893: Lt              "<" at 197:43-197:44
+1894: Ident           "T" at 197:44-197:45
+1895: Gt              ">" at 197:45-197:46
+1896: RParen          ")" at 197:46-197:47
+1897: Arrow           "->" at 197:48-197:50 (leading: Space)
+1898: Ident           "TaskResult" at 197:51-197:61 (leading: Space)
+1899: Lt              "<" at 197:61-197:62
+1900: Ident           "T" at 197:62-197:63
+1901: Gt              ">" at 197:63-197:64
+1902: Semicolon       ";" at 197:64-197:65
+1903: RBrace          "}" at 198:1-198:2 (leading: Newline)
+1904: At              "@" at 202:1-202:2 (leading: Newline, LineComment, Newline, LineComment, Newline)
+1905: Ident           "intrinsic" at 202:2-202:11
+1906: KwPub           "pub" at 203:1-203:4 (leading: Newline)
+1907: KwFn            "fn" at 203:5-203:7 (leading: Space)
+1908: Ident           "checkpoint" at 203:8-203:18 (leading: Space)
+1909: LParen          "(" at 203:18-203:19
+1910: RParen          ")" at 203:19-203:20
+1911: Arrow           "->" at 203:21-203:23 (leading: Space)
+1912: Ident           "Task" at 203:24-203:28 (leading: Space)
+1913: Lt              "<" at 203:28-203:29
+1914: NothingLit      "nothing" at 203:29-203:36
+1915: Gt              ">" at 203:36-203:37
+1916: Semicolon       ";" at 203:37-203:38
+1917: At              "@" at 206:1-206:2 (leading: Newline, LineComment, Newline)
+1918: Ident           "intrinsic" at 206:2-206:11
+1919: KwPub           "pub" at 206:12-206:15 (leading: Space)
+1920: KwFn            "fn" at 206:16-206:18 (leading: Space)
+1921: Ident           "sleep" at 206:19-206:24 (leading: Space)
+1922: LParen          "(" at 206:24-206:25
+1923: Ident           "ms" at 206:25-206:27
+1924: Colon           ":" at 206:27-206:28
+1925: Ident           "uint" at 206:29-206:33 (leading: Space)
+1926: RParen          ")" at 206:33-206:34
+1927: Arrow           "->" at 206:35-206:37 (leading: Space)
+1928: Ident           "Task" at 206:38-206:42 (leading: Space)
+1929: Lt              "<" at 206:42-206:43
+1930: NothingLit      "nothing" at 206:43-206:50
+1931: Gt              ">" at 206:50-206:51
+1932: Semicolon       ";" at 206:51-206:52
+1933: At              "@" at 210:1-210:2 (leading: Newline, LineComment, Newline, LineComment, Newline)
+1934: Ident           "intrinsic" at 210:2-210:11
+1935: KwPub           "pub" at 210:12-210:15 (leading: Space)
+1936: KwFn            "fn" at 210:16-210:18 (leading: Space)
+1937: Ident           "timeout" at 210:19-210:26 (leading: Space)
+1938: Lt              "<" at 210:26-210:27
+1939: Ident           "T" at 210:27-210:28
+1940: Gt              ">" at 210:28-210:29
+1941: LParen          "(" at 210:29-210:30
+1942: Ident           "t" at 210:30-210:31
+1943: Colon           ":" at 210:31-210:32
+1944: Ident           "Task" at 210:33-210:37 (leading: Space)
+1945: Lt              "<" at 210:37-210:38
+1946: Ident           "T" at 210:38-210:39
+1947: Gt              ">" at 210:39-210:40
+1948: Comma           "," at 210:40-210:41
+1949: Ident           "ms" at 210:42-210:44 (leading: Space)
+1950: Colon           ":" at 210:44-210:45
+1951: Ident           "uint" at 210:46-210:50 (leading: Space)
+1952: RParen          ")" at 210:50-210:51
+1953: Arrow           "->" at 210:52-210:54 (leading: Space)
+1954: Ident           "TaskResult" at 210:55-210:65 (leading: Space)
+1955: Lt              "<" at 210:65-210:66
+1956: Ident           "T" at 210:66-210:67
+1957: Gt              ">" at 210:67-210:68
+1958: Semicolon       ";" at 210:68-210:69
+1959: At              "@" at 213:1-213:2 (leading: Newline, LineComment, Newline)
+1960: Ident           "copy" at 213:2-213:6
+1961: At              "@" at 214:1-214:2 (leading: Newline)
+1962: Ident           "intrinsic" at 214:2-214:11
+1963: KwPub           "pub" at 215:1-215:4 (leading: Newline)
+1964: KwType          "type" at 215:5-215:9 (leading: Space)
+1965: Ident           "Channel" at 215:10-215:17 (leading: Space)
+1966: Lt              "<" at 215:17-215:18
+1967: Ident           "T" at 215:18-215:19
+1968: Gt              ">" at 215:19-215:20
+1969: Assign          "=" at 215:21-215:22 (leading: Space)
+1970: LBrace          "{" at 215:23-215:24 (leading: Space)
+1971: Ident           "__opaque" at 216:5-216:13 (leading: Newline, Space)
+1972: Colon           ":" at 216:13-216:14
+1973: Star            "*" at 216:15-216:16 (leading: Space)
+1974: Ident           "byte" at 216:16-216:20
+1975: Comma           "," at 216:20-216:21
+1976: RBrace          "}" at 217:1-217:2 (leading: Newline)
+1977: Semicolon       ";" at 217:2-217:3
+1978: KwExtern        "extern" at 219:1-219:7 (leading: Newline)
+1979: Lt              "<" at 219:7-219:8
+1980: Ident           "Channel" at 219:8-219:15
+1981: Lt              "<" at 219:15-219:16
+1982: Ident           "T" at 219:16-219:17
+1983: Shr             ">>" at 219:17-219:19
+1984: LBrace          "{" at 219:20-219:21 (leading: Space)
+1985: At              "@" at 221:5-221:6 (leading: Newline, Space, LineComment, Newline, Space)
+1986: Ident           "intrinsic" at 221:6-221:15
+1987: KwPub           "pub" at 221:16-221:19 (leading: Space)
+1988: KwFn            "fn" at 221:20-221:22 (leading: Space)
+1989: Ident           "new" at 221:23-221:26 (leading: Space)
+1990: LParen          "(" at 221:26-221:27
+1991: Ident           "capacity" at 221:27-221:35
+1992: Colon           ":" at 221:35-221:36
+1993: Ident           "uint" at 221:37-221:41 (leading: Space)
+1994: RParen          ")" at 221:41-221:42
+1995: Arrow           "->" at 221:43-221:45 (leading: Space)
+1996: KwOwn           "own" at 221:46-221:49 (leading: Space)
+1997: Ident           "Channel" at 221:50-221:57 (leading: Space)
+1998: Lt              "<" at 221:57-221:58
+1999: Ident           "T" at 221:58-221:59
+2000: Gt              ">" at 221:59-221:60
+2001: Semicolon       ";" at 221:60-221:61
+2002: At              "@" at 223:5-223:6 (leading: Newline, Space, LineComment, Newline, Space)
+2003: Ident           "intrinsic" at 223:6-223:15
+2004: KwPub           "pub" at 223:16-223:19 (leading: Space)
+2005: KwFn            "fn" at 223:20-223:22 (leading: Space)
+2006: Ident           "send" at 223:23-223:27 (leading: Space)
+2007: LParen          "(" at 223:27-223:28
+2008: Ident           "self" at 223:28-223:32
+2009: Colon           ":" at 223:32-223:33
+2010: Amp             "&" at 223:34-223:35 (leading: Space)
+2011: Ident           "Channel" at 223:35-223:42
+2012: Lt              "<" at 223:42-223:43
+2013: Ident           "T" at 223:43-223:44
+2014: Gt              ">" at 223:44-223:45
+2015: Comma           "," at 223:45-223:46
+2016: Ident           "value" at 223:47-223:52 (leading: Space)
+2017: Colon           ":" at 223:52-223:53
+2018: KwOwn           "own" at 223:54-223:57 (leading: Space)
+2019: Ident           "T" at 223:58-223:59 (leading: Space)
+2020: RParen          ")" at 223:59-223:60
+2021: Arrow           "->" at 223:61-223:63 (leading: Space)
+2022: NothingLit      "nothing" at 223:64-223:71 (leading: Space)
+2023: Semicolon       ";" at 223:71-223:72
+2024: At              "@" at 225:5-225:6 (leading: Newline, Space, LineComment, Newline, Space)
+2025: Ident           "intrinsic" at 225:6-225:15
+2026: KwPub           "pub" at 225:16-225:19 (leading: Space)
+2027: KwFn            "fn" at 225:20-225:22 (leading: Space)
+2028: Ident           "recv" at 225:23-225:27 (leading: Space)
+2029: LParen          "(" at 225:27-225:28
+2030: Ident           "self" at 225:28-225:32
+2031: Colon           ":" at 225:32-225:33
+2032: Amp             "&" at 225:34-225:35 (leading: Space)
+2033: Ident           "Channel" at 225:35-225:42
+2034: Lt              "<" at 225:42-225:43
+2035: Ident           "T" at 225:43-225:44
+2036: Gt              ">" at 225:44-225:45
+2037: RParen          ")" at 225:45-225:46
+2038: Arrow           "->" at 225:47-225:49 (leading: Space)
+2039: Ident           "Option" at 225:50-225:56 (leading: Space)
+2040: Lt              "<" at 225:56-225:57
+2041: Ident           "T" at 225:57-225:58
+2042: Gt              ">" at 225:58-225:59
+2043: Semicolon       ";" at 225:59-225:60
+2044: At              "@" at 227:5-227:6 (leading: Newline, Space, LineComment, Newline, Space)
+2045: Ident           "intrinsic" at 227:6-227:15
+2046: KwPub           "pub" at 227:16-227:19 (leading: Space)
+2047: KwFn            "fn" at 227:20-227:22 (leading: Space)
+2048: Ident           "try_send" at 227:23-227:31 (leading: Space)
+2049: LParen          "(" at 227:31-227:32
+2050: Ident           "self" at 227:32-227:36
+2051: Colon           ":" at 227:36-227:37
+2052: Amp             "&" at 227:38-227:39 (leading: Space)
+2053: Ident           "Channel" at 227:39-227:46
+2054: Lt              "<" at 227:46-227:47
+2055: Ident           "T" at 227:47-227:48
+2056: Gt              ">" at 227:48-227:49
+2057: Comma           "," at 227:49-227:50
+2058: Ident           "value" at 227:51-227:56 (leading: Space)
+2059: Colon           ":" at 227:56-227:57
+2060: KwOwn           "own" at 227:58-227:61 (leading: Space)
+2061: Ident           "T" at 227:62-227:63 (leading: Space)
+2062: RParen          ")" at 227:63-227:64
+2063: Arrow           "->" at 227:65-227:67 (leading: Space)
+2064: Ident           "bool" at 227:68-227:72 (leading: Space)
+2065: Semicolon       ";" at 227:72-227:73
+2066: At              "@" at 229:5-229:6 (leading: Newline, Space, LineComment, Newline, Space)
+2067: Ident           "intrinsic" at 229:6-229:15
+2068: KwPub           "pub" at 229:16-229:19 (leading: Space)
+2069: KwFn            "fn" at 229:20-229:22 (leading: Space)
+2070: Ident           "try_recv" at 229:23-229:31 (leading: Space)
+2071: LParen          "(" at 229:31-229:32
+2072: Ident           "self" at 229:32-229:36
+2073: Colon           ":" at 229:36-229:37
+2074: Amp             "&" at 229:38-229:39 (leading: Space)
+2075: Ident           "Channel" at 229:39-229:46
+2076: Lt              "<" at 229:46-229:47
+2077: Ident           "T" at 229:47-229:48
+2078: Gt              ">" at 229:48-229:49
+2079: RParen          ")" at 229:49-229:50
+2080: Arrow           "->" at 229:51-229:53 (leading: Space)
+2081: Ident           "Option" at 229:54-229:60 (leading: Space)
+2082: Lt              "<" at 229:60-229:61
+2083: Ident           "T" at 229:61-229:62
+2084: Gt              ">" at 229:62-229:63
+2085: Semicolon       ";" at 229:63-229:64
+2086: At              "@" at 231:5-231:6 (leading: Newline, Space, LineComment, Newline, Space)
+2087: Ident           "intrinsic" at 231:6-231:15
+2088: KwPub           "pub" at 231:16-231:19 (leading: Space)
+2089: KwFn            "fn" at 231:20-231:22 (leading: Space)
+2090: Ident           "close" at 231:23-231:28 (leading: Space)
+2091: LParen          "(" at 231:28-231:29
+2092: Ident           "self" at 231:29-231:33
+2093: Colon           ":" at 231:33-231:34
+2094: Amp             "&" at 231:35-231:36 (leading: Space)
+2095: Ident           "Channel" at 231:36-231:43
+2096: Lt              "<" at 231:43-231:44
+2097: Ident           "T" at 231:44-231:45
+2098: Gt              ">" at 231:45-231:46
+2099: RParen          ")" at 231:46-231:47
+2100: Arrow           "->" at 231:48-231:50 (leading: Space)
+2101: NothingLit      "nothing" at 231:51-231:58 (leading: Space)
+2102: Semicolon       ";" at 231:58-231:59
+2103: RBrace          "}" at 232:1-232:2 (leading: Newline)
+2104: At              "@" at 234:1-234:2 (leading: Newline)
+2105: Ident           "intrinsic" at 234:2-234:11
+2106: KwFn            "fn" at 235:1-235:3 (leading: Newline)
+2107: Ident           "make_channel" at 235:4-235:16 (leading: Space)
+2108: Lt              "<" at 235:16-235:17
+2109: Ident           "T" at 235:17-235:18
+2110: Gt              ">" at 235:18-235:19
+2111: LParen          "(" at 235:19-235:20
+2112: Ident           "capacity" at 235:20-235:28
+2113: Colon           ":" at 235:28-235:29
+2114: Ident           "uint" at 235:30-235:34 (leading: Space)
+2115: RParen          ")" at 235:34-235:35
+2116: Arrow           "->" at 235:36-235:38 (leading: Space)
+2117: KwOwn           "own" at 235:39-235:42 (leading: Space)
+2118: Ident           "Channel" at 235:43-235:50 (leading: Space)
+2119: Lt              "<" at 235:50-235:51
+2120: Ident           "T" at 235:51-235:52
+2121: Gt              ">" at 235:52-235:53
+2122: Semicolon       ";" at 235:53-235:54
+2123: KwPub           "pub" at 237:1-237:4 (leading: Newline)
+2124: KwContract      "contract" at 237:5-237:13 (leading: Space)
+2125: Ident           "Bounded" at 237:14-237:21 (leading: Space)
+2126: Lt              "<" at 237:21-237:22
+2127: Ident           "T" at 237:22-237:23
+2128: Gt              ">" at 237:23-237:24
+2129: LBrace          "{" at 237:25-237:26 (leading: Space)
+2130: KwFn            "fn" at 238:5-238:7 (leading: Newline, Space)
+2131: Ident           "__min_value" at 238:8-238:19 (leading: Space)
+2132: LParen          "(" at 238:19-238:20
+2133: RParen          ")" at 238:20-238:21
+2134: Arrow           "->" at 238:22-238:24 (leading: Space)
+2135: Ident           "T" at 238:25-238:26 (leading: Space)
+2136: Semicolon       ";" at 238:26-238:27
+2137: KwFn            "fn" at 239:5-239:7 (leading: Newline, Space)
+2138: Ident           "__max_value" at 239:8-239:19 (leading: Space)
+2139: LParen          "(" at 239:19-239:20
+2140: RParen          ")" at 239:20-239:21
+2141: Arrow           "->" at 239:22-239:24 (leading: Space)
+2142: Ident           "T" at 239:25-239:26 (leading: Space)
+2143: Semicolon       ";" at 239:26-239:27
+2144: RBrace          "}" at 240:1-240:2 (leading: Newline)
+2145: KwPub           "pub" at 242:1-242:4 (leading: Newline)
+2146: KwContract      "contract" at 242:5-242:13 (leading: Space)
+2147: Ident           "HasLength" at 242:14-242:23 (leading: Space)
+2148: Lt              "<" at 242:23-242:24
+2149: Ident           "T" at 242:24-242:25
+2150: Gt              ">" at 242:25-242:26
+2151: LBrace          "{" at 242:27-242:28 (leading: Space)
+2152: KwFn            "fn" at 243:5-243:7 (leading: Newline, Space)
+2153: Ident           "__len" at 243:8-243:13 (leading: Space)
+2154: LParen          "(" at 243:13-243:14
+2155: Ident           "self" at 243:14-243:18
+2156: Colon           ":" at 243:18-243:19
+2157: Amp             "&" at 243:20-243:21 (leading: Space)
+2158: Ident           "T" at 243:21-243:22
+2159: RParen          ")" at 243:22-243:23
+2160: Arrow           "->" at 243:24-243:26 (leading: Space)
+2161: Ident           "uint" at 243:27-243:31 (leading: Space)
+2162: Semicolon       ";" at 243:31-243:32
+2163: RBrace          "}" at 244:1-244:2 (leading: Newline)
+2164: KwPub           "pub" at 246:1-246:4 (leading: Newline)
+2165: KwContract      "contract" at 246:5-246:13 (leading: Space)
+2166: Ident           "Printable" at 246:14-246:23 (leading: Space)
+2167: Lt              "<" at 246:23-246:24
+2168: Ident           "T" at 246:24-246:25
+2169: Gt              ">" at 246:25-246:26
+2170: LBrace          "{" at 246:27-246:28 (leading: Space)
+2171: KwFn            "fn" at 247:5-247:7 (leading: Newline, Space)
+2172: Ident           "__to" at 247:8-247:12 (leading: Space)
+2173: LParen          "(" at 247:12-247:13
+2174: Ident           "self" at 247:13-247:17
+2175: Colon           ":" at 247:17-247:18
+2176: Amp             "&" at 247:19-247:20 (leading: Space)
+2177: Ident           "T" at 247:20-247:21
+2178: Comma           "," at 247:21-247:22
+2179: Ident           "target" at 247:23-247:29 (leading: Space)
+2180: Colon           ":" at 247:29-247:30
+2181: Ident           "string" at 247:31-247:37 (leading: Space)
+2182: RParen          ")" at 247:37-247:38
+2183: Arrow           "->" at 247:39-247:41 (leading: Space)
+2184: Ident           "string" at 247:42-247:48 (leading: Space)
+2185: Semicolon       ";" at 247:48-247:49
+2186: RBrace          "}" at 248:1-248:2 (leading: Newline)
+2187: KwPub           "pub" at 250:1-250:4 (leading: Newline)
+2188: KwFn            "fn" at 250:5-250:7 (leading: Space)
+2189: Ident           "max_value" at 250:8-250:17 (leading: Space)
+2190: Lt              "<" at 250:17-250:18
+2191: Ident           "T" at 250:18-250:19
+2192: Colon           ":" at 250:19-250:20
+2193: Ident           "Bounded" at 250:21-250:28 (leading: Space)
+2194: Lt              "<" at 250:28-250:29
+2195: Ident           "T" at 250:29-250:30
+2196: Shr             ">>" at 250:30-250:32
+2197: LParen          "(" at 250:32-250:33
+2198: RParen          ")" at 250:33-250:34
+2199: Arrow           "->" at 250:35-250:37 (leading: Space)
+2200: Ident           "T" at 250:38-250:39 (leading: Space)
+2201: LBrace          "{" at 250:40-250:41 (leading: Space)
+2202: KwReturn        "return" at 251:5-251:11 (leading: Newline, Space)
+2203: Ident           "T" at 251:12-251:13 (leading: Space)
+2204: Dot             "." at 251:13-251:14
+2205: Ident           "__max_value" at 251:14-251:25
+2206: LParen          "(" at 251:25-251:26
+2207: RParen          ")" at 251:26-251:27
+2208: Semicolon       ";" at 251:27-251:28
+2209: RBrace          "}" at 252:1-252:2 (leading: Newline)
+2210: KwPub           "pub" at 254:1-254:4 (leading: Newline)
+2211: KwFn            "fn" at 254:5-254:7 (leading: Space)
+2212: Ident           "min_value" at 254:8-254:17 (leading: Space)
+2213: Lt              "<" at 254:17-254:18
+2214: Ident           "T" at 254:18-254:19
+2215: Colon           ":" at 254:19-254:20
+2216: Ident           "Bounded" at 254:21-254:28 (leading: Space)
+2217: Lt              "<" at 254:28-254:29
+2218: Ident           "T" at 254:29-254:30
+2219: Shr             ">>" at 254:30-254:32
+2220: LParen          "(" at 254:32-254:33
+2221: RParen          ")" at 254:33-254:34
+2222: Arrow           "->" at 254:35-254:37 (leading: Space)
+2223: Ident           "T" at 254:38-254:39 (leading: Space)
+2224: LBrace          "{" at 254:40-254:41 (leading: Space)
+2225: KwReturn        "return" at 255:5-255:11 (leading: Newline, Space)
+2226: Ident           "T" at 255:12-255:13 (leading: Space)
+2227: Dot             "." at 255:13-255:14
+2228: Ident           "__min_value" at 255:14-255:25
+2229: LParen          "(" at 255:25-255:26
+2230: RParen          ")" at 255:26-255:27
+2231: Semicolon       ";" at 255:27-255:28
+2232: RBrace          "}" at 256:1-256:2 (leading: Newline)
+2233: KwExtern        "extern" at 258:1-258:7 (leading: Newline)
+2234: Lt              "<" at 258:7-258:8
+2235: Ident           "int" at 258:8-258:11
+2236: Gt              ">" at 258:11-258:12
+2237: LBrace          "{" at 258:13-258:14 (leading: Space)
+2238: At              "@" at 259:5-259:6 (leading: Newline, Space)
+2239: Ident           "intrinsic" at 259:6-259:15
+2240: KwFn            "fn" at 259:16-259:18 (leading: Space)
+2241: Ident           "__add" at 259:19-259:24 (leading: Space)
+2242: LParen          "(" at 259:24-259:25
+2243: Ident           "self" at 259:25-259:29
+2244: Colon           ":" at 259:29-259:30
+2245: Ident           "int" at 259:31-259:34 (leading: Space)
+2246: Comma           "," at 259:34-259:35
+2247: Ident           "other" at 259:36-259:41 (leading: Space)
+2248: Colon           ":" at 259:41-259:42
+2249: Ident           "int" at 259:43-259:46 (leading: Space)
+2250: RParen          ")" at 259:46-259:47
+2251: Arrow           "->" at 259:48-259:50 (leading: Space)
+2252: Ident           "int" at 259:51-259:54 (leading: Space)
+2253: Semicolon       ";" at 259:54-259:55
+2254: At              "@" at 260:5-260:6 (leading: Newline, Space)
+2255: Ident           "intrinsic" at 260:6-260:15
+2256: KwFn            "fn" at 260:16-260:18 (leading: Space)
+2257: Ident           "__sub" at 260:19-260:24 (leading: Space)
+2258: LParen          "(" at 260:24-260:25
+2259: Ident           "self" at 260:25-260:29
+2260: Colon           ":" at 260:29-260:30
+2261: Ident           "int" at 260:31-260:34 (leading: Space)
+2262: Comma           "," at 260:34-260:35
+2263: Ident           "other" at 260:36-260:41 (leading: Space)
+2264: Colon           ":" at 260:41-260:42
+2265: Ident           "int" at 260:43-260:46 (leading: Space)
+2266: RParen          ")" at 260:46-260:47
+2267: Arrow           "->" at 260:48-260:50 (leading: Space)
+2268: Ident           "int" at 260:51-260:54 (leading: Space)
+2269: Semicolon       ";" at 260:54-260:55
+2270: At              "@" at 261:5-261:6 (leading: Newline, Space)
+2271: Ident           "intrinsic" at 261:6-261:15
+2272: KwFn            "fn" at 261:16-261:18 (leading: Space)
+2273: Ident           "__mul" at 261:19-261:24 (leading: Space)
+2274: LParen          "(" at 261:24-261:25
+2275: Ident           "self" at 261:25-261:29
+2276: Colon           ":" at 261:29-261:30
+2277: Ident           "int" at 261:31-261:34 (leading: Space)
+2278: Comma           "," at 261:34-261:35
+2279: Ident           "other" at 261:36-261:41 (leading: Space)
+2280: Colon           ":" at 261:41-261:42
+2281: Ident           "int" at 261:43-261:46 (leading: Space)
+2282: RParen          ")" at 261:46-261:47
+2283: Arrow           "->" at 261:48-261:50 (leading: Space)
+2284: Ident           "int" at 261:51-261:54 (leading: Space)
+2285: Semicolon       ";" at 261:54-261:55
+2286: At              "@" at 262:5-262:6 (leading: Newline, Space)
+2287: Ident           "intrinsic" at 262:6-262:15
+2288: KwFn            "fn" at 262:16-262:18 (leading: Space)
+2289: Ident           "__div" at 262:19-262:24 (leading: Space)
+2290: LParen          "(" at 262:24-262:25
+2291: Ident           "self" at 262:25-262:29
+2292: Colon           ":" at 262:29-262:30
+2293: Ident           "int" at 262:31-262:34 (leading: Space)
+2294: Comma           "," at 262:34-262:35
+2295: Ident           "other" at 262:36-262:41 (leading: Space)
+2296: Colon           ":" at 262:41-262:42
+2297: Ident           "int" at 262:43-262:46 (leading: Space)
+2298: RParen          ")" at 262:46-262:47
+2299: Arrow           "->" at 262:48-262:50 (leading: Space)
+2300: Ident           "int" at 262:51-262:54 (leading: Space)
+2301: Semicolon       ";" at 262:54-262:55
+2302: At              "@" at 263:5-263:6 (leading: Newline, Space)
+2303: Ident           "intrinsic" at 263:6-263:15
+2304: KwFn            "fn" at 263:16-263:18 (leading: Space)
+2305: Ident           "__mod" at 263:19-263:24 (leading: Space)
+2306: LParen          "(" at 263:24-263:25
+2307: Ident           "self" at 263:25-263:29
+2308: Colon           ":" at 263:29-263:30
+2309: Ident           "int" at 263:31-263:34 (leading: Space)
+2310: Comma           "," at 263:34-263:35
+2311: Ident           "other" at 263:36-263:41 (leading: Space)
+2312: Colon           ":" at 263:41-263:42
+2313: Ident           "int" at 263:43-263:46 (leading: Space)
+2314: RParen          ")" at 263:46-263:47
+2315: Arrow           "->" at 263:48-263:50 (leading: Space)
+2316: Ident           "int" at 263:51-263:54 (leading: Space)
+2317: Semicolon       ";" at 263:54-263:55
+2318: At              "@" at 264:5-264:6 (leading: Newline, Space)
+2319: Ident           "intrinsic" at 264:6-264:15
+2320: KwFn            "fn" at 264:16-264:18 (leading: Space)
+2321: Ident           "__bit_and" at 264:19-264:28 (leading: Space)
+2322: LParen          "(" at 264:28-264:29
+2323: Ident           "self" at 264:29-264:33
+2324: Colon           ":" at 264:33-264:34
+2325: Ident           "int" at 264:35-264:38 (leading: Space)
+2326: Comma           "," at 264:38-264:39
+2327: Ident           "other" at 264:40-264:45 (leading: Space)
+2328: Colon           ":" at 264:45-264:46
+2329: Ident           "int" at 264:47-264:50 (leading: Space)
+2330: RParen          ")" at 264:50-264:51
+2331: Arrow           "->" at 264:52-264:54 (leading: Space)
+2332: Ident           "int" at 264:55-264:58 (leading: Space)
+2333: Semicolon       ";" at 264:58-264:59
+2334: At              "@" at 265:5-265:6 (leading: Newline, Space)
+2335: Ident           "intrinsic" at 265:6-265:15
+2336: KwFn            "fn" at 265:16-265:18 (leading: Space)
+2337: Ident           "__bit_or" at 265:19-265:27 (leading: Space)
+2338: LParen          "(" at 265:27-265:28
+2339: Ident           "self" at 265:28-265:32
+2340: Colon           ":" at 265:32-265:33
+2341: Ident           "int" at 265:34-265:37 (leading: Space)
+2342: Comma           "," at 265:37-265:38
+2343: Ident           "other" at 265:39-265:44 (leading: Space)
+2344: Colon           ":" at 265:44-265:45
+2345: Ident           "int" at 265:46-265:49 (leading: Space)
+2346: RParen          ")" at 265:49-265:50
+2347: Arrow           "->" at 265:51-265:53 (leading: Space)
+2348: Ident           "int" at 265:54-265:57 (leading: Space)
+2349: Semicolon       ";" at 265:57-265:58
+2350: At              "@" at 266:5-266:6 (leading: Newline, Space)
+2351: Ident           "intrinsic" at 266:6-266:15
+2352: KwFn            "fn" at 266:16-266:18 (leading: Space)
+2353: Ident           "__bit_xor" at 266:19-266:28 (leading: Space)
+2354: LParen          "(" at 266:28-266:29
+2355: Ident           "self" at 266:29-266:33
+2356: Colon           ":" at 266:33-266:34
+2357: Ident           "int" at 266:35-266:38 (leading: Space)
+2358: Comma           "," at 266:38-266:39
+2359: Ident           "other" at 266:40-266:45 (leading: Space)
+2360: Colon           ":" at 266:45-266:46
+2361: Ident           "int" at 266:47-266:50 (leading: Space)
+2362: RParen          ")" at 266:50-266:51
+2363: Arrow           "->" at 266:52-266:54 (leading: Space)
+2364: Ident           "int" at 266:55-266:58 (leading: Space)
+2365: Semicolon       ";" at 266:58-266:59
+2366: At              "@" at 267:5-267:6 (leading: Newline, Space)
+2367: Ident           "intrinsic" at 267:6-267:15
+2368: KwFn            "fn" at 267:16-267:18 (leading: Space)
+2369: Ident           "__shl" at 267:19-267:24 (leading: Space)
+2370: LParen          "(" at 267:24-267:25
+2371: Ident           "self" at 267:25-267:29
+2372: Colon           ":" at 267:29-267:30
+2373: Ident           "int" at 267:31-267:34 (leading: Space)
+2374: Comma           "," at 267:34-267:35
+2375: Ident           "other" at 267:36-267:41 (leading: Space)
+2376: Colon           ":" at 267:41-267:42
+2377: Ident           "int" at 267:43-267:46 (leading: Space)
+2378: RParen          ")" at 267:46-267:47
+2379: Arrow           "->" at 267:48-267:50 (leading: Space)
+2380: Ident           "int" at 267:51-267:54 (leading: Space)
+2381: Semicolon       ";" at 267:54-267:55
+2382: At              "@" at 268:5-268:6 (leading: Newline, Space)
+2383: Ident           "intrinsic" at 268:6-268:15
+2384: KwFn            "fn" at 268:16-268:18 (leading: Space)
+2385: Ident           "__shr" at 268:19-268:24 (leading: Space)
+2386: LParen          "(" at 268:24-268:25
+2387: Ident           "self" at 268:25-268:29
+2388: Colon           ":" at 268:29-268:30
+2389: Ident           "int" at 268:31-268:34 (leading: Space)
+2390: Comma           "," at 268:34-268:35
+2391: Ident           "other" at 268:36-268:41 (leading: Space)
+2392: Colon           ":" at 268:41-268:42
+2393: Ident           "int" at 268:43-268:46 (leading: Space)
+2394: RParen          ")" at 268:46-268:47
+2395: Arrow           "->" at 268:48-268:50 (leading: Space)
+2396: Ident           "int" at 268:51-268:54 (leading: Space)
+2397: Semicolon       ";" at 268:54-268:55
+2398: At              "@" at 269:5-269:6 (leading: Newline, Space)
+2399: Ident           "intrinsic" at 269:6-269:15
+2400: KwFn            "fn" at 269:16-269:18 (leading: Space)
+2401: Ident           "__lt" at 269:19-269:23 (leading: Space)
+2402: LParen          "(" at 269:23-269:24
+2403: Ident           "self" at 269:24-269:28
+2404: Colon           ":" at 269:28-269:29
+2405: Ident           "int" at 269:30-269:33 (leading: Space)
+2406: Comma           "," at 269:33-269:34
+2407: Ident           "other" at 269:35-269:40 (leading: Space)
+2408: Colon           ":" at 269:40-269:41
+2409: Ident           "int" at 269:42-269:45 (leading: Space)
+2410: RParen          ")" at 269:45-269:46
+2411: Arrow           "->" at 269:47-269:49 (leading: Space)
+2412: Ident           "bool" at 269:50-269:54 (leading: Space)
+2413: Semicolon       ";" at 269:54-269:55
+2414: At              "@" at 270:5-270:6 (leading: Newline, Space)
+2415: Ident           "intrinsic" at 270:6-270:15
+2416: KwFn            "fn" at 270:16-270:18 (leading: Space)
+2417: Ident           "__le" at 270:19-270:23 (leading: Space)
+2418: LParen          "(" at 270:23-270:24
+2419: Ident           "self" at 270:24-270:28
+2420: Colon           ":" at 270:28-270:29
+2421: Ident           "int" at 270:30-270:33 (leading: Space)
+2422: Comma           "," at 270:33-270:34
+2423: Ident           "other" at 270:35-270:40 (leading: Space)
+2424: Colon           ":" at 270:40-270:41
+2425: Ident           "int" at 270:42-270:45 (leading: Space)
+2426: RParen          ")" at 270:45-270:46
+2427: Arrow           "->" at 270:47-270:49 (leading: Space)
+2428: Ident           "bool" at 270:50-270:54 (leading: Space)
+2429: Semicolon       ";" at 270:54-270:55
+2430: At              "@" at 271:5-271:6 (leading: Newline, Space)
+2431: Ident           "intrinsic" at 271:6-271:15
+2432: KwFn            "fn" at 271:16-271:18 (leading: Space)
+2433: Ident           "__eq" at 271:19-271:23 (leading: Space)
+2434: LParen          "(" at 271:23-271:24
+2435: Ident           "self" at 271:24-271:28
+2436: Colon           ":" at 271:28-271:29
+2437: Ident           "int" at 271:30-271:33 (leading: Space)
+2438: Comma           "," at 271:33-271:34
+2439: Ident           "other" at 271:35-271:40 (leading: Space)
+2440: Colon           ":" at 271:40-271:41
+2441: Ident           "int" at 271:42-271:45 (leading: Space)
+2442: RParen          ")" at 271:45-271:46
+2443: Arrow           "->" at 271:47-271:49 (leading: Space)
+2444: Ident           "bool" at 271:50-271:54 (leading: Space)
+2445: Semicolon       ";" at 271:54-271:55
+2446: At              "@" at 272:5-272:6 (leading: Newline, Space)
+2447: Ident           "intrinsic" at 272:6-272:15
+2448: KwFn            "fn" at 272:16-272:18 (leading: Space)
+2449: Ident           "__ne" at 272:19-272:23 (leading: Space)
+2450: LParen          "(" at 272:23-272:24
+2451: Ident           "self" at 272:24-272:28
+2452: Colon           ":" at 272:28-272:29
+2453: Ident           "int" at 272:30-272:33 (leading: Space)
+2454: Comma           "," at 272:33-272:34
+2455: Ident           "other" at 272:35-272:40 (leading: Space)
+2456: Colon           ":" at 272:40-272:41
+2457: Ident           "int" at 272:42-272:45 (leading: Space)
+2458: RParen          ")" at 272:45-272:46
+2459: Arrow           "->" at 272:47-272:49 (leading: Space)
+2460: Ident           "bool" at 272:50-272:54 (leading: Space)
+2461: Semicolon       ";" at 272:54-272:55
+2462: At              "@" at 273:5-273:6 (leading: Newline, Space)
+2463: Ident           "intrinsic" at 273:6-273:15
+2464: KwFn            "fn" at 273:16-273:18 (leading: Space)
+2465: Ident           "__ge" at 273:19-273:23 (leading: Space)
+2466: LParen          "(" at 273:23-273:24
+2467: Ident           "self" at 273:24-273:28
+2468: Colon           ":" at 273:28-273:29
+2469: Ident           "int" at 273:30-273:33 (leading: Space)
+2470: Comma           "," at 273:33-273:34
+2471: Ident           "other" at 273:35-273:40 (leading: Space)
+2472: Colon           ":" at 273:40-273:41
+2473: Ident           "int" at 273:42-273:45 (leading: Space)
+2474: RParen          ")" at 273:45-273:46
+2475: Arrow           "->" at 273:47-273:49 (leading: Space)
+2476: Ident           "bool" at 273:50-273:54 (leading: Space)
+2477: Semicolon       ";" at 273:54-273:55
+2478: At              "@" at 274:5-274:6 (leading: Newline, Space)
+2479: Ident           "intrinsic" at 274:6-274:15
+2480: KwFn            "fn" at 274:16-274:18 (leading: Space)
+2481: Ident           "__gt" at 274:19-274:23 (leading: Space)
+2482: LParen          "(" at 274:23-274:24
+2483: Ident           "self" at 274:24-274:28
+2484: Colon           ":" at 274:28-274:29
+2485: Ident           "int" at 274:30-274:33 (leading: Space)
+2486: Comma           "," at 274:33-274:34
+2487: Ident           "other" at 274:35-274:40 (leading: Space)
+2488: Colon           ":" at 274:40-274:41
+2489: Ident           "int" at 274:42-274:45 (leading: Space)
+2490: RParen          ")" at 274:45-274:46
+2491: Arrow           "->" at 274:47-274:49 (leading: Space)
+2492: Ident           "bool" at 274:50-274:54 (leading: Space)
+2493: Semicolon       ";" at 274:54-274:55
+2494: At              "@" at 275:5-275:6 (leading: Newline, Space)
+2495: Ident           "intrinsic" at 275:6-275:15
+2496: KwFn            "fn" at 275:16-275:18 (leading: Space)
+2497: Ident           "__pos" at 275:19-275:24 (leading: Space)
+2498: LParen          "(" at 275:24-275:25
+2499: Ident           "self" at 275:25-275:29
+2500: Colon           ":" at 275:29-275:30
+2501: Ident           "int" at 275:31-275:34 (leading: Space)
+2502: RParen          ")" at 275:34-275:35
+2503: Arrow           "->" at 275:36-275:38 (leading: Space)
+2504: Ident           "int" at 275:39-275:42 (leading: Space)
+2505: Semicolon       ";" at 275:42-275:43
+2506: At              "@" at 276:5-276:6 (leading: Newline, Space)
+2507: Ident           "intrinsic" at 276:6-276:15
+2508: KwFn            "fn" at 276:16-276:18 (leading: Space)
+2509: Ident           "__neg" at 276:19-276:24 (leading: Space)
+2510: LParen          "(" at 276:24-276:25
+2511: Ident           "self" at 276:25-276:29
+2512: Colon           ":" at 276:29-276:30
+2513: Ident           "int" at 276:31-276:34 (leading: Space)
+2514: RParen          ")" at 276:34-276:35
+2515: Arrow           "->" at 276:36-276:38 (leading: Space)
+2516: Ident           "int" at 276:39-276:42 (leading: Space)
+2517: Semicolon       ";" at 276:42-276:43
+2518: At              "@" at 277:5-277:6 (leading: Newline, Space)
+2519: Ident           "intrinsic" at 277:6-277:15
+2520: KwFn            "fn" at 277:16-277:18 (leading: Space)
+2521: Ident           "__abs" at 277:19-277:24 (leading: Space)
+2522: LParen          "(" at 277:24-277:25
+2523: Ident           "self" at 277:25-277:29
+2524: Colon           ":" at 277:29-277:30
+2525: Ident           "int" at 277:31-277:34 (leading: Space)
+2526: RParen          ")" at 277:34-277:35
+2527: Arrow           "->" at 277:36-277:38 (leading: Space)
+2528: Ident           "int" at 277:39-277:42 (leading: Space)
+2529: Semicolon       ";" at 277:42-277:43
+2530: At              "@" at 278:5-278:6 (leading: Newline, Space)
+2531: Ident           "intrinsic" at 278:6-278:15
+2532: KwFn            "fn" at 278:16-278:18 (leading: Space)
+2533: Ident           "__to" at 278:19-278:23 (leading: Space)
+2534: LParen          "(" at 278:23-278:24
+2535: Ident           "self" at 278:24-278:28
+2536: Colon           ":" at 278:28-278:29
+2537: Ident           "int" at 278:30-278:33 (leading: Space)
+2538: Comma           "," at 278:33-278:34
+2539: Ident           "target" at 278:35-278:41 (leading: Space)
+2540: Colon           ":" at 278:41-278:42
+2541: Ident           "string" at 278:43-278:49 (leading: Space)
+2542: RParen          ")" at 278:49-278:50
+2543: Arrow           "->" at 278:51-278:53 (leading: Space)
+2544: Ident           "string" at 278:54-278:60 (leading: Space)
+2545: Semicolon       ";" at 278:60-278:61
+2546: At              "@" at 279:5-279:6 (leading: Newline, Space)
+2547: Ident           "overload" at 279:6-279:14
+2548: KwPub           "pub" at 279:15-279:18 (leading: Space)
+2549: KwFn            "fn" at 279:19-279:21 (leading: Space)
+2550: Ident           "__to" at 279:22-279:26 (leading: Space)
+2551: LParen          "(" at 279:26-279:27
+2552: Ident           "self" at 279:27-279:31
+2553: Colon           ":" at 279:31-279:32
+2554: Amp             "&" at 279:33-279:34 (leading: Space)
+2555: Ident           "int" at 279:34-279:37
+2556: Comma           "," at 279:37-279:38
+2557: Underscore      "_" at 279:39-279:40 (leading: Space)
+2558: Colon           ":" at 279:40-279:41
+2559: Ident           "string" at 279:42-279:48 (leading: Space)
+2560: RParen          ")" at 279:48-279:49
+2561: Arrow           "->" at 279:50-279:52 (leading: Space)
+2562: Ident           "string" at 279:53-279:59 (leading: Space)
+2563: LBrace          "{" at 279:60-279:61 (leading: Space)
+2564: KwReturn        "return" at 280:9-280:15 (leading: Newline, Space)
+2565: LParen          "(" at 280:16-280:17 (leading: Space)
+2566: Star            "*" at 280:17-280:18
+2567: Ident           "self" at 280:18-280:22
+2568: RParen          ")" at 280:22-280:23
+2569: KwTo            "to" at 280:24-280:26 (leading: Space)
+2570: Ident           "string" at 280:27-280:33 (leading: Space)
+2571: Semicolon       ";" at 280:33-280:34
+2572: RBrace          "}" at 281:5-281:6 (leading: Newline, Space)
+2573: At              "@" at 282:5-282:6 (leading: Newline, Space)
+2574: Ident           "intrinsic" at 282:6-282:15
+2575: At              "@" at 282:16-282:17 (leading: Space)
+2576: Ident           "overload" at 282:17-282:25
+2577: KwFn            "fn" at 282:26-282:28 (leading: Space)
+2578: Ident           "__to" at 282:29-282:33 (leading: Space)
+2579: LParen          "(" at 282:33-282:34
+2580: Ident           "self" at 282:34-282:38
+2581: Colon           ":" at 282:38-282:39
+2582: Ident           "int" at 282:40-282:43 (leading: Space)
+2583: Comma           "," at 282:43-282:44
+2584: Ident           "target" at 282:45-282:51 (leading: Space)
+2585: Colon           ":" at 282:51-282:52
+2586: Ident           "float" at 282:53-282:58 (leading: Space)
+2587: RParen          ")" at 282:58-282:59
+2588: Arrow           "->" at 282:60-282:62 (leading: Space)
+2589: Ident           "float" at 282:63-282:68 (leading: Space)
+2590: Semicolon       ";" at 282:68-282:69
+2591: At              "@" at 283:5-283:6 (leading: Newline, Space)
+2592: Ident           "intrinsic" at 283:6-283:15
+2593: At              "@" at 283:16-283:17 (leading: Space)
+2594: Ident           "overload" at 283:17-283:25
+2595: KwFn            "fn" at 283:26-283:28 (leading: Space)
+2596: Ident           "__to" at 283:29-283:33 (leading: Space)
+2597: LParen          "(" at 283:33-283:34
+2598: Ident           "self" at 283:34-283:38
+2599: Colon           ":" at 283:38-283:39
+2600: Ident           "int" at 283:40-283:43 (leading: Space)
+2601: Comma           "," at 283:43-283:44
+2602: Ident           "target" at 283:45-283:51 (leading: Space)
+2603: Colon           ":" at 283:51-283:52
+2604: Ident           "uint" at 283:53-283:57 (leading: Space)
+2605: RParen          ")" at 283:57-283:58
+2606: Arrow           "->" at 283:59-283:61 (leading: Space)
+2607: Ident           "uint" at 283:62-283:66 (leading: Space)
+2608: Semicolon       ";" at 283:66-283:67
+2609: At              "@" at 284:5-284:6 (leading: Newline, Space)
+2610: Ident           "intrinsic" at 284:6-284:15
+2611: At              "@" at 284:16-284:17 (leading: Space)
+2612: Ident           "overload" at 284:17-284:25
+2613: KwFn            "fn" at 284:26-284:28 (leading: Space)
+2614: Ident           "__to" at 284:29-284:33 (leading: Space)
+2615: LParen          "(" at 284:33-284:34
+2616: Ident           "self" at 284:34-284:38
+2617: Colon           ":" at 284:38-284:39
+2618: Ident           "int" at 284:40-284:43 (leading: Space)
+2619: Comma           "," at 284:43-284:44
+2620: Ident           "target" at 284:45-284:51 (leading: Space)
+2621: Colon           ":" at 284:51-284:52
+2622: Ident           "int8" at 284:53-284:57 (leading: Space)
+2623: RParen          ")" at 284:57-284:58
+2624: Arrow           "->" at 284:59-284:61 (leading: Space)
+2625: Ident           "int8" at 284:62-284:66 (leading: Space)
+2626: Semicolon       ";" at 284:66-284:67
+2627: At              "@" at 285:5-285:6 (leading: Newline, Space)
+2628: Ident           "intrinsic" at 285:6-285:15
+2629: At              "@" at 285:16-285:17 (leading: Space)
+2630: Ident           "overload" at 285:17-285:25
+2631: KwFn            "fn" at 285:26-285:28 (leading: Space)
+2632: Ident           "__to" at 285:29-285:33 (leading: Space)
+2633: LParen          "(" at 285:33-285:34
+2634: Ident           "self" at 285:34-285:38
+2635: Colon           ":" at 285:38-285:39
+2636: Ident           "int" at 285:40-285:43 (leading: Space)
+2637: Comma           "," at 285:43-285:44
+2638: Ident           "target" at 285:45-285:51 (leading: Space)
+2639: Colon           ":" at 285:51-285:52
+2640: Ident           "int16" at 285:53-285:58 (leading: Space)
+2641: RParen          ")" at 285:58-285:59
+2642: Arrow           "->" at 285:60-285:62 (leading: Space)
+2643: Ident           "int16" at 285:63-285:68 (leading: Space)
+2644: Semicolon       ";" at 285:68-285:69
+2645: At              "@" at 286:5-286:6 (leading: Newline, Space)
+2646: Ident           "intrinsic" at 286:6-286:15
+2647: At              "@" at 286:16-286:17 (leading: Space)
+2648: Ident           "overload" at 286:17-286:25
+2649: KwFn            "fn" at 286:26-286:28 (leading: Space)
+2650: Ident           "__to" at 286:29-286:33 (leading: Space)
+2651: LParen          "(" at 286:33-286:34
+2652: Ident           "self" at 286:34-286:38
+2653: Colon           ":" at 286:38-286:39
+2654: Ident           "int" at 286:40-286:43 (leading: Space)
+2655: Comma           "," at 286:43-286:44
+2656: Ident           "target" at 286:45-286:51 (leading: Space)
+2657: Colon           ":" at 286:51-286:52
+2658: Ident           "int32" at 286:53-286:58 (leading: Space)
+2659: RParen          ")" at 286:58-286:59
+2660: Arrow           "->" at 286:60-286:62 (leading: Space)
+2661: Ident           "int32" at 286:63-286:68 (leading: Space)
+2662: Semicolon       ";" at 286:68-286:69
+2663: At              "@" at 287:5-287:6 (leading: Newline, Space)
+2664: Ident           "intrinsic" at 287:6-287:15
+2665: At              "@" at 287:16-287:17 (leading: Space)
+2666: Ident           "overload" at 287:17-287:25
+2667: KwFn            "fn" at 287:26-287:28 (leading: Space)
+2668: Ident           "__to" at 287:29-287:33 (leading: Space)
+2669: LParen          "(" at 287:33-287:34
+2670: Ident           "self" at 287:34-287:38
+2671: Colon           ":" at 287:38-287:39
+2672: Ident           "int" at 287:40-287:43 (leading: Space)
+2673: Comma           "," at 287:43-287:44
+2674: Ident           "target" at 287:45-287:51 (leading: Space)
+2675: Colon           ":" at 287:51-287:52
+2676: Ident           "int64" at 287:53-287:58 (leading: Space)
+2677: RParen          ")" at 287:58-287:59
+2678: Arrow           "->" at 287:60-287:62 (leading: Space)
+2679: Ident           "int64" at 287:63-287:68 (leading: Space)
+2680: Semicolon       ";" at 287:68-287:69
+2681: At              "@" at 288:5-288:6 (leading: Newline, Space)
+2682: Ident           "intrinsic" at 288:6-288:15
+2683: At              "@" at 288:16-288:17 (leading: Space)
+2684: Ident           "overload" at 288:17-288:25
+2685: KwFn            "fn" at 288:26-288:28 (leading: Space)
+2686: Ident           "__to" at 288:29-288:33 (leading: Space)
+2687: LParen          "(" at 288:33-288:34
+2688: Ident           "self" at 288:34-288:38
+2689: Colon           ":" at 288:38-288:39
+2690: Ident           "int" at 288:40-288:43 (leading: Space)
+2691: Comma           "," at 288:43-288:44
+2692: Ident           "target" at 288:45-288:51 (leading: Space)
+2693: Colon           ":" at 288:51-288:52
+2694: Ident           "uint8" at 288:53-288:58 (leading: Space)
+2695: RParen          ")" at 288:58-288:59
+2696: Arrow           "->" at 288:60-288:62 (leading: Space)
+2697: Ident           "uint8" at 288:63-288:68 (leading: Space)
+2698: Semicolon       ";" at 288:68-288:69
+2699: At              "@" at 289:5-289:6 (leading: Newline, Space)
+2700: Ident           "intrinsic" at 289:6-289:15
+2701: At              "@" at 289:16-289:17 (leading: Space)
+2702: Ident           "overload" at 289:17-289:25
+2703: KwFn            "fn" at 289:26-289:28 (leading: Space)
+2704: Ident           "__to" at 289:29-289:33 (leading: Space)
+2705: LParen          "(" at 289:33-289:34
+2706: Ident           "self" at 289:34-289:38
+2707: Colon           ":" at 289:38-289:39
+2708: Ident           "int" at 289:40-289:43 (leading: Space)
+2709: Comma           "," at 289:43-289:44
+2710: Ident           "target" at 289:45-289:51 (leading: Space)
+2711: Colon           ":" at 289:51-289:52
+2712: Ident           "uint16" at 289:53-289:59 (leading: Space)
+2713: RParen          ")" at 289:59-289:60
+2714: Arrow           "->" at 289:61-289:63 (leading: Space)
+2715: Ident           "uint16" at 289:64-289:70 (leading: Space)
+2716: Semicolon       ";" at 289:70-289:71
+2717: At              "@" at 290:5-290:6 (leading: Newline, Space)
+2718: Ident           "intrinsic" at 290:6-290:15
+2719: At              "@" at 290:16-290:17 (leading: Space)
+2720: Ident           "overload" at 290:17-290:25
+2721: KwFn            "fn" at 290:26-290:28 (leading: Space)
+2722: Ident           "__to" at 290:29-290:33 (leading: Space)
+2723: LParen          "(" at 290:33-290:34
+2724: Ident           "self" at 290:34-290:38
+2725: Colon           ":" at 290:38-290:39
+2726: Ident           "int" at 290:40-290:43 (leading: Space)
+2727: Comma           "," at 290:43-290:44
+2728: Ident           "target" at 290:45-290:51 (leading: Space)
+2729: Colon           ":" at 290:51-290:52
+2730: Ident           "uint32" at 290:53-290:59 (leading: Space)
+2731: RParen          ")" at 290:59-290:60
+2732: Arrow           "->" at 290:61-290:63 (leading: Space)
+2733: Ident           "uint32" at 290:64-290:70 (leading: Space)
+2734: Semicolon       ";" at 290:70-290:71
+2735: At              "@" at 291:5-291:6 (leading: Newline, Space)
+2736: Ident           "intrinsic" at 291:6-291:15
+2737: At              "@" at 291:16-291:17 (leading: Space)
+2738: Ident           "overload" at 291:17-291:25
+2739: KwFn            "fn" at 291:26-291:28 (leading: Space)
+2740: Ident           "__to" at 291:29-291:33 (leading: Space)
+2741: LParen          "(" at 291:33-291:34
+2742: Ident           "self" at 291:34-291:38
+2743: Colon           ":" at 291:38-291:39
+2744: Ident           "int" at 291:40-291:43 (leading: Space)
+2745: Comma           "," at 291:43-291:44
+2746: Ident           "target" at 291:45-291:51 (leading: Space)
+2747: Colon           ":" at 291:51-291:52
+2748: Ident           "uint64" at 291:53-291:59 (leading: Space)
+2749: RParen          ")" at 291:59-291:60
+2750: Arrow           "->" at 291:61-291:63 (leading: Space)
+2751: Ident           "uint64" at 291:64-291:70 (leading: Space)
+2752: Semicolon       ";" at 291:70-291:71
+2753: At              "@" at 292:5-292:6 (leading: Newline, Space)
+2754: Ident           "intrinsic" at 292:6-292:15
+2755: At              "@" at 292:16-292:17 (leading: Space)
+2756: Ident           "overload" at 292:17-292:25
+2757: KwFn            "fn" at 292:26-292:28 (leading: Space)
+2758: Ident           "__to" at 292:29-292:33 (leading: Space)
+2759: LParen          "(" at 292:33-292:34
+2760: Ident           "self" at 292:34-292:38
+2761: Colon           ":" at 292:38-292:39
+2762: Ident           "int" at 292:40-292:43 (leading: Space)
+2763: Comma           "," at 292:43-292:44
+2764: Ident           "target" at 292:45-292:51 (leading: Space)
+2765: Colon           ":" at 292:51-292:52
+2766: Ident           "float16" at 292:53-292:60 (leading: Space)
+2767: RParen          ")" at 292:60-292:61
+2768: Arrow           "->" at 292:62-292:64 (leading: Space)
+2769: Ident           "float16" at 292:65-292:72 (leading: Space)
+2770: Semicolon       ";" at 292:72-292:73
+2771: At              "@" at 293:5-293:6 (leading: Newline, Space)
+2772: Ident           "intrinsic" at 293:6-293:15
+2773: At              "@" at 293:16-293:17 (leading: Space)
+2774: Ident           "overload" at 293:17-293:25
+2775: KwFn            "fn" at 293:26-293:28 (leading: Space)
+2776: Ident           "__to" at 293:29-293:33 (leading: Space)
+2777: LParen          "(" at 293:33-293:34
+2778: Ident           "self" at 293:34-293:38
+2779: Colon           ":" at 293:38-293:39
+2780: Ident           "int" at 293:40-293:43 (leading: Space)
+2781: Comma           "," at 293:43-293:44
+2782: Ident           "target" at 293:45-293:51 (leading: Space)
+2783: Colon           ":" at 293:51-293:52
+2784: Ident           "float32" at 293:53-293:60 (leading: Space)
+2785: RParen          ")" at 293:60-293:61
+2786: Arrow           "->" at 293:62-293:64 (leading: Space)
+2787: Ident           "float32" at 293:65-293:72 (leading: Space)
+2788: Semicolon       ";" at 293:72-293:73
+2789: At              "@" at 294:5-294:6 (leading: Newline, Space)
+2790: Ident           "intrinsic" at 294:6-294:15
+2791: At              "@" at 294:16-294:17 (leading: Space)
+2792: Ident           "overload" at 294:17-294:25
+2793: KwFn            "fn" at 294:26-294:28 (leading: Space)
+2794: Ident           "__to" at 294:29-294:33 (leading: Space)
+2795: LParen          "(" at 294:33-294:34
+2796: Ident           "self" at 294:34-294:38
+2797: Colon           ":" at 294:38-294:39
+2798: Ident           "int" at 294:40-294:43 (leading: Space)
+2799: Comma           "," at 294:43-294:44
+2800: Ident           "target" at 294:45-294:51 (leading: Space)
+2801: Colon           ":" at 294:51-294:52
+2802: Ident           "float64" at 294:53-294:60 (leading: Space)
+2803: RParen          ")" at 294:60-294:61
+2804: Arrow           "->" at 294:62-294:64 (leading: Space)
+2805: Ident           "float64" at 294:65-294:72 (leading: Space)
+2806: Semicolon       ";" at 294:72-294:73
+2807: At              "@" at 296:5-296:6 (leading: Newline, Space, LineComment, Newline, Space)
+2808: Ident           "intrinsic" at 296:6-296:15
+2809: KwPub           "pub" at 296:16-296:19 (leading: Space)
+2810: KwFn            "fn" at 296:20-296:22 (leading: Space)
+2811: Ident           "from_str" at 296:23-296:31 (leading: Space)
+2812: LParen          "(" at 296:31-296:32
+2813: Ident           "s" at 296:32-296:33
+2814: Colon           ":" at 296:33-296:34
+2815: Amp             "&" at 296:35-296:36 (leading: Space)
+2816: Ident           "string" at 296:36-296:42
+2817: RParen          ")" at 296:42-296:43
+2818: Arrow           "->" at 296:44-296:46 (leading: Space)
+2819: Ident           "Erring" at 296:47-296:53 (leading: Space)
+2820: Lt              "<" at 296:53-296:54
+2821: Ident           "int" at 296:54-296:57
+2822: Comma           "," at 296:57-296:58
+2823: Ident           "Error" at 296:59-296:64 (leading: Space)
+2824: Gt              ">" at 296:64-296:65
+2825: Semicolon       ";" at 296:65-296:66
+2826: RBrace          "}" at 297:1-297:2 (leading: Newline)
+2827: KwExtern        "extern" at 299:1-299:7 (leading: Newline)
+2828: Lt              "<" at 299:7-299:8
+2829: Ident           "uint" at 299:8-299:12
+2830: Gt              ">" at 299:12-299:13
+2831: LBrace          "{" at 299:14-299:15 (leading: Space)
+2832: At              "@" at 300:5-300:6 (leading: Newline, Space)
+2833: Ident           "intrinsic" at 300:6-300:15
+2834: KwFn            "fn" at 300:16-300:18 (leading: Space)
+2835: Ident           "__add" at 300:19-300:24 (leading: Space)
+2836: LParen          "(" at 300:24-300:25
+2837: Ident           "self" at 300:25-300:29
+2838: Colon           ":" at 300:29-300:30
+2839: Ident           "uint" at 300:31-300:35 (leading: Space)
+2840: Comma           "," at 300:35-300:36
+2841: Ident           "other" at 300:37-300:42 (leading: Space)
+2842: Colon           ":" at 300:42-300:43
+2843: Ident           "uint" at 300:44-300:48 (leading: Space)
+2844: RParen          ")" at 300:48-300:49
+2845: Arrow           "->" at 300:50-300:52 (leading: Space)
+2846: Ident           "uint" at 300:53-300:57 (leading: Space)
+2847: Semicolon       ";" at 300:57-300:58
+2848: At              "@" at 301:5-301:6 (leading: Newline, Space)
+2849: Ident           "intrinsic" at 301:6-301:15
+2850: KwFn            "fn" at 301:16-301:18 (leading: Space)
+2851: Ident           "__sub" at 301:19-301:24 (leading: Space)
+2852: LParen          "(" at 301:24-301:25
+2853: Ident           "self" at 301:25-301:29
+2854: Colon           ":" at 301:29-301:30
+2855: Ident           "uint" at 301:31-301:35 (leading: Space)
+2856: Comma           "," at 301:35-301:36
+2857: Ident           "other" at 301:37-301:42 (leading: Space)
+2858: Colon           ":" at 301:42-301:43
+2859: Ident           "uint" at 301:44-301:48 (leading: Space)
+2860: RParen          ")" at 301:48-301:49
+2861: Arrow           "->" at 301:50-301:52 (leading: Space)
+2862: Ident           "uint" at 301:53-301:57 (leading: Space)
+2863: Semicolon       ";" at 301:57-301:58
+2864: At              "@" at 302:5-302:6 (leading: Newline, Space)
+2865: Ident           "intrinsic" at 302:6-302:15
+2866: KwFn            "fn" at 302:16-302:18 (leading: Space)
+2867: Ident           "__mul" at 302:19-302:24 (leading: Space)
+2868: LParen          "(" at 302:24-302:25
+2869: Ident           "self" at 302:25-302:29
+2870: Colon           ":" at 302:29-302:30
+2871: Ident           "uint" at 302:31-302:35 (leading: Space)
+2872: Comma           "," at 302:35-302:36
+2873: Ident           "other" at 302:37-302:42 (leading: Space)
+2874: Colon           ":" at 302:42-302:43
+2875: Ident           "uint" at 302:44-302:48 (leading: Space)
+2876: RParen          ")" at 302:48-302:49
+2877: Arrow           "->" at 302:50-302:52 (leading: Space)
+2878: Ident           "uint" at 302:53-302:57 (leading: Space)
+2879: Semicolon       ";" at 302:57-302:58
+2880: At              "@" at 303:5-303:6 (leading: Newline, Space)
+2881: Ident           "intrinsic" at 303:6-303:15
+2882: KwFn            "fn" at 303:16-303:18 (leading: Space)
+2883: Ident           "__div" at 303:19-303:24 (leading: Space)
+2884: LParen          "(" at 303:24-303:25
+2885: Ident           "self" at 303:25-303:29
+2886: Colon           ":" at 303:29-303:30
+2887: Ident           "uint" at 303:31-303:35 (leading: Space)
+2888: Comma           "," at 303:35-303:36
+2889: Ident           "other" at 303:37-303:42 (leading: Space)
+2890: Colon           ":" at 303:42-303:43
+2891: Ident           "uint" at 303:44-303:48 (leading: Space)
+2892: RParen          ")" at 303:48-303:49
+2893: Arrow           "->" at 303:50-303:52 (leading: Space)
+2894: Ident           "uint" at 303:53-303:57 (leading: Space)
+2895: Semicolon       ";" at 303:57-303:58
+2896: At              "@" at 304:5-304:6 (leading: Newline, Space)
+2897: Ident           "intrinsic" at 304:6-304:15
+2898: KwFn            "fn" at 304:16-304:18 (leading: Space)
+2899: Ident           "__mod" at 304:19-304:24 (leading: Space)
+2900: LParen          "(" at 304:24-304:25
+2901: Ident           "self" at 304:25-304:29
+2902: Colon           ":" at 304:29-304:30
+2903: Ident           "uint" at 304:31-304:35 (leading: Space)
+2904: Comma           "," at 304:35-304:36
+2905: Ident           "other" at 304:37-304:42 (leading: Space)
+2906: Colon           ":" at 304:42-304:43
+2907: Ident           "uint" at 304:44-304:48 (leading: Space)
+2908: RParen          ")" at 304:48-304:49
+2909: Arrow           "->" at 304:50-304:52 (leading: Space)
+2910: Ident           "uint" at 304:53-304:57 (leading: Space)
+2911: Semicolon       ";" at 304:57-304:58
+2912: At              "@" at 305:5-305:6 (leading: Newline, Space)
+2913: Ident           "intrinsic" at 305:6-305:15
+2914: KwFn            "fn" at 305:16-305:18 (leading: Space)
+2915: Ident           "__bit_and" at 305:19-305:28 (leading: Space)
+2916: LParen          "(" at 305:28-305:29
+2917: Ident           "self" at 305:29-305:33
+2918: Colon           ":" at 305:33-305:34
+2919: Ident           "uint" at 305:35-305:39 (leading: Space)
+2920: Comma           "," at 305:39-305:40
+2921: Ident           "other" at 305:41-305:46 (leading: Space)
+2922: Colon           ":" at 305:46-305:47
+2923: Ident           "uint" at 305:48-305:52 (leading: Space)
+2924: RParen          ")" at 305:52-305:53
+2925: Arrow           "->" at 305:54-305:56 (leading: Space)
+2926: Ident           "uint" at 305:57-305:61 (leading: Space)
+2927: Semicolon       ";" at 305:61-305:62
+2928: At              "@" at 306:5-306:6 (leading: Newline, Space)
+2929: Ident           "intrinsic" at 306:6-306:15
+2930: KwFn            "fn" at 306:16-306:18 (leading: Space)
+2931: Ident           "__bit_or" at 306:19-306:27 (leading: Space)
+2932: LParen          "(" at 306:27-306:28
+2933: Ident           "self" at 306:28-306:32
+2934: Colon           ":" at 306:32-306:33
+2935: Ident           "uint" at 306:34-306:38 (leading: Space)
+2936: Comma           "," at 306:38-306:39
+2937: Ident           "other" at 306:40-306:45 (leading: Space)
+2938: Colon           ":" at 306:45-306:46
+2939: Ident           "uint" at 306:47-306:51 (leading: Space)
+2940: RParen          ")" at 306:51-306:52
+2941: Arrow           "->" at 306:53-306:55 (leading: Space)
+2942: Ident           "uint" at 306:56-306:60 (leading: Space)
+2943: Semicolon       ";" at 306:60-306:61
+2944: At              "@" at 307:5-307:6 (leading: Newline, Space)
+2945: Ident           "intrinsic" at 307:6-307:15
+2946: KwFn            "fn" at 307:16-307:18 (leading: Space)
+2947: Ident           "__bit_xor" at 307:19-307:28 (leading: Space)
+2948: LParen          "(" at 307:28-307:29
+2949: Ident           "self" at 307:29-307:33
+2950: Colon           ":" at 307:33-307:34
+2951: Ident           "uint" at 307:35-307:39 (leading: Space)
+2952: Comma           "," at 307:39-307:40
+2953: Ident           "other" at 307:41-307:46 (leading: Space)
+2954: Colon           ":" at 307:46-307:47
+2955: Ident           "uint" at 307:48-307:52 (leading: Space)
+2956: RParen          ")" at 307:52-307:53
+2957: Arrow           "->" at 307:54-307:56 (leading: Space)
+2958: Ident           "uint" at 307:57-307:61 (leading: Space)
+2959: Semicolon       ";" at 307:61-307:62
+2960: At              "@" at 308:5-308:6 (leading: Newline, Space)
+2961: Ident           "intrinsic" at 308:6-308:15
+2962: KwFn            "fn" at 308:16-308:18 (leading: Space)
+2963: Ident           "__shl" at 308:19-308:24 (leading: Space)
+2964: LParen          "(" at 308:24-308:25
+2965: Ident           "self" at 308:25-308:29
+2966: Colon           ":" at 308:29-308:30
+2967: Ident           "uint" at 308:31-308:35 (leading: Space)
+2968: Comma           "," at 308:35-308:36
+2969: Ident           "other" at 308:37-308:42 (leading: Space)
+2970: Colon           ":" at 308:42-308:43
+2971: Ident           "uint" at 308:44-308:48 (leading: Space)
+2972: RParen          ")" at 308:48-308:49
+2973: Arrow           "->" at 308:50-308:52 (leading: Space)
+2974: Ident           "uint" at 308:53-308:57 (leading: Space)
+2975: Semicolon       ";" at 308:57-308:58
+2976: At              "@" at 309:5-309:6 (leading: Newline, Space)
+2977: Ident           "intrinsic" at 309:6-309:15
+2978: KwFn            "fn" at 309:16-309:18 (leading: Space)
+2979: Ident           "__shr" at 309:19-309:24 (leading: Space)
+2980: LParen          "(" at 309:24-309:25
+2981: Ident           "self" at 309:25-309:29
+2982: Colon           ":" at 309:29-309:30
+2983: Ident           "uint" at 309:31-309:35 (leading: Space)
+2984: Comma           "," at 309:35-309:36
+2985: Ident           "other" at 309:37-309:42 (leading: Space)
+2986: Colon           ":" at 309:42-309:43
+2987: Ident           "uint" at 309:44-309:48 (leading: Space)
+2988: RParen          ")" at 309:48-309:49
+2989: Arrow           "->" at 309:50-309:52 (leading: Space)
+2990: Ident           "uint" at 309:53-309:57 (leading: Space)
+2991: Semicolon       ";" at 309:57-309:58
+2992: At              "@" at 310:5-310:6 (leading: Newline, Space)
+2993: Ident           "intrinsic" at 310:6-310:15
+2994: KwFn            "fn" at 310:16-310:18 (leading: Space)
+2995: Ident           "__lt" at 310:19-310:23 (leading: Space)
+2996: LParen          "(" at 310:23-310:24
+2997: Ident           "self" at 310:24-310:28
+2998: Colon           ":" at 310:28-310:29
+2999: Ident           "uint" at 310:30-310:34 (leading: Space)
+3000: Comma           "," at 310:34-310:35
+3001: Ident           "other" at 310:36-310:41 (leading: Space)
+3002: Colon           ":" at 310:41-310:42
+3003: Ident           "uint" at 310:43-310:47 (leading: Space)
+3004: RParen          ")" at 310:47-310:48
+3005: Arrow           "->" at 310:49-310:51 (leading: Space)
+3006: Ident           "bool" at 310:52-310:56 (leading: Space)
+3007: Semicolon       ";" at 310:56-310:57
+3008: At              "@" at 311:5-311:6 (leading: Newline, Space)
+3009: Ident           "intrinsic" at 311:6-311:15
+3010: KwFn            "fn" at 311:16-311:18 (leading: Space)
+3011: Ident           "__le" at 311:19-311:23 (leading: Space)
+3012: LParen          "(" at 311:23-311:24
+3013: Ident           "self" at 311:24-311:28
+3014: Colon           ":" at 311:28-311:29
+3015: Ident           "uint" at 311:30-311:34 (leading: Space)
+3016: Comma           "," at 311:34-311:35
+3017: Ident           "other" at 311:36-311:41 (leading: Space)
+3018: Colon           ":" at 311:41-311:42
+3019: Ident           "uint" at 311:43-311:47 (leading: Space)
+3020: RParen          ")" at 311:47-311:48
+3021: Arrow           "->" at 311:49-311:51 (leading: Space)
+3022: Ident           "bool" at 311:52-311:56 (leading: Space)
+3023: Semicolon       ";" at 311:56-311:57
+3024: At              "@" at 312:5-312:6 (leading: Newline, Space)
+3025: Ident           "intrinsic" at 312:6-312:15
+3026: KwFn            "fn" at 312:16-312:18 (leading: Space)
+3027: Ident           "__eq" at 312:19-312:23 (leading: Space)
+3028: LParen          "(" at 312:23-312:24
+3029: Ident           "self" at 312:24-312:28
+3030: Colon           ":" at 312:28-312:29
+3031: Ident           "uint" at 312:30-312:34 (leading: Space)
+3032: Comma           "," at 312:34-312:35
+3033: Ident           "other" at 312:36-312:41 (leading: Space)
+3034: Colon           ":" at 312:41-312:42
+3035: Ident           "uint" at 312:43-312:47 (leading: Space)
+3036: RParen          ")" at 312:47-312:48
+3037: Arrow           "->" at 312:49-312:51 (leading: Space)
+3038: Ident           "bool" at 312:52-312:56 (leading: Space)
+3039: Semicolon       ";" at 312:56-312:57
+3040: At              "@" at 313:5-313:6 (leading: Newline, Space)
+3041: Ident           "intrinsic" at 313:6-313:15
+3042: KwFn            "fn" at 313:16-313:18 (leading: Space)
+3043: Ident           "__ne" at 313:19-313:23 (leading: Space)
+3044: LParen          "(" at 313:23-313:24
+3045: Ident           "self" at 313:24-313:28
+3046: Colon           ":" at 313:28-313:29
+3047: Ident           "uint" at 313:30-313:34 (leading: Space)
+3048: Comma           "," at 313:34-313:35
+3049: Ident           "other" at 313:36-313:41 (leading: Space)
+3050: Colon           ":" at 313:41-313:42
+3051: Ident           "uint" at 313:43-313:47 (leading: Space)
+3052: RParen          ")" at 313:47-313:48
+3053: Arrow           "->" at 313:49-313:51 (leading: Space)
+3054: Ident           "bool" at 313:52-313:56 (leading: Space)
+3055: Semicolon       ";" at 313:56-313:57
+3056: At              "@" at 314:5-314:6 (leading: Newline, Space)
+3057: Ident           "intrinsic" at 314:6-314:15
+3058: KwFn            "fn" at 314:16-314:18 (leading: Space)
+3059: Ident           "__ge" at 314:19-314:23 (leading: Space)
+3060: LParen          "(" at 314:23-314:24
+3061: Ident           "self" at 314:24-314:28
+3062: Colon           ":" at 314:28-314:29
+3063: Ident           "uint" at 314:30-314:34 (leading: Space)
+3064: Comma           "," at 314:34-314:35
+3065: Ident           "other" at 314:36-314:41 (leading: Space)
+3066: Colon           ":" at 314:41-314:42
+3067: Ident           "uint" at 314:43-314:47 (leading: Space)
+3068: RParen          ")" at 314:47-314:48
+3069: Arrow           "->" at 314:49-314:51 (leading: Space)
+3070: Ident           "bool" at 314:52-314:56 (leading: Space)
+3071: Semicolon       ";" at 314:56-314:57
+3072: At              "@" at 315:5-315:6 (leading: Newline, Space)
+3073: Ident           "intrinsic" at 315:6-315:15
+3074: KwFn            "fn" at 315:16-315:18 (leading: Space)
+3075: Ident           "__gt" at 315:19-315:23 (leading: Space)
+3076: LParen          "(" at 315:23-315:24
+3077: Ident           "self" at 315:24-315:28
+3078: Colon           ":" at 315:28-315:29
+3079: Ident           "uint" at 315:30-315:34 (leading: Space)
+3080: Comma           "," at 315:34-315:35
+3081: Ident           "other" at 315:36-315:41 (leading: Space)
+3082: Colon           ":" at 315:41-315:42
+3083: Ident           "uint" at 315:43-315:47 (leading: Space)
+3084: RParen          ")" at 315:47-315:48
+3085: Arrow           "->" at 315:49-315:51 (leading: Space)
+3086: Ident           "bool" at 315:52-315:56 (leading: Space)
+3087: Semicolon       ";" at 315:56-315:57
+3088: At              "@" at 316:5-316:6 (leading: Newline, Space)
+3089: Ident           "intrinsic" at 316:6-316:15
+3090: KwFn            "fn" at 316:16-316:18 (leading: Space)
+3091: Ident           "__pos" at 316:19-316:24 (leading: Space)
+3092: LParen          "(" at 316:24-316:25
+3093: Ident           "self" at 316:25-316:29
+3094: Colon           ":" at 316:29-316:30
+3095: Ident           "uint" at 316:31-316:35 (leading: Space)
+3096: RParen          ")" at 316:35-316:36
+3097: Arrow           "->" at 316:37-316:39 (leading: Space)
+3098: Ident           "uint" at 316:40-316:44 (leading: Space)
+3099: Semicolon       ";" at 316:44-316:45
+3100: At              "@" at 317:5-317:6 (leading: Newline, Space)
+3101: Ident           "intrinsic" at 317:6-317:15
+3102: KwFn            "fn" at 317:16-317:18 (leading: Space)
+3103: Ident           "__abs" at 317:19-317:24 (leading: Space)
+3104: LParen          "(" at 317:24-317:25
+3105: Ident           "self" at 317:25-317:29
+3106: Colon           ":" at 317:29-317:30
+3107: Ident           "uint" at 317:31-317:35 (leading: Space)
+3108: RParen          ")" at 317:35-317:36
+3109: Arrow           "->" at 317:37-317:39 (leading: Space)
+3110: Ident           "uint" at 317:40-317:44 (leading: Space)
+3111: Semicolon       ";" at 317:44-317:45
+3112: At              "@" at 318:5-318:6 (leading: Newline, Space)
+3113: Ident           "intrinsic" at 318:6-318:15
+3114: KwFn            "fn" at 318:16-318:18 (leading: Space)
+3115: Ident           "__to" at 318:19-318:23 (leading: Space)
+3116: LParen          "(" at 318:23-318:24
+3117: Ident           "self" at 318:24-318:28
+3118: Colon           ":" at 318:28-318:29
+3119: Ident           "uint" at 318:30-318:34 (leading: Space)
+3120: Comma           "," at 318:34-318:35
+3121: Ident           "target" at 318:36-318:42 (leading: Space)
+3122: Colon           ":" at 318:42-318:43
+3123: Ident           "string" at 318:44-318:50 (leading: Space)
+3124: RParen          ")" at 318:50-318:51
+3125: Arrow           "->" at 318:52-318:54 (leading: Space)
+3126: Ident           "string" at 318:55-318:61 (leading: Space)
+3127: Semicolon       ";" at 318:61-318:62
+3128: At              "@" at 319:5-319:6 (leading: Newline, Space)
+3129: Ident           "overload" at 319:6-319:14
+3130: KwPub           "pub" at 319:15-319:18 (leading: Space)
+3131: KwFn            "fn" at 319:19-319:21 (leading: Space)
+3132: Ident           "__to" at 319:22-319:26 (leading: Space)
+3133: LParen          "(" at 319:26-319:27
+3134: Ident           "self" at 319:27-319:31
+3135: Colon           ":" at 319:31-319:32
+3136: Amp             "&" at 319:33-319:34 (leading: Space)
+3137: Ident           "uint" at 319:34-319:38
+3138: Comma           "," at 319:38-319:39
+3139: Underscore      "_" at 319:40-319:41 (leading: Space)
+3140: Colon           ":" at 319:41-319:42
+3141: Ident           "string" at 319:43-319:49 (leading: Space)
+3142: RParen          ")" at 319:49-319:50
+3143: Arrow           "->" at 319:51-319:53 (leading: Space)
+3144: Ident           "string" at 319:54-319:60 (leading: Space)
+3145: LBrace          "{" at 319:61-319:62 (leading: Space)
+3146: KwReturn        "return" at 320:9-320:15 (leading: Newline, Space)
+3147: LParen          "(" at 320:16-320:17 (leading: Space)
+3148: Star            "*" at 320:17-320:18
+3149: Ident           "self" at 320:18-320:22
+3150: RParen          ")" at 320:22-320:23
+3151: KwTo            "to" at 320:24-320:26 (leading: Space)
+3152: Ident           "string" at 320:27-320:33 (leading: Space)
+3153: Semicolon       ";" at 320:33-320:34
+3154: RBrace          "}" at 321:5-321:6 (leading: Newline, Space)
+3155: At              "@" at 322:5-322:6 (leading: Newline, Space)
+3156: Ident           "intrinsic" at 322:6-322:15
+3157: At              "@" at 322:16-322:17 (leading: Space)
+3158: Ident           "overload" at 322:17-322:25
+3159: KwFn            "fn" at 322:26-322:28 (leading: Space)
+3160: Ident           "__to" at 322:29-322:33 (leading: Space)
+3161: LParen          "(" at 322:33-322:34
+3162: Ident           "self" at 322:34-322:38
+3163: Colon           ":" at 322:38-322:39
+3164: Ident           "uint" at 322:40-322:44 (leading: Space)
+3165: Comma           "," at 322:44-322:45
+3166: Ident           "target" at 322:46-322:52 (leading: Space)
+3167: Colon           ":" at 322:52-322:53
+3168: Ident           "int" at 322:54-322:57 (leading: Space)
+3169: RParen          ")" at 322:57-322:58
+3170: Arrow           "->" at 322:59-322:61 (leading: Space)
+3171: Ident           "int" at 322:62-322:65 (leading: Space)
+3172: Semicolon       ";" at 322:65-322:66
+3173: At              "@" at 323:5-323:6 (leading: Newline, Space)
+3174: Ident           "intrinsic" at 323:6-323:15
+3175: At              "@" at 323:16-323:17 (leading: Space)
+3176: Ident           "overload" at 323:17-323:25
+3177: KwFn            "fn" at 323:26-323:28 (leading: Space)
+3178: Ident           "__to" at 323:29-323:33 (leading: Space)
+3179: LParen          "(" at 323:33-323:34
+3180: Ident           "self" at 323:34-323:38
+3181: Colon           ":" at 323:38-323:39
+3182: Ident           "uint" at 323:40-323:44 (leading: Space)
+3183: Comma           "," at 323:44-323:45
+3184: Ident           "target" at 323:46-323:52 (leading: Space)
+3185: Colon           ":" at 323:52-323:53
+3186: Ident           "float" at 323:54-323:59 (leading: Space)
+3187: RParen          ")" at 323:59-323:60
+3188: Arrow           "->" at 323:61-323:63 (leading: Space)
+3189: Ident           "float" at 323:64-323:69 (leading: Space)
+3190: Semicolon       ";" at 323:69-323:70
+3191: At              "@" at 324:5-324:6 (leading: Newline, Space)
+3192: Ident           "intrinsic" at 324:6-324:15
+3193: At              "@" at 324:16-324:17 (leading: Space)
+3194: Ident           "overload" at 324:17-324:25
+3195: KwFn            "fn" at 324:26-324:28 (leading: Space)
+3196: Ident           "__to" at 324:29-324:33 (leading: Space)
+3197: LParen          "(" at 324:33-324:34
+3198: Ident           "self" at 324:34-324:38
+3199: Colon           ":" at 324:38-324:39
+3200: Ident           "uint" at 324:40-324:44 (leading: Space)
+3201: Comma           "," at 324:44-324:45
+3202: Ident           "target" at 324:46-324:52 (leading: Space)
+3203: Colon           ":" at 324:52-324:53
+3204: Ident           "int8" at 324:54-324:58 (leading: Space)
+3205: RParen          ")" at 324:58-324:59
+3206: Arrow           "->" at 324:60-324:62 (leading: Space)
+3207: Ident           "int8" at 324:63-324:67 (leading: Space)
+3208: Semicolon       ";" at 324:67-324:68
+3209: At              "@" at 325:5-325:6 (leading: Newline, Space)
+3210: Ident           "intrinsic" at 325:6-325:15
+3211: At              "@" at 325:16-325:17 (leading: Space)
+3212: Ident           "overload" at 325:17-325:25
+3213: KwFn            "fn" at 325:26-325:28 (leading: Space)
+3214: Ident           "__to" at 325:29-325:33 (leading: Space)
+3215: LParen          "(" at 325:33-325:34
+3216: Ident           "self" at 325:34-325:38
+3217: Colon           ":" at 325:38-325:39
+3218: Ident           "uint" at 325:40-325:44 (leading: Space)
+3219: Comma           "," at 325:44-325:45
+3220: Ident           "target" at 325:46-325:52 (leading: Space)
+3221: Colon           ":" at 325:52-325:53
+3222: Ident           "int16" at 325:54-325:59 (leading: Space)
+3223: RParen          ")" at 325:59-325:60
+3224: Arrow           "->" at 325:61-325:63 (leading: Space)
+3225: Ident           "int16" at 325:64-325:69 (leading: Space)
+3226: Semicolon       ";" at 325:69-325:70
+3227: At              "@" at 326:5-326:6 (leading: Newline, Space)
+3228: Ident           "intrinsic" at 326:6-326:15
+3229: At              "@" at 326:16-326:17 (leading: Space)
+3230: Ident           "overload" at 326:17-326:25
+3231: KwFn            "fn" at 326:26-326:28 (leading: Space)
+3232: Ident           "__to" at 326:29-326:33 (leading: Space)
+3233: LParen          "(" at 326:33-326:34
+3234: Ident           "self" at 326:34-326:38
+3235: Colon           ":" at 326:38-326:39
+3236: Ident           "uint" at 326:40-326:44 (leading: Space)
+3237: Comma           "," at 326:44-326:45
+3238: Ident           "target" at 326:46-326:52 (leading: Space)
+3239: Colon           ":" at 326:52-326:53
+3240: Ident           "int32" at 326:54-326:59 (leading: Space)
+3241: RParen          ")" at 326:59-326:60
+3242: Arrow           "->" at 326:61-326:63 (leading: Space)
+3243: Ident           "int32" at 326:64-326:69 (leading: Space)
+3244: Semicolon       ";" at 326:69-326:70
+3245: At              "@" at 327:5-327:6 (leading: Newline, Space)
+3246: Ident           "intrinsic" at 327:6-327:15
+3247: At              "@" at 327:16-327:17 (leading: Space)
+3248: Ident           "overload" at 327:17-327:25
+3249: KwFn            "fn" at 327:26-327:28 (leading: Space)
+3250: Ident           "__to" at 327:29-327:33 (leading: Space)
+3251: LParen          "(" at 327:33-327:34
+3252: Ident           "self" at 327:34-327:38
+3253: Colon           ":" at 327:38-327:39
+3254: Ident           "uint" at 327:40-327:44 (leading: Space)
+3255: Comma           "," at 327:44-327:45
+3256: Ident           "target" at 327:46-327:52 (leading: Space)
+3257: Colon           ":" at 327:52-327:53
+3258: Ident           "int64" at 327:54-327:59 (leading: Space)
+3259: RParen          ")" at 327:59-327:60
+3260: Arrow           "->" at 327:61-327:63 (leading: Space)
+3261: Ident           "int64" at 327:64-327:69 (leading: Space)
+3262: Semicolon       ";" at 327:69-327:70
+3263: At              "@" at 328:5-328:6 (leading: Newline, Space)
+3264: Ident           "intrinsic" at 328:6-328:15
+3265: At              "@" at 328:16-328:17 (leading: Space)
+3266: Ident           "overload" at 328:17-328:25
+3267: KwFn            "fn" at 328:26-328:28 (leading: Space)
+3268: Ident           "__to" at 328:29-328:33 (leading: Space)
+3269: LParen          "(" at 328:33-328:34
+3270: Ident           "self" at 328:34-328:38
+3271: Colon           ":" at 328:38-328:39
+3272: Ident           "uint" at 328:40-328:44 (leading: Space)
+3273: Comma           "," at 328:44-328:45
+3274: Ident           "target" at 328:46-328:52 (leading: Space)
+3275: Colon           ":" at 328:52-328:53
+3276: Ident           "uint8" at 328:54-328:59 (leading: Space)
+3277: RParen          ")" at 328:59-328:60
+3278: Arrow           "->" at 328:61-328:63 (leading: Space)
+3279: Ident           "uint8" at 328:64-328:69 (leading: Space)
+3280: Semicolon       ";" at 328:69-328:70
+3281: At              "@" at 329:5-329:6 (leading: Newline, Space)
+3282: Ident           "intrinsic" at 329:6-329:15
+3283: At              "@" at 329:16-329:17 (leading: Space)
+3284: Ident           "overload" at 329:17-329:25
+3285: KwFn            "fn" at 329:26-329:28 (leading: Space)
+3286: Ident           "__to" at 329:29-329:33 (leading: Space)
+3287: LParen          "(" at 329:33-329:34
+3288: Ident           "self" at 329:34-329:38
+3289: Colon           ":" at 329:38-329:39
+3290: Ident           "uint" at 329:40-329:44 (leading: Space)
+3291: Comma           "," at 329:44-329:45
+3292: Ident           "target" at 329:46-329:52 (leading: Space)
+3293: Colon           ":" at 329:52-329:53
+3294: Ident           "uint16" at 329:54-329:60 (leading: Space)
+3295: RParen          ")" at 329:60-329:61
+3296: Arrow           "->" at 329:62-329:64 (leading: Space)
+3297: Ident           "uint16" at 329:65-329:71 (leading: Space)
+3298: Semicolon       ";" at 329:71-329:72
+3299: At              "@" at 330:5-330:6 (leading: Newline, Space)
+3300: Ident           "intrinsic" at 330:6-330:15
+3301: At              "@" at 330:16-330:17 (leading: Space)
+3302: Ident           "overload" at 330:17-330:25
+3303: KwFn            "fn" at 330:26-330:28 (leading: Space)
+3304: Ident           "__to" at 330:29-330:33 (leading: Space)
+3305: LParen          "(" at 330:33-330:34
+3306: Ident           "self" at 330:34-330:38
+3307: Colon           ":" at 330:38-330:39
+3308: Ident           "uint" at 330:40-330:44 (leading: Space)
+3309: Comma           "," at 330:44-330:45
+3310: Ident           "target" at 330:46-330:52 (leading: Space)
+3311: Colon           ":" at 330:52-330:53
+3312: Ident           "uint32" at 330:54-330:60 (leading: Space)
+3313: RParen          ")" at 330:60-330:61
+3314: Arrow           "->" at 330:62-330:64 (leading: Space)
+3315: Ident           "uint32" at 330:65-330:71 (leading: Space)
+3316: Semicolon       ";" at 330:71-330:72
+3317: At              "@" at 331:5-331:6 (leading: Newline, Space)
+3318: Ident           "intrinsic" at 331:6-331:15
+3319: At              "@" at 331:16-331:17 (leading: Space)
+3320: Ident           "overload" at 331:17-331:25
+3321: KwFn            "fn" at 331:26-331:28 (leading: Space)
+3322: Ident           "__to" at 331:29-331:33 (leading: Space)
+3323: LParen          "(" at 331:33-331:34
+3324: Ident           "self" at 331:34-331:38
+3325: Colon           ":" at 331:38-331:39
+3326: Ident           "uint" at 331:40-331:44 (leading: Space)
+3327: Comma           "," at 331:44-331:45
+3328: Ident           "target" at 331:46-331:52 (leading: Space)
+3329: Colon           ":" at 331:52-331:53
+3330: Ident           "uint64" at 331:54-331:60 (leading: Space)
+3331: RParen          ")" at 331:60-331:61
+3332: Arrow           "->" at 331:62-331:64 (leading: Space)
+3333: Ident           "uint64" at 331:65-331:71 (leading: Space)
+3334: Semicolon       ";" at 331:71-331:72
+3335: At              "@" at 332:5-332:6 (leading: Newline, Space)
+3336: Ident           "intrinsic" at 332:6-332:15
+3337: At              "@" at 332:16-332:17 (leading: Space)
+3338: Ident           "overload" at 332:17-332:25
+3339: KwFn            "fn" at 332:26-332:28 (leading: Space)
+3340: Ident           "__to" at 332:29-332:33 (leading: Space)
+3341: LParen          "(" at 332:33-332:34
+3342: Ident           "self" at 332:34-332:38
+3343: Colon           ":" at 332:38-332:39
+3344: Ident           "uint" at 332:40-332:44 (leading: Space)
+3345: Comma           "," at 332:44-332:45
+3346: Ident           "target" at 332:46-332:52 (leading: Space)
+3347: Colon           ":" at 332:52-332:53
+3348: Ident           "float16" at 332:54-332:61 (leading: Space)
+3349: RParen          ")" at 332:61-332:62
+3350: Arrow           "->" at 332:63-332:65 (leading: Space)
+3351: Ident           "float16" at 332:66-332:73 (leading: Space)
+3352: Semicolon       ";" at 332:73-332:74
+3353: At              "@" at 333:5-333:6 (leading: Newline, Space)
+3354: Ident           "intrinsic" at 333:6-333:15
+3355: At              "@" at 333:16-333:17 (leading: Space)
+3356: Ident           "overload" at 333:17-333:25
+3357: KwFn            "fn" at 333:26-333:28 (leading: Space)
+3358: Ident           "__to" at 333:29-333:33 (leading: Space)
+3359: LParen          "(" at 333:33-333:34
+3360: Ident           "self" at 333:34-333:38
+3361: Colon           ":" at 333:38-333:39
+3362: Ident           "uint" at 333:40-333:44 (leading: Space)
+3363: Comma           "," at 333:44-333:45
+3364: Ident           "target" at 333:46-333:52 (leading: Space)
+3365: Colon           ":" at 333:52-333:53
+3366: Ident           "float32" at 333:54-333:61 (leading: Space)
+3367: RParen          ")" at 333:61-333:62
+3368: Arrow           "->" at 333:63-333:65 (leading: Space)
+3369: Ident           "float32" at 333:66-333:73 (leading: Space)
+3370: Semicolon       ";" at 333:73-333:74
+3371: At              "@" at 334:5-334:6 (leading: Newline, Space)
+3372: Ident           "intrinsic" at 334:6-334:15
+3373: At              "@" at 334:16-334:17 (leading: Space)
+3374: Ident           "overload" at 334:17-334:25
+3375: KwFn            "fn" at 334:26-334:28 (leading: Space)
+3376: Ident           "__to" at 334:29-334:33 (leading: Space)
+3377: LParen          "(" at 334:33-334:34
+3378: Ident           "self" at 334:34-334:38
+3379: Colon           ":" at 334:38-334:39
+3380: Ident           "uint" at 334:40-334:44 (leading: Space)
+3381: Comma           "," at 334:44-334:45
+3382: Ident           "target" at 334:46-334:52 (leading: Space)
+3383: Colon           ":" at 334:52-334:53
+3384: Ident           "float64" at 334:54-334:61 (leading: Space)
+3385: RParen          ")" at 334:61-334:62
+3386: Arrow           "->" at 334:63-334:65 (leading: Space)
+3387: Ident           "float64" at 334:66-334:73 (leading: Space)
+3388: Semicolon       ";" at 334:73-334:74
+3389: At              "@" at 336:5-336:6 (leading: Newline, Space, LineComment, Newline, Space)
+3390: Ident           "intrinsic" at 336:6-336:15
+3391: KwPub           "pub" at 336:16-336:19 (leading: Space)
+3392: KwFn            "fn" at 336:20-336:22 (leading: Space)
+3393: Ident           "from_str" at 336:23-336:31 (leading: Space)
+3394: LParen          "(" at 336:31-336:32
+3395: Ident           "s" at 336:32-336:33
+3396: Colon           ":" at 336:33-336:34
+3397: Amp             "&" at 336:35-336:36 (leading: Space)
+3398: Ident           "string" at 336:36-336:42
+3399: RParen          ")" at 336:42-336:43
+3400: Arrow           "->" at 336:44-336:46 (leading: Space)
+3401: Ident           "Erring" at 336:47-336:53 (leading: Space)
+3402: Lt              "<" at 336:53-336:54
+3403: Ident           "uint" at 336:54-336:58
+3404: Comma           "," at 336:58-336:59
+3405: Ident           "Error" at 336:60-336:65 (leading: Space)
+3406: Gt              ">" at 336:65-336:66
+3407: Semicolon       ";" at 336:66-336:67
+3408: RBrace          "}" at 337:1-337:2 (leading: Newline)
+3409: KwExtern        "extern" at 339:1-339:7 (leading: Newline)
+3410: Lt              "<" at 339:7-339:8
+3411: Ident           "int8" at 339:8-339:12
+3412: Gt              ">" at 339:12-339:13
+3413: LBrace          "{" at 339:14-339:15 (leading: Space)
+3414: KwPub           "pub" at 340:5-340:8 (leading: Newline, Space)
+3415: KwFn            "fn" at 340:9-340:11 (leading: Space)
+3416: Ident           "__min_value" at 340:12-340:23 (leading: Space)
+3417: LParen          "(" at 340:23-340:24
+3418: RParen          ")" at 340:24-340:25
+3419: Arrow           "->" at 340:26-340:28 (leading: Space)
+3420: Ident           "int8" at 340:29-340:33 (leading: Space)
+3421: LBrace          "{" at 340:34-340:35 (leading: Space)
+3422: KwReturn        "return" at 340:36-340:42 (leading: Space)
+3423: LParen          "(" at 340:43-340:44 (leading: Space)
+3424: Minus           "-" at 340:44-340:45
+3425: IntLit          "128" at 340:45-340:48
+3426: RParen          ")" at 340:48-340:49
+3427: Colon           ":" at 340:49-340:50
+3428: Ident           "int8" at 340:50-340:54
+3429: Semicolon       ";" at 340:54-340:55
+3430: RBrace          "}" at 340:56-340:57 (leading: Space)
+3431: KwPub           "pub" at 341:5-341:8 (leading: Newline, Space)
+3432: KwFn            "fn" at 341:9-341:11 (leading: Space)
+3433: Ident           "__max_value" at 341:12-341:23 (leading: Space)
+3434: LParen          "(" at 341:23-341:24
+3435: RParen          ")" at 341:24-341:25
+3436: Arrow           "->" at 341:26-341:28 (leading: Space)
+3437: Ident           "int8" at 341:29-341:33 (leading: Space)
+3438: LBrace          "{" at 341:34-341:35 (leading: Space)
+3439: KwReturn        "return" at 341:36-341:42 (leading: Space)
+3440: LParen          "(" at 341:43-341:44 (leading: Space)
+3441: IntLit          "127" at 341:44-341:47
+3442: RParen          ")" at 341:47-341:48
+3443: Colon           ":" at 341:48-341:49
+3444: Ident           "int8" at 341:49-341:53
+3445: Semicolon       ";" at 341:53-341:54
+3446: RBrace          "}" at 341:55-341:56 (leading: Space)
+3447: At              "@" at 342:5-342:6 (leading: Newline, Space)
+3448: Ident           "intrinsic" at 342:6-342:15
+3449: KwFn            "fn" at 342:16-342:18 (leading: Space)
+3450: Ident           "__add" at 342:19-342:24 (leading: Space)
+3451: LParen          "(" at 342:24-342:25
+3452: Ident           "self" at 342:25-342:29
+3453: Colon           ":" at 342:29-342:30
+3454: Ident           "int8" at 342:31-342:35 (leading: Space)
+3455: Comma           "," at 342:35-342:36
+3456: Ident           "other" at 342:37-342:42 (leading: Space)
+3457: Colon           ":" at 342:42-342:43
+3458: Ident           "int8" at 342:44-342:48 (leading: Space)
+3459: RParen          ")" at 342:48-342:49
+3460: Arrow           "->" at 342:50-342:52 (leading: Space)
+3461: Ident           "int8" at 342:53-342:57 (leading: Space)
+3462: Semicolon       ";" at 342:57-342:58
+3463: At              "@" at 343:5-343:6 (leading: Newline, Space)
+3464: Ident           "intrinsic" at 343:6-343:15
+3465: KwFn            "fn" at 343:16-343:18 (leading: Space)
+3466: Ident           "__sub" at 343:19-343:24 (leading: Space)
+3467: LParen          "(" at 343:24-343:25
+3468: Ident           "self" at 343:25-343:29
+3469: Colon           ":" at 343:29-343:30
+3470: Ident           "int8" at 343:31-343:35 (leading: Space)
+3471: Comma           "," at 343:35-343:36
+3472: Ident           "other" at 343:37-343:42 (leading: Space)
+3473: Colon           ":" at 343:42-343:43
+3474: Ident           "int8" at 343:44-343:48 (leading: Space)
+3475: RParen          ")" at 343:48-343:49
+3476: Arrow           "->" at 343:50-343:52 (leading: Space)
+3477: Ident           "int8" at 343:53-343:57 (leading: Space)
+3478: Semicolon       ";" at 343:57-343:58
+3479: At              "@" at 344:5-344:6 (leading: Newline, Space)
+3480: Ident           "intrinsic" at 344:6-344:15
+3481: KwFn            "fn" at 344:16-344:18 (leading: Space)
+3482: Ident           "__mul" at 344:19-344:24 (leading: Space)
+3483: LParen          "(" at 344:24-344:25
+3484: Ident           "self" at 344:25-344:29
+3485: Colon           ":" at 344:29-344:30
+3486: Ident           "int8" at 344:31-344:35 (leading: Space)
+3487: Comma           "," at 344:35-344:36
+3488: Ident           "other" at 344:37-344:42 (leading: Space)
+3489: Colon           ":" at 344:42-344:43
+3490: Ident           "int8" at 344:44-344:48 (leading: Space)
+3491: RParen          ")" at 344:48-344:49
+3492: Arrow           "->" at 344:50-344:52 (leading: Space)
+3493: Ident           "int8" at 344:53-344:57 (leading: Space)
+3494: Semicolon       ";" at 344:57-344:58
+3495: At              "@" at 345:5-345:6 (leading: Newline, Space)
+3496: Ident           "intrinsic" at 345:6-345:15
+3497: KwFn            "fn" at 345:16-345:18 (leading: Space)
+3498: Ident           "__div" at 345:19-345:24 (leading: Space)
+3499: LParen          "(" at 345:24-345:25
+3500: Ident           "self" at 345:25-345:29
+3501: Colon           ":" at 345:29-345:30
+3502: Ident           "int8" at 345:31-345:35 (leading: Space)
+3503: Comma           "," at 345:35-345:36
+3504: Ident           "other" at 345:37-345:42 (leading: Space)
+3505: Colon           ":" at 345:42-345:43
+3506: Ident           "int8" at 345:44-345:48 (leading: Space)
+3507: RParen          ")" at 345:48-345:49
+3508: Arrow           "->" at 345:50-345:52 (leading: Space)
+3509: Ident           "int8" at 345:53-345:57 (leading: Space)
+3510: Semicolon       ";" at 345:57-345:58
+3511: At              "@" at 346:5-346:6 (leading: Newline, Space)
+3512: Ident           "intrinsic" at 346:6-346:15
+3513: KwFn            "fn" at 346:16-346:18 (leading: Space)
+3514: Ident           "__mod" at 346:19-346:24 (leading: Space)
+3515: LParen          "(" at 346:24-346:25
+3516: Ident           "self" at 346:25-346:29
+3517: Colon           ":" at 346:29-346:30
+3518: Ident           "int8" at 346:31-346:35 (leading: Space)
+3519: Comma           "," at 346:35-346:36
+3520: Ident           "other" at 346:37-346:42 (leading: Space)
+3521: Colon           ":" at 346:42-346:43
+3522: Ident           "int8" at 346:44-346:48 (leading: Space)
+3523: RParen          ")" at 346:48-346:49
+3524: Arrow           "->" at 346:50-346:52 (leading: Space)
+3525: Ident           "int8" at 346:53-346:57 (leading: Space)
+3526: Semicolon       ";" at 346:57-346:58
+3527: At              "@" at 347:5-347:6 (leading: Newline, Space)
+3528: Ident           "intrinsic" at 347:6-347:15
+3529: KwFn            "fn" at 347:16-347:18 (leading: Space)
+3530: Ident           "__bit_and" at 347:19-347:28 (leading: Space)
+3531: LParen          "(" at 347:28-347:29
+3532: Ident           "self" at 347:29-347:33
+3533: Colon           ":" at 347:33-347:34
+3534: Ident           "int8" at 347:35-347:39 (leading: Space)
+3535: Comma           "," at 347:39-347:40
+3536: Ident           "other" at 347:41-347:46 (leading: Space)
+3537: Colon           ":" at 347:46-347:47
+3538: Ident           "int8" at 347:48-347:52 (leading: Space)
+3539: RParen          ")" at 347:52-347:53
+3540: Arrow           "->" at 347:54-347:56 (leading: Space)
+3541: Ident           "int8" at 347:57-347:61 (leading: Space)
+3542: Semicolon       ";" at 347:61-347:62
+3543: At              "@" at 348:5-348:6 (leading: Newline, Space)
+3544: Ident           "intrinsic" at 348:6-348:15
+3545: KwFn            "fn" at 348:16-348:18 (leading: Space)
+3546: Ident           "__bit_or" at 348:19-348:27 (leading: Space)
+3547: LParen          "(" at 348:27-348:28
+3548: Ident           "self" at 348:28-348:32
+3549: Colon           ":" at 348:32-348:33
+3550: Ident           "int8" at 348:34-348:38 (leading: Space)
+3551: Comma           "," at 348:38-348:39
+3552: Ident           "other" at 348:40-348:45 (leading: Space)
+3553: Colon           ":" at 348:45-348:46
+3554: Ident           "int8" at 348:47-348:51 (leading: Space)
+3555: RParen          ")" at 348:51-348:52
+3556: Arrow           "->" at 348:53-348:55 (leading: Space)
+3557: Ident           "int8" at 348:56-348:60 (leading: Space)
+3558: Semicolon       ";" at 348:60-348:61
+3559: At              "@" at 349:5-349:6 (leading: Newline, Space)
+3560: Ident           "intrinsic" at 349:6-349:15
+3561: KwFn            "fn" at 349:16-349:18 (leading: Space)
+3562: Ident           "__bit_xor" at 349:19-349:28 (leading: Space)
+3563: LParen          "(" at 349:28-349:29
+3564: Ident           "self" at 349:29-349:33
+3565: Colon           ":" at 349:33-349:34
+3566: Ident           "int8" at 349:35-349:39 (leading: Space)
+3567: Comma           "," at 349:39-349:40
+3568: Ident           "other" at 349:41-349:46 (leading: Space)
+3569: Colon           ":" at 349:46-349:47
+3570: Ident           "int8" at 349:48-349:52 (leading: Space)
+3571: RParen          ")" at 349:52-349:53
+3572: Arrow           "->" at 349:54-349:56 (leading: Space)
+3573: Ident           "int8" at 349:57-349:61 (leading: Space)
+3574: Semicolon       ";" at 349:61-349:62
+3575: At              "@" at 350:5-350:6 (leading: Newline, Space)
+3576: Ident           "intrinsic" at 350:6-350:15
+3577: KwFn            "fn" at 350:16-350:18 (leading: Space)
+3578: Ident           "__shl" at 350:19-350:24 (leading: Space)
+3579: LParen          "(" at 350:24-350:25
+3580: Ident           "self" at 350:25-350:29
+3581: Colon           ":" at 350:29-350:30
+3582: Ident           "int8" at 350:31-350:35 (leading: Space)
+3583: Comma           "," at 350:35-350:36
+3584: Ident           "other" at 350:37-350:42 (leading: Space)
+3585: Colon           ":" at 350:42-350:43
+3586: Ident           "int8" at 350:44-350:48 (leading: Space)
+3587: RParen          ")" at 350:48-350:49
+3588: Arrow           "->" at 350:50-350:52 (leading: Space)
+3589: Ident           "int8" at 350:53-350:57 (leading: Space)
+3590: Semicolon       ";" at 350:57-350:58
+3591: At              "@" at 351:5-351:6 (leading: Newline, Space)
+3592: Ident           "intrinsic" at 351:6-351:15
+3593: KwFn            "fn" at 351:16-351:18 (leading: Space)
+3594: Ident           "__shr" at 351:19-351:24 (leading: Space)
+3595: LParen          "(" at 351:24-351:25
+3596: Ident           "self" at 351:25-351:29
+3597: Colon           ":" at 351:29-351:30
+3598: Ident           "int8" at 351:31-351:35 (leading: Space)
+3599: Comma           "," at 351:35-351:36
+3600: Ident           "other" at 351:37-351:42 (leading: Space)
+3601: Colon           ":" at 351:42-351:43
+3602: Ident           "int8" at 351:44-351:48 (leading: Space)
+3603: RParen          ")" at 351:48-351:49
+3604: Arrow           "->" at 351:50-351:52 (leading: Space)
+3605: Ident           "int8" at 351:53-351:57 (leading: Space)
+3606: Semicolon       ";" at 351:57-351:58
+3607: At              "@" at 352:5-352:6 (leading: Newline, Space)
+3608: Ident           "intrinsic" at 352:6-352:15
+3609: KwFn            "fn" at 352:16-352:18 (leading: Space)
+3610: Ident           "__lt" at 352:19-352:23 (leading: Space)
+3611: LParen          "(" at 352:23-352:24
+3612: Ident           "self" at 352:24-352:28
+3613: Colon           ":" at 352:28-352:29
+3614: Ident           "int8" at 352:30-352:34 (leading: Space)
+3615: Comma           "," at 352:34-352:35
+3616: Ident           "other" at 352:36-352:41 (leading: Space)
+3617: Colon           ":" at 352:41-352:42
+3618: Ident           "int8" at 352:43-352:47 (leading: Space)
+3619: RParen          ")" at 352:47-352:48
+3620: Arrow           "->" at 352:49-352:51 (leading: Space)
+3621: Ident           "bool" at 352:52-352:56 (leading: Space)
+3622: Semicolon       ";" at 352:56-352:57
+3623: At              "@" at 353:5-353:6 (leading: Newline, Space)
+3624: Ident           "intrinsic" at 353:6-353:15
+3625: KwFn            "fn" at 353:16-353:18 (leading: Space)
+3626: Ident           "__le" at 353:19-353:23 (leading: Space)
+3627: LParen          "(" at 353:23-353:24
+3628: Ident           "self" at 353:24-353:28
+3629: Colon           ":" at 353:28-353:29
+3630: Ident           "int8" at 353:30-353:34 (leading: Space)
+3631: Comma           "," at 353:34-353:35
+3632: Ident           "other" at 353:36-353:41 (leading: Space)
+3633: Colon           ":" at 353:41-353:42
+3634: Ident           "int8" at 353:43-353:47 (leading: Space)
+3635: RParen          ")" at 353:47-353:48
+3636: Arrow           "->" at 353:49-353:51 (leading: Space)
+3637: Ident           "bool" at 353:52-353:56 (leading: Space)
+3638: Semicolon       ";" at 353:56-353:57
+3639: At              "@" at 354:5-354:6 (leading: Newline, Space)
+3640: Ident           "intrinsic" at 354:6-354:15
+3641: KwFn            "fn" at 354:16-354:18 (leading: Space)
+3642: Ident           "__eq" at 354:19-354:23 (leading: Space)
+3643: LParen          "(" at 354:23-354:24
+3644: Ident           "self" at 354:24-354:28
+3645: Colon           ":" at 354:28-354:29
+3646: Ident           "int8" at 354:30-354:34 (leading: Space)
+3647: Comma           "," at 354:34-354:35
+3648: Ident           "other" at 354:36-354:41 (leading: Space)
+3649: Colon           ":" at 354:41-354:42
+3650: Ident           "int8" at 354:43-354:47 (leading: Space)
+3651: RParen          ")" at 354:47-354:48
+3652: Arrow           "->" at 354:49-354:51 (leading: Space)
+3653: Ident           "bool" at 354:52-354:56 (leading: Space)
+3654: Semicolon       ";" at 354:56-354:57
+3655: At              "@" at 355:5-355:6 (leading: Newline, Space)
+3656: Ident           "intrinsic" at 355:6-355:15
+3657: KwFn            "fn" at 355:16-355:18 (leading: Space)
+3658: Ident           "__ne" at 355:19-355:23 (leading: Space)
+3659: LParen          "(" at 355:23-355:24
+3660: Ident           "self" at 355:24-355:28
+3661: Colon           ":" at 355:28-355:29
+3662: Ident           "int8" at 355:30-355:34 (leading: Space)
+3663: Comma           "," at 355:34-355:35
+3664: Ident           "other" at 355:36-355:41 (leading: Space)
+3665: Colon           ":" at 355:41-355:42
+3666: Ident           "int8" at 355:43-355:47 (leading: Space)
+3667: RParen          ")" at 355:47-355:48
+3668: Arrow           "->" at 355:49-355:51 (leading: Space)
+3669: Ident           "bool" at 355:52-355:56 (leading: Space)
+3670: Semicolon       ";" at 355:56-355:57
+3671: At              "@" at 356:5-356:6 (leading: Newline, Space)
+3672: Ident           "intrinsic" at 356:6-356:15
+3673: KwFn            "fn" at 356:16-356:18 (leading: Space)
+3674: Ident           "__ge" at 356:19-356:23 (leading: Space)
+3675: LParen          "(" at 356:23-356:24
+3676: Ident           "self" at 356:24-356:28
+3677: Colon           ":" at 356:28-356:29
+3678: Ident           "int8" at 356:30-356:34 (leading: Space)
+3679: Comma           "," at 356:34-356:35
+3680: Ident           "other" at 356:36-356:41 (leading: Space)
+3681: Colon           ":" at 356:41-356:42
+3682: Ident           "int8" at 356:43-356:47 (leading: Space)
+3683: RParen          ")" at 356:47-356:48
+3684: Arrow           "->" at 356:49-356:51 (leading: Space)
+3685: Ident           "bool" at 356:52-356:56 (leading: Space)
+3686: Semicolon       ";" at 356:56-356:57
+3687: At              "@" at 357:5-357:6 (leading: Newline, Space)
+3688: Ident           "intrinsic" at 357:6-357:15
+3689: KwFn            "fn" at 357:16-357:18 (leading: Space)
+3690: Ident           "__gt" at 357:19-357:23 (leading: Space)
+3691: LParen          "(" at 357:23-357:24
+3692: Ident           "self" at 357:24-357:28
+3693: Colon           ":" at 357:28-357:29
+3694: Ident           "int8" at 357:30-357:34 (leading: Space)
+3695: Comma           "," at 357:34-357:35
+3696: Ident           "other" at 357:36-357:41 (leading: Space)
+3697: Colon           ":" at 357:41-357:42
+3698: Ident           "int8" at 357:43-357:47 (leading: Space)
+3699: RParen          ")" at 357:47-357:48
+3700: Arrow           "->" at 357:49-357:51 (leading: Space)
+3701: Ident           "bool" at 357:52-357:56 (leading: Space)
+3702: Semicolon       ";" at 357:56-357:57
+3703: At              "@" at 358:5-358:6 (leading: Newline, Space)
+3704: Ident           "intrinsic" at 358:6-358:15
+3705: KwFn            "fn" at 358:16-358:18 (leading: Space)
+3706: Ident           "__pos" at 358:19-358:24 (leading: Space)
+3707: LParen          "(" at 358:24-358:25
+3708: Ident           "self" at 358:25-358:29
+3709: Colon           ":" at 358:29-358:30
+3710: Ident           "int8" at 358:31-358:35 (leading: Space)
+3711: RParen          ")" at 358:35-358:36
+3712: Arrow           "->" at 358:37-358:39 (leading: Space)
+3713: Ident           "int8" at 358:40-358:44 (leading: Space)
+3714: Semicolon       ";" at 358:44-358:45
+3715: At              "@" at 359:5-359:6 (leading: Newline, Space)
+3716: Ident           "intrinsic" at 359:6-359:15
+3717: KwFn            "fn" at 359:16-359:18 (leading: Space)
+3718: Ident           "__neg" at 359:19-359:24 (leading: Space)
+3719: LParen          "(" at 359:24-359:25
+3720: Ident           "self" at 359:25-359:29
+3721: Colon           ":" at 359:29-359:30
+3722: Ident           "int8" at 359:31-359:35 (leading: Space)
+3723: RParen          ")" at 359:35-359:36
+3724: Arrow           "->" at 359:37-359:39 (leading: Space)
+3725: Ident           "int8" at 359:40-359:44 (leading: Space)
+3726: Semicolon       ";" at 359:44-359:45
+3727: At              "@" at 360:5-360:6 (leading: Newline, Space)
+3728: Ident           "intrinsic" at 360:6-360:15
+3729: KwFn            "fn" at 360:16-360:18 (leading: Space)
+3730: Ident           "__abs" at 360:19-360:24 (leading: Space)
+3731: LParen          "(" at 360:24-360:25
+3732: Ident           "self" at 360:25-360:29
+3733: Colon           ":" at 360:29-360:30
+3734: Ident           "int8" at 360:31-360:35 (leading: Space)
+3735: RParen          ")" at 360:35-360:36
+3736: Arrow           "->" at 360:37-360:39 (leading: Space)
+3737: Ident           "int8" at 360:40-360:44 (leading: Space)
+3738: Semicolon       ";" at 360:44-360:45
+3739: At              "@" at 361:5-361:6 (leading: Newline, Space)
+3740: Ident           "intrinsic" at 361:6-361:15
+3741: KwFn            "fn" at 361:16-361:18 (leading: Space)
+3742: Ident           "__to" at 361:19-361:23 (leading: Space)
+3743: LParen          "(" at 361:23-361:24
+3744: Ident           "self" at 361:24-361:28
+3745: Colon           ":" at 361:28-361:29
+3746: Ident           "int8" at 361:30-361:34 (leading: Space)
+3747: Comma           "," at 361:34-361:35
+3748: Ident           "target" at 361:36-361:42 (leading: Space)
+3749: Colon           ":" at 361:42-361:43
+3750: Ident           "int" at 361:44-361:47 (leading: Space)
+3751: RParen          ")" at 361:47-361:48
+3752: Arrow           "->" at 361:49-361:51 (leading: Space)
+3753: Ident           "int" at 361:52-361:55 (leading: Space)
+3754: Semicolon       ";" at 361:55-361:56
+3755: At              "@" at 362:5-362:6 (leading: Newline, Space)
+3756: Ident           "intrinsic" at 362:6-362:15
+3757: At              "@" at 362:16-362:17 (leading: Space)
+3758: Ident           "overload" at 362:17-362:25
+3759: KwFn            "fn" at 362:26-362:28 (leading: Space)
+3760: Ident           "__to" at 362:29-362:33 (leading: Space)
+3761: LParen          "(" at 362:33-362:34
+3762: Ident           "self" at 362:34-362:38
+3763: Colon           ":" at 362:38-362:39
+3764: Ident           "int8" at 362:40-362:44 (leading: Space)
+3765: Comma           "," at 362:44-362:45
+3766: Ident           "target" at 362:46-362:52 (leading: Space)
+3767: Colon           ":" at 362:52-362:53
+3768: Ident           "int16" at 362:54-362:59 (leading: Space)
+3769: RParen          ")" at 362:59-362:60
+3770: Arrow           "->" at 362:61-362:63 (leading: Space)
+3771: Ident           "int16" at 362:64-362:69 (leading: Space)
+3772: Semicolon       ";" at 362:69-362:70
+3773: At              "@" at 363:5-363:6 (leading: Newline, Space)
+3774: Ident           "intrinsic" at 363:6-363:15
+3775: At              "@" at 363:16-363:17 (leading: Space)
+3776: Ident           "overload" at 363:17-363:25
+3777: KwFn            "fn" at 363:26-363:28 (leading: Space)
+3778: Ident           "__to" at 363:29-363:33 (leading: Space)
+3779: LParen          "(" at 363:33-363:34
+3780: Ident           "self" at 363:34-363:38
+3781: Colon           ":" at 363:38-363:39
+3782: Ident           "int8" at 363:40-363:44 (leading: Space)
+3783: Comma           "," at 363:44-363:45
+3784: Ident           "target" at 363:46-363:52 (leading: Space)
+3785: Colon           ":" at 363:52-363:53
+3786: Ident           "int32" at 363:54-363:59 (leading: Space)
+3787: RParen          ")" at 363:59-363:60
+3788: Arrow           "->" at 363:61-363:63 (leading: Space)
+3789: Ident           "int32" at 363:64-363:69 (leading: Space)
+3790: Semicolon       ";" at 363:69-363:70
+3791: At              "@" at 364:5-364:6 (leading: Newline, Space)
+3792: Ident           "intrinsic" at 364:6-364:15
+3793: At              "@" at 364:16-364:17 (leading: Space)
+3794: Ident           "overload" at 364:17-364:25
+3795: KwFn            "fn" at 364:26-364:28 (leading: Space)
+3796: Ident           "__to" at 364:29-364:33 (leading: Space)
+3797: LParen          "(" at 364:33-364:34
+3798: Ident           "self" at 364:34-364:38
+3799: Colon           ":" at 364:38-364:39
+3800: Ident           "int8" at 364:40-364:44 (leading: Space)
+3801: Comma           "," at 364:44-364:45
+3802: Ident           "target" at 364:46-364:52 (leading: Space)
+3803: Colon           ":" at 364:52-364:53
+3804: Ident           "int64" at 364:54-364:59 (leading: Space)
+3805: RParen          ")" at 364:59-364:60
+3806: Arrow           "->" at 364:61-364:63 (leading: Space)
+3807: Ident           "int64" at 364:64-364:69 (leading: Space)
+3808: Semicolon       ";" at 364:69-364:70
+3809: At              "@" at 365:5-365:6 (leading: Newline, Space)
+3810: Ident           "intrinsic" at 365:6-365:15
+3811: KwPub           "pub" at 365:16-365:19 (leading: Space)
+3812: KwFn            "fn" at 365:20-365:22 (leading: Space)
+3813: Ident           "from_str" at 365:23-365:31 (leading: Space)
+3814: LParen          "(" at 365:31-365:32
+3815: Ident           "s" at 365:32-365:33
+3816: Colon           ":" at 365:33-365:34
+3817: Amp             "&" at 365:35-365:36 (leading: Space)
+3818: Ident           "string" at 365:36-365:42
+3819: RParen          ")" at 365:42-365:43
+3820: Arrow           "->" at 365:44-365:46 (leading: Space)
+3821: Ident           "Erring" at 365:47-365:53 (leading: Space)
+3822: Lt              "<" at 365:53-365:54
+3823: Ident           "int8" at 365:54-365:58
+3824: Comma           "," at 365:58-365:59
+3825: Ident           "Error" at 365:60-365:65 (leading: Space)
+3826: Gt              ">" at 365:65-365:66
+3827: Semicolon       ";" at 365:66-365:67
+3828: RBrace          "}" at 366:1-366:2 (leading: Newline)
+3829: KwExtern        "extern" at 368:1-368:7 (leading: Newline)
+3830: Lt              "<" at 368:7-368:8
+3831: Ident           "int16" at 368:8-368:13
+3832: Gt              ">" at 368:13-368:14
+3833: LBrace          "{" at 368:15-368:16 (leading: Space)
+3834: KwPub           "pub" at 369:5-369:8 (leading: Newline, Space)
+3835: KwFn            "fn" at 369:9-369:11 (leading: Space)
+3836: Ident           "__min_value" at 369:12-369:23 (leading: Space)
+3837: LParen          "(" at 369:23-369:24
+3838: RParen          ")" at 369:24-369:25
+3839: Arrow           "->" at 369:26-369:28 (leading: Space)
+3840: Ident           "int16" at 369:29-369:34 (leading: Space)
+3841: LBrace          "{" at 369:35-369:36 (leading: Space)
+3842: KwReturn        "return" at 369:37-369:43 (leading: Space)
+3843: LParen          "(" at 369:44-369:45 (leading: Space)
+3844: Minus           "-" at 369:45-369:46
+3845: IntLit          "32_768" at 369:46-369:52
+3846: RParen          ")" at 369:52-369:53
+3847: Colon           ":" at 369:53-369:54
+3848: Ident           "int16" at 369:54-369:59
+3849: Semicolon       ";" at 369:59-369:60
+3850: RBrace          "}" at 369:61-369:62 (leading: Space)
+3851: KwPub           "pub" at 370:5-370:8 (leading: Newline, Space)
+3852: KwFn            "fn" at 370:9-370:11 (leading: Space)
+3853: Ident           "__max_value" at 370:12-370:23 (leading: Space)
+3854: LParen          "(" at 370:23-370:24
+3855: RParen          ")" at 370:24-370:25
+3856: Arrow           "->" at 370:26-370:28 (leading: Space)
+3857: Ident           "int16" at 370:29-370:34 (leading: Space)
+3858: LBrace          "{" at 370:35-370:36 (leading: Space)
+3859: KwReturn        "return" at 370:37-370:43 (leading: Space)
+3860: LParen          "(" at 370:44-370:45 (leading: Space)
+3861: IntLit          "32_767" at 370:45-370:51
+3862: RParen          ")" at 370:51-370:52
+3863: Colon           ":" at 370:52-370:53
+3864: Ident           "int16" at 370:53-370:58
+3865: Semicolon       ";" at 370:58-370:59
+3866: RBrace          "}" at 370:60-370:61 (leading: Space)
+3867: At              "@" at 371:5-371:6 (leading: Newline, Space)
+3868: Ident           "intrinsic" at 371:6-371:15
+3869: KwFn            "fn" at 371:16-371:18 (leading: Space)
+3870: Ident           "__add" at 371:19-371:24 (leading: Space)
+3871: LParen          "(" at 371:24-371:25
+3872: Ident           "self" at 371:25-371:29
+3873: Colon           ":" at 371:29-371:30
+3874: Ident           "int16" at 371:31-371:36 (leading: Space)
+3875: Comma           "," at 371:36-371:37
+3876: Ident           "other" at 371:38-371:43 (leading: Space)
+3877: Colon           ":" at 371:43-371:44
+3878: Ident           "int16" at 371:45-371:50 (leading: Space)
+3879: RParen          ")" at 371:50-371:51
+3880: Arrow           "->" at 371:52-371:54 (leading: Space)
+3881: Ident           "int16" at 371:55-371:60 (leading: Space)
+3882: Semicolon       ";" at 371:60-371:61
+3883: At              "@" at 372:5-372:6 (leading: Newline, Space)
+3884: Ident           "intrinsic" at 372:6-372:15
+3885: KwFn            "fn" at 372:16-372:18 (leading: Space)
+3886: Ident           "__sub" at 372:19-372:24 (leading: Space)
+3887: LParen          "(" at 372:24-372:25
+3888: Ident           "self" at 372:25-372:29
+3889: Colon           ":" at 372:29-372:30
+3890: Ident           "int16" at 372:31-372:36 (leading: Space)
+3891: Comma           "," at 372:36-372:37
+3892: Ident           "other" at 372:38-372:43 (leading: Space)
+3893: Colon           ":" at 372:43-372:44
+3894: Ident           "int16" at 372:45-372:50 (leading: Space)
+3895: RParen          ")" at 372:50-372:51
+3896: Arrow           "->" at 372:52-372:54 (leading: Space)
+3897: Ident           "int16" at 372:55-372:60 (leading: Space)
+3898: Semicolon       ";" at 372:60-372:61
+3899: At              "@" at 373:5-373:6 (leading: Newline, Space)
+3900: Ident           "intrinsic" at 373:6-373:15
+3901: KwFn            "fn" at 373:16-373:18 (leading: Space)
+3902: Ident           "__mul" at 373:19-373:24 (leading: Space)
+3903: LParen          "(" at 373:24-373:25
+3904: Ident           "self" at 373:25-373:29
+3905: Colon           ":" at 373:29-373:30
+3906: Ident           "int16" at 373:31-373:36 (leading: Space)
+3907: Comma           "," at 373:36-373:37
+3908: Ident           "other" at 373:38-373:43 (leading: Space)
+3909: Colon           ":" at 373:43-373:44
+3910: Ident           "int16" at 373:45-373:50 (leading: Space)
+3911: RParen          ")" at 373:50-373:51
+3912: Arrow           "->" at 373:52-373:54 (leading: Space)
+3913: Ident           "int16" at 373:55-373:60 (leading: Space)
+3914: Semicolon       ";" at 373:60-373:61
+3915: At              "@" at 374:5-374:6 (leading: Newline, Space)
+3916: Ident           "intrinsic" at 374:6-374:15
+3917: KwFn            "fn" at 374:16-374:18 (leading: Space)
+3918: Ident           "__div" at 374:19-374:24 (leading: Space)
+3919: LParen          "(" at 374:24-374:25
+3920: Ident           "self" at 374:25-374:29
+3921: Colon           ":" at 374:29-374:30
+3922: Ident           "int16" at 374:31-374:36 (leading: Space)
+3923: Comma           "," at 374:36-374:37
+3924: Ident           "other" at 374:38-374:43 (leading: Space)
+3925: Colon           ":" at 374:43-374:44
+3926: Ident           "int16" at 374:45-374:50 (leading: Space)
+3927: RParen          ")" at 374:50-374:51
+3928: Arrow           "->" at 374:52-374:54 (leading: Space)
+3929: Ident           "int16" at 374:55-374:60 (leading: Space)
+3930: Semicolon       ";" at 374:60-374:61
+3931: At              "@" at 375:5-375:6 (leading: Newline, Space)
+3932: Ident           "intrinsic" at 375:6-375:15
+3933: KwFn            "fn" at 375:16-375:18 (leading: Space)
+3934: Ident           "__mod" at 375:19-375:24 (leading: Space)
+3935: LParen          "(" at 375:24-375:25
+3936: Ident           "self" at 375:25-375:29
+3937: Colon           ":" at 375:29-375:30
+3938: Ident           "int16" at 375:31-375:36 (leading: Space)
+3939: Comma           "," at 375:36-375:37
+3940: Ident           "other" at 375:38-375:43 (leading: Space)
+3941: Colon           ":" at 375:43-375:44
+3942: Ident           "int16" at 375:45-375:50 (leading: Space)
+3943: RParen          ")" at 375:50-375:51
+3944: Arrow           "->" at 375:52-375:54 (leading: Space)
+3945: Ident           "int16" at 375:55-375:60 (leading: Space)
+3946: Semicolon       ";" at 375:60-375:61
+3947: At              "@" at 376:5-376:6 (leading: Newline, Space)
+3948: Ident           "intrinsic" at 376:6-376:15
+3949: KwFn            "fn" at 376:16-376:18 (leading: Space)
+3950: Ident           "__bit_and" at 376:19-376:28 (leading: Space)
+3951: LParen          "(" at 376:28-376:29
+3952: Ident           "self" at 376:29-376:33
+3953: Colon           ":" at 376:33-376:34
+3954: Ident           "int16" at 376:35-376:40 (leading: Space)
+3955: Comma           "," at 376:40-376:41
+3956: Ident           "other" at 376:42-376:47 (leading: Space)
+3957: Colon           ":" at 376:47-376:48
+3958: Ident           "int16" at 376:49-376:54 (leading: Space)
+3959: RParen          ")" at 376:54-376:55
+3960: Arrow           "->" at 376:56-376:58 (leading: Space)
+3961: Ident           "int16" at 376:59-376:64 (leading: Space)
+3962: Semicolon       ";" at 376:64-376:65
+3963: At              "@" at 377:5-377:6 (leading: Newline, Space)
+3964: Ident           "intrinsic" at 377:6-377:15
+3965: KwFn            "fn" at 377:16-377:18 (leading: Space)
+3966: Ident           "__bit_or" at 377:19-377:27 (leading: Space)
+3967: LParen          "(" at 377:27-377:28
+3968: Ident           "self" at 377:28-377:32
+3969: Colon           ":" at 377:32-377:33
+3970: Ident           "int16" at 377:34-377:39 (leading: Space)
+3971: Comma           "," at 377:39-377:40
+3972: Ident           "other" at 377:41-377:46 (leading: Space)
+3973: Colon           ":" at 377:46-377:47
+3974: Ident           "int16" at 377:48-377:53 (leading: Space)
+3975: RParen          ")" at 377:53-377:54
+3976: Arrow           "->" at 377:55-377:57 (leading: Space)
+3977: Ident           "int16" at 377:58-377:63 (leading: Space)
+3978: Semicolon       ";" at 377:63-377:64
+3979: At              "@" at 378:5-378:6 (leading: Newline, Space)
+3980: Ident           "intrinsic" at 378:6-378:15
+3981: KwFn            "fn" at 378:16-378:18 (leading: Space)
+3982: Ident           "__bit_xor" at 378:19-378:28 (leading: Space)
+3983: LParen          "(" at 378:28-378:29
+3984: Ident           "self" at 378:29-378:33
+3985: Colon           ":" at 378:33-378:34
+3986: Ident           "int16" at 378:35-378:40 (leading: Space)
+3987: Comma           "," at 378:40-378:41
+3988: Ident           "other" at 378:42-378:47 (leading: Space)
+3989: Colon           ":" at 378:47-378:48
+3990: Ident           "int16" at 378:49-378:54 (leading: Space)
+3991: RParen          ")" at 378:54-378:55
+3992: Arrow           "->" at 378:56-378:58 (leading: Space)
+3993: Ident           "int16" at 378:59-378:64 (leading: Space)
+3994: Semicolon       ";" at 378:64-378:65
+3995: At              "@" at 379:5-379:6 (leading: Newline, Space)
+3996: Ident           "intrinsic" at 379:6-379:15
+3997: KwFn            "fn" at 379:16-379:18 (leading: Space)
+3998: Ident           "__shl" at 379:19-379:24 (leading: Space)
+3999: LParen          "(" at 379:24-379:25
+4000: Ident           "self" at 379:25-379:29
+4001: Colon           ":" at 379:29-379:30
+4002: Ident           "int16" at 379:31-379:36 (leading: Space)
+4003: Comma           "," at 379:36-379:37
+4004: Ident           "other" at 379:38-379:43 (leading: Space)
+4005: Colon           ":" at 379:43-379:44
+4006: Ident           "int16" at 379:45-379:50 (leading: Space)
+4007: RParen          ")" at 379:50-379:51
+4008: Arrow           "->" at 379:52-379:54 (leading: Space)
+4009: Ident           "int16" at 379:55-379:60 (leading: Space)
+4010: Semicolon       ";" at 379:60-379:61
+4011: At              "@" at 380:5-380:6 (leading: Newline, Space)
+4012: Ident           "intrinsic" at 380:6-380:15
+4013: KwFn            "fn" at 380:16-380:18 (leading: Space)
+4014: Ident           "__shr" at 380:19-380:24 (leading: Space)
+4015: LParen          "(" at 380:24-380:25
+4016: Ident           "self" at 380:25-380:29
+4017: Colon           ":" at 380:29-380:30
+4018: Ident           "int16" at 380:31-380:36 (leading: Space)
+4019: Comma           "," at 380:36-380:37
+4020: Ident           "other" at 380:38-380:43 (leading: Space)
+4021: Colon           ":" at 380:43-380:44
+4022: Ident           "int16" at 380:45-380:50 (leading: Space)
+4023: RParen          ")" at 380:50-380:51
+4024: Arrow           "->" at 380:52-380:54 (leading: Space)
+4025: Ident           "int16" at 380:55-380:60 (leading: Space)
+4026: Semicolon       ";" at 380:60-380:61
+4027: At              "@" at 381:5-381:6 (leading: Newline, Space)
+4028: Ident           "intrinsic" at 381:6-381:15
+4029: KwFn            "fn" at 381:16-381:18 (leading: Space)
+4030: Ident           "__lt" at 381:19-381:23 (leading: Space)
+4031: LParen          "(" at 381:23-381:24
+4032: Ident           "self" at 381:24-381:28
+4033: Colon           ":" at 381:28-381:29
+4034: Ident           "int16" at 381:30-381:35 (leading: Space)
+4035: Comma           "," at 381:35-381:36
+4036: Ident           "other" at 381:37-381:42 (leading: Space)
+4037: Colon           ":" at 381:42-381:43
+4038: Ident           "int16" at 381:44-381:49 (leading: Space)
+4039: RParen          ")" at 381:49-381:50
+4040: Arrow           "->" at 381:51-381:53 (leading: Space)
+4041: Ident           "bool" at 381:54-381:58 (leading: Space)
+4042: Semicolon       ";" at 381:58-381:59
+4043: At              "@" at 382:5-382:6 (leading: Newline, Space)
+4044: Ident           "intrinsic" at 382:6-382:15
+4045: KwFn            "fn" at 382:16-382:18 (leading: Space)
+4046: Ident           "__le" at 382:19-382:23 (leading: Space)
+4047: LParen          "(" at 382:23-382:24
+4048: Ident           "self" at 382:24-382:28
+4049: Colon           ":" at 382:28-382:29
+4050: Ident           "int16" at 382:30-382:35 (leading: Space)
+4051: Comma           "," at 382:35-382:36
+4052: Ident           "other" at 382:37-382:42 (leading: Space)
+4053: Colon           ":" at 382:42-382:43
+4054: Ident           "int16" at 382:44-382:49 (leading: Space)
+4055: RParen          ")" at 382:49-382:50
+4056: Arrow           "->" at 382:51-382:53 (leading: Space)
+4057: Ident           "bool" at 382:54-382:58 (leading: Space)
+4058: Semicolon       ";" at 382:58-382:59
+4059: At              "@" at 383:5-383:6 (leading: Newline, Space)
+4060: Ident           "intrinsic" at 383:6-383:15
+4061: KwFn            "fn" at 383:16-383:18 (leading: Space)
+4062: Ident           "__eq" at 383:19-383:23 (leading: Space)
+4063: LParen          "(" at 383:23-383:24
+4064: Ident           "self" at 383:24-383:28
+4065: Colon           ":" at 383:28-383:29
+4066: Ident           "int16" at 383:30-383:35 (leading: Space)
+4067: Comma           "," at 383:35-383:36
+4068: Ident           "other" at 383:37-383:42 (leading: Space)
+4069: Colon           ":" at 383:42-383:43
+4070: Ident           "int16" at 383:44-383:49 (leading: Space)
+4071: RParen          ")" at 383:49-383:50
+4072: Arrow           "->" at 383:51-383:53 (leading: Space)
+4073: Ident           "bool" at 383:54-383:58 (leading: Space)
+4074: Semicolon       ";" at 383:58-383:59
+4075: At              "@" at 384:5-384:6 (leading: Newline, Space)
+4076: Ident           "intrinsic" at 384:6-384:15
+4077: KwFn            "fn" at 384:16-384:18 (leading: Space)
+4078: Ident           "__ne" at 384:19-384:23 (leading: Space)
+4079: LParen          "(" at 384:23-384:24
+4080: Ident           "self" at 384:24-384:28
+4081: Colon           ":" at 384:28-384:29
+4082: Ident           "int16" at 384:30-384:35 (leading: Space)
+4083: Comma           "," at 384:35-384:36
+4084: Ident           "other" at 384:37-384:42 (leading: Space)
+4085: Colon           ":" at 384:42-384:43
+4086: Ident           "int16" at 384:44-384:49 (leading: Space)
+4087: RParen          ")" at 384:49-384:50
+4088: Arrow           "->" at 384:51-384:53 (leading: Space)
+4089: Ident           "bool" at 384:54-384:58 (leading: Space)
+4090: Semicolon       ";" at 384:58-384:59
+4091: At              "@" at 385:5-385:6 (leading: Newline, Space)
+4092: Ident           "intrinsic" at 385:6-385:15
+4093: KwFn            "fn" at 385:16-385:18 (leading: Space)
+4094: Ident           "__ge" at 385:19-385:23 (leading: Space)
+4095: LParen          "(" at 385:23-385:24
+4096: Ident           "self" at 385:24-385:28
+4097: Colon           ":" at 385:28-385:29
+4098: Ident           "int16" at 385:30-385:35 (leading: Space)
+4099: Comma           "," at 385:35-385:36
+4100: Ident           "other" at 385:37-385:42 (leading: Space)
+4101: Colon           ":" at 385:42-385:43
+4102: Ident           "int16" at 385:44-385:49 (leading: Space)
+4103: RParen          ")" at 385:49-385:50
+4104: Arrow           "->" at 385:51-385:53 (leading: Space)
+4105: Ident           "bool" at 385:54-385:58 (leading: Space)
+4106: Semicolon       ";" at 385:58-385:59
+4107: At              "@" at 386:5-386:6 (leading: Newline, Space)
+4108: Ident           "intrinsic" at 386:6-386:15
+4109: KwFn            "fn" at 386:16-386:18 (leading: Space)
+4110: Ident           "__gt" at 386:19-386:23 (leading: Space)
+4111: LParen          "(" at 386:23-386:24
+4112: Ident           "self" at 386:24-386:28
+4113: Colon           ":" at 386:28-386:29
+4114: Ident           "int16" at 386:30-386:35 (leading: Space)
+4115: Comma           "," at 386:35-386:36
+4116: Ident           "other" at 386:37-386:42 (leading: Space)
+4117: Colon           ":" at 386:42-386:43
+4118: Ident           "int16" at 386:44-386:49 (leading: Space)
+4119: RParen          ")" at 386:49-386:50
+4120: Arrow           "->" at 386:51-386:53 (leading: Space)
+4121: Ident           "bool" at 386:54-386:58 (leading: Space)
+4122: Semicolon       ";" at 386:58-386:59
+4123: At              "@" at 387:5-387:6 (leading: Newline, Space)
+4124: Ident           "intrinsic" at 387:6-387:15
+4125: KwFn            "fn" at 387:16-387:18 (leading: Space)
+4126: Ident           "__pos" at 387:19-387:24 (leading: Space)
+4127: LParen          "(" at 387:24-387:25
+4128: Ident           "self" at 387:25-387:29
+4129: Colon           ":" at 387:29-387:30
+4130: Ident           "int16" at 387:31-387:36 (leading: Space)
+4131: RParen          ")" at 387:36-387:37
+4132: Arrow           "->" at 387:38-387:40 (leading: Space)
+4133: Ident           "int16" at 387:41-387:46 (leading: Space)
+4134: Semicolon       ";" at 387:46-387:47
+4135: At              "@" at 388:5-388:6 (leading: Newline, Space)
+4136: Ident           "intrinsic" at 388:6-388:15
+4137: KwFn            "fn" at 388:16-388:18 (leading: Space)
+4138: Ident           "__neg" at 388:19-388:24 (leading: Space)
+4139: LParen          "(" at 388:24-388:25
+4140: Ident           "self" at 388:25-388:29
+4141: Colon           ":" at 388:29-388:30
+4142: Ident           "int16" at 388:31-388:36 (leading: Space)
+4143: RParen          ")" at 388:36-388:37
+4144: Arrow           "->" at 388:38-388:40 (leading: Space)
+4145: Ident           "int16" at 388:41-388:46 (leading: Space)
+4146: Semicolon       ";" at 388:46-388:47
+4147: At              "@" at 389:5-389:6 (leading: Newline, Space)
+4148: Ident           "intrinsic" at 389:6-389:15
+4149: KwFn            "fn" at 389:16-389:18 (leading: Space)
+4150: Ident           "__abs" at 389:19-389:24 (leading: Space)
+4151: LParen          "(" at 389:24-389:25
+4152: Ident           "self" at 389:25-389:29
+4153: Colon           ":" at 389:29-389:30
+4154: Ident           "int16" at 389:31-389:36 (leading: Space)
+4155: RParen          ")" at 389:36-389:37
+4156: Arrow           "->" at 389:38-389:40 (leading: Space)
+4157: Ident           "int16" at 389:41-389:46 (leading: Space)
+4158: Semicolon       ";" at 389:46-389:47
+4159: At              "@" at 390:5-390:6 (leading: Newline, Space)
+4160: Ident           "intrinsic" at 390:6-390:15
+4161: KwFn            "fn" at 390:16-390:18 (leading: Space)
+4162: Ident           "__to" at 390:19-390:23 (leading: Space)
+4163: LParen          "(" at 390:23-390:24
+4164: Ident           "self" at 390:24-390:28
+4165: Colon           ":" at 390:28-390:29
+4166: Ident           "int16" at 390:30-390:35 (leading: Space)
+4167: Comma           "," at 390:35-390:36
+4168: Ident           "target" at 390:37-390:43 (leading: Space)
+4169: Colon           ":" at 390:43-390:44
+4170: Ident           "int" at 390:45-390:48 (leading: Space)
+4171: RParen          ")" at 390:48-390:49
+4172: Arrow           "->" at 390:50-390:52 (leading: Space)
+4173: Ident           "int" at 390:53-390:56 (leading: Space)
+4174: Semicolon       ";" at 390:56-390:57
+4175: At              "@" at 391:5-391:6 (leading: Newline, Space)
+4176: Ident           "intrinsic" at 391:6-391:15
+4177: At              "@" at 391:16-391:17 (leading: Space)
+4178: Ident           "overload" at 391:17-391:25
+4179: KwFn            "fn" at 391:26-391:28 (leading: Space)
+4180: Ident           "__to" at 391:29-391:33 (leading: Space)
+4181: LParen          "(" at 391:33-391:34
+4182: Ident           "self" at 391:34-391:38
+4183: Colon           ":" at 391:38-391:39
+4184: Ident           "int16" at 391:40-391:45 (leading: Space)
+4185: Comma           "," at 391:45-391:46
+4186: Ident           "target" at 391:47-391:53 (leading: Space)
+4187: Colon           ":" at 391:53-391:54
+4188: Ident           "int8" at 391:55-391:59 (leading: Space)
+4189: RParen          ")" at 391:59-391:60
+4190: Arrow           "->" at 391:61-391:63 (leading: Space)
+4191: Ident           "int8" at 391:64-391:68 (leading: Space)
+4192: Semicolon       ";" at 391:68-391:69
+4193: At              "@" at 392:5-392:6 (leading: Newline, Space)
+4194: Ident           "intrinsic" at 392:6-392:15
+4195: At              "@" at 392:16-392:17 (leading: Space)
+4196: Ident           "overload" at 392:17-392:25
+4197: KwFn            "fn" at 392:26-392:28 (leading: Space)
+4198: Ident           "__to" at 392:29-392:33 (leading: Space)
+4199: LParen          "(" at 392:33-392:34
+4200: Ident           "self" at 392:34-392:38
+4201: Colon           ":" at 392:38-392:39
+4202: Ident           "int16" at 392:40-392:45 (leading: Space)
+4203: Comma           "," at 392:45-392:46
+4204: Ident           "target" at 392:47-392:53 (leading: Space)
+4205: Colon           ":" at 392:53-392:54
+4206: Ident           "int32" at 392:55-392:60 (leading: Space)
+4207: RParen          ")" at 392:60-392:61
+4208: Arrow           "->" at 392:62-392:64 (leading: Space)
+4209: Ident           "int32" at 392:65-392:70 (leading: Space)
+4210: Semicolon       ";" at 392:70-392:71
+4211: At              "@" at 393:5-393:6 (leading: Newline, Space)
+4212: Ident           "intrinsic" at 393:6-393:15
+4213: At              "@" at 393:16-393:17 (leading: Space)
+4214: Ident           "overload" at 393:17-393:25
+4215: KwFn            "fn" at 393:26-393:28 (leading: Space)
+4216: Ident           "__to" at 393:29-393:33 (leading: Space)
+4217: LParen          "(" at 393:33-393:34
+4218: Ident           "self" at 393:34-393:38
+4219: Colon           ":" at 393:38-393:39
+4220: Ident           "int16" at 393:40-393:45 (leading: Space)
+4221: Comma           "," at 393:45-393:46
+4222: Ident           "target" at 393:47-393:53 (leading: Space)
+4223: Colon           ":" at 393:53-393:54
+4224: Ident           "int64" at 393:55-393:60 (leading: Space)
+4225: RParen          ")" at 393:60-393:61
+4226: Arrow           "->" at 393:62-393:64 (leading: Space)
+4227: Ident           "int64" at 393:65-393:70 (leading: Space)
+4228: Semicolon       ";" at 393:70-393:71
+4229: At              "@" at 394:5-394:6 (leading: Newline, Space)
+4230: Ident           "intrinsic" at 394:6-394:15
+4231: KwPub           "pub" at 394:16-394:19 (leading: Space)
+4232: KwFn            "fn" at 394:20-394:22 (leading: Space)
+4233: Ident           "from_str" at 394:23-394:31 (leading: Space)
+4234: LParen          "(" at 394:31-394:32
+4235: Ident           "s" at 394:32-394:33
+4236: Colon           ":" at 394:33-394:34
+4237: Amp             "&" at 394:35-394:36 (leading: Space)
+4238: Ident           "string" at 394:36-394:42
+4239: RParen          ")" at 394:42-394:43
+4240: Arrow           "->" at 394:44-394:46 (leading: Space)
+4241: Ident           "Erring" at 394:47-394:53 (leading: Space)
+4242: Lt              "<" at 394:53-394:54
+4243: Ident           "int16" at 394:54-394:59
+4244: Comma           "," at 394:59-394:60
+4245: Ident           "Error" at 394:61-394:66 (leading: Space)
+4246: Gt              ">" at 394:66-394:67
+4247: Semicolon       ";" at 394:67-394:68
+4248: RBrace          "}" at 395:1-395:2 (leading: Newline)
+4249: KwExtern        "extern" at 397:1-397:7 (leading: Newline)
+4250: Lt              "<" at 397:7-397:8
+4251: Ident           "int32" at 397:8-397:13
+4252: Gt              ">" at 397:13-397:14
+4253: LBrace          "{" at 397:15-397:16 (leading: Space)
+4254: KwPub           "pub" at 398:5-398:8 (leading: Newline, Space)
+4255: KwFn            "fn" at 398:9-398:11 (leading: Space)
+4256: Ident           "__min_value" at 398:12-398:23 (leading: Space)
+4257: LParen          "(" at 398:23-398:24
+4258: RParen          ")" at 398:24-398:25
+4259: Arrow           "->" at 398:26-398:28 (leading: Space)
+4260: Ident           "int32" at 398:29-398:34 (leading: Space)
+4261: LBrace          "{" at 398:35-398:36 (leading: Space)
+4262: KwReturn        "return" at 398:37-398:43 (leading: Space)
+4263: LParen          "(" at 398:44-398:45 (leading: Space)
+4264: Minus           "-" at 398:45-398:46
+4265: IntLit          "2_147_483_648" at 398:46-398:59
+4266: RParen          ")" at 398:59-398:60
+4267: Colon           ":" at 398:60-398:61
+4268: Ident           "int32" at 398:61-398:66
+4269: Semicolon       ";" at 398:66-398:67
+4270: RBrace          "}" at 398:68-398:69 (leading: Space)
+4271: KwPub           "pub" at 399:5-399:8 (leading: Newline, Space)
+4272: KwFn            "fn" at 399:9-399:11 (leading: Space)
+4273: Ident           "__max_value" at 399:12-399:23 (leading: Space)
+4274: LParen          "(" at 399:23-399:24
+4275: RParen          ")" at 399:24-399:25
+4276: Arrow           "->" at 399:26-399:28 (leading: Space)
+4277: Ident           "int32" at 399:29-399:34 (leading: Space)
+4278: LBrace          "{" at 399:35-399:36 (leading: Space)
+4279: KwReturn        "return" at 399:37-399:43 (leading: Space)
+4280: LParen          "(" at 399:44-399:45 (leading: Space)
+4281: IntLit          "2_147_483_647" at 399:45-399:58
+4282: RParen          ")" at 399:58-399:59
+4283: Colon           ":" at 399:59-399:60
+4284: Ident           "int32" at 399:60-399:65
+4285: Semicolon       ";" at 399:65-399:66
+4286: RBrace          "}" at 399:67-399:68 (leading: Space)
+4287: At              "@" at 400:5-400:6 (leading: Newline, Space)
+4288: Ident           "intrinsic" at 400:6-400:15
+4289: KwFn            "fn" at 400:16-400:18 (leading: Space)
+4290: Ident           "__add" at 400:19-400:24 (leading: Space)
+4291: LParen          "(" at 400:24-400:25
+4292: Ident           "self" at 400:25-400:29
+4293: Colon           ":" at 400:29-400:30
+4294: Ident           "int32" at 400:31-400:36 (leading: Space)
+4295: Comma           "," at 400:36-400:37
+4296: Ident           "other" at 400:38-400:43 (leading: Space)
+4297: Colon           ":" at 400:43-400:44
+4298: Ident           "int32" at 400:45-400:50 (leading: Space)
+4299: RParen          ")" at 400:50-400:51
+4300: Arrow           "->" at 400:52-400:54 (leading: Space)
+4301: Ident           "int32" at 400:55-400:60 (leading: Space)
+4302: Semicolon       ";" at 400:60-400:61
+4303: At              "@" at 401:5-401:6 (leading: Newline, Space)
+4304: Ident           "intrinsic" at 401:6-401:15
+4305: KwFn            "fn" at 401:16-401:18 (leading: Space)
+4306: Ident           "__sub" at 401:19-401:24 (leading: Space)
+4307: LParen          "(" at 401:24-401:25
+4308: Ident           "self" at 401:25-401:29
+4309: Colon           ":" at 401:29-401:30
+4310: Ident           "int32" at 401:31-401:36 (leading: Space)
+4311: Comma           "," at 401:36-401:37
+4312: Ident           "other" at 401:38-401:43 (leading: Space)
+4313: Colon           ":" at 401:43-401:44
+4314: Ident           "int32" at 401:45-401:50 (leading: Space)
+4315: RParen          ")" at 401:50-401:51
+4316: Arrow           "->" at 401:52-401:54 (leading: Space)
+4317: Ident           "int32" at 401:55-401:60 (leading: Space)
+4318: Semicolon       ";" at 401:60-401:61
+4319: At              "@" at 402:5-402:6 (leading: Newline, Space)
+4320: Ident           "intrinsic" at 402:6-402:15
+4321: KwFn            "fn" at 402:16-402:18 (leading: Space)
+4322: Ident           "__mul" at 402:19-402:24 (leading: Space)
+4323: LParen          "(" at 402:24-402:25
+4324: Ident           "self" at 402:25-402:29
+4325: Colon           ":" at 402:29-402:30
+4326: Ident           "int32" at 402:31-402:36 (leading: Space)
+4327: Comma           "," at 402:36-402:37
+4328: Ident           "other" at 402:38-402:43 (leading: Space)
+4329: Colon           ":" at 402:43-402:44
+4330: Ident           "int32" at 402:45-402:50 (leading: Space)
+4331: RParen          ")" at 402:50-402:51
+4332: Arrow           "->" at 402:52-402:54 (leading: Space)
+4333: Ident           "int32" at 402:55-402:60 (leading: Space)
+4334: Semicolon       ";" at 402:60-402:61
+4335: At              "@" at 403:5-403:6 (leading: Newline, Space)
+4336: Ident           "intrinsic" at 403:6-403:15
+4337: KwFn            "fn" at 403:16-403:18 (leading: Space)
+4338: Ident           "__div" at 403:19-403:24 (leading: Space)
+4339: LParen          "(" at 403:24-403:25
+4340: Ident           "self" at 403:25-403:29
+4341: Colon           ":" at 403:29-403:30
+4342: Ident           "int32" at 403:31-403:36 (leading: Space)
+4343: Comma           "," at 403:36-403:37
+4344: Ident           "other" at 403:38-403:43 (leading: Space)
+4345: Colon           ":" at 403:43-403:44
+4346: Ident           "int32" at 403:45-403:50 (leading: Space)
+4347: RParen          ")" at 403:50-403:51
+4348: Arrow           "->" at 403:52-403:54 (leading: Space)
+4349: Ident           "int32" at 403:55-403:60 (leading: Space)
+4350: Semicolon       ";" at 403:60-403:61
+4351: At              "@" at 404:5-404:6 (leading: Newline, Space)
+4352: Ident           "intrinsic" at 404:6-404:15
+4353: KwFn            "fn" at 404:16-404:18 (leading: Space)
+4354: Ident           "__mod" at 404:19-404:24 (leading: Space)
+4355: LParen          "(" at 404:24-404:25
+4356: Ident           "self" at 404:25-404:29
+4357: Colon           ":" at 404:29-404:30
+4358: Ident           "int32" at 404:31-404:36 (leading: Space)
+4359: Comma           "," at 404:36-404:37
+4360: Ident           "other" at 404:38-404:43 (leading: Space)
+4361: Colon           ":" at 404:43-404:44
+4362: Ident           "int32" at 404:45-404:50 (leading: Space)
+4363: RParen          ")" at 404:50-404:51
+4364: Arrow           "->" at 404:52-404:54 (leading: Space)
+4365: Ident           "int32" at 404:55-404:60 (leading: Space)
+4366: Semicolon       ";" at 404:60-404:61
+4367: At              "@" at 405:5-405:6 (leading: Newline, Space)
+4368: Ident           "intrinsic" at 405:6-405:15
+4369: KwFn            "fn" at 405:16-405:18 (leading: Space)
+4370: Ident           "__bit_and" at 405:19-405:28 (leading: Space)
+4371: LParen          "(" at 405:28-405:29
+4372: Ident           "self" at 405:29-405:33
+4373: Colon           ":" at 405:33-405:34
+4374: Ident           "int32" at 405:35-405:40 (leading: Space)
+4375: Comma           "," at 405:40-405:41
+4376: Ident           "other" at 405:42-405:47 (leading: Space)
+4377: Colon           ":" at 405:47-405:48
+4378: Ident           "int32" at 405:49-405:54 (leading: Space)
+4379: RParen          ")" at 405:54-405:55
+4380: Arrow           "->" at 405:56-405:58 (leading: Space)
+4381: Ident           "int32" at 405:59-405:64 (leading: Space)
+4382: Semicolon       ";" at 405:64-405:65
+4383: At              "@" at 406:5-406:6 (leading: Newline, Space)
+4384: Ident           "intrinsic" at 406:6-406:15
+4385: KwFn            "fn" at 406:16-406:18 (leading: Space)
+4386: Ident           "__bit_or" at 406:19-406:27 (leading: Space)
+4387: LParen          "(" at 406:27-406:28
+4388: Ident           "self" at 406:28-406:32
+4389: Colon           ":" at 406:32-406:33
+4390: Ident           "int32" at 406:34-406:39 (leading: Space)
+4391: Comma           "," at 406:39-406:40
+4392: Ident           "other" at 406:41-406:46 (leading: Space)
+4393: Colon           ":" at 406:46-406:47
+4394: Ident           "int32" at 406:48-406:53 (leading: Space)
+4395: RParen          ")" at 406:53-406:54
+4396: Arrow           "->" at 406:55-406:57 (leading: Space)
+4397: Ident           "int32" at 406:58-406:63 (leading: Space)
+4398: Semicolon       ";" at 406:63-406:64
+4399: At              "@" at 407:5-407:6 (leading: Newline, Space)
+4400: Ident           "intrinsic" at 407:6-407:15
+4401: KwFn            "fn" at 407:16-407:18 (leading: Space)
+4402: Ident           "__bit_xor" at 407:19-407:28 (leading: Space)
+4403: LParen          "(" at 407:28-407:29
+4404: Ident           "self" at 407:29-407:33
+4405: Colon           ":" at 407:33-407:34
+4406: Ident           "int32" at 407:35-407:40 (leading: Space)
+4407: Comma           "," at 407:40-407:41
+4408: Ident           "other" at 407:42-407:47 (leading: Space)
+4409: Colon           ":" at 407:47-407:48
+4410: Ident           "int32" at 407:49-407:54 (leading: Space)
+4411: RParen          ")" at 407:54-407:55
+4412: Arrow           "->" at 407:56-407:58 (leading: Space)
+4413: Ident           "int32" at 407:59-407:64 (leading: Space)
+4414: Semicolon       ";" at 407:64-407:65
+4415: At              "@" at 408:5-408:6 (leading: Newline, Space)
+4416: Ident           "intrinsic" at 408:6-408:15
+4417: KwFn            "fn" at 408:16-408:18 (leading: Space)
+4418: Ident           "__shl" at 408:19-408:24 (leading: Space)
+4419: LParen          "(" at 408:24-408:25
+4420: Ident           "self" at 408:25-408:29
+4421: Colon           ":" at 408:29-408:30
+4422: Ident           "int32" at 408:31-408:36 (leading: Space)
+4423: Comma           "," at 408:36-408:37
+4424: Ident           "other" at 408:38-408:43 (leading: Space)
+4425: Colon           ":" at 408:43-408:44
+4426: Ident           "int32" at 408:45-408:50 (leading: Space)
+4427: RParen          ")" at 408:50-408:51
+4428: Arrow           "->" at 408:52-408:54 (leading: Space)
+4429: Ident           "int32" at 408:55-408:60 (leading: Space)
+4430: Semicolon       ";" at 408:60-408:61
+4431: At              "@" at 409:5-409:6 (leading: Newline, Space)
+4432: Ident           "intrinsic" at 409:6-409:15
+4433: KwFn            "fn" at 409:16-409:18 (leading: Space)
+4434: Ident           "__shr" at 409:19-409:24 (leading: Space)
+4435: LParen          "(" at 409:24-409:25
+4436: Ident           "self" at 409:25-409:29
+4437: Colon           ":" at 409:29-409:30
+4438: Ident           "int32" at 409:31-409:36 (leading: Space)
+4439: Comma           "," at 409:36-409:37
+4440: Ident           "other" at 409:38-409:43 (leading: Space)
+4441: Colon           ":" at 409:43-409:44
+4442: Ident           "int32" at 409:45-409:50 (leading: Space)
+4443: RParen          ")" at 409:50-409:51
+4444: Arrow           "->" at 409:52-409:54 (leading: Space)
+4445: Ident           "int32" at 409:55-409:60 (leading: Space)
+4446: Semicolon       ";" at 409:60-409:61
+4447: At              "@" at 410:5-410:6 (leading: Newline, Space)
+4448: Ident           "intrinsic" at 410:6-410:15
+4449: KwFn            "fn" at 410:16-410:18 (leading: Space)
+4450: Ident           "__lt" at 410:19-410:23 (leading: Space)
+4451: LParen          "(" at 410:23-410:24
+4452: Ident           "self" at 410:24-410:28
+4453: Colon           ":" at 410:28-410:29
+4454: Ident           "int32" at 410:30-410:35 (leading: Space)
+4455: Comma           "," at 410:35-410:36
+4456: Ident           "other" at 410:37-410:42 (leading: Space)
+4457: Colon           ":" at 410:42-410:43
+4458: Ident           "int32" at 410:44-410:49 (leading: Space)
+4459: RParen          ")" at 410:49-410:50
+4460: Arrow           "->" at 410:51-410:53 (leading: Space)
+4461: Ident           "bool" at 410:54-410:58 (leading: Space)
+4462: Semicolon       ";" at 410:58-410:59
+4463: At              "@" at 411:5-411:6 (leading: Newline, Space)
+4464: Ident           "intrinsic" at 411:6-411:15
+4465: KwFn            "fn" at 411:16-411:18 (leading: Space)
+4466: Ident           "__le" at 411:19-411:23 (leading: Space)
+4467: LParen          "(" at 411:23-411:24
+4468: Ident           "self" at 411:24-411:28
+4469: Colon           ":" at 411:28-411:29
+4470: Ident           "int32" at 411:30-411:35 (leading: Space)
+4471: Comma           "," at 411:35-411:36
+4472: Ident           "other" at 411:37-411:42 (leading: Space)
+4473: Colon           ":" at 411:42-411:43
+4474: Ident           "int32" at 411:44-411:49 (leading: Space)
+4475: RParen          ")" at 411:49-411:50
+4476: Arrow           "->" at 411:51-411:53 (leading: Space)
+4477: Ident           "bool" at 411:54-411:58 (leading: Space)
+4478: Semicolon       ";" at 411:58-411:59
+4479: At              "@" at 412:5-412:6 (leading: Newline, Space)
+4480: Ident           "intrinsic" at 412:6-412:15
+4481: KwFn            "fn" at 412:16-412:18 (leading: Space)
+4482: Ident           "__eq" at 412:19-412:23 (leading: Space)
+4483: LParen          "(" at 412:23-412:24
+4484: Ident           "self" at 412:24-412:28
+4485: Colon           ":" at 412:28-412:29
+4486: Ident           "int32" at 412:30-412:35 (leading: Space)
+4487: Comma           "," at 412:35-412:36
+4488: Ident           "other" at 412:37-412:42 (leading: Space)
+4489: Colon           ":" at 412:42-412:43
+4490: Ident           "int32" at 412:44-412:49 (leading: Space)
+4491: RParen          ")" at 412:49-412:50
+4492: Arrow           "->" at 412:51-412:53 (leading: Space)
+4493: Ident           "bool" at 412:54-412:58 (leading: Space)
+4494: Semicolon       ";" at 412:58-412:59
+4495: At              "@" at 413:5-413:6 (leading: Newline, Space)
+4496: Ident           "intrinsic" at 413:6-413:15
+4497: KwFn            "fn" at 413:16-413:18 (leading: Space)
+4498: Ident           "__ne" at 413:19-413:23 (leading: Space)
+4499: LParen          "(" at 413:23-413:24
+4500: Ident           "self" at 413:24-413:28
+4501: Colon           ":" at 413:28-413:29
+4502: Ident           "int32" at 413:30-413:35 (leading: Space)
+4503: Comma           "," at 413:35-413:36
+4504: Ident           "other" at 413:37-413:42 (leading: Space)
+4505: Colon           ":" at 413:42-413:43
+4506: Ident           "int32" at 413:44-413:49 (leading: Space)
+4507: RParen          ")" at 413:49-413:50
+4508: Arrow           "->" at 413:51-413:53 (leading: Space)
+4509: Ident           "bool" at 413:54-413:58 (leading: Space)
+4510: Semicolon       ";" at 413:58-413:59
+4511: At              "@" at 414:5-414:6 (leading: Newline, Space)
+4512: Ident           "intrinsic" at 414:6-414:15
+4513: KwFn            "fn" at 414:16-414:18 (leading: Space)
+4514: Ident           "__ge" at 414:19-414:23 (leading: Space)
+4515: LParen          "(" at 414:23-414:24
+4516: Ident           "self" at 414:24-414:28
+4517: Colon           ":" at 414:28-414:29
+4518: Ident           "int32" at 414:30-414:35 (leading: Space)
+4519: Comma           "," at 414:35-414:36
+4520: Ident           "other" at 414:37-414:42 (leading: Space)
+4521: Colon           ":" at 414:42-414:43
+4522: Ident           "int32" at 414:44-414:49 (leading: Space)
+4523: RParen          ")" at 414:49-414:50
+4524: Arrow           "->" at 414:51-414:53 (leading: Space)
+4525: Ident           "bool" at 414:54-414:58 (leading: Space)
+4526: Semicolon       ";" at 414:58-414:59
+4527: At              "@" at 415:5-415:6 (leading: Newline, Space)
+4528: Ident           "intrinsic" at 415:6-415:15
+4529: KwFn            "fn" at 415:16-415:18 (leading: Space)
+4530: Ident           "__gt" at 415:19-415:23 (leading: Space)
+4531: LParen          "(" at 415:23-415:24
+4532: Ident           "self" at 415:24-415:28
+4533: Colon           ":" at 415:28-415:29
+4534: Ident           "int32" at 415:30-415:35 (leading: Space)
+4535: Comma           "," at 415:35-415:36
+4536: Ident           "other" at 415:37-415:42 (leading: Space)
+4537: Colon           ":" at 415:42-415:43
+4538: Ident           "int32" at 415:44-415:49 (leading: Space)
+4539: RParen          ")" at 415:49-415:50
+4540: Arrow           "->" at 415:51-415:53 (leading: Space)
+4541: Ident           "bool" at 415:54-415:58 (leading: Space)
+4542: Semicolon       ";" at 415:58-415:59
+4543: At              "@" at 416:5-416:6 (leading: Newline, Space)
+4544: Ident           "intrinsic" at 416:6-416:15
+4545: KwFn            "fn" at 416:16-416:18 (leading: Space)
+4546: Ident           "__pos" at 416:19-416:24 (leading: Space)
+4547: LParen          "(" at 416:24-416:25
+4548: Ident           "self" at 416:25-416:29
+4549: Colon           ":" at 416:29-416:30
+4550: Ident           "int32" at 416:31-416:36 (leading: Space)
+4551: RParen          ")" at 416:36-416:37
+4552: Arrow           "->" at 416:38-416:40 (leading: Space)
+4553: Ident           "int32" at 416:41-416:46 (leading: Space)
+4554: Semicolon       ";" at 416:46-416:47
+4555: At              "@" at 417:5-417:6 (leading: Newline, Space)
+4556: Ident           "intrinsic" at 417:6-417:15
+4557: KwFn            "fn" at 417:16-417:18 (leading: Space)
+4558: Ident           "__neg" at 417:19-417:24 (leading: Space)
+4559: LParen          "(" at 417:24-417:25
+4560: Ident           "self" at 417:25-417:29
+4561: Colon           ":" at 417:29-417:30
+4562: Ident           "int32" at 417:31-417:36 (leading: Space)
+4563: RParen          ")" at 417:36-417:37
+4564: Arrow           "->" at 417:38-417:40 (leading: Space)
+4565: Ident           "int32" at 417:41-417:46 (leading: Space)
+4566: Semicolon       ";" at 417:46-417:47
+4567: At              "@" at 418:5-418:6 (leading: Newline, Space)
+4568: Ident           "intrinsic" at 418:6-418:15
+4569: KwFn            "fn" at 418:16-418:18 (leading: Space)
+4570: Ident           "__abs" at 418:19-418:24 (leading: Space)
+4571: LParen          "(" at 418:24-418:25
+4572: Ident           "self" at 418:25-418:29
+4573: Colon           ":" at 418:29-418:30
+4574: Ident           "int32" at 418:31-418:36 (leading: Space)
+4575: RParen          ")" at 418:36-418:37
+4576: Arrow           "->" at 418:38-418:40 (leading: Space)
+4577: Ident           "int32" at 418:41-418:46 (leading: Space)
+4578: Semicolon       ";" at 418:46-418:47
+4579: At              "@" at 419:5-419:6 (leading: Newline, Space)
+4580: Ident           "intrinsic" at 419:6-419:15
+4581: KwFn            "fn" at 419:16-419:18 (leading: Space)
+4582: Ident           "__to" at 419:19-419:23 (leading: Space)
+4583: LParen          "(" at 419:23-419:24
+4584: Ident           "self" at 419:24-419:28
+4585: Colon           ":" at 419:28-419:29
+4586: Ident           "int32" at 419:30-419:35 (leading: Space)
+4587: Comma           "," at 419:35-419:36
+4588: Ident           "target" at 419:37-419:43 (leading: Space)
+4589: Colon           ":" at 419:43-419:44
+4590: Ident           "int" at 419:45-419:48 (leading: Space)
+4591: RParen          ")" at 419:48-419:49
+4592: Arrow           "->" at 419:50-419:52 (leading: Space)
+4593: Ident           "int" at 419:53-419:56 (leading: Space)
+4594: Semicolon       ";" at 419:56-419:57
+4595: At              "@" at 420:5-420:6 (leading: Newline, Space)
+4596: Ident           "intrinsic" at 420:6-420:15
+4597: At              "@" at 420:16-420:17 (leading: Space)
+4598: Ident           "overload" at 420:17-420:25
+4599: KwFn            "fn" at 420:26-420:28 (leading: Space)
+4600: Ident           "__to" at 420:29-420:33 (leading: Space)
+4601: LParen          "(" at 420:33-420:34
+4602: Ident           "self" at 420:34-420:38
+4603: Colon           ":" at 420:38-420:39
+4604: Ident           "int32" at 420:40-420:45 (leading: Space)
+4605: Comma           "," at 420:45-420:46
+4606: Ident           "target" at 420:47-420:53 (leading: Space)
+4607: Colon           ":" at 420:53-420:54
+4608: Ident           "int8" at 420:55-420:59 (leading: Space)
+4609: RParen          ")" at 420:59-420:60
+4610: Arrow           "->" at 420:61-420:63 (leading: Space)
+4611: Ident           "int8" at 420:64-420:68 (leading: Space)
+4612: Semicolon       ";" at 420:68-420:69
+4613: At              "@" at 421:5-421:6 (leading: Newline, Space)
+4614: Ident           "intrinsic" at 421:6-421:15
+4615: At              "@" at 421:16-421:17 (leading: Space)
+4616: Ident           "overload" at 421:17-421:25
+4617: KwFn            "fn" at 421:26-421:28 (leading: Space)
+4618: Ident           "__to" at 421:29-421:33 (leading: Space)
+4619: LParen          "(" at 421:33-421:34
+4620: Ident           "self" at 421:34-421:38
+4621: Colon           ":" at 421:38-421:39
+4622: Ident           "int32" at 421:40-421:45 (leading: Space)
+4623: Comma           "," at 421:45-421:46
+4624: Ident           "target" at 421:47-421:53 (leading: Space)
+4625: Colon           ":" at 421:53-421:54
+4626: Ident           "int16" at 421:55-421:60 (leading: Space)
+4627: RParen          ")" at 421:60-421:61
+4628: Arrow           "->" at 421:62-421:64 (leading: Space)
+4629: Ident           "int16" at 421:65-421:70 (leading: Space)
+4630: Semicolon       ";" at 421:70-421:71
+4631: At              "@" at 422:5-422:6 (leading: Newline, Space)
+4632: Ident           "intrinsic" at 422:6-422:15
+4633: At              "@" at 422:16-422:17 (leading: Space)
+4634: Ident           "overload" at 422:17-422:25
+4635: KwFn            "fn" at 422:26-422:28 (leading: Space)
+4636: Ident           "__to" at 422:29-422:33 (leading: Space)
+4637: LParen          "(" at 422:33-422:34
+4638: Ident           "self" at 422:34-422:38
+4639: Colon           ":" at 422:38-422:39
+4640: Ident           "int32" at 422:40-422:45 (leading: Space)
+4641: Comma           "," at 422:45-422:46
+4642: Ident           "target" at 422:47-422:53 (leading: Space)
+4643: Colon           ":" at 422:53-422:54
+4644: Ident           "int64" at 422:55-422:60 (leading: Space)
+4645: RParen          ")" at 422:60-422:61
+4646: Arrow           "->" at 422:62-422:64 (leading: Space)
+4647: Ident           "int64" at 422:65-422:70 (leading: Space)
+4648: Semicolon       ";" at 422:70-422:71
+4649: At              "@" at 423:5-423:6 (leading: Newline, Space)
+4650: Ident           "intrinsic" at 423:6-423:15
+4651: KwPub           "pub" at 423:16-423:19 (leading: Space)
+4652: KwFn            "fn" at 423:20-423:22 (leading: Space)
+4653: Ident           "from_str" at 423:23-423:31 (leading: Space)
+4654: LParen          "(" at 423:31-423:32
+4655: Ident           "s" at 423:32-423:33
+4656: Colon           ":" at 423:33-423:34
+4657: Amp             "&" at 423:35-423:36 (leading: Space)
+4658: Ident           "string" at 423:36-423:42
+4659: RParen          ")" at 423:42-423:43
+4660: Arrow           "->" at 423:44-423:46 (leading: Space)
+4661: Ident           "Erring" at 423:47-423:53 (leading: Space)
+4662: Lt              "<" at 423:53-423:54
+4663: Ident           "int32" at 423:54-423:59
+4664: Comma           "," at 423:59-423:60
+4665: Ident           "Error" at 423:61-423:66 (leading: Space)
+4666: Gt              ">" at 423:66-423:67
+4667: Semicolon       ";" at 423:67-423:68
+4668: RBrace          "}" at 424:1-424:2 (leading: Newline)
+4669: KwExtern        "extern" at 426:1-426:7 (leading: Newline)
+4670: Lt              "<" at 426:7-426:8
+4671: Ident           "int64" at 426:8-426:13
+4672: Gt              ">" at 426:13-426:14
+4673: LBrace          "{" at 426:15-426:16 (leading: Space)
+4674: KwPub           "pub" at 427:5-427:8 (leading: Newline, Space)
+4675: KwFn            "fn" at 427:9-427:11 (leading: Space)
+4676: Ident           "__min_value" at 427:12-427:23 (leading: Space)
+4677: LParen          "(" at 427:23-427:24
+4678: RParen          ")" at 427:24-427:25
+4679: Arrow           "->" at 427:26-427:28 (leading: Space)
+4680: Ident           "int64" at 427:29-427:34 (leading: Space)
+4681: LBrace          "{" at 427:35-427:36 (leading: Space)
+4682: KwReturn        "return" at 427:37-427:43 (leading: Space)
+4683: LParen          "(" at 427:44-427:45 (leading: Space)
+4684: Minus           "-" at 427:45-427:46
+4685: IntLit          "9_223_372_036_854_775_808" at 427:46-427:71
+4686: RParen          ")" at 427:71-427:72
+4687: Colon           ":" at 427:72-427:73
+4688: Ident           "int64" at 427:73-427:78
+4689: Semicolon       ";" at 427:78-427:79
+4690: RBrace          "}" at 427:80-427:81 (leading: Space)
+4691: KwPub           "pub" at 428:5-428:8 (leading: Newline, Space)
+4692: KwFn            "fn" at 428:9-428:11 (leading: Space)
+4693: Ident           "__max_value" at 428:12-428:23 (leading: Space)
+4694: LParen          "(" at 428:23-428:24
+4695: RParen          ")" at 428:24-428:25
+4696: Arrow           "->" at 428:26-428:28 (leading: Space)
+4697: Ident           "int64" at 428:29-428:34 (leading: Space)
+4698: LBrace          "{" at 428:35-428:36 (leading: Space)
+4699: KwReturn        "return" at 428:37-428:43 (leading: Space)
+4700: LParen          "(" at 428:44-428:45 (leading: Space)
+4701: IntLit          "9_223_372_036_854_775_807" at 428:45-428:70
+4702: RParen          ")" at 428:70-428:71
+4703: Colon           ":" at 428:71-428:72
+4704: Ident           "int64" at 428:72-428:77
+4705: Semicolon       ";" at 428:77-428:78
+4706: RBrace          "}" at 428:79-428:80 (leading: Space)
+4707: At              "@" at 429:5-429:6 (leading: Newline, Space)
+4708: Ident           "intrinsic" at 429:6-429:15
+4709: KwFn            "fn" at 429:16-429:18 (leading: Space)
+4710: Ident           "__add" at 429:19-429:24 (leading: Space)
+4711: LParen          "(" at 429:24-429:25
+4712: Ident           "self" at 429:25-429:29
+4713: Colon           ":" at 429:29-429:30
+4714: Ident           "int64" at 429:31-429:36 (leading: Space)
+4715: Comma           "," at 429:36-429:37
+4716: Ident           "other" at 429:38-429:43 (leading: Space)
+4717: Colon           ":" at 429:43-429:44
+4718: Ident           "int64" at 429:45-429:50 (leading: Space)
+4719: RParen          ")" at 429:50-429:51
+4720: Arrow           "->" at 429:52-429:54 (leading: Space)
+4721: Ident           "int64" at 429:55-429:60 (leading: Space)
+4722: Semicolon       ";" at 429:60-429:61
+4723: At              "@" at 430:5-430:6 (leading: Newline, Space)
+4724: Ident           "intrinsic" at 430:6-430:15
+4725: KwFn            "fn" at 430:16-430:18 (leading: Space)
+4726: Ident           "__sub" at 430:19-430:24 (leading: Space)
+4727: LParen          "(" at 430:24-430:25
+4728: Ident           "self" at 430:25-430:29
+4729: Colon           ":" at 430:29-430:30
+4730: Ident           "int64" at 430:31-430:36 (leading: Space)
+4731: Comma           "," at 430:36-430:37
+4732: Ident           "other" at 430:38-430:43 (leading: Space)
+4733: Colon           ":" at 430:43-430:44
+4734: Ident           "int64" at 430:45-430:50 (leading: Space)
+4735: RParen          ")" at 430:50-430:51
+4736: Arrow           "->" at 430:52-430:54 (leading: Space)
+4737: Ident           "int64" at 430:55-430:60 (leading: Space)
+4738: Semicolon       ";" at 430:60-430:61
+4739: At              "@" at 431:5-431:6 (leading: Newline, Space)
+4740: Ident           "intrinsic" at 431:6-431:15
+4741: KwFn            "fn" at 431:16-431:18 (leading: Space)
+4742: Ident           "__mul" at 431:19-431:24 (leading: Space)
+4743: LParen          "(" at 431:24-431:25
+4744: Ident           "self" at 431:25-431:29
+4745: Colon           ":" at 431:29-431:30
+4746: Ident           "int64" at 431:31-431:36 (leading: Space)
+4747: Comma           "," at 431:36-431:37
+4748: Ident           "other" at 431:38-431:43 (leading: Space)
+4749: Colon           ":" at 431:43-431:44
+4750: Ident           "int64" at 431:45-431:50 (leading: Space)
+4751: RParen          ")" at 431:50-431:51
+4752: Arrow           "->" at 431:52-431:54 (leading: Space)
+4753: Ident           "int64" at 431:55-431:60 (leading: Space)
+4754: Semicolon       ";" at 431:60-431:61
+4755: At              "@" at 432:5-432:6 (leading: Newline, Space)
+4756: Ident           "intrinsic" at 432:6-432:15
+4757: KwFn            "fn" at 432:16-432:18 (leading: Space)
+4758: Ident           "__div" at 432:19-432:24 (leading: Space)
+4759: LParen          "(" at 432:24-432:25
+4760: Ident           "self" at 432:25-432:29
+4761: Colon           ":" at 432:29-432:30
+4762: Ident           "int64" at 432:31-432:36 (leading: Space)
+4763: Comma           "," at 432:36-432:37
+4764: Ident           "other" at 432:38-432:43 (leading: Space)
+4765: Colon           ":" at 432:43-432:44
+4766: Ident           "int64" at 432:45-432:50 (leading: Space)
+4767: RParen          ")" at 432:50-432:51
+4768: Arrow           "->" at 432:52-432:54 (leading: Space)
+4769: Ident           "int64" at 432:55-432:60 (leading: Space)
+4770: Semicolon       ";" at 432:60-432:61
+4771: At              "@" at 433:5-433:6 (leading: Newline, Space)
+4772: Ident           "intrinsic" at 433:6-433:15
+4773: KwFn            "fn" at 433:16-433:18 (leading: Space)
+4774: Ident           "__mod" at 433:19-433:24 (leading: Space)
+4775: LParen          "(" at 433:24-433:25
+4776: Ident           "self" at 433:25-433:29
+4777: Colon           ":" at 433:29-433:30
+4778: Ident           "int64" at 433:31-433:36 (leading: Space)
+4779: Comma           "," at 433:36-433:37
+4780: Ident           "other" at 433:38-433:43 (leading: Space)
+4781: Colon           ":" at 433:43-433:44
+4782: Ident           "int64" at 433:45-433:50 (leading: Space)
+4783: RParen          ")" at 433:50-433:51
+4784: Arrow           "->" at 433:52-433:54 (leading: Space)
+4785: Ident           "int64" at 433:55-433:60 (leading: Space)
+4786: Semicolon       ";" at 433:60-433:61
+4787: At              "@" at 434:5-434:6 (leading: Newline, Space)
+4788: Ident           "intrinsic" at 434:6-434:15
+4789: KwFn            "fn" at 434:16-434:18 (leading: Space)
+4790: Ident           "__bit_and" at 434:19-434:28 (leading: Space)
+4791: LParen          "(" at 434:28-434:29
+4792: Ident           "self" at 434:29-434:33
+4793: Colon           ":" at 434:33-434:34
+4794: Ident           "int64" at 434:35-434:40 (leading: Space)
+4795: Comma           "," at 434:40-434:41
+4796: Ident           "other" at 434:42-434:47 (leading: Space)
+4797: Colon           ":" at 434:47-434:48
+4798: Ident           "int64" at 434:49-434:54 (leading: Space)
+4799: RParen          ")" at 434:54-434:55
+4800: Arrow           "->" at 434:56-434:58 (leading: Space)
+4801: Ident           "int64" at 434:59-434:64 (leading: Space)
+4802: Semicolon       ";" at 434:64-434:65
+4803: At              "@" at 435:5-435:6 (leading: Newline, Space)
+4804: Ident           "intrinsic" at 435:6-435:15
+4805: KwFn            "fn" at 435:16-435:18 (leading: Space)
+4806: Ident           "__bit_or" at 435:19-435:27 (leading: Space)
+4807: LParen          "(" at 435:27-435:28
+4808: Ident           "self" at 435:28-435:32
+4809: Colon           ":" at 435:32-435:33
+4810: Ident           "int64" at 435:34-435:39 (leading: Space)
+4811: Comma           "," at 435:39-435:40
+4812: Ident           "other" at 435:41-435:46 (leading: Space)
+4813: Colon           ":" at 435:46-435:47
+4814: Ident           "int64" at 435:48-435:53 (leading: Space)
+4815: RParen          ")" at 435:53-435:54
+4816: Arrow           "->" at 435:55-435:57 (leading: Space)
+4817: Ident           "int64" at 435:58-435:63 (leading: Space)
+4818: Semicolon       ";" at 435:63-435:64
+4819: At              "@" at 436:5-436:6 (leading: Newline, Space)
+4820: Ident           "intrinsic" at 436:6-436:15
+4821: KwFn            "fn" at 436:16-436:18 (leading: Space)
+4822: Ident           "__bit_xor" at 436:19-436:28 (leading: Space)
+4823: LParen          "(" at 436:28-436:29
+4824: Ident           "self" at 436:29-436:33
+4825: Colon           ":" at 436:33-436:34
+4826: Ident           "int64" at 436:35-436:40 (leading: Space)
+4827: Comma           "," at 436:40-436:41
+4828: Ident           "other" at 436:42-436:47 (leading: Space)
+4829: Colon           ":" at 436:47-436:48
+4830: Ident           "int64" at 436:49-436:54 (leading: Space)
+4831: RParen          ")" at 436:54-436:55
+4832: Arrow           "->" at 436:56-436:58 (leading: Space)
+4833: Ident           "int64" at 436:59-436:64 (leading: Space)
+4834: Semicolon       ";" at 436:64-436:65
+4835: At              "@" at 437:5-437:6 (leading: Newline, Space)
+4836: Ident           "intrinsic" at 437:6-437:15
+4837: KwFn            "fn" at 437:16-437:18 (leading: Space)
+4838: Ident           "__shl" at 437:19-437:24 (leading: Space)
+4839: LParen          "(" at 437:24-437:25
+4840: Ident           "self" at 437:25-437:29
+4841: Colon           ":" at 437:29-437:30
+4842: Ident           "int64" at 437:31-437:36 (leading: Space)
+4843: Comma           "," at 437:36-437:37
+4844: Ident           "other" at 437:38-437:43 (leading: Space)
+4845: Colon           ":" at 437:43-437:44
+4846: Ident           "int64" at 437:45-437:50 (leading: Space)
+4847: RParen          ")" at 437:50-437:51
+4848: Arrow           "->" at 437:52-437:54 (leading: Space)
+4849: Ident           "int64" at 437:55-437:60 (leading: Space)
+4850: Semicolon       ";" at 437:60-437:61
+4851: At              "@" at 438:5-438:6 (leading: Newline, Space)
+4852: Ident           "intrinsic" at 438:6-438:15
+4853: KwFn            "fn" at 438:16-438:18 (leading: Space)
+4854: Ident           "__shr" at 438:19-438:24 (leading: Space)
+4855: LParen          "(" at 438:24-438:25
+4856: Ident           "self" at 438:25-438:29
+4857: Colon           ":" at 438:29-438:30
+4858: Ident           "int64" at 438:31-438:36 (leading: Space)
+4859: Comma           "," at 438:36-438:37
+4860: Ident           "other" at 438:38-438:43 (leading: Space)
+4861: Colon           ":" at 438:43-438:44
+4862: Ident           "int64" at 438:45-438:50 (leading: Space)
+4863: RParen          ")" at 438:50-438:51
+4864: Arrow           "->" at 438:52-438:54 (leading: Space)
+4865: Ident           "int64" at 438:55-438:60 (leading: Space)
+4866: Semicolon       ";" at 438:60-438:61
+4867: At              "@" at 439:5-439:6 (leading: Newline, Space)
+4868: Ident           "intrinsic" at 439:6-439:15
+4869: KwFn            "fn" at 439:16-439:18 (leading: Space)
+4870: Ident           "__lt" at 439:19-439:23 (leading: Space)
+4871: LParen          "(" at 439:23-439:24
+4872: Ident           "self" at 439:24-439:28
+4873: Colon           ":" at 439:28-439:29
+4874: Ident           "int64" at 439:30-439:35 (leading: Space)
+4875: Comma           "," at 439:35-439:36
+4876: Ident           "other" at 439:37-439:42 (leading: Space)
+4877: Colon           ":" at 439:42-439:43
+4878: Ident           "int64" at 439:44-439:49 (leading: Space)
+4879: RParen          ")" at 439:49-439:50
+4880: Arrow           "->" at 439:51-439:53 (leading: Space)
+4881: Ident           "bool" at 439:54-439:58 (leading: Space)
+4882: Semicolon       ";" at 439:58-439:59
+4883: At              "@" at 440:5-440:6 (leading: Newline, Space)
+4884: Ident           "intrinsic" at 440:6-440:15
+4885: KwFn            "fn" at 440:16-440:18 (leading: Space)
+4886: Ident           "__le" at 440:19-440:23 (leading: Space)
+4887: LParen          "(" at 440:23-440:24
+4888: Ident           "self" at 440:24-440:28
+4889: Colon           ":" at 440:28-440:29
+4890: Ident           "int64" at 440:30-440:35 (leading: Space)
+4891: Comma           "," at 440:35-440:36
+4892: Ident           "other" at 440:37-440:42 (leading: Space)
+4893: Colon           ":" at 440:42-440:43
+4894: Ident           "int64" at 440:44-440:49 (leading: Space)
+4895: RParen          ")" at 440:49-440:50
+4896: Arrow           "->" at 440:51-440:53 (leading: Space)
+4897: Ident           "bool" at 440:54-440:58 (leading: Space)
+4898: Semicolon       ";" at 440:58-440:59
+4899: At              "@" at 441:5-441:6 (leading: Newline, Space)
+4900: Ident           "intrinsic" at 441:6-441:15
+4901: KwFn            "fn" at 441:16-441:18 (leading: Space)
+4902: Ident           "__eq" at 441:19-441:23 (leading: Space)
+4903: LParen          "(" at 441:23-441:24
+4904: Ident           "self" at 441:24-441:28
+4905: Colon           ":" at 441:28-441:29
+4906: Ident           "int64" at 441:30-441:35 (leading: Space)
+4907: Comma           "," at 441:35-441:36
+4908: Ident           "other" at 441:37-441:42 (leading: Space)
+4909: Colon           ":" at 441:42-441:43
+4910: Ident           "int64" at 441:44-441:49 (leading: Space)
+4911: RParen          ")" at 441:49-441:50
+4912: Arrow           "->" at 441:51-441:53 (leading: Space)
+4913: Ident           "bool" at 441:54-441:58 (leading: Space)
+4914: Semicolon       ";" at 441:58-441:59
+4915: At              "@" at 442:5-442:6 (leading: Newline, Space)
+4916: Ident           "intrinsic" at 442:6-442:15
+4917: KwFn            "fn" at 442:16-442:18 (leading: Space)
+4918: Ident           "__ne" at 442:19-442:23 (leading: Space)
+4919: LParen          "(" at 442:23-442:24
+4920: Ident           "self" at 442:24-442:28
+4921: Colon           ":" at 442:28-442:29
+4922: Ident           "int64" at 442:30-442:35 (leading: Space)
+4923: Comma           "," at 442:35-442:36
+4924: Ident           "other" at 442:37-442:42 (leading: Space)
+4925: Colon           ":" at 442:42-442:43
+4926: Ident           "int64" at 442:44-442:49 (leading: Space)
+4927: RParen          ")" at 442:49-442:50
+4928: Arrow           "->" at 442:51-442:53 (leading: Space)
+4929: Ident           "bool" at 442:54-442:58 (leading: Space)
+4930: Semicolon       ";" at 442:58-442:59
+4931: At              "@" at 443:5-443:6 (leading: Newline, Space)
+4932: Ident           "intrinsic" at 443:6-443:15
+4933: KwFn            "fn" at 443:16-443:18 (leading: Space)
+4934: Ident           "__ge" at 443:19-443:23 (leading: Space)
+4935: LParen          "(" at 443:23-443:24
+4936: Ident           "self" at 443:24-443:28
+4937: Colon           ":" at 443:28-443:29
+4938: Ident           "int64" at 443:30-443:35 (leading: Space)
+4939: Comma           "," at 443:35-443:36
+4940: Ident           "other" at 443:37-443:42 (leading: Space)
+4941: Colon           ":" at 443:42-443:43
+4942: Ident           "int64" at 443:44-443:49 (leading: Space)
+4943: RParen          ")" at 443:49-443:50
+4944: Arrow           "->" at 443:51-443:53 (leading: Space)
+4945: Ident           "bool" at 443:54-443:58 (leading: Space)
+4946: Semicolon       ";" at 443:58-443:59
+4947: At              "@" at 444:5-444:6 (leading: Newline, Space)
+4948: Ident           "intrinsic" at 444:6-444:15
+4949: KwFn            "fn" at 444:16-444:18 (leading: Space)
+4950: Ident           "__gt" at 444:19-444:23 (leading: Space)
+4951: LParen          "(" at 444:23-444:24
+4952: Ident           "self" at 444:24-444:28
+4953: Colon           ":" at 444:28-444:29
+4954: Ident           "int64" at 444:30-444:35 (leading: Space)
+4955: Comma           "," at 444:35-444:36
+4956: Ident           "other" at 444:37-444:42 (leading: Space)
+4957: Colon           ":" at 444:42-444:43
+4958: Ident           "int64" at 444:44-444:49 (leading: Space)
+4959: RParen          ")" at 444:49-444:50
+4960: Arrow           "->" at 444:51-444:53 (leading: Space)
+4961: Ident           "bool" at 444:54-444:58 (leading: Space)
+4962: Semicolon       ";" at 444:58-444:59
+4963: At              "@" at 445:5-445:6 (leading: Newline, Space)
+4964: Ident           "intrinsic" at 445:6-445:15
+4965: KwFn            "fn" at 445:16-445:18 (leading: Space)
+4966: Ident           "__pos" at 445:19-445:24 (leading: Space)
+4967: LParen          "(" at 445:24-445:25
+4968: Ident           "self" at 445:25-445:29
+4969: Colon           ":" at 445:29-445:30
+4970: Ident           "int64" at 445:31-445:36 (leading: Space)
+4971: RParen          ")" at 445:36-445:37
+4972: Arrow           "->" at 445:38-445:40 (leading: Space)
+4973: Ident           "int64" at 445:41-445:46 (leading: Space)
+4974: Semicolon       ";" at 445:46-445:47
+4975: At              "@" at 446:5-446:6 (leading: Newline, Space)
+4976: Ident           "intrinsic" at 446:6-446:15
+4977: KwFn            "fn" at 446:16-446:18 (leading: Space)
+4978: Ident           "__neg" at 446:19-446:24 (leading: Space)
+4979: LParen          "(" at 446:24-446:25
+4980: Ident           "self" at 446:25-446:29
+4981: Colon           ":" at 446:29-446:30
+4982: Ident           "int64" at 446:31-446:36 (leading: Space)
+4983: RParen          ")" at 446:36-446:37
+4984: Arrow           "->" at 446:38-446:40 (leading: Space)
+4985: Ident           "int64" at 446:41-446:46 (leading: Space)
+4986: Semicolon       ";" at 446:46-446:47
+4987: At              "@" at 447:5-447:6 (leading: Newline, Space)
+4988: Ident           "intrinsic" at 447:6-447:15
+4989: KwFn            "fn" at 447:16-447:18 (leading: Space)
+4990: Ident           "__abs" at 447:19-447:24 (leading: Space)
+4991: LParen          "(" at 447:24-447:25
+4992: Ident           "self" at 447:25-447:29
+4993: Colon           ":" at 447:29-447:30
+4994: Ident           "int64" at 447:31-447:36 (leading: Space)
+4995: RParen          ")" at 447:36-447:37
+4996: Arrow           "->" at 447:38-447:40 (leading: Space)
+4997: Ident           "int64" at 447:41-447:46 (leading: Space)
+4998: Semicolon       ";" at 447:46-447:47
+4999: At              "@" at 448:5-448:6 (leading: Newline, Space)
+5000: Ident           "intrinsic" at 448:6-448:15
+5001: KwFn            "fn" at 448:16-448:18 (leading: Space)
+5002: Ident           "__to" at 448:19-448:23 (leading: Space)
+5003: LParen          "(" at 448:23-448:24
+5004: Ident           "self" at 448:24-448:28
+5005: Colon           ":" at 448:28-448:29
+5006: Ident           "int64" at 448:30-448:35 (leading: Space)
+5007: Comma           "," at 448:35-448:36
+5008: Ident           "target" at 448:37-448:43 (leading: Space)
+5009: Colon           ":" at 448:43-448:44
+5010: Ident           "int" at 448:45-448:48 (leading: Space)
+5011: RParen          ")" at 448:48-448:49
+5012: Arrow           "->" at 448:50-448:52 (leading: Space)
+5013: Ident           "int" at 448:53-448:56 (leading: Space)
+5014: Semicolon       ";" at 448:56-448:57
+5015: At              "@" at 449:5-449:6 (leading: Newline, Space)
+5016: Ident           "intrinsic" at 449:6-449:15
+5017: At              "@" at 449:16-449:17 (leading: Space)
+5018: Ident           "overload" at 449:17-449:25
+5019: KwFn            "fn" at 449:26-449:28 (leading: Space)
+5020: Ident           "__to" at 449:29-449:33 (leading: Space)
+5021: LParen          "(" at 449:33-449:34
+5022: Ident           "self" at 449:34-449:38
+5023: Colon           ":" at 449:38-449:39
+5024: Ident           "int64" at 449:40-449:45 (leading: Space)
+5025: Comma           "," at 449:45-449:46
+5026: Ident           "target" at 449:47-449:53 (leading: Space)
+5027: Colon           ":" at 449:53-449:54
+5028: Ident           "int8" at 449:55-449:59 (leading: Space)
+5029: RParen          ")" at 449:59-449:60
+5030: Arrow           "->" at 449:61-449:63 (leading: Space)
+5031: Ident           "int8" at 449:64-449:68 (leading: Space)
+5032: Semicolon       ";" at 449:68-449:69
+5033: At              "@" at 450:5-450:6 (leading: Newline, Space)
+5034: Ident           "intrinsic" at 450:6-450:15
+5035: At              "@" at 450:16-450:17 (leading: Space)
+5036: Ident           "overload" at 450:17-450:25
+5037: KwFn            "fn" at 450:26-450:28 (leading: Space)
+5038: Ident           "__to" at 450:29-450:33 (leading: Space)
+5039: LParen          "(" at 450:33-450:34
+5040: Ident           "self" at 450:34-450:38
+5041: Colon           ":" at 450:38-450:39
+5042: Ident           "int64" at 450:40-450:45 (leading: Space)
+5043: Comma           "," at 450:45-450:46
+5044: Ident           "target" at 450:47-450:53 (leading: Space)
+5045: Colon           ":" at 450:53-450:54
+5046: Ident           "int16" at 450:55-450:60 (leading: Space)
+5047: RParen          ")" at 450:60-450:61
+5048: Arrow           "->" at 450:62-450:64 (leading: Space)
+5049: Ident           "int16" at 450:65-450:70 (leading: Space)
+5050: Semicolon       ";" at 450:70-450:71
+5051: At              "@" at 451:5-451:6 (leading: Newline, Space)
+5052: Ident           "intrinsic" at 451:6-451:15
+5053: At              "@" at 451:16-451:17 (leading: Space)
+5054: Ident           "overload" at 451:17-451:25
+5055: KwFn            "fn" at 451:26-451:28 (leading: Space)
+5056: Ident           "__to" at 451:29-451:33 (leading: Space)
+5057: LParen          "(" at 451:33-451:34
+5058: Ident           "self" at 451:34-451:38
+5059: Colon           ":" at 451:38-451:39
+5060: Ident           "int64" at 451:40-451:45 (leading: Space)
+5061: Comma           "," at 451:45-451:46
+5062: Ident           "target" at 451:47-451:53 (leading: Space)
+5063: Colon           ":" at 451:53-451:54
+5064: Ident           "int32" at 451:55-451:60 (leading: Space)
+5065: RParen          ")" at 451:60-451:61
+5066: Arrow           "->" at 451:62-451:64 (leading: Space)
+5067: Ident           "int32" at 451:65-451:70 (leading: Space)
+5068: Semicolon       ";" at 451:70-451:71
+5069: At              "@" at 452:5-452:6 (leading: Newline, Space)
+5070: Ident           "intrinsic" at 452:6-452:15
+5071: KwPub           "pub" at 452:16-452:19 (leading: Space)
+5072: KwFn            "fn" at 452:20-452:22 (leading: Space)
+5073: Ident           "from_str" at 452:23-452:31 (leading: Space)
+5074: LParen          "(" at 452:31-452:32
+5075: Ident           "s" at 452:32-452:33
+5076: Colon           ":" at 452:33-452:34
+5077: Amp             "&" at 452:35-452:36 (leading: Space)
+5078: Ident           "string" at 452:36-452:42
+5079: RParen          ")" at 452:42-452:43
+5080: Arrow           "->" at 452:44-452:46 (leading: Space)
+5081: Ident           "Erring" at 452:47-452:53 (leading: Space)
+5082: Lt              "<" at 452:53-452:54
+5083: Ident           "int64" at 452:54-452:59
+5084: Comma           "," at 452:59-452:60
+5085: Ident           "Error" at 452:61-452:66 (leading: Space)
+5086: Gt              ">" at 452:66-452:67
+5087: Semicolon       ";" at 452:67-452:68
+5088: RBrace          "}" at 453:1-453:2 (leading: Newline)
+5089: KwExtern        "extern" at 455:1-455:7 (leading: Newline)
+5090: Lt              "<" at 455:7-455:8
+5091: Ident           "uint8" at 455:8-455:13
+5092: Gt              ">" at 455:13-455:14
+5093: LBrace          "{" at 455:15-455:16 (leading: Space)
+5094: KwPub           "pub" at 456:5-456:8 (leading: Newline, Space)
+5095: KwFn            "fn" at 456:9-456:11 (leading: Space)
+5096: Ident           "__min_value" at 456:12-456:23 (leading: Space)
+5097: LParen          "(" at 456:23-456:24
+5098: RParen          ")" at 456:24-456:25
+5099: Arrow           "->" at 456:26-456:28 (leading: Space)
+5100: Ident           "uint8" at 456:29-456:34 (leading: Space)
+5101: LBrace          "{" at 456:35-456:36 (leading: Space)
+5102: KwReturn        "return" at 456:37-456:43 (leading: Space)
+5103: LParen          "(" at 456:44-456:45 (leading: Space)
+5104: IntLit          "0" at 456:45-456:46
+5105: RParen          ")" at 456:46-456:47
+5106: Colon           ":" at 456:47-456:48
+5107: Ident           "uint8" at 456:48-456:53
+5108: Semicolon       ";" at 456:53-456:54
+5109: RBrace          "}" at 456:55-456:56 (leading: Space)
+5110: KwPub           "pub" at 457:5-457:8 (leading: Newline, Space)
+5111: KwFn            "fn" at 457:9-457:11 (leading: Space)
+5112: Ident           "__max_value" at 457:12-457:23 (leading: Space)
+5113: LParen          "(" at 457:23-457:24
+5114: RParen          ")" at 457:24-457:25
+5115: Arrow           "->" at 457:26-457:28 (leading: Space)
+5116: Ident           "uint8" at 457:29-457:34 (leading: Space)
+5117: LBrace          "{" at 457:35-457:36 (leading: Space)
+5118: KwReturn        "return" at 457:37-457:43 (leading: Space)
+5119: LParen          "(" at 457:44-457:45 (leading: Space)
+5120: IntLit          "255" at 457:45-457:48
+5121: RParen          ")" at 457:48-457:49
+5122: Colon           ":" at 457:49-457:50
+5123: Ident           "uint8" at 457:50-457:55
+5124: Semicolon       ";" at 457:55-457:56
+5125: RBrace          "}" at 457:57-457:58 (leading: Space)
+5126: At              "@" at 458:5-458:6 (leading: Newline, Space)
+5127: Ident           "intrinsic" at 458:6-458:15
+5128: KwFn            "fn" at 458:16-458:18 (leading: Space)
+5129: Ident           "__add" at 458:19-458:24 (leading: Space)
+5130: LParen          "(" at 458:24-458:25
+5131: Ident           "self" at 458:25-458:29
+5132: Colon           ":" at 458:29-458:30
+5133: Ident           "uint8" at 458:31-458:36 (leading: Space)
+5134: Comma           "," at 458:36-458:37
+5135: Ident           "other" at 458:38-458:43 (leading: Space)
+5136: Colon           ":" at 458:43-458:44
+5137: Ident           "uint8" at 458:45-458:50 (leading: Space)
+5138: RParen          ")" at 458:50-458:51
+5139: Arrow           "->" at 458:52-458:54 (leading: Space)
+5140: Ident           "uint8" at 458:55-458:60 (leading: Space)
+5141: Semicolon       ";" at 458:60-458:61
+5142: At              "@" at 459:5-459:6 (leading: Newline, Space)
+5143: Ident           "intrinsic" at 459:6-459:15
+5144: KwFn            "fn" at 459:16-459:18 (leading: Space)
+5145: Ident           "__sub" at 459:19-459:24 (leading: Space)
+5146: LParen          "(" at 459:24-459:25
+5147: Ident           "self" at 459:25-459:29
+5148: Colon           ":" at 459:29-459:30
+5149: Ident           "uint8" at 459:31-459:36 (leading: Space)
+5150: Comma           "," at 459:36-459:37
+5151: Ident           "other" at 459:38-459:43 (leading: Space)
+5152: Colon           ":" at 459:43-459:44
+5153: Ident           "uint8" at 459:45-459:50 (leading: Space)
+5154: RParen          ")" at 459:50-459:51
+5155: Arrow           "->" at 459:52-459:54 (leading: Space)
+5156: Ident           "uint8" at 459:55-459:60 (leading: Space)
+5157: Semicolon       ";" at 459:60-459:61
+5158: At              "@" at 460:5-460:6 (leading: Newline, Space)
+5159: Ident           "intrinsic" at 460:6-460:15
+5160: KwFn            "fn" at 460:16-460:18 (leading: Space)
+5161: Ident           "__mul" at 460:19-460:24 (leading: Space)
+5162: LParen          "(" at 460:24-460:25
+5163: Ident           "self" at 460:25-460:29
+5164: Colon           ":" at 460:29-460:30
+5165: Ident           "uint8" at 460:31-460:36 (leading: Space)
+5166: Comma           "," at 460:36-460:37
+5167: Ident           "other" at 460:38-460:43 (leading: Space)
+5168: Colon           ":" at 460:43-460:44
+5169: Ident           "uint8" at 460:45-460:50 (leading: Space)
+5170: RParen          ")" at 460:50-460:51
+5171: Arrow           "->" at 460:52-460:54 (leading: Space)
+5172: Ident           "uint8" at 460:55-460:60 (leading: Space)
+5173: Semicolon       ";" at 460:60-460:61
+5174: At              "@" at 461:5-461:6 (leading: Newline, Space)
+5175: Ident           "intrinsic" at 461:6-461:15
+5176: KwFn            "fn" at 461:16-461:18 (leading: Space)
+5177: Ident           "__div" at 461:19-461:24 (leading: Space)
+5178: LParen          "(" at 461:24-461:25
+5179: Ident           "self" at 461:25-461:29
+5180: Colon           ":" at 461:29-461:30
+5181: Ident           "uint8" at 461:31-461:36 (leading: Space)
+5182: Comma           "," at 461:36-461:37
+5183: Ident           "other" at 461:38-461:43 (leading: Space)
+5184: Colon           ":" at 461:43-461:44
+5185: Ident           "uint8" at 461:45-461:50 (leading: Space)
+5186: RParen          ")" at 461:50-461:51
+5187: Arrow           "->" at 461:52-461:54 (leading: Space)
+5188: Ident           "uint8" at 461:55-461:60 (leading: Space)
+5189: Semicolon       ";" at 461:60-461:61
+5190: At              "@" at 462:5-462:6 (leading: Newline, Space)
+5191: Ident           "intrinsic" at 462:6-462:15
+5192: KwFn            "fn" at 462:16-462:18 (leading: Space)
+5193: Ident           "__mod" at 462:19-462:24 (leading: Space)
+5194: LParen          "(" at 462:24-462:25
+5195: Ident           "self" at 462:25-462:29
+5196: Colon           ":" at 462:29-462:30
+5197: Ident           "uint8" at 462:31-462:36 (leading: Space)
+5198: Comma           "," at 462:36-462:37
+5199: Ident           "other" at 462:38-462:43 (leading: Space)
+5200: Colon           ":" at 462:43-462:44
+5201: Ident           "uint8" at 462:45-462:50 (leading: Space)
+5202: RParen          ")" at 462:50-462:51
+5203: Arrow           "->" at 462:52-462:54 (leading: Space)
+5204: Ident           "uint8" at 462:55-462:60 (leading: Space)
+5205: Semicolon       ";" at 462:60-462:61
+5206: At              "@" at 463:5-463:6 (leading: Newline, Space)
+5207: Ident           "intrinsic" at 463:6-463:15
+5208: KwFn            "fn" at 463:16-463:18 (leading: Space)
+5209: Ident           "__bit_and" at 463:19-463:28 (leading: Space)
+5210: LParen          "(" at 463:28-463:29
+5211: Ident           "self" at 463:29-463:33
+5212: Colon           ":" at 463:33-463:34
+5213: Ident           "uint8" at 463:35-463:40 (leading: Space)
+5214: Comma           "," at 463:40-463:41
+5215: Ident           "other" at 463:42-463:47 (leading: Space)
+5216: Colon           ":" at 463:47-463:48
+5217: Ident           "uint8" at 463:49-463:54 (leading: Space)
+5218: RParen          ")" at 463:54-463:55
+5219: Arrow           "->" at 463:56-463:58 (leading: Space)
+5220: Ident           "uint8" at 463:59-463:64 (leading: Space)
+5221: Semicolon       ";" at 463:64-463:65
+5222: At              "@" at 464:5-464:6 (leading: Newline, Space)
+5223: Ident           "intrinsic" at 464:6-464:15
+5224: KwFn            "fn" at 464:16-464:18 (leading: Space)
+5225: Ident           "__bit_or" at 464:19-464:27 (leading: Space)
+5226: LParen          "(" at 464:27-464:28
+5227: Ident           "self" at 464:28-464:32
+5228: Colon           ":" at 464:32-464:33
+5229: Ident           "uint8" at 464:34-464:39 (leading: Space)
+5230: Comma           "," at 464:39-464:40
+5231: Ident           "other" at 464:41-464:46 (leading: Space)
+5232: Colon           ":" at 464:46-464:47
+5233: Ident           "uint8" at 464:48-464:53 (leading: Space)
+5234: RParen          ")" at 464:53-464:54
+5235: Arrow           "->" at 464:55-464:57 (leading: Space)
+5236: Ident           "uint8" at 464:58-464:63 (leading: Space)
+5237: Semicolon       ";" at 464:63-464:64
+5238: At              "@" at 465:5-465:6 (leading: Newline, Space)
+5239: Ident           "intrinsic" at 465:6-465:15
+5240: KwFn            "fn" at 465:16-465:18 (leading: Space)
+5241: Ident           "__bit_xor" at 465:19-465:28 (leading: Space)
+5242: LParen          "(" at 465:28-465:29
+5243: Ident           "self" at 465:29-465:33
+5244: Colon           ":" at 465:33-465:34
+5245: Ident           "uint8" at 465:35-465:40 (leading: Space)
+5246: Comma           "," at 465:40-465:41
+5247: Ident           "other" at 465:42-465:47 (leading: Space)
+5248: Colon           ":" at 465:47-465:48
+5249: Ident           "uint8" at 465:49-465:54 (leading: Space)
+5250: RParen          ")" at 465:54-465:55
+5251: Arrow           "->" at 465:56-465:58 (leading: Space)
+5252: Ident           "uint8" at 465:59-465:64 (leading: Space)
+5253: Semicolon       ";" at 465:64-465:65
+5254: At              "@" at 466:5-466:6 (leading: Newline, Space)
+5255: Ident           "intrinsic" at 466:6-466:15
+5256: KwFn            "fn" at 466:16-466:18 (leading: Space)
+5257: Ident           "__shl" at 466:19-466:24 (leading: Space)
+5258: LParen          "(" at 466:24-466:25
+5259: Ident           "self" at 466:25-466:29
+5260: Colon           ":" at 466:29-466:30
+5261: Ident           "uint8" at 466:31-466:36 (leading: Space)
+5262: Comma           "," at 466:36-466:37
+5263: Ident           "other" at 466:38-466:43 (leading: Space)
+5264: Colon           ":" at 466:43-466:44
+5265: Ident           "uint8" at 466:45-466:50 (leading: Space)
+5266: RParen          ")" at 466:50-466:51
+5267: Arrow           "->" at 466:52-466:54 (leading: Space)
+5268: Ident           "uint8" at 466:55-466:60 (leading: Space)
+5269: Semicolon       ";" at 466:60-466:61
+5270: At              "@" at 467:5-467:6 (leading: Newline, Space)
+5271: Ident           "intrinsic" at 467:6-467:15
+5272: KwFn            "fn" at 467:16-467:18 (leading: Space)
+5273: Ident           "__shr" at 467:19-467:24 (leading: Space)
+5274: LParen          "(" at 467:24-467:25
+5275: Ident           "self" at 467:25-467:29
+5276: Colon           ":" at 467:29-467:30
+5277: Ident           "uint8" at 467:31-467:36 (leading: Space)
+5278: Comma           "," at 467:36-467:37
+5279: Ident           "other" at 467:38-467:43 (leading: Space)
+5280: Colon           ":" at 467:43-467:44
+5281: Ident           "uint8" at 467:45-467:50 (leading: Space)
+5282: RParen          ")" at 467:50-467:51
+5283: Arrow           "->" at 467:52-467:54 (leading: Space)
+5284: Ident           "uint8" at 467:55-467:60 (leading: Space)
+5285: Semicolon       ";" at 467:60-467:61
+5286: At              "@" at 468:5-468:6 (leading: Newline, Space)
+5287: Ident           "intrinsic" at 468:6-468:15
+5288: KwFn            "fn" at 468:16-468:18 (leading: Space)
+5289: Ident           "__lt" at 468:19-468:23 (leading: Space)
+5290: LParen          "(" at 468:23-468:24
+5291: Ident           "self" at 468:24-468:28
+5292: Colon           ":" at 468:28-468:29
+5293: Ident           "uint8" at 468:30-468:35 (leading: Space)
+5294: Comma           "," at 468:35-468:36
+5295: Ident           "other" at 468:37-468:42 (leading: Space)
+5296: Colon           ":" at 468:42-468:43
+5297: Ident           "uint8" at 468:44-468:49 (leading: Space)
+5298: RParen          ")" at 468:49-468:50
+5299: Arrow           "->" at 468:51-468:53 (leading: Space)
+5300: Ident           "bool" at 468:54-468:58 (leading: Space)
+5301: Semicolon       ";" at 468:58-468:59
+5302: At              "@" at 469:5-469:6 (leading: Newline, Space)
+5303: Ident           "intrinsic" at 469:6-469:15
+5304: KwFn            "fn" at 469:16-469:18 (leading: Space)
+5305: Ident           "__le" at 469:19-469:23 (leading: Space)
+5306: LParen          "(" at 469:23-469:24
+5307: Ident           "self" at 469:24-469:28
+5308: Colon           ":" at 469:28-469:29
+5309: Ident           "uint8" at 469:30-469:35 (leading: Space)
+5310: Comma           "," at 469:35-469:36
+5311: Ident           "other" at 469:37-469:42 (leading: Space)
+5312: Colon           ":" at 469:42-469:43
+5313: Ident           "uint8" at 469:44-469:49 (leading: Space)
+5314: RParen          ")" at 469:49-469:50
+5315: Arrow           "->" at 469:51-469:53 (leading: Space)
+5316: Ident           "bool" at 469:54-469:58 (leading: Space)
+5317: Semicolon       ";" at 469:58-469:59
+5318: At              "@" at 470:5-470:6 (leading: Newline, Space)
+5319: Ident           "intrinsic" at 470:6-470:15
+5320: KwFn            "fn" at 470:16-470:18 (leading: Space)
+5321: Ident           "__eq" at 470:19-470:23 (leading: Space)
+5322: LParen          "(" at 470:23-470:24
+5323: Ident           "self" at 470:24-470:28
+5324: Colon           ":" at 470:28-470:29
+5325: Ident           "uint8" at 470:30-470:35 (leading: Space)
+5326: Comma           "," at 470:35-470:36
+5327: Ident           "other" at 470:37-470:42 (leading: Space)
+5328: Colon           ":" at 470:42-470:43
+5329: Ident           "uint8" at 470:44-470:49 (leading: Space)
+5330: RParen          ")" at 470:49-470:50
+5331: Arrow           "->" at 470:51-470:53 (leading: Space)
+5332: Ident           "bool" at 470:54-470:58 (leading: Space)
+5333: Semicolon       ";" at 470:58-470:59
+5334: At              "@" at 471:5-471:6 (leading: Newline, Space)
+5335: Ident           "intrinsic" at 471:6-471:15
+5336: KwFn            "fn" at 471:16-471:18 (leading: Space)
+5337: Ident           "__ne" at 471:19-471:23 (leading: Space)
+5338: LParen          "(" at 471:23-471:24
+5339: Ident           "self" at 471:24-471:28
+5340: Colon           ":" at 471:28-471:29
+5341: Ident           "uint8" at 471:30-471:35 (leading: Space)
+5342: Comma           "," at 471:35-471:36
+5343: Ident           "other" at 471:37-471:42 (leading: Space)
+5344: Colon           ":" at 471:42-471:43
+5345: Ident           "uint8" at 471:44-471:49 (leading: Space)
+5346: RParen          ")" at 471:49-471:50
+5347: Arrow           "->" at 471:51-471:53 (leading: Space)
+5348: Ident           "bool" at 471:54-471:58 (leading: Space)
+5349: Semicolon       ";" at 471:58-471:59
+5350: At              "@" at 472:5-472:6 (leading: Newline, Space)
+5351: Ident           "intrinsic" at 472:6-472:15
+5352: KwFn            "fn" at 472:16-472:18 (leading: Space)
+5353: Ident           "__ge" at 472:19-472:23 (leading: Space)
+5354: LParen          "(" at 472:23-472:24
+5355: Ident           "self" at 472:24-472:28
+5356: Colon           ":" at 472:28-472:29
+5357: Ident           "uint8" at 472:30-472:35 (leading: Space)
+5358: Comma           "," at 472:35-472:36
+5359: Ident           "other" at 472:37-472:42 (leading: Space)
+5360: Colon           ":" at 472:42-472:43
+5361: Ident           "uint8" at 472:44-472:49 (leading: Space)
+5362: RParen          ")" at 472:49-472:50
+5363: Arrow           "->" at 472:51-472:53 (leading: Space)
+5364: Ident           "bool" at 472:54-472:58 (leading: Space)
+5365: Semicolon       ";" at 472:58-472:59
+5366: At              "@" at 473:5-473:6 (leading: Newline, Space)
+5367: Ident           "intrinsic" at 473:6-473:15
+5368: KwFn            "fn" at 473:16-473:18 (leading: Space)
+5369: Ident           "__gt" at 473:19-473:23 (leading: Space)
+5370: LParen          "(" at 473:23-473:24
+5371: Ident           "self" at 473:24-473:28
+5372: Colon           ":" at 473:28-473:29
+5373: Ident           "uint8" at 473:30-473:35 (leading: Space)
+5374: Comma           "," at 473:35-473:36
+5375: Ident           "other" at 473:37-473:42 (leading: Space)
+5376: Colon           ":" at 473:42-473:43
+5377: Ident           "uint8" at 473:44-473:49 (leading: Space)
+5378: RParen          ")" at 473:49-473:50
+5379: Arrow           "->" at 473:51-473:53 (leading: Space)
+5380: Ident           "bool" at 473:54-473:58 (leading: Space)
+5381: Semicolon       ";" at 473:58-473:59
+5382: At              "@" at 474:5-474:6 (leading: Newline, Space)
+5383: Ident           "intrinsic" at 474:6-474:15
+5384: KwFn            "fn" at 474:16-474:18 (leading: Space)
+5385: Ident           "__pos" at 474:19-474:24 (leading: Space)
+5386: LParen          "(" at 474:24-474:25
+5387: Ident           "self" at 474:25-474:29
+5388: Colon           ":" at 474:29-474:30
+5389: Ident           "uint8" at 474:31-474:36 (leading: Space)
+5390: RParen          ")" at 474:36-474:37
+5391: Arrow           "->" at 474:38-474:40 (leading: Space)
+5392: Ident           "uint8" at 474:41-474:46 (leading: Space)
+5393: Semicolon       ";" at 474:46-474:47
+5394: At              "@" at 475:5-475:6 (leading: Newline, Space)
+5395: Ident           "intrinsic" at 475:6-475:15
+5396: KwFn            "fn" at 475:16-475:18 (leading: Space)
+5397: Ident           "__abs" at 475:19-475:24 (leading: Space)
+5398: LParen          "(" at 475:24-475:25
+5399: Ident           "self" at 475:25-475:29
+5400: Colon           ":" at 475:29-475:30
+5401: Ident           "uint8" at 475:31-475:36 (leading: Space)
+5402: RParen          ")" at 475:36-475:37
+5403: Arrow           "->" at 475:38-475:40 (leading: Space)
+5404: Ident           "uint8" at 475:41-475:46 (leading: Space)
+5405: Semicolon       ";" at 475:46-475:47
+5406: At              "@" at 476:5-476:6 (leading: Newline, Space)
+5407: Ident           "intrinsic" at 476:6-476:15
+5408: KwFn            "fn" at 476:16-476:18 (leading: Space)
+5409: Ident           "__to" at 476:19-476:23 (leading: Space)
+5410: LParen          "(" at 476:23-476:24
+5411: Ident           "self" at 476:24-476:28
+5412: Colon           ":" at 476:28-476:29
+5413: Ident           "uint8" at 476:30-476:35 (leading: Space)
+5414: Comma           "," at 476:35-476:36
+5415: Ident           "target" at 476:37-476:43 (leading: Space)
+5416: Colon           ":" at 476:43-476:44
+5417: Ident           "uint" at 476:45-476:49 (leading: Space)
+5418: RParen          ")" at 476:49-476:50
+5419: Arrow           "->" at 476:51-476:53 (leading: Space)
+5420: Ident           "uint" at 476:54-476:58 (leading: Space)
+5421: Semicolon       ";" at 476:58-476:59
+5422: At              "@" at 477:5-477:6 (leading: Newline, Space)
+5423: Ident           "intrinsic" at 477:6-477:15
+5424: At              "@" at 477:16-477:17 (leading: Space)
+5425: Ident           "overload" at 477:17-477:25
+5426: KwFn            "fn" at 477:26-477:28 (leading: Space)
+5427: Ident           "__to" at 477:29-477:33 (leading: Space)
+5428: LParen          "(" at 477:33-477:34
+5429: Ident           "self" at 477:34-477:38
+5430: Colon           ":" at 477:38-477:39
+5431: Ident           "uint8" at 477:40-477:45 (leading: Space)
+5432: Comma           "," at 477:45-477:46
+5433: Ident           "target" at 477:47-477:53 (leading: Space)
+5434: Colon           ":" at 477:53-477:54
+5435: Ident           "uint16" at 477:55-477:61 (leading: Space)
+5436: RParen          ")" at 477:61-477:62
+5437: Arrow           "->" at 477:63-477:65 (leading: Space)
+5438: Ident           "uint16" at 477:66-477:72 (leading: Space)
+5439: Semicolon       ";" at 477:72-477:73
+5440: At              "@" at 478:5-478:6 (leading: Newline, Space)
+5441: Ident           "intrinsic" at 478:6-478:15
+5442: At              "@" at 478:16-478:17 (leading: Space)
+5443: Ident           "overload" at 478:17-478:25
+5444: KwFn            "fn" at 478:26-478:28 (leading: Space)
+5445: Ident           "__to" at 478:29-478:33 (leading: Space)
+5446: LParen          "(" at 478:33-478:34
+5447: Ident           "self" at 478:34-478:38
+5448: Colon           ":" at 478:38-478:39
+5449: Ident           "uint8" at 478:40-478:45 (leading: Space)
+5450: Comma           "," at 478:45-478:46
+5451: Ident           "target" at 478:47-478:53 (leading: Space)
+5452: Colon           ":" at 478:53-478:54
+5453: Ident           "uint32" at 478:55-478:61 (leading: Space)
+5454: RParen          ")" at 478:61-478:62
+5455: Arrow           "->" at 478:63-478:65 (leading: Space)
+5456: Ident           "uint32" at 478:66-478:72 (leading: Space)
+5457: Semicolon       ";" at 478:72-478:73
+5458: At              "@" at 479:5-479:6 (leading: Newline, Space)
+5459: Ident           "intrinsic" at 479:6-479:15
+5460: At              "@" at 479:16-479:17 (leading: Space)
+5461: Ident           "overload" at 479:17-479:25
+5462: KwFn            "fn" at 479:26-479:28 (leading: Space)
+5463: Ident           "__to" at 479:29-479:33 (leading: Space)
+5464: LParen          "(" at 479:33-479:34
+5465: Ident           "self" at 479:34-479:38
+5466: Colon           ":" at 479:38-479:39
+5467: Ident           "uint8" at 479:40-479:45 (leading: Space)
+5468: Comma           "," at 479:45-479:46
+5469: Ident           "target" at 479:47-479:53 (leading: Space)
+5470: Colon           ":" at 479:53-479:54
+5471: Ident           "uint64" at 479:55-479:61 (leading: Space)
+5472: RParen          ")" at 479:61-479:62
+5473: Arrow           "->" at 479:63-479:65 (leading: Space)
+5474: Ident           "uint64" at 479:66-479:72 (leading: Space)
+5475: Semicolon       ";" at 479:72-479:73
+5476: At              "@" at 480:5-480:6 (leading: Newline, Space)
+5477: Ident           "intrinsic" at 480:6-480:15
+5478: KwPub           "pub" at 480:16-480:19 (leading: Space)
+5479: KwFn            "fn" at 480:20-480:22 (leading: Space)
+5480: Ident           "from_str" at 480:23-480:31 (leading: Space)
+5481: LParen          "(" at 480:31-480:32
+5482: Ident           "s" at 480:32-480:33
+5483: Colon           ":" at 480:33-480:34
+5484: Amp             "&" at 480:35-480:36 (leading: Space)
+5485: Ident           "string" at 480:36-480:42
+5486: RParen          ")" at 480:42-480:43
+5487: Arrow           "->" at 480:44-480:46 (leading: Space)
+5488: Ident           "Erring" at 480:47-480:53 (leading: Space)
+5489: Lt              "<" at 480:53-480:54
+5490: Ident           "uint8" at 480:54-480:59
+5491: Comma           "," at 480:59-480:60
+5492: Ident           "Error" at 480:61-480:66 (leading: Space)
+5493: Gt              ">" at 480:66-480:67
+5494: Semicolon       ";" at 480:67-480:68
+5495: RBrace          "}" at 481:1-481:2 (leading: Newline)
+5496: KwExtern        "extern" at 483:1-483:7 (leading: Newline)
+5497: Lt              "<" at 483:7-483:8
+5498: Ident           "uint16" at 483:8-483:14
+5499: Gt              ">" at 483:14-483:15
+5500: LBrace          "{" at 483:16-483:17 (leading: Space)
+5501: KwPub           "pub" at 484:5-484:8 (leading: Newline, Space)
+5502: KwFn            "fn" at 484:9-484:11 (leading: Space)
+5503: Ident           "__min_value" at 484:12-484:23 (leading: Space)
+5504: LParen          "(" at 484:23-484:24
+5505: RParen          ")" at 484:24-484:25
+5506: Arrow           "->" at 484:26-484:28 (leading: Space)
+5507: Ident           "uint16" at 484:29-484:35 (leading: Space)
+5508: LBrace          "{" at 484:36-484:37 (leading: Space)
+5509: KwReturn        "return" at 484:38-484:44 (leading: Space)
+5510: LParen          "(" at 484:45-484:46 (leading: Space)
+5511: IntLit          "0" at 484:46-484:47
+5512: RParen          ")" at 484:47-484:48
+5513: Colon           ":" at 484:48-484:49
+5514: Ident           "uint16" at 484:49-484:55
+5515: Semicolon       ";" at 484:55-484:56
+5516: RBrace          "}" at 484:57-484:58 (leading: Space)
+5517: KwPub           "pub" at 485:5-485:8 (leading: Newline, Space)
+5518: KwFn            "fn" at 485:9-485:11 (leading: Space)
+5519: Ident           "__max_value" at 485:12-485:23 (leading: Space)
+5520: LParen          "(" at 485:23-485:24
+5521: RParen          ")" at 485:24-485:25
+5522: Arrow           "->" at 485:26-485:28 (leading: Space)
+5523: Ident           "uint16" at 485:29-485:35 (leading: Space)
+5524: LBrace          "{" at 485:36-485:37 (leading: Space)
+5525: KwReturn        "return" at 485:38-485:44 (leading: Space)
+5526: LParen          "(" at 485:45-485:46 (leading: Space)
+5527: IntLit          "65_535" at 485:46-485:52
+5528: RParen          ")" at 485:52-485:53
+5529: Colon           ":" at 485:53-485:54
+5530: Ident           "uint16" at 485:54-485:60
+5531: Semicolon       ";" at 485:60-485:61
+5532: RBrace          "}" at 485:62-485:63 (leading: Space)
+5533: At              "@" at 486:5-486:6 (leading: Newline, Space)
+5534: Ident           "intrinsic" at 486:6-486:15
+5535: KwFn            "fn" at 486:16-486:18 (leading: Space)
+5536: Ident           "__add" at 486:19-486:24 (leading: Space)
+5537: LParen          "(" at 486:24-486:25
+5538: Ident           "self" at 486:25-486:29
+5539: Colon           ":" at 486:29-486:30
+5540: Ident           "uint16" at 486:31-486:37 (leading: Space)
+5541: Comma           "," at 486:37-486:38
+5542: Ident           "other" at 486:39-486:44 (leading: Space)
+5543: Colon           ":" at 486:44-486:45
+5544: Ident           "uint16" at 486:46-486:52 (leading: Space)
+5545: RParen          ")" at 486:52-486:53
+5546: Arrow           "->" at 486:54-486:56 (leading: Space)
+5547: Ident           "uint16" at 486:57-486:63 (leading: Space)
+5548: Semicolon       ";" at 486:63-486:64
+5549: At              "@" at 487:5-487:6 (leading: Newline, Space)
+5550: Ident           "intrinsic" at 487:6-487:15
+5551: KwFn            "fn" at 487:16-487:18 (leading: Space)
+5552: Ident           "__sub" at 487:19-487:24 (leading: Space)
+5553: LParen          "(" at 487:24-487:25
+5554: Ident           "self" at 487:25-487:29
+5555: Colon           ":" at 487:29-487:30
+5556: Ident           "uint16" at 487:31-487:37 (leading: Space)
+5557: Comma           "," at 487:37-487:38
+5558: Ident           "other" at 487:39-487:44 (leading: Space)
+5559: Colon           ":" at 487:44-487:45
+5560: Ident           "uint16" at 487:46-487:52 (leading: Space)
+5561: RParen          ")" at 487:52-487:53
+5562: Arrow           "->" at 487:54-487:56 (leading: Space)
+5563: Ident           "uint16" at 487:57-487:63 (leading: Space)
+5564: Semicolon       ";" at 487:63-487:64
+5565: At              "@" at 488:5-488:6 (leading: Newline, Space)
+5566: Ident           "intrinsic" at 488:6-488:15
+5567: KwFn            "fn" at 488:16-488:18 (leading: Space)
+5568: Ident           "__mul" at 488:19-488:24 (leading: Space)
+5569: LParen          "(" at 488:24-488:25
+5570: Ident           "self" at 488:25-488:29
+5571: Colon           ":" at 488:29-488:30
+5572: Ident           "uint16" at 488:31-488:37 (leading: Space)
+5573: Comma           "," at 488:37-488:38
+5574: Ident           "other" at 488:39-488:44 (leading: Space)
+5575: Colon           ":" at 488:44-488:45
+5576: Ident           "uint16" at 488:46-488:52 (leading: Space)
+5577: RParen          ")" at 488:52-488:53
+5578: Arrow           "->" at 488:54-488:56 (leading: Space)
+5579: Ident           "uint16" at 488:57-488:63 (leading: Space)
+5580: Semicolon       ";" at 488:63-488:64
+5581: At              "@" at 489:5-489:6 (leading: Newline, Space)
+5582: Ident           "intrinsic" at 489:6-489:15
+5583: KwFn            "fn" at 489:16-489:18 (leading: Space)
+5584: Ident           "__div" at 489:19-489:24 (leading: Space)
+5585: LParen          "(" at 489:24-489:25
+5586: Ident           "self" at 489:25-489:29
+5587: Colon           ":" at 489:29-489:30
+5588: Ident           "uint16" at 489:31-489:37 (leading: Space)
+5589: Comma           "," at 489:37-489:38
+5590: Ident           "other" at 489:39-489:44 (leading: Space)
+5591: Colon           ":" at 489:44-489:45
+5592: Ident           "uint16" at 489:46-489:52 (leading: Space)
+5593: RParen          ")" at 489:52-489:53
+5594: Arrow           "->" at 489:54-489:56 (leading: Space)
+5595: Ident           "uint16" at 489:57-489:63 (leading: Space)
+5596: Semicolon       ";" at 489:63-489:64
+5597: At              "@" at 490:5-490:6 (leading: Newline, Space)
+5598: Ident           "intrinsic" at 490:6-490:15
+5599: KwFn            "fn" at 490:16-490:18 (leading: Space)
+5600: Ident           "__mod" at 490:19-490:24 (leading: Space)
+5601: LParen          "(" at 490:24-490:25
+5602: Ident           "self" at 490:25-490:29
+5603: Colon           ":" at 490:29-490:30
+5604: Ident           "uint16" at 490:31-490:37 (leading: Space)
+5605: Comma           "," at 490:37-490:38
+5606: Ident           "other" at 490:39-490:44 (leading: Space)
+5607: Colon           ":" at 490:44-490:45
+5608: Ident           "uint16" at 490:46-490:52 (leading: Space)
+5609: RParen          ")" at 490:52-490:53
+5610: Arrow           "->" at 490:54-490:56 (leading: Space)
+5611: Ident           "uint16" at 490:57-490:63 (leading: Space)
+5612: Semicolon       ";" at 490:63-490:64
+5613: At              "@" at 491:5-491:6 (leading: Newline, Space)
+5614: Ident           "intrinsic" at 491:6-491:15
+5615: KwFn            "fn" at 491:16-491:18 (leading: Space)
+5616: Ident           "__bit_and" at 491:19-491:28 (leading: Space)
+5617: LParen          "(" at 491:28-491:29
+5618: Ident           "self" at 491:29-491:33
+5619: Colon           ":" at 491:33-491:34
+5620: Ident           "uint16" at 491:35-491:41 (leading: Space)
+5621: Comma           "," at 491:41-491:42
+5622: Ident           "other" at 491:43-491:48 (leading: Space)
+5623: Colon           ":" at 491:48-491:49
+5624: Ident           "uint16" at 491:50-491:56 (leading: Space)
+5625: RParen          ")" at 491:56-491:57
+5626: Arrow           "->" at 491:58-491:60 (leading: Space)
+5627: Ident           "uint16" at 491:61-491:67 (leading: Space)
+5628: Semicolon       ";" at 491:67-491:68
+5629: At              "@" at 492:5-492:6 (leading: Newline, Space)
+5630: Ident           "intrinsic" at 492:6-492:15
+5631: KwFn            "fn" at 492:16-492:18 (leading: Space)
+5632: Ident           "__bit_or" at 492:19-492:27 (leading: Space)
+5633: LParen          "(" at 492:27-492:28
+5634: Ident           "self" at 492:28-492:32
+5635: Colon           ":" at 492:32-492:33
+5636: Ident           "uint16" at 492:34-492:40 (leading: Space)
+5637: Comma           "," at 492:40-492:41
+5638: Ident           "other" at 492:42-492:47 (leading: Space)
+5639: Colon           ":" at 492:47-492:48
+5640: Ident           "uint16" at 492:49-492:55 (leading: Space)
+5641: RParen          ")" at 492:55-492:56
+5642: Arrow           "->" at 492:57-492:59 (leading: Space)
+5643: Ident           "uint16" at 492:60-492:66 (leading: Space)
+5644: Semicolon       ";" at 492:66-492:67
+5645: At              "@" at 493:5-493:6 (leading: Newline, Space)
+5646: Ident           "intrinsic" at 493:6-493:15
+5647: KwFn            "fn" at 493:16-493:18 (leading: Space)
+5648: Ident           "__bit_xor" at 493:19-493:28 (leading: Space)
+5649: LParen          "(" at 493:28-493:29
+5650: Ident           "self" at 493:29-493:33
+5651: Colon           ":" at 493:33-493:34
+5652: Ident           "uint16" at 493:35-493:41 (leading: Space)
+5653: Comma           "," at 493:41-493:42
+5654: Ident           "other" at 493:43-493:48 (leading: Space)
+5655: Colon           ":" at 493:48-493:49
+5656: Ident           "uint16" at 493:50-493:56 (leading: Space)
+5657: RParen          ")" at 493:56-493:57
+5658: Arrow           "->" at 493:58-493:60 (leading: Space)
+5659: Ident           "uint16" at 493:61-493:67 (leading: Space)
+5660: Semicolon       ";" at 493:67-493:68
+5661: At              "@" at 494:5-494:6 (leading: Newline, Space)
+5662: Ident           "intrinsic" at 494:6-494:15
+5663: KwFn            "fn" at 494:16-494:18 (leading: Space)
+5664: Ident           "__shl" at 494:19-494:24 (leading: Space)
+5665: LParen          "(" at 494:24-494:25
+5666: Ident           "self" at 494:25-494:29
+5667: Colon           ":" at 494:29-494:30
+5668: Ident           "uint16" at 494:31-494:37 (leading: Space)
+5669: Comma           "," at 494:37-494:38
+5670: Ident           "other" at 494:39-494:44 (leading: Space)
+5671: Colon           ":" at 494:44-494:45
+5672: Ident           "uint16" at 494:46-494:52 (leading: Space)
+5673: RParen          ")" at 494:52-494:53
+5674: Arrow           "->" at 494:54-494:56 (leading: Space)
+5675: Ident           "uint16" at 494:57-494:63 (leading: Space)
+5676: Semicolon       ";" at 494:63-494:64
+5677: At              "@" at 495:5-495:6 (leading: Newline, Space)
+5678: Ident           "intrinsic" at 495:6-495:15
+5679: KwFn            "fn" at 495:16-495:18 (leading: Space)
+5680: Ident           "__shr" at 495:19-495:24 (leading: Space)
+5681: LParen          "(" at 495:24-495:25
+5682: Ident           "self" at 495:25-495:29
+5683: Colon           ":" at 495:29-495:30
+5684: Ident           "uint16" at 495:31-495:37 (leading: Space)
+5685: Comma           "," at 495:37-495:38
+5686: Ident           "other" at 495:39-495:44 (leading: Space)
+5687: Colon           ":" at 495:44-495:45
+5688: Ident           "uint16" at 495:46-495:52 (leading: Space)
+5689: RParen          ")" at 495:52-495:53
+5690: Arrow           "->" at 495:54-495:56 (leading: Space)
+5691: Ident           "uint16" at 495:57-495:63 (leading: Space)
+5692: Semicolon       ";" at 495:63-495:64
+5693: At              "@" at 496:5-496:6 (leading: Newline, Space)
+5694: Ident           "intrinsic" at 496:6-496:15
+5695: KwFn            "fn" at 496:16-496:18 (leading: Space)
+5696: Ident           "__lt" at 496:19-496:23 (leading: Space)
+5697: LParen          "(" at 496:23-496:24
+5698: Ident           "self" at 496:24-496:28
+5699: Colon           ":" at 496:28-496:29
+5700: Ident           "uint16" at 496:30-496:36 (leading: Space)
+5701: Comma           "," at 496:36-496:37
+5702: Ident           "other" at 496:38-496:43 (leading: Space)
+5703: Colon           ":" at 496:43-496:44
+5704: Ident           "uint16" at 496:45-496:51 (leading: Space)
+5705: RParen          ")" at 496:51-496:52
+5706: Arrow           "->" at 496:53-496:55 (leading: Space)
+5707: Ident           "bool" at 496:56-496:60 (leading: Space)
+5708: Semicolon       ";" at 496:60-496:61
+5709: At              "@" at 497:5-497:6 (leading: Newline, Space)
+5710: Ident           "intrinsic" at 497:6-497:15
+5711: KwFn            "fn" at 497:16-497:18 (leading: Space)
+5712: Ident           "__le" at 497:19-497:23 (leading: Space)
+5713: LParen          "(" at 497:23-497:24
+5714: Ident           "self" at 497:24-497:28
+5715: Colon           ":" at 497:28-497:29
+5716: Ident           "uint16" at 497:30-497:36 (leading: Space)
+5717: Comma           "," at 497:36-497:37
+5718: Ident           "other" at 497:38-497:43 (leading: Space)
+5719: Colon           ":" at 497:43-497:44
+5720: Ident           "uint16" at 497:45-497:51 (leading: Space)
+5721: RParen          ")" at 497:51-497:52
+5722: Arrow           "->" at 497:53-497:55 (leading: Space)
+5723: Ident           "bool" at 497:56-497:60 (leading: Space)
+5724: Semicolon       ";" at 497:60-497:61
+5725: At              "@" at 498:5-498:6 (leading: Newline, Space)
+5726: Ident           "intrinsic" at 498:6-498:15
+5727: KwFn            "fn" at 498:16-498:18 (leading: Space)
+5728: Ident           "__eq" at 498:19-498:23 (leading: Space)
+5729: LParen          "(" at 498:23-498:24
+5730: Ident           "self" at 498:24-498:28
+5731: Colon           ":" at 498:28-498:29
+5732: Ident           "uint16" at 498:30-498:36 (leading: Space)
+5733: Comma           "," at 498:36-498:37
+5734: Ident           "other" at 498:38-498:43 (leading: Space)
+5735: Colon           ":" at 498:43-498:44
+5736: Ident           "uint16" at 498:45-498:51 (leading: Space)
+5737: RParen          ")" at 498:51-498:52
+5738: Arrow           "->" at 498:53-498:55 (leading: Space)
+5739: Ident           "bool" at 498:56-498:60 (leading: Space)
+5740: Semicolon       ";" at 498:60-498:61
+5741: At              "@" at 499:5-499:6 (leading: Newline, Space)
+5742: Ident           "intrinsic" at 499:6-499:15
+5743: KwFn            "fn" at 499:16-499:18 (leading: Space)
+5744: Ident           "__ne" at 499:19-499:23 (leading: Space)
+5745: LParen          "(" at 499:23-499:24
+5746: Ident           "self" at 499:24-499:28
+5747: Colon           ":" at 499:28-499:29
+5748: Ident           "uint16" at 499:30-499:36 (leading: Space)
+5749: Comma           "," at 499:36-499:37
+5750: Ident           "other" at 499:38-499:43 (leading: Space)
+5751: Colon           ":" at 499:43-499:44
+5752: Ident           "uint16" at 499:45-499:51 (leading: Space)
+5753: RParen          ")" at 499:51-499:52
+5754: Arrow           "->" at 499:53-499:55 (leading: Space)
+5755: Ident           "bool" at 499:56-499:60 (leading: Space)
+5756: Semicolon       ";" at 499:60-499:61
+5757: At              "@" at 500:5-500:6 (leading: Newline, Space)
+5758: Ident           "intrinsic" at 500:6-500:15
+5759: KwFn            "fn" at 500:16-500:18 (leading: Space)
+5760: Ident           "__ge" at 500:19-500:23 (leading: Space)
+5761: LParen          "(" at 500:23-500:24
+5762: Ident           "self" at 500:24-500:28
+5763: Colon           ":" at 500:28-500:29
+5764: Ident           "uint16" at 500:30-500:36 (leading: Space)
+5765: Comma           "," at 500:36-500:37
+5766: Ident           "other" at 500:38-500:43 (leading: Space)
+5767: Colon           ":" at 500:43-500:44
+5768: Ident           "uint16" at 500:45-500:51 (leading: Space)
+5769: RParen          ")" at 500:51-500:52
+5770: Arrow           "->" at 500:53-500:55 (leading: Space)
+5771: Ident           "bool" at 500:56-500:60 (leading: Space)
+5772: Semicolon       ";" at 500:60-500:61
+5773: At              "@" at 501:5-501:6 (leading: Newline, Space)
+5774: Ident           "intrinsic" at 501:6-501:15
+5775: KwFn            "fn" at 501:16-501:18 (leading: Space)
+5776: Ident           "__gt" at 501:19-501:23 (leading: Space)
+5777: LParen          "(" at 501:23-501:24
+5778: Ident           "self" at 501:24-501:28
+5779: Colon           ":" at 501:28-501:29
+5780: Ident           "uint16" at 501:30-501:36 (leading: Space)
+5781: Comma           "," at 501:36-501:37
+5782: Ident           "other" at 501:38-501:43 (leading: Space)
+5783: Colon           ":" at 501:43-501:44
+5784: Ident           "uint16" at 501:45-501:51 (leading: Space)
+5785: RParen          ")" at 501:51-501:52
+5786: Arrow           "->" at 501:53-501:55 (leading: Space)
+5787: Ident           "bool" at 501:56-501:60 (leading: Space)
+5788: Semicolon       ";" at 501:60-501:61
+5789: At              "@" at 502:5-502:6 (leading: Newline, Space)
+5790: Ident           "intrinsic" at 502:6-502:15
+5791: KwFn            "fn" at 502:16-502:18 (leading: Space)
+5792: Ident           "__pos" at 502:19-502:24 (leading: Space)
+5793: LParen          "(" at 502:24-502:25
+5794: Ident           "self" at 502:25-502:29
+5795: Colon           ":" at 502:29-502:30
+5796: Ident           "uint16" at 502:31-502:37 (leading: Space)
+5797: RParen          ")" at 502:37-502:38
+5798: Arrow           "->" at 502:39-502:41 (leading: Space)
+5799: Ident           "uint16" at 502:42-502:48 (leading: Space)
+5800: Semicolon       ";" at 502:48-502:49
+5801: At              "@" at 503:5-503:6 (leading: Newline, Space)
+5802: Ident           "intrinsic" at 503:6-503:15
+5803: KwFn            "fn" at 503:16-503:18 (leading: Space)
+5804: Ident           "__abs" at 503:19-503:24 (leading: Space)
+5805: LParen          "(" at 503:24-503:25
+5806: Ident           "self" at 503:25-503:29
+5807: Colon           ":" at 503:29-503:30
+5808: Ident           "uint16" at 503:31-503:37 (leading: Space)
+5809: RParen          ")" at 503:37-503:38
+5810: Arrow           "->" at 503:39-503:41 (leading: Space)
+5811: Ident           "uint16" at 503:42-503:48 (leading: Space)
+5812: Semicolon       ";" at 503:48-503:49
+5813: At              "@" at 504:5-504:6 (leading: Newline, Space)
+5814: Ident           "intrinsic" at 504:6-504:15
+5815: KwFn            "fn" at 504:16-504:18 (leading: Space)
+5816: Ident           "__to" at 504:19-504:23 (leading: Space)
+5817: LParen          "(" at 504:23-504:24
+5818: Ident           "self" at 504:24-504:28
+5819: Colon           ":" at 504:28-504:29
+5820: Ident           "uint16" at 504:30-504:36 (leading: Space)
+5821: Comma           "," at 504:36-504:37
+5822: Ident           "target" at 504:38-504:44 (leading: Space)
+5823: Colon           ":" at 504:44-504:45
+5824: Ident           "uint" at 504:46-504:50 (leading: Space)
+5825: RParen          ")" at 504:50-504:51
+5826: Arrow           "->" at 504:52-504:54 (leading: Space)
+5827: Ident           "uint" at 504:55-504:59 (leading: Space)
+5828: Semicolon       ";" at 504:59-504:60
+5829: At              "@" at 505:5-505:6 (leading: Newline, Space)
+5830: Ident           "intrinsic" at 505:6-505:15
+5831: At              "@" at 505:16-505:17 (leading: Space)
+5832: Ident           "overload" at 505:17-505:25
+5833: KwFn            "fn" at 505:26-505:28 (leading: Space)
+5834: Ident           "__to" at 505:29-505:33 (leading: Space)
+5835: LParen          "(" at 505:33-505:34
+5836: Ident           "self" at 505:34-505:38
+5837: Colon           ":" at 505:38-505:39
+5838: Ident           "uint16" at 505:40-505:46 (leading: Space)
+5839: Comma           "," at 505:46-505:47
+5840: Ident           "target" at 505:48-505:54 (leading: Space)
+5841: Colon           ":" at 505:54-505:55
+5842: Ident           "uint8" at 505:56-505:61 (leading: Space)
+5843: RParen          ")" at 505:61-505:62
+5844: Arrow           "->" at 505:63-505:65 (leading: Space)
+5845: Ident           "uint8" at 505:66-505:71 (leading: Space)
+5846: Semicolon       ";" at 505:71-505:72
+5847: At              "@" at 506:5-506:6 (leading: Newline, Space)
+5848: Ident           "intrinsic" at 506:6-506:15
+5849: At              "@" at 506:16-506:17 (leading: Space)
+5850: Ident           "overload" at 506:17-506:25
+5851: KwFn            "fn" at 506:26-506:28 (leading: Space)
+5852: Ident           "__to" at 506:29-506:33 (leading: Space)
+5853: LParen          "(" at 506:33-506:34
+5854: Ident           "self" at 506:34-506:38
+5855: Colon           ":" at 506:38-506:39
+5856: Ident           "uint16" at 506:40-506:46 (leading: Space)
+5857: Comma           "," at 506:46-506:47
+5858: Ident           "target" at 506:48-506:54 (leading: Space)
+5859: Colon           ":" at 506:54-506:55
+5860: Ident           "uint32" at 506:56-506:62 (leading: Space)
+5861: RParen          ")" at 506:62-506:63
+5862: Arrow           "->" at 506:64-506:66 (leading: Space)
+5863: Ident           "uint32" at 506:67-506:73 (leading: Space)
+5864: Semicolon       ";" at 506:73-506:74
+5865: At              "@" at 507:5-507:6 (leading: Newline, Space)
+5866: Ident           "intrinsic" at 507:6-507:15
+5867: At              "@" at 507:16-507:17 (leading: Space)
+5868: Ident           "overload" at 507:17-507:25
+5869: KwFn            "fn" at 507:26-507:28 (leading: Space)
+5870: Ident           "__to" at 507:29-507:33 (leading: Space)
+5871: LParen          "(" at 507:33-507:34
+5872: Ident           "self" at 507:34-507:38
+5873: Colon           ":" at 507:38-507:39
+5874: Ident           "uint16" at 507:40-507:46 (leading: Space)
+5875: Comma           "," at 507:46-507:47
+5876: Ident           "target" at 507:48-507:54 (leading: Space)
+5877: Colon           ":" at 507:54-507:55
+5878: Ident           "uint64" at 507:56-507:62 (leading: Space)
+5879: RParen          ")" at 507:62-507:63
+5880: Arrow           "->" at 507:64-507:66 (leading: Space)
+5881: Ident           "uint64" at 507:67-507:73 (leading: Space)
+5882: Semicolon       ";" at 507:73-507:74
+5883: At              "@" at 508:5-508:6 (leading: Newline, Space)
+5884: Ident           "intrinsic" at 508:6-508:15
+5885: KwPub           "pub" at 508:16-508:19 (leading: Space)
+5886: KwFn            "fn" at 508:20-508:22 (leading: Space)
+5887: Ident           "from_str" at 508:23-508:31 (leading: Space)
+5888: LParen          "(" at 508:31-508:32
+5889: Ident           "s" at 508:32-508:33
+5890: Colon           ":" at 508:33-508:34
+5891: Amp             "&" at 508:35-508:36 (leading: Space)
+5892: Ident           "string" at 508:36-508:42
+5893: RParen          ")" at 508:42-508:43
+5894: Arrow           "->" at 508:44-508:46 (leading: Space)
+5895: Ident           "Erring" at 508:47-508:53 (leading: Space)
+5896: Lt              "<" at 508:53-508:54
+5897: Ident           "uint16" at 508:54-508:60
+5898: Comma           "," at 508:60-508:61
+5899: Ident           "Error" at 508:62-508:67 (leading: Space)
+5900: Gt              ">" at 508:67-508:68
+5901: Semicolon       ";" at 508:68-508:69
+5902: RBrace          "}" at 509:1-509:2 (leading: Newline)
+5903: KwExtern        "extern" at 511:1-511:7 (leading: Newline)
+5904: Lt              "<" at 511:7-511:8
+5905: Ident           "uint32" at 511:8-511:14
+5906: Gt              ">" at 511:14-511:15
+5907: LBrace          "{" at 511:16-511:17 (leading: Space)
+5908: KwPub           "pub" at 512:5-512:8 (leading: Newline, Space)
+5909: KwFn            "fn" at 512:9-512:11 (leading: Space)
+5910: Ident           "__min_value" at 512:12-512:23 (leading: Space)
+5911: LParen          "(" at 512:23-512:24
+5912: RParen          ")" at 512:24-512:25
+5913: Arrow           "->" at 512:26-512:28 (leading: Space)
+5914: Ident           "uint32" at 512:29-512:35 (leading: Space)
+5915: LBrace          "{" at 512:36-512:37 (leading: Space)
+5916: KwReturn        "return" at 512:38-512:44 (leading: Space)
+5917: LParen          "(" at 512:45-512:46 (leading: Space)
+5918: IntLit          "0" at 512:46-512:47
+5919: RParen          ")" at 512:47-512:48
+5920: Colon           ":" at 512:48-512:49
+5921: Ident           "uint32" at 512:49-512:55
+5922: Semicolon       ";" at 512:55-512:56
+5923: RBrace          "}" at 512:57-512:58 (leading: Space)
+5924: KwPub           "pub" at 513:5-513:8 (leading: Newline, Space)
+5925: KwFn            "fn" at 513:9-513:11 (leading: Space)
+5926: Ident           "__max_value" at 513:12-513:23 (leading: Space)
+5927: LParen          "(" at 513:23-513:24
+5928: RParen          ")" at 513:24-513:25
+5929: Arrow           "->" at 513:26-513:28 (leading: Space)
+5930: Ident           "uint32" at 513:29-513:35 (leading: Space)
+5931: LBrace          "{" at 513:36-513:37 (leading: Space)
+5932: KwReturn        "return" at 513:38-513:44 (leading: Space)
+5933: LParen          "(" at 513:45-513:46 (leading: Space)
+5934: IntLit          "4_294_967_295" at 513:46-513:59
+5935: RParen          ")" at 513:59-513:60
+5936: Colon           ":" at 513:60-513:61
+5937: Ident           "uint32" at 513:61-513:67
+5938: Semicolon       ";" at 513:67-513:68
+5939: RBrace          "}" at 513:69-513:70 (leading: Space)
+5940: At              "@" at 514:5-514:6 (leading: Newline, Space)
+5941: Ident           "intrinsic" at 514:6-514:15
+5942: KwFn            "fn" at 514:16-514:18 (leading: Space)
+5943: Ident           "__add" at 514:19-514:24 (leading: Space)
+5944: LParen          "(" at 514:24-514:25
+5945: Ident           "self" at 514:25-514:29
+5946: Colon           ":" at 514:29-514:30
+5947: Ident           "uint32" at 514:31-514:37 (leading: Space)
+5948: Comma           "," at 514:37-514:38
+5949: Ident           "other" at 514:39-514:44 (leading: Space)
+5950: Colon           ":" at 514:44-514:45
+5951: Ident           "uint32" at 514:46-514:52 (leading: Space)
+5952: RParen          ")" at 514:52-514:53
+5953: Arrow           "->" at 514:54-514:56 (leading: Space)
+5954: Ident           "uint32" at 514:57-514:63 (leading: Space)
+5955: Semicolon       ";" at 514:63-514:64
+5956: At              "@" at 515:5-515:6 (leading: Newline, Space)
+5957: Ident           "intrinsic" at 515:6-515:15
+5958: KwFn            "fn" at 515:16-515:18 (leading: Space)
+5959: Ident           "__sub" at 515:19-515:24 (leading: Space)
+5960: LParen          "(" at 515:24-515:25
+5961: Ident           "self" at 515:25-515:29
+5962: Colon           ":" at 515:29-515:30
+5963: Ident           "uint32" at 515:31-515:37 (leading: Space)
+5964: Comma           "," at 515:37-515:38
+5965: Ident           "other" at 515:39-515:44 (leading: Space)
+5966: Colon           ":" at 515:44-515:45
+5967: Ident           "uint32" at 515:46-515:52 (leading: Space)
+5968: RParen          ")" at 515:52-515:53
+5969: Arrow           "->" at 515:54-515:56 (leading: Space)
+5970: Ident           "uint32" at 515:57-515:63 (leading: Space)
+5971: Semicolon       ";" at 515:63-515:64
+5972: At              "@" at 516:5-516:6 (leading: Newline, Space)
+5973: Ident           "intrinsic" at 516:6-516:15
+5974: KwFn            "fn" at 516:16-516:18 (leading: Space)
+5975: Ident           "__mul" at 516:19-516:24 (leading: Space)
+5976: LParen          "(" at 516:24-516:25
+5977: Ident           "self" at 516:25-516:29
+5978: Colon           ":" at 516:29-516:30
+5979: Ident           "uint32" at 516:31-516:37 (leading: Space)
+5980: Comma           "," at 516:37-516:38
+5981: Ident           "other" at 516:39-516:44 (leading: Space)
+5982: Colon           ":" at 516:44-516:45
+5983: Ident           "uint32" at 516:46-516:52 (leading: Space)
+5984: RParen          ")" at 516:52-516:53
+5985: Arrow           "->" at 516:54-516:56 (leading: Space)
+5986: Ident           "uint32" at 516:57-516:63 (leading: Space)
+5987: Semicolon       ";" at 516:63-516:64
+5988: At              "@" at 517:5-517:6 (leading: Newline, Space)
+5989: Ident           "intrinsic" at 517:6-517:15
+5990: KwFn            "fn" at 517:16-517:18 (leading: Space)
+5991: Ident           "__div" at 517:19-517:24 (leading: Space)
+5992: LParen          "(" at 517:24-517:25
+5993: Ident           "self" at 517:25-517:29
+5994: Colon           ":" at 517:29-517:30
+5995: Ident           "uint32" at 517:31-517:37 (leading: Space)
+5996: Comma           "," at 517:37-517:38
+5997: Ident           "other" at 517:39-517:44 (leading: Space)
+5998: Colon           ":" at 517:44-517:45
+5999: Ident           "uint32" at 517:46-517:52 (leading: Space)
+6000: RParen          ")" at 517:52-517:53
+6001: Arrow           "->" at 517:54-517:56 (leading: Space)
+6002: Ident           "uint32" at 517:57-517:63 (leading: Space)
+6003: Semicolon       ";" at 517:63-517:64
+6004: At              "@" at 518:5-518:6 (leading: Newline, Space)
+6005: Ident           "intrinsic" at 518:6-518:15
+6006: KwFn            "fn" at 518:16-518:18 (leading: Space)
+6007: Ident           "__mod" at 518:19-518:24 (leading: Space)
+6008: LParen          "(" at 518:24-518:25
+6009: Ident           "self" at 518:25-518:29
+6010: Colon           ":" at 518:29-518:30
+6011: Ident           "uint32" at 518:31-518:37 (leading: Space)
+6012: Comma           "," at 518:37-518:38
+6013: Ident           "other" at 518:39-518:44 (leading: Space)
+6014: Colon           ":" at 518:44-518:45
+6015: Ident           "uint32" at 518:46-518:52 (leading: Space)
+6016: RParen          ")" at 518:52-518:53
+6017: Arrow           "->" at 518:54-518:56 (leading: Space)
+6018: Ident           "uint32" at 518:57-518:63 (leading: Space)
+6019: Semicolon       ";" at 518:63-518:64
+6020: At              "@" at 519:5-519:6 (leading: Newline, Space)
+6021: Ident           "intrinsic" at 519:6-519:15
+6022: KwFn            "fn" at 519:16-519:18 (leading: Space)
+6023: Ident           "__bit_and" at 519:19-519:28 (leading: Space)
+6024: LParen          "(" at 519:28-519:29
+6025: Ident           "self" at 519:29-519:33
+6026: Colon           ":" at 519:33-519:34
+6027: Ident           "uint32" at 519:35-519:41 (leading: Space)
+6028: Comma           "," at 519:41-519:42
+6029: Ident           "other" at 519:43-519:48 (leading: Space)
+6030: Colon           ":" at 519:48-519:49
+6031: Ident           "uint32" at 519:50-519:56 (leading: Space)
+6032: RParen          ")" at 519:56-519:57
+6033: Arrow           "->" at 519:58-519:60 (leading: Space)
+6034: Ident           "uint32" at 519:61-519:67 (leading: Space)
+6035: Semicolon       ";" at 519:67-519:68
+6036: At              "@" at 520:5-520:6 (leading: Newline, Space)
+6037: Ident           "intrinsic" at 520:6-520:15
+6038: KwFn            "fn" at 520:16-520:18 (leading: Space)
+6039: Ident           "__bit_or" at 520:19-520:27 (leading: Space)
+6040: LParen          "(" at 520:27-520:28
+6041: Ident           "self" at 520:28-520:32
+6042: Colon           ":" at 520:32-520:33
+6043: Ident           "uint32" at 520:34-520:40 (leading: Space)
+6044: Comma           "," at 520:40-520:41
+6045: Ident           "other" at 520:42-520:47 (leading: Space)
+6046: Colon           ":" at 520:47-520:48
+6047: Ident           "uint32" at 520:49-520:55 (leading: Space)
+6048: RParen          ")" at 520:55-520:56
+6049: Arrow           "->" at 520:57-520:59 (leading: Space)
+6050: Ident           "uint32" at 520:60-520:66 (leading: Space)
+6051: Semicolon       ";" at 520:66-520:67
+6052: At              "@" at 521:5-521:6 (leading: Newline, Space)
+6053: Ident           "intrinsic" at 521:6-521:15
+6054: KwFn            "fn" at 521:16-521:18 (leading: Space)
+6055: Ident           "__bit_xor" at 521:19-521:28 (leading: Space)
+6056: LParen          "(" at 521:28-521:29
+6057: Ident           "self" at 521:29-521:33
+6058: Colon           ":" at 521:33-521:34
+6059: Ident           "uint32" at 521:35-521:41 (leading: Space)
+6060: Comma           "," at 521:41-521:42
+6061: Ident           "other" at 521:43-521:48 (leading: Space)
+6062: Colon           ":" at 521:48-521:49
+6063: Ident           "uint32" at 521:50-521:56 (leading: Space)
+6064: RParen          ")" at 521:56-521:57
+6065: Arrow           "->" at 521:58-521:60 (leading: Space)
+6066: Ident           "uint32" at 521:61-521:67 (leading: Space)
+6067: Semicolon       ";" at 521:67-521:68
+6068: At              "@" at 522:5-522:6 (leading: Newline, Space)
+6069: Ident           "intrinsic" at 522:6-522:15
+6070: KwFn            "fn" at 522:16-522:18 (leading: Space)
+6071: Ident           "__shl" at 522:19-522:24 (leading: Space)
+6072: LParen          "(" at 522:24-522:25
+6073: Ident           "self" at 522:25-522:29
+6074: Colon           ":" at 522:29-522:30
+6075: Ident           "uint32" at 522:31-522:37 (leading: Space)
+6076: Comma           "," at 522:37-522:38
+6077: Ident           "other" at 522:39-522:44 (leading: Space)
+6078: Colon           ":" at 522:44-522:45
+6079: Ident           "uint32" at 522:46-522:52 (leading: Space)
+6080: RParen          ")" at 522:52-522:53
+6081: Arrow           "->" at 522:54-522:56 (leading: Space)
+6082: Ident           "uint32" at 522:57-522:63 (leading: Space)
+6083: Semicolon       ";" at 522:63-522:64
+6084: At              "@" at 523:5-523:6 (leading: Newline, Space)
+6085: Ident           "intrinsic" at 523:6-523:15
+6086: KwFn            "fn" at 523:16-523:18 (leading: Space)
+6087: Ident           "__shr" at 523:19-523:24 (leading: Space)
+6088: LParen          "(" at 523:24-523:25
+6089: Ident           "self" at 523:25-523:29
+6090: Colon           ":" at 523:29-523:30
+6091: Ident           "uint32" at 523:31-523:37 (leading: Space)
+6092: Comma           "," at 523:37-523:38
+6093: Ident           "other" at 523:39-523:44 (leading: Space)
+6094: Colon           ":" at 523:44-523:45
+6095: Ident           "uint32" at 523:46-523:52 (leading: Space)
+6096: RParen          ")" at 523:52-523:53
+6097: Arrow           "->" at 523:54-523:56 (leading: Space)
+6098: Ident           "uint32" at 523:57-523:63 (leading: Space)
+6099: Semicolon       ";" at 523:63-523:64
+6100: At              "@" at 524:5-524:6 (leading: Newline, Space)
+6101: Ident           "intrinsic" at 524:6-524:15
+6102: KwFn            "fn" at 524:16-524:18 (leading: Space)
+6103: Ident           "__lt" at 524:19-524:23 (leading: Space)
+6104: LParen          "(" at 524:23-524:24
+6105: Ident           "self" at 524:24-524:28
+6106: Colon           ":" at 524:28-524:29
+6107: Ident           "uint32" at 524:30-524:36 (leading: Space)
+6108: Comma           "," at 524:36-524:37
+6109: Ident           "other" at 524:38-524:43 (leading: Space)
+6110: Colon           ":" at 524:43-524:44
+6111: Ident           "uint32" at 524:45-524:51 (leading: Space)
+6112: RParen          ")" at 524:51-524:52
+6113: Arrow           "->" at 524:53-524:55 (leading: Space)
+6114: Ident           "bool" at 524:56-524:60 (leading: Space)
+6115: Semicolon       ";" at 524:60-524:61
+6116: At              "@" at 525:5-525:6 (leading: Newline, Space)
+6117: Ident           "intrinsic" at 525:6-525:15
+6118: KwFn            "fn" at 525:16-525:18 (leading: Space)
+6119: Ident           "__le" at 525:19-525:23 (leading: Space)
+6120: LParen          "(" at 525:23-525:24
+6121: Ident           "self" at 525:24-525:28
+6122: Colon           ":" at 525:28-525:29
+6123: Ident           "uint32" at 525:30-525:36 (leading: Space)
+6124: Comma           "," at 525:36-525:37
+6125: Ident           "other" at 525:38-525:43 (leading: Space)
+6126: Colon           ":" at 525:43-525:44
+6127: Ident           "uint32" at 525:45-525:51 (leading: Space)
+6128: RParen          ")" at 525:51-525:52
+6129: Arrow           "->" at 525:53-525:55 (leading: Space)
+6130: Ident           "bool" at 525:56-525:60 (leading: Space)
+6131: Semicolon       ";" at 525:60-525:61
+6132: At              "@" at 526:5-526:6 (leading: Newline, Space)
+6133: Ident           "intrinsic" at 526:6-526:15
+6134: KwFn            "fn" at 526:16-526:18 (leading: Space)
+6135: Ident           "__eq" at 526:19-526:23 (leading: Space)
+6136: LParen          "(" at 526:23-526:24
+6137: Ident           "self" at 526:24-526:28
+6138: Colon           ":" at 526:28-526:29
+6139: Ident           "uint32" at 526:30-526:36 (leading: Space)
+6140: Comma           "," at 526:36-526:37
+6141: Ident           "other" at 526:38-526:43 (leading: Space)
+6142: Colon           ":" at 526:43-526:44
+6143: Ident           "uint32" at 526:45-526:51 (leading: Space)
+6144: RParen          ")" at 526:51-526:52
+6145: Arrow           "->" at 526:53-526:55 (leading: Space)
+6146: Ident           "bool" at 526:56-526:60 (leading: Space)
+6147: Semicolon       ";" at 526:60-526:61
+6148: At              "@" at 527:5-527:6 (leading: Newline, Space)
+6149: Ident           "intrinsic" at 527:6-527:15
+6150: KwFn            "fn" at 527:16-527:18 (leading: Space)
+6151: Ident           "__ne" at 527:19-527:23 (leading: Space)
+6152: LParen          "(" at 527:23-527:24
+6153: Ident           "self" at 527:24-527:28
+6154: Colon           ":" at 527:28-527:29
+6155: Ident           "uint32" at 527:30-527:36 (leading: Space)
+6156: Comma           "," at 527:36-527:37
+6157: Ident           "other" at 527:38-527:43 (leading: Space)
+6158: Colon           ":" at 527:43-527:44
+6159: Ident           "uint32" at 527:45-527:51 (leading: Space)
+6160: RParen          ")" at 527:51-527:52
+6161: Arrow           "->" at 527:53-527:55 (leading: Space)
+6162: Ident           "bool" at 527:56-527:60 (leading: Space)
+6163: Semicolon       ";" at 527:60-527:61
+6164: At              "@" at 528:5-528:6 (leading: Newline, Space)
+6165: Ident           "intrinsic" at 528:6-528:15
+6166: KwFn            "fn" at 528:16-528:18 (leading: Space)
+6167: Ident           "__ge" at 528:19-528:23 (leading: Space)
+6168: LParen          "(" at 528:23-528:24
+6169: Ident           "self" at 528:24-528:28
+6170: Colon           ":" at 528:28-528:29
+6171: Ident           "uint32" at 528:30-528:36 (leading: Space)
+6172: Comma           "," at 528:36-528:37
+6173: Ident           "other" at 528:38-528:43 (leading: Space)
+6174: Colon           ":" at 528:43-528:44
+6175: Ident           "uint32" at 528:45-528:51 (leading: Space)
+6176: RParen          ")" at 528:51-528:52
+6177: Arrow           "->" at 528:53-528:55 (leading: Space)
+6178: Ident           "bool" at 528:56-528:60 (leading: Space)
+6179: Semicolon       ";" at 528:60-528:61
+6180: At              "@" at 529:5-529:6 (leading: Newline, Space)
+6181: Ident           "intrinsic" at 529:6-529:15
+6182: KwFn            "fn" at 529:16-529:18 (leading: Space)
+6183: Ident           "__gt" at 529:19-529:23 (leading: Space)
+6184: LParen          "(" at 529:23-529:24
+6185: Ident           "self" at 529:24-529:28
+6186: Colon           ":" at 529:28-529:29
+6187: Ident           "uint32" at 529:30-529:36 (leading: Space)
+6188: Comma           "," at 529:36-529:37
+6189: Ident           "other" at 529:38-529:43 (leading: Space)
+6190: Colon           ":" at 529:43-529:44
+6191: Ident           "uint32" at 529:45-529:51 (leading: Space)
+6192: RParen          ")" at 529:51-529:52
+6193: Arrow           "->" at 529:53-529:55 (leading: Space)
+6194: Ident           "bool" at 529:56-529:60 (leading: Space)
+6195: Semicolon       ";" at 529:60-529:61
+6196: At              "@" at 530:5-530:6 (leading: Newline, Space)
+6197: Ident           "intrinsic" at 530:6-530:15
+6198: KwFn            "fn" at 530:16-530:18 (leading: Space)
+6199: Ident           "__pos" at 530:19-530:24 (leading: Space)
+6200: LParen          "(" at 530:24-530:25
+6201: Ident           "self" at 530:25-530:29
+6202: Colon           ":" at 530:29-530:30
+6203: Ident           "uint32" at 530:31-530:37 (leading: Space)
+6204: RParen          ")" at 530:37-530:38
+6205: Arrow           "->" at 530:39-530:41 (leading: Space)
+6206: Ident           "uint32" at 530:42-530:48 (leading: Space)
+6207: Semicolon       ";" at 530:48-530:49
+6208: At              "@" at 531:5-531:6 (leading: Newline, Space)
+6209: Ident           "intrinsic" at 531:6-531:15
+6210: KwFn            "fn" at 531:16-531:18 (leading: Space)
+6211: Ident           "__abs" at 531:19-531:24 (leading: Space)
+6212: LParen          "(" at 531:24-531:25
+6213: Ident           "self" at 531:25-531:29
+6214: Colon           ":" at 531:29-531:30
+6215: Ident           "uint32" at 531:31-531:37 (leading: Space)
+6216: RParen          ")" at 531:37-531:38
+6217: Arrow           "->" at 531:39-531:41 (leading: Space)
+6218: Ident           "uint32" at 531:42-531:48 (leading: Space)
+6219: Semicolon       ";" at 531:48-531:49
+6220: At              "@" at 532:5-532:6 (leading: Newline, Space)
+6221: Ident           "intrinsic" at 532:6-532:15
+6222: KwFn            "fn" at 532:16-532:18 (leading: Space)
+6223: Ident           "__to" at 532:19-532:23 (leading: Space)
+6224: LParen          "(" at 532:23-532:24
+6225: Ident           "self" at 532:24-532:28
+6226: Colon           ":" at 532:28-532:29
+6227: Ident           "uint32" at 532:30-532:36 (leading: Space)
+6228: Comma           "," at 532:36-532:37
+6229: Ident           "target" at 532:38-532:44 (leading: Space)
+6230: Colon           ":" at 532:44-532:45
+6231: Ident           "uint" at 532:46-532:50 (leading: Space)
+6232: RParen          ")" at 532:50-532:51
+6233: Arrow           "->" at 532:52-532:54 (leading: Space)
+6234: Ident           "uint" at 532:55-532:59 (leading: Space)
+6235: Semicolon       ";" at 532:59-532:60
+6236: At              "@" at 533:5-533:6 (leading: Newline, Space)
+6237: Ident           "intrinsic" at 533:6-533:15
+6238: At              "@" at 533:16-533:17 (leading: Space)
+6239: Ident           "overload" at 533:17-533:25
+6240: KwFn            "fn" at 533:26-533:28 (leading: Space)
+6241: Ident           "__to" at 533:29-533:33 (leading: Space)
+6242: LParen          "(" at 533:33-533:34
+6243: Ident           "self" at 533:34-533:38
+6244: Colon           ":" at 533:38-533:39
+6245: Ident           "uint32" at 533:40-533:46 (leading: Space)
+6246: Comma           "," at 533:46-533:47
+6247: Ident           "target" at 533:48-533:54 (leading: Space)
+6248: Colon           ":" at 533:54-533:55
+6249: Ident           "uint8" at 533:56-533:61 (leading: Space)
+6250: RParen          ")" at 533:61-533:62
+6251: Arrow           "->" at 533:63-533:65 (leading: Space)
+6252: Ident           "uint8" at 533:66-533:71 (leading: Space)
+6253: Semicolon       ";" at 533:71-533:72
+6254: At              "@" at 534:5-534:6 (leading: Newline, Space)
+6255: Ident           "intrinsic" at 534:6-534:15
+6256: At              "@" at 534:16-534:17 (leading: Space)
+6257: Ident           "overload" at 534:17-534:25
+6258: KwFn            "fn" at 534:26-534:28 (leading: Space)
+6259: Ident           "__to" at 534:29-534:33 (leading: Space)
+6260: LParen          "(" at 534:33-534:34
+6261: Ident           "self" at 534:34-534:38
+6262: Colon           ":" at 534:38-534:39
+6263: Ident           "uint32" at 534:40-534:46 (leading: Space)
+6264: Comma           "," at 534:46-534:47
+6265: Ident           "target" at 534:48-534:54 (leading: Space)
+6266: Colon           ":" at 534:54-534:55
+6267: Ident           "uint16" at 534:56-534:62 (leading: Space)
+6268: RParen          ")" at 534:62-534:63
+6269: Arrow           "->" at 534:64-534:66 (leading: Space)
+6270: Ident           "uint16" at 534:67-534:73 (leading: Space)
+6271: Semicolon       ";" at 534:73-534:74
+6272: At              "@" at 535:5-535:6 (leading: Newline, Space)
+6273: Ident           "intrinsic" at 535:6-535:15
+6274: At              "@" at 535:16-535:17 (leading: Space)
+6275: Ident           "overload" at 535:17-535:25
+6276: KwFn            "fn" at 535:26-535:28 (leading: Space)
+6277: Ident           "__to" at 535:29-535:33 (leading: Space)
+6278: LParen          "(" at 535:33-535:34
+6279: Ident           "self" at 535:34-535:38
+6280: Colon           ":" at 535:38-535:39
+6281: Ident           "uint32" at 535:40-535:46 (leading: Space)
+6282: Comma           "," at 535:46-535:47
+6283: Ident           "target" at 535:48-535:54 (leading: Space)
+6284: Colon           ":" at 535:54-535:55
+6285: Ident           "uint64" at 535:56-535:62 (leading: Space)
+6286: RParen          ")" at 535:62-535:63
+6287: Arrow           "->" at 535:64-535:66 (leading: Space)
+6288: Ident           "uint64" at 535:67-535:73 (leading: Space)
+6289: Semicolon       ";" at 535:73-535:74
+6290: At              "@" at 536:5-536:6 (leading: Newline, Space)
+6291: Ident           "intrinsic" at 536:6-536:15
+6292: KwPub           "pub" at 536:16-536:19 (leading: Space)
+6293: KwFn            "fn" at 536:20-536:22 (leading: Space)
+6294: Ident           "from_str" at 536:23-536:31 (leading: Space)
+6295: LParen          "(" at 536:31-536:32
+6296: Ident           "s" at 536:32-536:33
+6297: Colon           ":" at 536:33-536:34
+6298: Amp             "&" at 536:35-536:36 (leading: Space)
+6299: Ident           "string" at 536:36-536:42
+6300: RParen          ")" at 536:42-536:43
+6301: Arrow           "->" at 536:44-536:46 (leading: Space)
+6302: Ident           "Erring" at 536:47-536:53 (leading: Space)
+6303: Lt              "<" at 536:53-536:54
+6304: Ident           "uint32" at 536:54-536:60
+6305: Comma           "," at 536:60-536:61
+6306: Ident           "Error" at 536:62-536:67 (leading: Space)
+6307: Gt              ">" at 536:67-536:68
+6308: Semicolon       ";" at 536:68-536:69
+6309: RBrace          "}" at 537:1-537:2 (leading: Newline)
+6310: KwExtern        "extern" at 539:1-539:7 (leading: Newline)
+6311: Lt              "<" at 539:7-539:8
+6312: Ident           "uint64" at 539:8-539:14
+6313: Gt              ">" at 539:14-539:15
+6314: LBrace          "{" at 539:16-539:17 (leading: Space)
+6315: KwPub           "pub" at 540:5-540:8 (leading: Newline, Space)
+6316: KwFn            "fn" at 540:9-540:11 (leading: Space)
+6317: Ident           "__min_value" at 540:12-540:23 (leading: Space)
+6318: LParen          "(" at 540:23-540:24
+6319: RParen          ")" at 540:24-540:25
+6320: Arrow           "->" at 540:26-540:28 (leading: Space)
+6321: Ident           "uint64" at 540:29-540:35 (leading: Space)
+6322: LBrace          "{" at 540:36-540:37 (leading: Space)
+6323: KwReturn        "return" at 540:38-540:44 (leading: Space)
+6324: LParen          "(" at 540:45-540:46 (leading: Space)
+6325: IntLit          "0" at 540:46-540:47
+6326: RParen          ")" at 540:47-540:48
+6327: Colon           ":" at 540:48-540:49
+6328: Ident           "uint64" at 540:49-540:55
+6329: Semicolon       ";" at 540:55-540:56
+6330: RBrace          "}" at 540:57-540:58 (leading: Space)
+6331: KwPub           "pub" at 541:5-541:8 (leading: Newline, Space)
+6332: KwFn            "fn" at 541:9-541:11 (leading: Space)
+6333: Ident           "__max_value" at 541:12-541:23 (leading: Space)
+6334: LParen          "(" at 541:23-541:24
+6335: RParen          ")" at 541:24-541:25
+6336: Arrow           "->" at 541:26-541:28 (leading: Space)
+6337: Ident           "uint64" at 541:29-541:35 (leading: Space)
+6338: LBrace          "{" at 541:36-541:37 (leading: Space)
+6339: KwReturn        "return" at 541:38-541:44 (leading: Space)
+6340: LParen          "(" at 541:45-541:46 (leading: Space)
+6341: IntLit          "18_446_744_073_709_551_615" at 541:46-541:72
+6342: RParen          ")" at 541:72-541:73
+6343: Colon           ":" at 541:73-541:74
+6344: Ident           "uint64" at 541:74-541:80
+6345: Semicolon       ";" at 541:80-541:81
+6346: RBrace          "}" at 541:82-541:83 (leading: Space)
+6347: At              "@" at 542:5-542:6 (leading: Newline, Space)
+6348: Ident           "intrinsic" at 542:6-542:15
+6349: KwFn            "fn" at 542:16-542:18 (leading: Space)
+6350: Ident           "__add" at 542:19-542:24 (leading: Space)
+6351: LParen          "(" at 542:24-542:25
+6352: Ident           "self" at 542:25-542:29
+6353: Colon           ":" at 542:29-542:30
+6354: Ident           "uint64" at 542:31-542:37 (leading: Space)
+6355: Comma           "," at 542:37-542:38
+6356: Ident           "other" at 542:39-542:44 (leading: Space)
+6357: Colon           ":" at 542:44-542:45
+6358: Ident           "uint64" at 542:46-542:52 (leading: Space)
+6359: RParen          ")" at 542:52-542:53
+6360: Arrow           "->" at 542:54-542:56 (leading: Space)
+6361: Ident           "uint64" at 542:57-542:63 (leading: Space)
+6362: Semicolon       ";" at 542:63-542:64
+6363: At              "@" at 543:5-543:6 (leading: Newline, Space)
+6364: Ident           "intrinsic" at 543:6-543:15
+6365: KwFn            "fn" at 543:16-543:18 (leading: Space)
+6366: Ident           "__sub" at 543:19-543:24 (leading: Space)
+6367: LParen          "(" at 543:24-543:25
+6368: Ident           "self" at 543:25-543:29
+6369: Colon           ":" at 543:29-543:30
+6370: Ident           "uint64" at 543:31-543:37 (leading: Space)
+6371: Comma           "," at 543:37-543:38
+6372: Ident           "other" at 543:39-543:44 (leading: Space)
+6373: Colon           ":" at 543:44-543:45
+6374: Ident           "uint64" at 543:46-543:52 (leading: Space)
+6375: RParen          ")" at 543:52-543:53
+6376: Arrow           "->" at 543:54-543:56 (leading: Space)
+6377: Ident           "uint64" at 543:57-543:63 (leading: Space)
+6378: Semicolon       ";" at 543:63-543:64
+6379: At              "@" at 544:5-544:6 (leading: Newline, Space)
+6380: Ident           "intrinsic" at 544:6-544:15
+6381: KwFn            "fn" at 544:16-544:18 (leading: Space)
+6382: Ident           "__mul" at 544:19-544:24 (leading: Space)
+6383: LParen          "(" at 544:24-544:25
+6384: Ident           "self" at 544:25-544:29
+6385: Colon           ":" at 544:29-544:30
+6386: Ident           "uint64" at 544:31-544:37 (leading: Space)
+6387: Comma           "," at 544:37-544:38
+6388: Ident           "other" at 544:39-544:44 (leading: Space)
+6389: Colon           ":" at 544:44-544:45
+6390: Ident           "uint64" at 544:46-544:52 (leading: Space)
+6391: RParen          ")" at 544:52-544:53
+6392: Arrow           "->" at 544:54-544:56 (leading: Space)
+6393: Ident           "uint64" at 544:57-544:63 (leading: Space)
+6394: Semicolon       ";" at 544:63-544:64
+6395: At              "@" at 545:5-545:6 (leading: Newline, Space)
+6396: Ident           "intrinsic" at 545:6-545:15
+6397: KwFn            "fn" at 545:16-545:18 (leading: Space)
+6398: Ident           "__div" at 545:19-545:24 (leading: Space)
+6399: LParen          "(" at 545:24-545:25
+6400: Ident           "self" at 545:25-545:29
+6401: Colon           ":" at 545:29-545:30
+6402: Ident           "uint64" at 545:31-545:37 (leading: Space)
+6403: Comma           "," at 545:37-545:38
+6404: Ident           "other" at 545:39-545:44 (leading: Space)
+6405: Colon           ":" at 545:44-545:45
+6406: Ident           "uint64" at 545:46-545:52 (leading: Space)
+6407: RParen          ")" at 545:52-545:53
+6408: Arrow           "->" at 545:54-545:56 (leading: Space)
+6409: Ident           "uint64" at 545:57-545:63 (leading: Space)
+6410: Semicolon       ";" at 545:63-545:64
+6411: At              "@" at 546:5-546:6 (leading: Newline, Space)
+6412: Ident           "intrinsic" at 546:6-546:15
+6413: KwFn            "fn" at 546:16-546:18 (leading: Space)
+6414: Ident           "__mod" at 546:19-546:24 (leading: Space)
+6415: LParen          "(" at 546:24-546:25
+6416: Ident           "self" at 546:25-546:29
+6417: Colon           ":" at 546:29-546:30
+6418: Ident           "uint64" at 546:31-546:37 (leading: Space)
+6419: Comma           "," at 546:37-546:38
+6420: Ident           "other" at 546:39-546:44 (leading: Space)
+6421: Colon           ":" at 546:44-546:45
+6422: Ident           "uint64" at 546:46-546:52 (leading: Space)
+6423: RParen          ")" at 546:52-546:53
+6424: Arrow           "->" at 546:54-546:56 (leading: Space)
+6425: Ident           "uint64" at 546:57-546:63 (leading: Space)
+6426: Semicolon       ";" at 546:63-546:64
+6427: At              "@" at 547:5-547:6 (leading: Newline, Space)
+6428: Ident           "intrinsic" at 547:6-547:15
+6429: KwFn            "fn" at 547:16-547:18 (leading: Space)
+6430: Ident           "__bit_and" at 547:19-547:28 (leading: Space)
+6431: LParen          "(" at 547:28-547:29
+6432: Ident           "self" at 547:29-547:33
+6433: Colon           ":" at 547:33-547:34
+6434: Ident           "uint64" at 547:35-547:41 (leading: Space)
+6435: Comma           "," at 547:41-547:42
+6436: Ident           "other" at 547:43-547:48 (leading: Space)
+6437: Colon           ":" at 547:48-547:49
+6438: Ident           "uint64" at 547:50-547:56 (leading: Space)
+6439: RParen          ")" at 547:56-547:57
+6440: Arrow           "->" at 547:58-547:60 (leading: Space)
+6441: Ident           "uint64" at 547:61-547:67 (leading: Space)
+6442: Semicolon       ";" at 547:67-547:68
+6443: At              "@" at 548:5-548:6 (leading: Newline, Space)
+6444: Ident           "intrinsic" at 548:6-548:15
+6445: KwFn            "fn" at 548:16-548:18 (leading: Space)
+6446: Ident           "__bit_or" at 548:19-548:27 (leading: Space)
+6447: LParen          "(" at 548:27-548:28
+6448: Ident           "self" at 548:28-548:32
+6449: Colon           ":" at 548:32-548:33
+6450: Ident           "uint64" at 548:34-548:40 (leading: Space)
+6451: Comma           "," at 548:40-548:41
+6452: Ident           "other" at 548:42-548:47 (leading: Space)
+6453: Colon           ":" at 548:47-548:48
+6454: Ident           "uint64" at 548:49-548:55 (leading: Space)
+6455: RParen          ")" at 548:55-548:56
+6456: Arrow           "->" at 548:57-548:59 (leading: Space)
+6457: Ident           "uint64" at 548:60-548:66 (leading: Space)
+6458: Semicolon       ";" at 548:66-548:67
+6459: At              "@" at 549:5-549:6 (leading: Newline, Space)
+6460: Ident           "intrinsic" at 549:6-549:15
+6461: KwFn            "fn" at 549:16-549:18 (leading: Space)
+6462: Ident           "__bit_xor" at 549:19-549:28 (leading: Space)
+6463: LParen          "(" at 549:28-549:29
+6464: Ident           "self" at 549:29-549:33
+6465: Colon           ":" at 549:33-549:34
+6466: Ident           "uint64" at 549:35-549:41 (leading: Space)
+6467: Comma           "," at 549:41-549:42
+6468: Ident           "other" at 549:43-549:48 (leading: Space)
+6469: Colon           ":" at 549:48-549:49
+6470: Ident           "uint64" at 549:50-549:56 (leading: Space)
+6471: RParen          ")" at 549:56-549:57
+6472: Arrow           "->" at 549:58-549:60 (leading: Space)
+6473: Ident           "uint64" at 549:61-549:67 (leading: Space)
+6474: Semicolon       ";" at 549:67-549:68
+6475: At              "@" at 550:5-550:6 (leading: Newline, Space)
+6476: Ident           "intrinsic" at 550:6-550:15
+6477: KwFn            "fn" at 550:16-550:18 (leading: Space)
+6478: Ident           "__shl" at 550:19-550:24 (leading: Space)
+6479: LParen          "(" at 550:24-550:25
+6480: Ident           "self" at 550:25-550:29
+6481: Colon           ":" at 550:29-550:30
+6482: Ident           "uint64" at 550:31-550:37 (leading: Space)
+6483: Comma           "," at 550:37-550:38
+6484: Ident           "other" at 550:39-550:44 (leading: Space)
+6485: Colon           ":" at 550:44-550:45
+6486: Ident           "uint64" at 550:46-550:52 (leading: Space)
+6487: RParen          ")" at 550:52-550:53
+6488: Arrow           "->" at 550:54-550:56 (leading: Space)
+6489: Ident           "uint64" at 550:57-550:63 (leading: Space)
+6490: Semicolon       ";" at 550:63-550:64
+6491: At              "@" at 551:5-551:6 (leading: Newline, Space)
+6492: Ident           "intrinsic" at 551:6-551:15
+6493: KwFn            "fn" at 551:16-551:18 (leading: Space)
+6494: Ident           "__shr" at 551:19-551:24 (leading: Space)
+6495: LParen          "(" at 551:24-551:25
+6496: Ident           "self" at 551:25-551:29
+6497: Colon           ":" at 551:29-551:30
+6498: Ident           "uint64" at 551:31-551:37 (leading: Space)
+6499: Comma           "," at 551:37-551:38
+6500: Ident           "other" at 551:39-551:44 (leading: Space)
+6501: Colon           ":" at 551:44-551:45
+6502: Ident           "uint64" at 551:46-551:52 (leading: Space)
+6503: RParen          ")" at 551:52-551:53
+6504: Arrow           "->" at 551:54-551:56 (leading: Space)
+6505: Ident           "uint64" at 551:57-551:63 (leading: Space)
+6506: Semicolon       ";" at 551:63-551:64
+6507: At              "@" at 552:5-552:6 (leading: Newline, Space)
+6508: Ident           "intrinsic" at 552:6-552:15
+6509: KwFn            "fn" at 552:16-552:18 (leading: Space)
+6510: Ident           "__lt" at 552:19-552:23 (leading: Space)
+6511: LParen          "(" at 552:23-552:24
+6512: Ident           "self" at 552:24-552:28
+6513: Colon           ":" at 552:28-552:29
+6514: Ident           "uint64" at 552:30-552:36 (leading: Space)
+6515: Comma           "," at 552:36-552:37
+6516: Ident           "other" at 552:38-552:43 (leading: Space)
+6517: Colon           ":" at 552:43-552:44
+6518: Ident           "uint64" at 552:45-552:51 (leading: Space)
+6519: RParen          ")" at 552:51-552:52
+6520: Arrow           "->" at 552:53-552:55 (leading: Space)
+6521: Ident           "bool" at 552:56-552:60 (leading: Space)
+6522: Semicolon       ";" at 552:60-552:61
+6523: At              "@" at 553:5-553:6 (leading: Newline, Space)
+6524: Ident           "intrinsic" at 553:6-553:15
+6525: KwFn            "fn" at 553:16-553:18 (leading: Space)
+6526: Ident           "__le" at 553:19-553:23 (leading: Space)
+6527: LParen          "(" at 553:23-553:24
+6528: Ident           "self" at 553:24-553:28
+6529: Colon           ":" at 553:28-553:29
+6530: Ident           "uint64" at 553:30-553:36 (leading: Space)
+6531: Comma           "," at 553:36-553:37
+6532: Ident           "other" at 553:38-553:43 (leading: Space)
+6533: Colon           ":" at 553:43-553:44
+6534: Ident           "uint64" at 553:45-553:51 (leading: Space)
+6535: RParen          ")" at 553:51-553:52
+6536: Arrow           "->" at 553:53-553:55 (leading: Space)
+6537: Ident           "bool" at 553:56-553:60 (leading: Space)
+6538: Semicolon       ";" at 553:60-553:61
+6539: At              "@" at 554:5-554:6 (leading: Newline, Space)
+6540: Ident           "intrinsic" at 554:6-554:15
+6541: KwFn            "fn" at 554:16-554:18 (leading: Space)
+6542: Ident           "__eq" at 554:19-554:23 (leading: Space)
+6543: LParen          "(" at 554:23-554:24
+6544: Ident           "self" at 554:24-554:28
+6545: Colon           ":" at 554:28-554:29
+6546: Ident           "uint64" at 554:30-554:36 (leading: Space)
+6547: Comma           "," at 554:36-554:37
+6548: Ident           "other" at 554:38-554:43 (leading: Space)
+6549: Colon           ":" at 554:43-554:44
+6550: Ident           "uint64" at 554:45-554:51 (leading: Space)
+6551: RParen          ")" at 554:51-554:52
+6552: Arrow           "->" at 554:53-554:55 (leading: Space)
+6553: Ident           "bool" at 554:56-554:60 (leading: Space)
+6554: Semicolon       ";" at 554:60-554:61
+6555: At              "@" at 555:5-555:6 (leading: Newline, Space)
+6556: Ident           "intrinsic" at 555:6-555:15
+6557: KwFn            "fn" at 555:16-555:18 (leading: Space)
+6558: Ident           "__ne" at 555:19-555:23 (leading: Space)
+6559: LParen          "(" at 555:23-555:24
+6560: Ident           "self" at 555:24-555:28
+6561: Colon           ":" at 555:28-555:29
+6562: Ident           "uint64" at 555:30-555:36 (leading: Space)
+6563: Comma           "," at 555:36-555:37
+6564: Ident           "other" at 555:38-555:43 (leading: Space)
+6565: Colon           ":" at 555:43-555:44
+6566: Ident           "uint64" at 555:45-555:51 (leading: Space)
+6567: RParen          ")" at 555:51-555:52
+6568: Arrow           "->" at 555:53-555:55 (leading: Space)
+6569: Ident           "bool" at 555:56-555:60 (leading: Space)
+6570: Semicolon       ";" at 555:60-555:61
+6571: At              "@" at 556:5-556:6 (leading: Newline, Space)
+6572: Ident           "intrinsic" at 556:6-556:15
+6573: KwFn            "fn" at 556:16-556:18 (leading: Space)
+6574: Ident           "__ge" at 556:19-556:23 (leading: Space)
+6575: LParen          "(" at 556:23-556:24
+6576: Ident           "self" at 556:24-556:28
+6577: Colon           ":" at 556:28-556:29
+6578: Ident           "uint64" at 556:30-556:36 (leading: Space)
+6579: Comma           "," at 556:36-556:37
+6580: Ident           "other" at 556:38-556:43 (leading: Space)
+6581: Colon           ":" at 556:43-556:44
+6582: Ident           "uint64" at 556:45-556:51 (leading: Space)
+6583: RParen          ")" at 556:51-556:52
+6584: Arrow           "->" at 556:53-556:55 (leading: Space)
+6585: Ident           "bool" at 556:56-556:60 (leading: Space)
+6586: Semicolon       ";" at 556:60-556:61
+6587: At              "@" at 557:5-557:6 (leading: Newline, Space)
+6588: Ident           "intrinsic" at 557:6-557:15
+6589: KwFn            "fn" at 557:16-557:18 (leading: Space)
+6590: Ident           "__gt" at 557:19-557:23 (leading: Space)
+6591: LParen          "(" at 557:23-557:24
+6592: Ident           "self" at 557:24-557:28
+6593: Colon           ":" at 557:28-557:29
+6594: Ident           "uint64" at 557:30-557:36 (leading: Space)
+6595: Comma           "," at 557:36-557:37
+6596: Ident           "other" at 557:38-557:43 (leading: Space)
+6597: Colon           ":" at 557:43-557:44
+6598: Ident           "uint64" at 557:45-557:51 (leading: Space)
+6599: RParen          ")" at 557:51-557:52
+6600: Arrow           "->" at 557:53-557:55 (leading: Space)
+6601: Ident           "bool" at 557:56-557:60 (leading: Space)
+6602: Semicolon       ";" at 557:60-557:61
+6603: At              "@" at 558:5-558:6 (leading: Newline, Space)
+6604: Ident           "intrinsic" at 558:6-558:15
+6605: KwFn            "fn" at 558:16-558:18 (leading: Space)
+6606: Ident           "__pos" at 558:19-558:24 (leading: Space)
+6607: LParen          "(" at 558:24-558:25
+6608: Ident           "self" at 558:25-558:29
+6609: Colon           ":" at 558:29-558:30
+6610: Ident           "uint64" at 558:31-558:37 (leading: Space)
+6611: RParen          ")" at 558:37-558:38
+6612: Arrow           "->" at 558:39-558:41 (leading: Space)
+6613: Ident           "uint64" at 558:42-558:48 (leading: Space)
+6614: Semicolon       ";" at 558:48-558:49
+6615: At              "@" at 559:5-559:6 (leading: Newline, Space)
+6616: Ident           "intrinsic" at 559:6-559:15
+6617: KwFn            "fn" at 559:16-559:18 (leading: Space)
+6618: Ident           "__abs" at 559:19-559:24 (leading: Space)
+6619: LParen          "(" at 559:24-559:25
+6620: Ident           "self" at 559:25-559:29
+6621: Colon           ":" at 559:29-559:30
+6622: Ident           "uint64" at 559:31-559:37 (leading: Space)
+6623: RParen          ")" at 559:37-559:38
+6624: Arrow           "->" at 559:39-559:41 (leading: Space)
+6625: Ident           "uint64" at 559:42-559:48 (leading: Space)
+6626: Semicolon       ";" at 559:48-559:49
+6627: At              "@" at 560:5-560:6 (leading: Newline, Space)
+6628: Ident           "intrinsic" at 560:6-560:15
+6629: KwFn            "fn" at 560:16-560:18 (leading: Space)
+6630: Ident           "__to" at 560:19-560:23 (leading: Space)
+6631: LParen          "(" at 560:23-560:24
+6632: Ident           "self" at 560:24-560:28
+6633: Colon           ":" at 560:28-560:29
+6634: Ident           "uint64" at 560:30-560:36 (leading: Space)
+6635: Comma           "," at 560:36-560:37
+6636: Ident           "target" at 560:38-560:44 (leading: Space)
+6637: Colon           ":" at 560:44-560:45
+6638: Ident           "uint" at 560:46-560:50 (leading: Space)
+6639: RParen          ")" at 560:50-560:51
+6640: Arrow           "->" at 560:52-560:54 (leading: Space)
+6641: Ident           "uint" at 560:55-560:59 (leading: Space)
+6642: Semicolon       ";" at 560:59-560:60
+6643: At              "@" at 561:5-561:6 (leading: Newline, Space)
+6644: Ident           "intrinsic" at 561:6-561:15
+6645: At              "@" at 561:16-561:17 (leading: Space)
+6646: Ident           "overload" at 561:17-561:25
+6647: KwFn            "fn" at 561:26-561:28 (leading: Space)
+6648: Ident           "__to" at 561:29-561:33 (leading: Space)
+6649: LParen          "(" at 561:33-561:34
+6650: Ident           "self" at 561:34-561:38
+6651: Colon           ":" at 561:38-561:39
+6652: Ident           "uint64" at 561:40-561:46 (leading: Space)
+6653: Comma           "," at 561:46-561:47
+6654: Ident           "target" at 561:48-561:54 (leading: Space)
+6655: Colon           ":" at 561:54-561:55
+6656: Ident           "uint8" at 561:56-561:61 (leading: Space)
+6657: RParen          ")" at 561:61-561:62
+6658: Arrow           "->" at 561:63-561:65 (leading: Space)
+6659: Ident           "uint8" at 561:66-561:71 (leading: Space)
+6660: Semicolon       ";" at 561:71-561:72
+6661: At              "@" at 562:5-562:6 (leading: Newline, Space)
+6662: Ident           "intrinsic" at 562:6-562:15
+6663: At              "@" at 562:16-562:17 (leading: Space)
+6664: Ident           "overload" at 562:17-562:25
+6665: KwFn            "fn" at 562:26-562:28 (leading: Space)
+6666: Ident           "__to" at 562:29-562:33 (leading: Space)
+6667: LParen          "(" at 562:33-562:34
+6668: Ident           "self" at 562:34-562:38
+6669: Colon           ":" at 562:38-562:39
+6670: Ident           "uint64" at 562:40-562:46 (leading: Space)
+6671: Comma           "," at 562:46-562:47
+6672: Ident           "target" at 562:48-562:54 (leading: Space)
+6673: Colon           ":" at 562:54-562:55
+6674: Ident           "uint16" at 562:56-562:62 (leading: Space)
+6675: RParen          ")" at 562:62-562:63
+6676: Arrow           "->" at 562:64-562:66 (leading: Space)
+6677: Ident           "uint16" at 562:67-562:73 (leading: Space)
+6678: Semicolon       ";" at 562:73-562:74
+6679: At              "@" at 563:5-563:6 (leading: Newline, Space)
+6680: Ident           "intrinsic" at 563:6-563:15
+6681: At              "@" at 563:16-563:17 (leading: Space)
+6682: Ident           "overload" at 563:17-563:25
+6683: KwFn            "fn" at 563:26-563:28 (leading: Space)
+6684: Ident           "__to" at 563:29-563:33 (leading: Space)
+6685: LParen          "(" at 563:33-563:34
+6686: Ident           "self" at 563:34-563:38
+6687: Colon           ":" at 563:38-563:39
+6688: Ident           "uint64" at 563:40-563:46 (leading: Space)
+6689: Comma           "," at 563:46-563:47
+6690: Ident           "target" at 563:48-563:54 (leading: Space)
+6691: Colon           ":" at 563:54-563:55
+6692: Ident           "uint32" at 563:56-563:62 (leading: Space)
+6693: RParen          ")" at 563:62-563:63
+6694: Arrow           "->" at 563:64-563:66 (leading: Space)
+6695: Ident           "uint32" at 563:67-563:73 (leading: Space)
+6696: Semicolon       ";" at 563:73-563:74
+6697: At              "@" at 564:5-564:6 (leading: Newline, Space)
+6698: Ident           "intrinsic" at 564:6-564:15
+6699: KwPub           "pub" at 564:16-564:19 (leading: Space)
+6700: KwFn            "fn" at 564:20-564:22 (leading: Space)
+6701: Ident           "from_str" at 564:23-564:31 (leading: Space)
+6702: LParen          "(" at 564:31-564:32
+6703: Ident           "s" at 564:32-564:33
+6704: Colon           ":" at 564:33-564:34
+6705: Amp             "&" at 564:35-564:36 (leading: Space)
+6706: Ident           "string" at 564:36-564:42
+6707: RParen          ")" at 564:42-564:43
+6708: Arrow           "->" at 564:44-564:46 (leading: Space)
+6709: Ident           "Erring" at 564:47-564:53 (leading: Space)
+6710: Lt              "<" at 564:53-564:54
+6711: Ident           "uint64" at 564:54-564:60
+6712: Comma           "," at 564:60-564:61
+6713: Ident           "Error" at 564:62-564:67 (leading: Space)
+6714: Gt              ">" at 564:67-564:68
+6715: Semicolon       ";" at 564:68-564:69
+6716: RBrace          "}" at 565:1-565:2 (leading: Newline)
+6717: KwExtern        "extern" at 567:1-567:7 (leading: Newline)
+6718: Lt              "<" at 567:7-567:8
+6719: Ident           "float16" at 567:8-567:15
+6720: Gt              ">" at 567:15-567:16
+6721: LBrace          "{" at 567:17-567:18 (leading: Space)
+6722: KwPub           "pub" at 568:5-568:8 (leading: Newline, Space)
+6723: KwFn            "fn" at 568:9-568:11 (leading: Space)
+6724: Ident           "__min_value" at 568:12-568:23 (leading: Space)
+6725: LParen          "(" at 568:23-568:24
+6726: RParen          ")" at 568:24-568:25
+6727: Arrow           "->" at 568:26-568:28 (leading: Space)
+6728: Ident           "float16" at 568:29-568:36 (leading: Space)
+6729: LBrace          "{" at 568:37-568:38 (leading: Space)
+6730: KwReturn        "return" at 568:39-568:45 (leading: Space)
+6731: LParen          "(" at 568:46-568:47 (leading: Space)
+6732: Minus           "-" at 568:47-568:48
+6733: FloatLit        "65504.0" at 568:48-568:55
+6734: RParen          ")" at 568:55-568:56
+6735: Colon           ":" at 568:56-568:57
+6736: Ident           "float16" at 568:57-568:64
+6737: Semicolon       ";" at 568:64-568:65
+6738: RBrace          "}" at 568:66-568:67 (leading: Space)
+6739: KwPub           "pub" at 569:5-569:8 (leading: Newline, Space)
+6740: KwFn            "fn" at 569:9-569:11 (leading: Space)
+6741: Ident           "__max_value" at 569:12-569:23 (leading: Space)
+6742: LParen          "(" at 569:23-569:24
+6743: RParen          ")" at 569:24-569:25
+6744: Arrow           "->" at 569:26-569:28 (leading: Space)
+6745: Ident           "float16" at 569:29-569:36 (leading: Space)
+6746: LBrace          "{" at 569:37-569:38 (leading: Space)
+6747: KwReturn        "return" at 569:39-569:45 (leading: Space)
+6748: LParen          "(" at 569:46-569:47 (leading: Space)
+6749: FloatLit        "65504.0" at 569:47-569:54
+6750: RParen          ")" at 569:54-569:55
+6751: Colon           ":" at 569:55-569:56
+6752: Ident           "float16" at 569:56-569:63
+6753: Semicolon       ";" at 569:63-569:64
+6754: RBrace          "}" at 569:65-569:66 (leading: Space)
+6755: At              "@" at 570:5-570:6 (leading: Newline, Space)
+6756: Ident           "intrinsic" at 570:6-570:15
+6757: KwFn            "fn" at 570:16-570:18 (leading: Space)
+6758: Ident           "__add" at 570:19-570:24 (leading: Space)
+6759: LParen          "(" at 570:24-570:25
+6760: Ident           "self" at 570:25-570:29
+6761: Colon           ":" at 570:29-570:30
+6762: Ident           "float16" at 570:31-570:38 (leading: Space)
+6763: Comma           "," at 570:38-570:39
+6764: Ident           "other" at 570:40-570:45 (leading: Space)
+6765: Colon           ":" at 570:45-570:46
+6766: Ident           "float16" at 570:47-570:54 (leading: Space)
+6767: RParen          ")" at 570:54-570:55
+6768: Arrow           "->" at 570:56-570:58 (leading: Space)
+6769: Ident           "float16" at 570:59-570:66 (leading: Space)
+6770: Semicolon       ";" at 570:66-570:67
+6771: At              "@" at 571:5-571:6 (leading: Newline, Space)
+6772: Ident           "intrinsic" at 571:6-571:15
+6773: KwFn            "fn" at 571:16-571:18 (leading: Space)
+6774: Ident           "__sub" at 571:19-571:24 (leading: Space)
+6775: LParen          "(" at 571:24-571:25
+6776: Ident           "self" at 571:25-571:29
+6777: Colon           ":" at 571:29-571:30
+6778: Ident           "float16" at 571:31-571:38 (leading: Space)
+6779: Comma           "," at 571:38-571:39
+6780: Ident           "other" at 571:40-571:45 (leading: Space)
+6781: Colon           ":" at 571:45-571:46
+6782: Ident           "float16" at 571:47-571:54 (leading: Space)
+6783: RParen          ")" at 571:54-571:55
+6784: Arrow           "->" at 571:56-571:58 (leading: Space)
+6785: Ident           "float16" at 571:59-571:66 (leading: Space)
+6786: Semicolon       ";" at 571:66-571:67
+6787: At              "@" at 572:5-572:6 (leading: Newline, Space)
+6788: Ident           "intrinsic" at 572:6-572:15
+6789: KwFn            "fn" at 572:16-572:18 (leading: Space)
+6790: Ident           "__mul" at 572:19-572:24 (leading: Space)
+6791: LParen          "(" at 572:24-572:25
+6792: Ident           "self" at 572:25-572:29
+6793: Colon           ":" at 572:29-572:30
+6794: Ident           "float16" at 572:31-572:38 (leading: Space)
+6795: Comma           "," at 572:38-572:39
+6796: Ident           "other" at 572:40-572:45 (leading: Space)
+6797: Colon           ":" at 572:45-572:46
+6798: Ident           "float16" at 572:47-572:54 (leading: Space)
+6799: RParen          ")" at 572:54-572:55
+6800: Arrow           "->" at 572:56-572:58 (leading: Space)
+6801: Ident           "float16" at 572:59-572:66 (leading: Space)
+6802: Semicolon       ";" at 572:66-572:67
+6803: At              "@" at 573:5-573:6 (leading: Newline, Space)
+6804: Ident           "intrinsic" at 573:6-573:15
+6805: KwFn            "fn" at 573:16-573:18 (leading: Space)
+6806: Ident           "__div" at 573:19-573:24 (leading: Space)
+6807: LParen          "(" at 573:24-573:25
+6808: Ident           "self" at 573:25-573:29
+6809: Colon           ":" at 573:29-573:30
+6810: Ident           "float16" at 573:31-573:38 (leading: Space)
+6811: Comma           "," at 573:38-573:39
+6812: Ident           "other" at 573:40-573:45 (leading: Space)
+6813: Colon           ":" at 573:45-573:46
+6814: Ident           "float16" at 573:47-573:54 (leading: Space)
+6815: RParen          ")" at 573:54-573:55
+6816: Arrow           "->" at 573:56-573:58 (leading: Space)
+6817: Ident           "float16" at 573:59-573:66 (leading: Space)
+6818: Semicolon       ";" at 573:66-573:67
+6819: At              "@" at 574:5-574:6 (leading: Newline, Space)
+6820: Ident           "intrinsic" at 574:6-574:15
+6821: KwFn            "fn" at 574:16-574:18 (leading: Space)
+6822: Ident           "__mod" at 574:19-574:24 (leading: Space)
+6823: LParen          "(" at 574:24-574:25
+6824: Ident           "self" at 574:25-574:29
+6825: Colon           ":" at 574:29-574:30
+6826: Ident           "float16" at 574:31-574:38 (leading: Space)
+6827: Comma           "," at 574:38-574:39
+6828: Ident           "other" at 574:40-574:45 (leading: Space)
+6829: Colon           ":" at 574:45-574:46
+6830: Ident           "float16" at 574:47-574:54 (leading: Space)
+6831: RParen          ")" at 574:54-574:55
+6832: Arrow           "->" at 574:56-574:58 (leading: Space)
+6833: Ident           "float16" at 574:59-574:66 (leading: Space)
+6834: Semicolon       ";" at 574:66-574:67
+6835: At              "@" at 575:5-575:6 (leading: Newline, Space)
+6836: Ident           "intrinsic" at 575:6-575:15
+6837: KwFn            "fn" at 575:16-575:18 (leading: Space)
+6838: Ident           "__lt" at 575:19-575:23 (leading: Space)
+6839: LParen          "(" at 575:23-575:24
+6840: Ident           "self" at 575:24-575:28
+6841: Colon           ":" at 575:28-575:29
+6842: Ident           "float16" at 575:30-575:37 (leading: Space)
+6843: Comma           "," at 575:37-575:38
+6844: Ident           "other" at 575:39-575:44 (leading: Space)
+6845: Colon           ":" at 575:44-575:45
+6846: Ident           "float16" at 575:46-575:53 (leading: Space)
+6847: RParen          ")" at 575:53-575:54
+6848: Arrow           "->" at 575:55-575:57 (leading: Space)
+6849: Ident           "bool" at 575:58-575:62 (leading: Space)
+6850: Semicolon       ";" at 575:62-575:63
+6851: At              "@" at 576:5-576:6 (leading: Newline, Space)
+6852: Ident           "intrinsic" at 576:6-576:15
+6853: KwFn            "fn" at 576:16-576:18 (leading: Space)
+6854: Ident           "__le" at 576:19-576:23 (leading: Space)
+6855: LParen          "(" at 576:23-576:24
+6856: Ident           "self" at 576:24-576:28
+6857: Colon           ":" at 576:28-576:29
+6858: Ident           "float16" at 576:30-576:37 (leading: Space)
+6859: Comma           "," at 576:37-576:38
+6860: Ident           "other" at 576:39-576:44 (leading: Space)
+6861: Colon           ":" at 576:44-576:45
+6862: Ident           "float16" at 576:46-576:53 (leading: Space)
+6863: RParen          ")" at 576:53-576:54
+6864: Arrow           "->" at 576:55-576:57 (leading: Space)
+6865: Ident           "bool" at 576:58-576:62 (leading: Space)
+6866: Semicolon       ";" at 576:62-576:63
+6867: At              "@" at 577:5-577:6 (leading: Newline, Space)
+6868: Ident           "intrinsic" at 577:6-577:15
+6869: KwFn            "fn" at 577:16-577:18 (leading: Space)
+6870: Ident           "__eq" at 577:19-577:23 (leading: Space)
+6871: LParen          "(" at 577:23-577:24
+6872: Ident           "self" at 577:24-577:28
+6873: Colon           ":" at 577:28-577:29
+6874: Ident           "float16" at 577:30-577:37 (leading: Space)
+6875: Comma           "," at 577:37-577:38
+6876: Ident           "other" at 577:39-577:44 (leading: Space)
+6877: Colon           ":" at 577:44-577:45
+6878: Ident           "float16" at 577:46-577:53 (leading: Space)
+6879: RParen          ")" at 577:53-577:54
+6880: Arrow           "->" at 577:55-577:57 (leading: Space)
+6881: Ident           "bool" at 577:58-577:62 (leading: Space)
+6882: Semicolon       ";" at 577:62-577:63
+6883: At              "@" at 578:5-578:6 (leading: Newline, Space)
+6884: Ident           "intrinsic" at 578:6-578:15
+6885: KwFn            "fn" at 578:16-578:18 (leading: Space)
+6886: Ident           "__ne" at 578:19-578:23 (leading: Space)
+6887: LParen          "(" at 578:23-578:24
+6888: Ident           "self" at 578:24-578:28
+6889: Colon           ":" at 578:28-578:29
+6890: Ident           "float16" at 578:30-578:37 (leading: Space)
+6891: Comma           "," at 578:37-578:38
+6892: Ident           "other" at 578:39-578:44 (leading: Space)
+6893: Colon           ":" at 578:44-578:45
+6894: Ident           "float16" at 578:46-578:53 (leading: Space)
+6895: RParen          ")" at 578:53-578:54
+6896: Arrow           "->" at 578:55-578:57 (leading: Space)
+6897: Ident           "bool" at 578:58-578:62 (leading: Space)
+6898: Semicolon       ";" at 578:62-578:63
+6899: At              "@" at 579:5-579:6 (leading: Newline, Space)
+6900: Ident           "intrinsic" at 579:6-579:15
+6901: KwFn            "fn" at 579:16-579:18 (leading: Space)
+6902: Ident           "__ge" at 579:19-579:23 (leading: Space)
+6903: LParen          "(" at 579:23-579:24
+6904: Ident           "self" at 579:24-579:28
+6905: Colon           ":" at 579:28-579:29
+6906: Ident           "float16" at 579:30-579:37 (leading: Space)
+6907: Comma           "," at 579:37-579:38
+6908: Ident           "other" at 579:39-579:44 (leading: Space)
+6909: Colon           ":" at 579:44-579:45
+6910: Ident           "float16" at 579:46-579:53 (leading: Space)
+6911: RParen          ")" at 579:53-579:54
+6912: Arrow           "->" at 579:55-579:57 (leading: Space)
+6913: Ident           "bool" at 579:58-579:62 (leading: Space)
+6914: Semicolon       ";" at 579:62-579:63
+6915: At              "@" at 580:5-580:6 (leading: Newline, Space)
+6916: Ident           "intrinsic" at 580:6-580:15
+6917: KwFn            "fn" at 580:16-580:18 (leading: Space)
+6918: Ident           "__gt" at 580:19-580:23 (leading: Space)
+6919: LParen          "(" at 580:23-580:24
+6920: Ident           "self" at 580:24-580:28
+6921: Colon           ":" at 580:28-580:29
+6922: Ident           "float16" at 580:30-580:37 (leading: Space)
+6923: Comma           "," at 580:37-580:38
+6924: Ident           "other" at 580:39-580:44 (leading: Space)
+6925: Colon           ":" at 580:44-580:45
+6926: Ident           "float16" at 580:46-580:53 (leading: Space)
+6927: RParen          ")" at 580:53-580:54
+6928: Arrow           "->" at 580:55-580:57 (leading: Space)
+6929: Ident           "bool" at 580:58-580:62 (leading: Space)
+6930: Semicolon       ";" at 580:62-580:63
+6931: At              "@" at 581:5-581:6 (leading: Newline, Space)
+6932: Ident           "intrinsic" at 581:6-581:15
+6933: KwFn            "fn" at 581:16-581:18 (leading: Space)
+6934: Ident           "__pos" at 581:19-581:24 (leading: Space)
+6935: LParen          "(" at 581:24-581:25
+6936: Ident           "self" at 581:25-581:29
+6937: Colon           ":" at 581:29-581:30
+6938: Ident           "float16" at 581:31-581:38 (leading: Space)
+6939: RParen          ")" at 581:38-581:39
+6940: Arrow           "->" at 581:40-581:42 (leading: Space)
+6941: Ident           "float16" at 581:43-581:50 (leading: Space)
+6942: Semicolon       ";" at 581:50-581:51
+6943: At              "@" at 582:5-582:6 (leading: Newline, Space)
+6944: Ident           "intrinsic" at 582:6-582:15
+6945: KwFn            "fn" at 582:16-582:18 (leading: Space)
+6946: Ident           "__neg" at 582:19-582:24 (leading: Space)
+6947: LParen          "(" at 582:24-582:25
+6948: Ident           "self" at 582:25-582:29
+6949: Colon           ":" at 582:29-582:30
+6950: Ident           "float16" at 582:31-582:38 (leading: Space)
+6951: RParen          ")" at 582:38-582:39
+6952: Arrow           "->" at 582:40-582:42 (leading: Space)
+6953: Ident           "float16" at 582:43-582:50 (leading: Space)
+6954: Semicolon       ";" at 582:50-582:51
+6955: At              "@" at 583:5-583:6 (leading: Newline, Space)
+6956: Ident           "intrinsic" at 583:6-583:15
+6957: KwFn            "fn" at 583:16-583:18 (leading: Space)
+6958: Ident           "__abs" at 583:19-583:24 (leading: Space)
+6959: LParen          "(" at 583:24-583:25
+6960: Ident           "self" at 583:25-583:29
+6961: Colon           ":" at 583:29-583:30
+6962: Ident           "float16" at 583:31-583:38 (leading: Space)
+6963: RParen          ")" at 583:38-583:39
+6964: Arrow           "->" at 583:40-583:42 (leading: Space)
+6965: Ident           "float16" at 583:43-583:50 (leading: Space)
+6966: Semicolon       ";" at 583:50-583:51
+6967: At              "@" at 584:5-584:6 (leading: Newline, Space)
+6968: Ident           "intrinsic" at 584:6-584:15
+6969: KwFn            "fn" at 584:16-584:18 (leading: Space)
+6970: Ident           "__to" at 584:19-584:23 (leading: Space)
+6971: LParen          "(" at 584:23-584:24
+6972: Ident           "self" at 584:24-584:28
+6973: Colon           ":" at 584:28-584:29
+6974: Ident           "float16" at 584:30-584:37 (leading: Space)
+6975: Comma           "," at 584:37-584:38
+6976: Ident           "target" at 584:39-584:45 (leading: Space)
+6977: Colon           ":" at 584:45-584:46
+6978: Ident           "float" at 584:47-584:52 (leading: Space)
+6979: RParen          ")" at 584:52-584:53
+6980: Arrow           "->" at 584:54-584:56 (leading: Space)
+6981: Ident           "float" at 584:57-584:62 (leading: Space)
+6982: Semicolon       ";" at 584:62-584:63
+6983: At              "@" at 585:5-585:6 (leading: Newline, Space)
+6984: Ident           "intrinsic" at 585:6-585:15
+6985: At              "@" at 585:16-585:17 (leading: Space)
+6986: Ident           "overload" at 585:17-585:25
+6987: KwFn            "fn" at 585:26-585:28 (leading: Space)
+6988: Ident           "__to" at 585:29-585:33 (leading: Space)
+6989: LParen          "(" at 585:33-585:34
+6990: Ident           "self" at 585:34-585:38
+6991: Colon           ":" at 585:38-585:39
+6992: Ident           "float16" at 585:40-585:47 (leading: Space)
+6993: Comma           "," at 585:47-585:48
+6994: Ident           "target" at 585:49-585:55 (leading: Space)
+6995: Colon           ":" at 585:55-585:56
+6996: Ident           "float32" at 585:57-585:64 (leading: Space)
+6997: RParen          ")" at 585:64-585:65
+6998: Arrow           "->" at 585:66-585:68 (leading: Space)
+6999: Ident           "float32" at 585:69-585:76 (leading: Space)
+7000: Semicolon       ";" at 585:76-585:77
+7001: At              "@" at 586:5-586:6 (leading: Newline, Space)
+7002: Ident           "intrinsic" at 586:6-586:15
+7003: At              "@" at 586:16-586:17 (leading: Space)
+7004: Ident           "overload" at 586:17-586:25
+7005: KwFn            "fn" at 586:26-586:28 (leading: Space)
+7006: Ident           "__to" at 586:29-586:33 (leading: Space)
+7007: LParen          "(" at 586:33-586:34
+7008: Ident           "self" at 586:34-586:38
+7009: Colon           ":" at 586:38-586:39
+7010: Ident           "float16" at 586:40-586:47 (leading: Space)
+7011: Comma           "," at 586:47-586:48
+7012: Ident           "target" at 586:49-586:55 (leading: Space)
+7013: Colon           ":" at 586:55-586:56
+7014: Ident           "float64" at 586:57-586:64 (leading: Space)
+7015: RParen          ")" at 586:64-586:65
+7016: Arrow           "->" at 586:66-586:68 (leading: Space)
+7017: Ident           "float64" at 586:69-586:76 (leading: Space)
+7018: Semicolon       ";" at 586:76-586:77
+7019: At              "@" at 587:5-587:6 (leading: Newline, Space)
+7020: Ident           "intrinsic" at 587:6-587:15
+7021: KwPub           "pub" at 587:16-587:19 (leading: Space)
+7022: KwFn            "fn" at 587:20-587:22 (leading: Space)
+7023: Ident           "from_str" at 587:23-587:31 (leading: Space)
+7024: LParen          "(" at 587:31-587:32
+7025: Ident           "s" at 587:32-587:33
+7026: Colon           ":" at 587:33-587:34
+7027: Amp             "&" at 587:35-587:36 (leading: Space)
+7028: Ident           "string" at 587:36-587:42
+7029: RParen          ")" at 587:42-587:43
+7030: Arrow           "->" at 587:44-587:46 (leading: Space)
+7031: Ident           "Erring" at 587:47-587:53 (leading: Space)
+7032: Lt              "<" at 587:53-587:54
+7033: Ident           "float16" at 587:54-587:61
+7034: Comma           "," at 587:61-587:62
+7035: Ident           "Error" at 587:63-587:68 (leading: Space)
+7036: Gt              ">" at 587:68-587:69
+7037: Semicolon       ";" at 587:69-587:70
+7038: RBrace          "}" at 588:1-588:2 (leading: Newline)
+7039: KwExtern        "extern" at 590:1-590:7 (leading: Newline)
+7040: Lt              "<" at 590:7-590:8
+7041: Ident           "float32" at 590:8-590:15
+7042: Gt              ">" at 590:15-590:16
+7043: LBrace          "{" at 590:17-590:18 (leading: Space)
+7044: KwPub           "pub" at 591:5-591:8 (leading: Newline, Space)
+7045: KwFn            "fn" at 591:9-591:11 (leading: Space)
+7046: Ident           "__min_value" at 591:12-591:23 (leading: Space)
+7047: LParen          "(" at 591:23-591:24
+7048: RParen          ")" at 591:24-591:25
+7049: Arrow           "->" at 591:26-591:28 (leading: Space)
+7050: Ident           "float32" at 591:29-591:36 (leading: Space)
+7051: LBrace          "{" at 591:37-591:38 (leading: Space)
+7052: KwReturn        "return" at 591:39-591:45 (leading: Space)
+7053: LParen          "(" at 591:46-591:47 (leading: Space)
+7054: Minus           "-" at 591:47-591:48
+7055: FloatLit        "3.402_823_466_385_2886e+38" at 591:48-591:74
+7056: RParen          ")" at 591:74-591:75
+7057: Colon           ":" at 591:75-591:76
+7058: Ident           "float32" at 591:76-591:83
+7059: Semicolon       ";" at 591:83-591:84
+7060: RBrace          "}" at 591:85-591:86 (leading: Space)
+7061: KwPub           "pub" at 592:5-592:8 (leading: Newline, Space)
+7062: KwFn            "fn" at 592:9-592:11 (leading: Space)
+7063: Ident           "__max_value" at 592:12-592:23 (leading: Space)
+7064: LParen          "(" at 592:23-592:24
+7065: RParen          ")" at 592:24-592:25
+7066: Arrow           "->" at 592:26-592:28 (leading: Space)
+7067: Ident           "float32" at 592:29-592:36 (leading: Space)
+7068: LBrace          "{" at 592:37-592:38 (leading: Space)
+7069: KwReturn        "return" at 592:39-592:45 (leading: Space)
+7070: LParen          "(" at 592:46-592:47 (leading: Space)
+7071: FloatLit        "3.402_823_466_385_2886e+38" at 592:47-592:73
+7072: RParen          ")" at 592:73-592:74
+7073: Colon           ":" at 592:74-592:75
+7074: Ident           "float32" at 592:75-592:82
+7075: Semicolon       ";" at 592:82-592:83
+7076: RBrace          "}" at 592:84-592:85 (leading: Space)
+7077: At              "@" at 593:5-593:6 (leading: Newline, Space)
+7078: Ident           "intrinsic" at 593:6-593:15
+7079: KwFn            "fn" at 593:16-593:18 (leading: Space)
+7080: Ident           "__add" at 593:19-593:24 (leading: Space)
+7081: LParen          "(" at 593:24-593:25
+7082: Ident           "self" at 593:25-593:29
+7083: Colon           ":" at 593:29-593:30
+7084: Ident           "float32" at 593:31-593:38 (leading: Space)
+7085: Comma           "," at 593:38-593:39
+7086: Ident           "other" at 593:40-593:45 (leading: Space)
+7087: Colon           ":" at 593:45-593:46
+7088: Ident           "float32" at 593:47-593:54 (leading: Space)
+7089: RParen          ")" at 593:54-593:55
+7090: Arrow           "->" at 593:56-593:58 (leading: Space)
+7091: Ident           "float32" at 593:59-593:66 (leading: Space)
+7092: Semicolon       ";" at 593:66-593:67
+7093: At              "@" at 594:5-594:6 (leading: Newline, Space)
+7094: Ident           "intrinsic" at 594:6-594:15
+7095: KwFn            "fn" at 594:16-594:18 (leading: Space)
+7096: Ident           "__sub" at 594:19-594:24 (leading: Space)
+7097: LParen          "(" at 594:24-594:25
+7098: Ident           "self" at 594:25-594:29
+7099: Colon           ":" at 594:29-594:30
+7100: Ident           "float32" at 594:31-594:38 (leading: Space)
+7101: Comma           "," at 594:38-594:39
+7102: Ident           "other" at 594:40-594:45 (leading: Space)
+7103: Colon           ":" at 594:45-594:46
+7104: Ident           "float32" at 594:47-594:54 (leading: Space)
+7105: RParen          ")" at 594:54-594:55
+7106: Arrow           "->" at 594:56-594:58 (leading: Space)
+7107: Ident           "float32" at 594:59-594:66 (leading: Space)
+7108: Semicolon       ";" at 594:66-594:67
+7109: At              "@" at 595:5-595:6 (leading: Newline, Space)
+7110: Ident           "intrinsic" at 595:6-595:15
+7111: KwFn            "fn" at 595:16-595:18 (leading: Space)
+7112: Ident           "__mul" at 595:19-595:24 (leading: Space)
+7113: LParen          "(" at 595:24-595:25
+7114: Ident           "self" at 595:25-595:29
+7115: Colon           ":" at 595:29-595:30
+7116: Ident           "float32" at 595:31-595:38 (leading: Space)
+7117: Comma           "," at 595:38-595:39
+7118: Ident           "other" at 595:40-595:45 (leading: Space)
+7119: Colon           ":" at 595:45-595:46
+7120: Ident           "float32" at 595:47-595:54 (leading: Space)
+7121: RParen          ")" at 595:54-595:55
+7122: Arrow           "->" at 595:56-595:58 (leading: Space)
+7123: Ident           "float32" at 595:59-595:66 (leading: Space)
+7124: Semicolon       ";" at 595:66-595:67
+7125: At              "@" at 596:5-596:6 (leading: Newline, Space)
+7126: Ident           "intrinsic" at 596:6-596:15
+7127: KwFn            "fn" at 596:16-596:18 (leading: Space)
+7128: Ident           "__div" at 596:19-596:24 (leading: Space)
+7129: LParen          "(" at 596:24-596:25
+7130: Ident           "self" at 596:25-596:29
+7131: Colon           ":" at 596:29-596:30
+7132: Ident           "float32" at 596:31-596:38 (leading: Space)
+7133: Comma           "," at 596:38-596:39
+7134: Ident           "other" at 596:40-596:45 (leading: Space)
+7135: Colon           ":" at 596:45-596:46
+7136: Ident           "float32" at 596:47-596:54 (leading: Space)
+7137: RParen          ")" at 596:54-596:55
+7138: Arrow           "->" at 596:56-596:58 (leading: Space)
+7139: Ident           "float32" at 596:59-596:66 (leading: Space)
+7140: Semicolon       ";" at 596:66-596:67
+7141: At              "@" at 597:5-597:6 (leading: Newline, Space)
+7142: Ident           "intrinsic" at 597:6-597:15
+7143: KwFn            "fn" at 597:16-597:18 (leading: Space)
+7144: Ident           "__mod" at 597:19-597:24 (leading: Space)
+7145: LParen          "(" at 597:24-597:25
+7146: Ident           "self" at 597:25-597:29
+7147: Colon           ":" at 597:29-597:30
+7148: Ident           "float32" at 597:31-597:38 (leading: Space)
+7149: Comma           "," at 597:38-597:39
+7150: Ident           "other" at 597:40-597:45 (leading: Space)
+7151: Colon           ":" at 597:45-597:46
+7152: Ident           "float32" at 597:47-597:54 (leading: Space)
+7153: RParen          ")" at 597:54-597:55
+7154: Arrow           "->" at 597:56-597:58 (leading: Space)
+7155: Ident           "float32" at 597:59-597:66 (leading: Space)
+7156: Semicolon       ";" at 597:66-597:67
+7157: At              "@" at 598:5-598:6 (leading: Newline, Space)
+7158: Ident           "intrinsic" at 598:6-598:15
+7159: KwFn            "fn" at 598:16-598:18 (leading: Space)
+7160: Ident           "__lt" at 598:19-598:23 (leading: Space)
+7161: LParen          "(" at 598:23-598:24
+7162: Ident           "self" at 598:24-598:28
+7163: Colon           ":" at 598:28-598:29
+7164: Ident           "float32" at 598:30-598:37 (leading: Space)
+7165: Comma           "," at 598:37-598:38
+7166: Ident           "other" at 598:39-598:44 (leading: Space)
+7167: Colon           ":" at 598:44-598:45
+7168: Ident           "float32" at 598:46-598:53 (leading: Space)
+7169: RParen          ")" at 598:53-598:54
+7170: Arrow           "->" at 598:55-598:57 (leading: Space)
+7171: Ident           "bool" at 598:58-598:62 (leading: Space)
+7172: Semicolon       ";" at 598:62-598:63
+7173: At              "@" at 599:5-599:6 (leading: Newline, Space)
+7174: Ident           "intrinsic" at 599:6-599:15
+7175: KwFn            "fn" at 599:16-599:18 (leading: Space)
+7176: Ident           "__le" at 599:19-599:23 (leading: Space)
+7177: LParen          "(" at 599:23-599:24
+7178: Ident           "self" at 599:24-599:28
+7179: Colon           ":" at 599:28-599:29
+7180: Ident           "float32" at 599:30-599:37 (leading: Space)
+7181: Comma           "," at 599:37-599:38
+7182: Ident           "other" at 599:39-599:44 (leading: Space)
+7183: Colon           ":" at 599:44-599:45
+7184: Ident           "float32" at 599:46-599:53 (leading: Space)
+7185: RParen          ")" at 599:53-599:54
+7186: Arrow           "->" at 599:55-599:57 (leading: Space)
+7187: Ident           "bool" at 599:58-599:62 (leading: Space)
+7188: Semicolon       ";" at 599:62-599:63
+7189: At              "@" at 600:5-600:6 (leading: Newline, Space)
+7190: Ident           "intrinsic" at 600:6-600:15
+7191: KwFn            "fn" at 600:16-600:18 (leading: Space)
+7192: Ident           "__eq" at 600:19-600:23 (leading: Space)
+7193: LParen          "(" at 600:23-600:24
+7194: Ident           "self" at 600:24-600:28
+7195: Colon           ":" at 600:28-600:29
+7196: Ident           "float32" at 600:30-600:37 (leading: Space)
+7197: Comma           "," at 600:37-600:38
+7198: Ident           "other" at 600:39-600:44 (leading: Space)
+7199: Colon           ":" at 600:44-600:45
+7200: Ident           "float32" at 600:46-600:53 (leading: Space)
+7201: RParen          ")" at 600:53-600:54
+7202: Arrow           "->" at 600:55-600:57 (leading: Space)
+7203: Ident           "bool" at 600:58-600:62 (leading: Space)
+7204: Semicolon       ";" at 600:62-600:63
+7205: At              "@" at 601:5-601:6 (leading: Newline, Space)
+7206: Ident           "intrinsic" at 601:6-601:15
+7207: KwFn            "fn" at 601:16-601:18 (leading: Space)
+7208: Ident           "__ne" at 601:19-601:23 (leading: Space)
+7209: LParen          "(" at 601:23-601:24
+7210: Ident           "self" at 601:24-601:28
+7211: Colon           ":" at 601:28-601:29
+7212: Ident           "float32" at 601:30-601:37 (leading: Space)
+7213: Comma           "," at 601:37-601:38
+7214: Ident           "other" at 601:39-601:44 (leading: Space)
+7215: Colon           ":" at 601:44-601:45
+7216: Ident           "float32" at 601:46-601:53 (leading: Space)
+7217: RParen          ")" at 601:53-601:54
+7218: Arrow           "->" at 601:55-601:57 (leading: Space)
+7219: Ident           "bool" at 601:58-601:62 (leading: Space)
+7220: Semicolon       ";" at 601:62-601:63
+7221: At              "@" at 602:5-602:6 (leading: Newline, Space)
+7222: Ident           "intrinsic" at 602:6-602:15
+7223: KwFn            "fn" at 602:16-602:18 (leading: Space)
+7224: Ident           "__ge" at 602:19-602:23 (leading: Space)
+7225: LParen          "(" at 602:23-602:24
+7226: Ident           "self" at 602:24-602:28
+7227: Colon           ":" at 602:28-602:29
+7228: Ident           "float32" at 602:30-602:37 (leading: Space)
+7229: Comma           "," at 602:37-602:38
+7230: Ident           "other" at 602:39-602:44 (leading: Space)
+7231: Colon           ":" at 602:44-602:45
+7232: Ident           "float32" at 602:46-602:53 (leading: Space)
+7233: RParen          ")" at 602:53-602:54
+7234: Arrow           "->" at 602:55-602:57 (leading: Space)
+7235: Ident           "bool" at 602:58-602:62 (leading: Space)
+7236: Semicolon       ";" at 602:62-602:63
+7237: At              "@" at 603:5-603:6 (leading: Newline, Space)
+7238: Ident           "intrinsic" at 603:6-603:15
+7239: KwFn            "fn" at 603:16-603:18 (leading: Space)
+7240: Ident           "__gt" at 603:19-603:23 (leading: Space)
+7241: LParen          "(" at 603:23-603:24
+7242: Ident           "self" at 603:24-603:28
+7243: Colon           ":" at 603:28-603:29
+7244: Ident           "float32" at 603:30-603:37 (leading: Space)
+7245: Comma           "," at 603:37-603:38
+7246: Ident           "other" at 603:39-603:44 (leading: Space)
+7247: Colon           ":" at 603:44-603:45
+7248: Ident           "float32" at 603:46-603:53 (leading: Space)
+7249: RParen          ")" at 603:53-603:54
+7250: Arrow           "->" at 603:55-603:57 (leading: Space)
+7251: Ident           "bool" at 603:58-603:62 (leading: Space)
+7252: Semicolon       ";" at 603:62-603:63
+7253: At              "@" at 604:5-604:6 (leading: Newline, Space)
+7254: Ident           "intrinsic" at 604:6-604:15
+7255: KwFn            "fn" at 604:16-604:18 (leading: Space)
+7256: Ident           "__pos" at 604:19-604:24 (leading: Space)
+7257: LParen          "(" at 604:24-604:25
+7258: Ident           "self" at 604:25-604:29
+7259: Colon           ":" at 604:29-604:30
+7260: Ident           "float32" at 604:31-604:38 (leading: Space)
+7261: RParen          ")" at 604:38-604:39
+7262: Arrow           "->" at 604:40-604:42 (leading: Space)
+7263: Ident           "float32" at 604:43-604:50 (leading: Space)
+7264: Semicolon       ";" at 604:50-604:51
+7265: At              "@" at 605:5-605:6 (leading: Newline, Space)
+7266: Ident           "intrinsic" at 605:6-605:15
+7267: KwFn            "fn" at 605:16-605:18 (leading: Space)
+7268: Ident           "__neg" at 605:19-605:24 (leading: Space)
+7269: LParen          "(" at 605:24-605:25
+7270: Ident           "self" at 605:25-605:29
+7271: Colon           ":" at 605:29-605:30
+7272: Ident           "float32" at 605:31-605:38 (leading: Space)
+7273: RParen          ")" at 605:38-605:39
+7274: Arrow           "->" at 605:40-605:42 (leading: Space)
+7275: Ident           "float32" at 605:43-605:50 (leading: Space)
+7276: Semicolon       ";" at 605:50-605:51
+7277: At              "@" at 606:5-606:6 (leading: Newline, Space)
+7278: Ident           "intrinsic" at 606:6-606:15
+7279: KwFn            "fn" at 606:16-606:18 (leading: Space)
+7280: Ident           "__abs" at 606:19-606:24 (leading: Space)
+7281: LParen          "(" at 606:24-606:25
+7282: Ident           "self" at 606:25-606:29
+7283: Colon           ":" at 606:29-606:30
+7284: Ident           "float32" at 606:31-606:38 (leading: Space)
+7285: RParen          ")" at 606:38-606:39
+7286: Arrow           "->" at 606:40-606:42 (leading: Space)
+7287: Ident           "float32" at 606:43-606:50 (leading: Space)
+7288: Semicolon       ";" at 606:50-606:51
+7289: At              "@" at 607:5-607:6 (leading: Newline, Space)
+7290: Ident           "intrinsic" at 607:6-607:15
+7291: KwFn            "fn" at 607:16-607:18 (leading: Space)
+7292: Ident           "__to" at 607:19-607:23 (leading: Space)
+7293: LParen          "(" at 607:23-607:24
+7294: Ident           "self" at 607:24-607:28
+7295: Colon           ":" at 607:28-607:29
+7296: Ident           "float32" at 607:30-607:37 (leading: Space)
+7297: Comma           "," at 607:37-607:38
+7298: Ident           "target" at 607:39-607:45 (leading: Space)
+7299: Colon           ":" at 607:45-607:46
+7300: Ident           "float" at 607:47-607:52 (leading: Space)
+7301: RParen          ")" at 607:52-607:53
+7302: Arrow           "->" at 607:54-607:56 (leading: Space)
+7303: Ident           "float" at 607:57-607:62 (leading: Space)
+7304: Semicolon       ";" at 607:62-607:63
+7305: At              "@" at 608:5-608:6 (leading: Newline, Space)
+7306: Ident           "intrinsic" at 608:6-608:15
+7307: At              "@" at 608:16-608:17 (leading: Space)
+7308: Ident           "overload" at 608:17-608:25
+7309: KwFn            "fn" at 608:26-608:28 (leading: Space)
+7310: Ident           "__to" at 608:29-608:33 (leading: Space)
+7311: LParen          "(" at 608:33-608:34
+7312: Ident           "self" at 608:34-608:38
+7313: Colon           ":" at 608:38-608:39
+7314: Ident           "float32" at 608:40-608:47 (leading: Space)
+7315: Comma           "," at 608:47-608:48
+7316: Ident           "target" at 608:49-608:55 (leading: Space)
+7317: Colon           ":" at 608:55-608:56
+7318: Ident           "float16" at 608:57-608:64 (leading: Space)
+7319: RParen          ")" at 608:64-608:65
+7320: Arrow           "->" at 608:66-608:68 (leading: Space)
+7321: Ident           "float16" at 608:69-608:76 (leading: Space)
+7322: Semicolon       ";" at 608:76-608:77
+7323: At              "@" at 609:5-609:6 (leading: Newline, Space)
+7324: Ident           "intrinsic" at 609:6-609:15
+7325: At              "@" at 609:16-609:17 (leading: Space)
+7326: Ident           "overload" at 609:17-609:25
+7327: KwFn            "fn" at 609:26-609:28 (leading: Space)
+7328: Ident           "__to" at 609:29-609:33 (leading: Space)
+7329: LParen          "(" at 609:33-609:34
+7330: Ident           "self" at 609:34-609:38
+7331: Colon           ":" at 609:38-609:39
+7332: Ident           "float32" at 609:40-609:47 (leading: Space)
+7333: Comma           "," at 609:47-609:48
+7334: Ident           "target" at 609:49-609:55 (leading: Space)
+7335: Colon           ":" at 609:55-609:56
+7336: Ident           "float64" at 609:57-609:64 (leading: Space)
+7337: RParen          ")" at 609:64-609:65
+7338: Arrow           "->" at 609:66-609:68 (leading: Space)
+7339: Ident           "float64" at 609:69-609:76 (leading: Space)
+7340: Semicolon       ";" at 609:76-609:77
+7341: At              "@" at 610:5-610:6 (leading: Newline, Space)
+7342: Ident           "intrinsic" at 610:6-610:15
+7343: KwPub           "pub" at 610:16-610:19 (leading: Space)
+7344: KwFn            "fn" at 610:20-610:22 (leading: Space)
+7345: Ident           "from_str" at 610:23-610:31 (leading: Space)
+7346: LParen          "(" at 610:31-610:32
+7347: Ident           "s" at 610:32-610:33
+7348: Colon           ":" at 610:33-610:34
+7349: Amp             "&" at 610:35-610:36 (leading: Space)
+7350: Ident           "string" at 610:36-610:42
+7351: RParen          ")" at 610:42-610:43
+7352: Arrow           "->" at 610:44-610:46 (leading: Space)
+7353: Ident           "Erring" at 610:47-610:53 (leading: Space)
+7354: Lt              "<" at 610:53-610:54
+7355: Ident           "float32" at 610:54-610:61
+7356: Comma           "," at 610:61-610:62
+7357: Ident           "Error" at 610:63-610:68 (leading: Space)
+7358: Gt              ">" at 610:68-610:69
+7359: Semicolon       ";" at 610:69-610:70
+7360: RBrace          "}" at 611:1-611:2 (leading: Newline)
+7361: KwExtern        "extern" at 613:1-613:7 (leading: Newline)
+7362: Lt              "<" at 613:7-613:8
+7363: Ident           "float64" at 613:8-613:15
+7364: Gt              ">" at 613:15-613:16
+7365: LBrace          "{" at 613:17-613:18 (leading: Space)
+7366: KwPub           "pub" at 614:5-614:8 (leading: Newline, Space)
+7367: KwFn            "fn" at 614:9-614:11 (leading: Space)
+7368: Ident           "__min_value" at 614:12-614:23 (leading: Space)
+7369: LParen          "(" at 614:23-614:24
+7370: RParen          ")" at 614:24-614:25
+7371: Arrow           "->" at 614:26-614:28 (leading: Space)
+7372: Ident           "float64" at 614:29-614:36 (leading: Space)
+7373: LBrace          "{" at 614:37-614:38 (leading: Space)
+7374: KwReturn        "return" at 614:39-614:45 (leading: Space)
+7375: LParen          "(" at 614:46-614:47 (leading: Space)
+7376: Minus           "-" at 614:47-614:48
+7377: FloatLit        "1.797_693_134_862_3157e+308" at 614:48-614:75
+7378: RParen          ")" at 614:75-614:76
+7379: Colon           ":" at 614:76-614:77
+7380: Ident           "float64" at 614:77-614:84
+7381: Semicolon       ";" at 614:84-614:85
+7382: RBrace          "}" at 614:86-614:87 (leading: Space)
+7383: KwPub           "pub" at 615:5-615:8 (leading: Newline, Space)
+7384: KwFn            "fn" at 615:9-615:11 (leading: Space)
+7385: Ident           "__max_value" at 615:12-615:23 (leading: Space)
+7386: LParen          "(" at 615:23-615:24
+7387: RParen          ")" at 615:24-615:25
+7388: Arrow           "->" at 615:26-615:28 (leading: Space)
+7389: Ident           "float64" at 615:29-615:36 (leading: Space)
+7390: LBrace          "{" at 615:37-615:38 (leading: Space)
+7391: KwReturn        "return" at 615:39-615:45 (leading: Space)
+7392: LParen          "(" at 615:46-615:47 (leading: Space)
+7393: FloatLit        "1.797_693_134_862_3157e+308" at 615:47-615:74
+7394: RParen          ")" at 615:74-615:75
+7395: Colon           ":" at 615:75-615:76
+7396: Ident           "float64" at 615:76-615:83
+7397: Semicolon       ";" at 615:83-615:84
+7398: RBrace          "}" at 615:85-615:86 (leading: Space)
+7399: At              "@" at 616:5-616:6 (leading: Newline, Space)
+7400: Ident           "intrinsic" at 616:6-616:15
+7401: KwFn            "fn" at 616:16-616:18 (leading: Space)
+7402: Ident           "__add" at 616:19-616:24 (leading: Space)
+7403: LParen          "(" at 616:24-616:25
+7404: Ident           "self" at 616:25-616:29
+7405: Colon           ":" at 616:29-616:30
+7406: Ident           "float64" at 616:31-616:38 (leading: Space)
+7407: Comma           "," at 616:38-616:39
+7408: Ident           "other" at 616:40-616:45 (leading: Space)
+7409: Colon           ":" at 616:45-616:46
+7410: Ident           "float64" at 616:47-616:54 (leading: Space)
+7411: RParen          ")" at 616:54-616:55
+7412: Arrow           "->" at 616:56-616:58 (leading: Space)
+7413: Ident           "float64" at 616:59-616:66 (leading: Space)
+7414: Semicolon       ";" at 616:66-616:67
+7415: At              "@" at 617:5-617:6 (leading: Newline, Space)
+7416: Ident           "intrinsic" at 617:6-617:15
+7417: KwFn            "fn" at 617:16-617:18 (leading: Space)
+7418: Ident           "__sub" at 617:19-617:24 (leading: Space)
+7419: LParen          "(" at 617:24-617:25
+7420: Ident           "self" at 617:25-617:29
+7421: Colon           ":" at 617:29-617:30
+7422: Ident           "float64" at 617:31-617:38 (leading: Space)
+7423: Comma           "," at 617:38-617:39
+7424: Ident           "other" at 617:40-617:45 (leading: Space)
+7425: Colon           ":" at 617:45-617:46
+7426: Ident           "float64" at 617:47-617:54 (leading: Space)
+7427: RParen          ")" at 617:54-617:55
+7428: Arrow           "->" at 617:56-617:58 (leading: Space)
+7429: Ident           "float64" at 617:59-617:66 (leading: Space)
+7430: Semicolon       ";" at 617:66-617:67
+7431: At              "@" at 618:5-618:6 (leading: Newline, Space)
+7432: Ident           "intrinsic" at 618:6-618:15
+7433: KwFn            "fn" at 618:16-618:18 (leading: Space)
+7434: Ident           "__mul" at 618:19-618:24 (leading: Space)
+7435: LParen          "(" at 618:24-618:25
+7436: Ident           "self" at 618:25-618:29
+7437: Colon           ":" at 618:29-618:30
+7438: Ident           "float64" at 618:31-618:38 (leading: Space)
+7439: Comma           "," at 618:38-618:39
+7440: Ident           "other" at 618:40-618:45 (leading: Space)
+7441: Colon           ":" at 618:45-618:46
+7442: Ident           "float64" at 618:47-618:54 (leading: Space)
+7443: RParen          ")" at 618:54-618:55
+7444: Arrow           "->" at 618:56-618:58 (leading: Space)
+7445: Ident           "float64" at 618:59-618:66 (leading: Space)
+7446: Semicolon       ";" at 618:66-618:67
+7447: At              "@" at 619:5-619:6 (leading: Newline, Space)
+7448: Ident           "intrinsic" at 619:6-619:15
+7449: KwFn            "fn" at 619:16-619:18 (leading: Space)
+7450: Ident           "__div" at 619:19-619:24 (leading: Space)
+7451: LParen          "(" at 619:24-619:25
+7452: Ident           "self" at 619:25-619:29
+7453: Colon           ":" at 619:29-619:30
+7454: Ident           "float64" at 619:31-619:38 (leading: Space)
+7455: Comma           "," at 619:38-619:39
+7456: Ident           "other" at 619:40-619:45 (leading: Space)
+7457: Colon           ":" at 619:45-619:46
+7458: Ident           "float64" at 619:47-619:54 (leading: Space)
+7459: RParen          ")" at 619:54-619:55
+7460: Arrow           "->" at 619:56-619:58 (leading: Space)
+7461: Ident           "float64" at 619:59-619:66 (leading: Space)
+7462: Semicolon       ";" at 619:66-619:67
+7463: At              "@" at 620:5-620:6 (leading: Newline, Space)
+7464: Ident           "intrinsic" at 620:6-620:15
+7465: KwFn            "fn" at 620:16-620:18 (leading: Space)
+7466: Ident           "__mod" at 620:19-620:24 (leading: Space)
+7467: LParen          "(" at 620:24-620:25
+7468: Ident           "self" at 620:25-620:29
+7469: Colon           ":" at 620:29-620:30
+7470: Ident           "float64" at 620:31-620:38 (leading: Space)
+7471: Comma           "," at 620:38-620:39
+7472: Ident           "other" at 620:40-620:45 (leading: Space)
+7473: Colon           ":" at 620:45-620:46
+7474: Ident           "float64" at 620:47-620:54 (leading: Space)
+7475: RParen          ")" at 620:54-620:55
+7476: Arrow           "->" at 620:56-620:58 (leading: Space)
+7477: Ident           "float64" at 620:59-620:66 (leading: Space)
+7478: Semicolon       ";" at 620:66-620:67
+7479: At              "@" at 621:5-621:6 (leading: Newline, Space)
+7480: Ident           "intrinsic" at 621:6-621:15
+7481: KwFn            "fn" at 621:16-621:18 (leading: Space)
+7482: Ident           "__lt" at 621:19-621:23 (leading: Space)
+7483: LParen          "(" at 621:23-621:24
+7484: Ident           "self" at 621:24-621:28
+7485: Colon           ":" at 621:28-621:29
+7486: Ident           "float64" at 621:30-621:37 (leading: Space)
+7487: Comma           "," at 621:37-621:38
+7488: Ident           "other" at 621:39-621:44 (leading: Space)
+7489: Colon           ":" at 621:44-621:45
+7490: Ident           "float64" at 621:46-621:53 (leading: Space)
+7491: RParen          ")" at 621:53-621:54
+7492: Arrow           "->" at 621:55-621:57 (leading: Space)
+7493: Ident           "bool" at 621:58-621:62 (leading: Space)
+7494: Semicolon       ";" at 621:62-621:63
+7495: At              "@" at 622:5-622:6 (leading: Newline, Space)
+7496: Ident           "intrinsic" at 622:6-622:15
+7497: KwFn            "fn" at 622:16-622:18 (leading: Space)
+7498: Ident           "__le" at 622:19-622:23 (leading: Space)
+7499: LParen          "(" at 622:23-622:24
+7500: Ident           "self" at 622:24-622:28
+7501: Colon           ":" at 622:28-622:29
+7502: Ident           "float64" at 622:30-622:37 (leading: Space)
+7503: Comma           "," at 622:37-622:38
+7504: Ident           "other" at 622:39-622:44 (leading: Space)
+7505: Colon           ":" at 622:44-622:45
+7506: Ident           "float64" at 622:46-622:53 (leading: Space)
+7507: RParen          ")" at 622:53-622:54
+7508: Arrow           "->" at 622:55-622:57 (leading: Space)
+7509: Ident           "bool" at 622:58-622:62 (leading: Space)
+7510: Semicolon       ";" at 622:62-622:63
+7511: At              "@" at 623:5-623:6 (leading: Newline, Space)
+7512: Ident           "intrinsic" at 623:6-623:15
+7513: KwFn            "fn" at 623:16-623:18 (leading: Space)
+7514: Ident           "__eq" at 623:19-623:23 (leading: Space)
+7515: LParen          "(" at 623:23-623:24
+7516: Ident           "self" at 623:24-623:28
+7517: Colon           ":" at 623:28-623:29
+7518: Ident           "float64" at 623:30-623:37 (leading: Space)
+7519: Comma           "," at 623:37-623:38
+7520: Ident           "other" at 623:39-623:44 (leading: Space)
+7521: Colon           ":" at 623:44-623:45
+7522: Ident           "float64" at 623:46-623:53 (leading: Space)
+7523: RParen          ")" at 623:53-623:54
+7524: Arrow           "->" at 623:55-623:57 (leading: Space)
+7525: Ident           "bool" at 623:58-623:62 (leading: Space)
+7526: Semicolon       ";" at 623:62-623:63
+7527: At              "@" at 624:5-624:6 (leading: Newline, Space)
+7528: Ident           "intrinsic" at 624:6-624:15
+7529: KwFn            "fn" at 624:16-624:18 (leading: Space)
+7530: Ident           "__ne" at 624:19-624:23 (leading: Space)
+7531: LParen          "(" at 624:23-624:24
+7532: Ident           "self" at 624:24-624:28
+7533: Colon           ":" at 624:28-624:29
+7534: Ident           "float64" at 624:30-624:37 (leading: Space)
+7535: Comma           "," at 624:37-624:38
+7536: Ident           "other" at 624:39-624:44 (leading: Space)
+7537: Colon           ":" at 624:44-624:45
+7538: Ident           "float64" at 624:46-624:53 (leading: Space)
+7539: RParen          ")" at 624:53-624:54
+7540: Arrow           "->" at 624:55-624:57 (leading: Space)
+7541: Ident           "bool" at 624:58-624:62 (leading: Space)
+7542: Semicolon       ";" at 624:62-624:63
+7543: At              "@" at 625:5-625:6 (leading: Newline, Space)
+7544: Ident           "intrinsic" at 625:6-625:15
+7545: KwFn            "fn" at 625:16-625:18 (leading: Space)
+7546: Ident           "__ge" at 625:19-625:23 (leading: Space)
+7547: LParen          "(" at 625:23-625:24
+7548: Ident           "self" at 625:24-625:28
+7549: Colon           ":" at 625:28-625:29
+7550: Ident           "float64" at 625:30-625:37 (leading: Space)
+7551: Comma           "," at 625:37-625:38
+7552: Ident           "other" at 625:39-625:44 (leading: Space)
+7553: Colon           ":" at 625:44-625:45
+7554: Ident           "float64" at 625:46-625:53 (leading: Space)
+7555: RParen          ")" at 625:53-625:54
+7556: Arrow           "->" at 625:55-625:57 (leading: Space)
+7557: Ident           "bool" at 625:58-625:62 (leading: Space)
+7558: Semicolon       ";" at 625:62-625:63
+7559: At              "@" at 626:5-626:6 (leading: Newline, Space)
+7560: Ident           "intrinsic" at 626:6-626:15
+7561: KwFn            "fn" at 626:16-626:18 (leading: Space)
+7562: Ident           "__gt" at 626:19-626:23 (leading: Space)
+7563: LParen          "(" at 626:23-626:24
+7564: Ident           "self" at 626:24-626:28
+7565: Colon           ":" at 626:28-626:29
+7566: Ident           "float64" at 626:30-626:37 (leading: Space)
+7567: Comma           "," at 626:37-626:38
+7568: Ident           "other" at 626:39-626:44 (leading: Space)
+7569: Colon           ":" at 626:44-626:45
+7570: Ident           "float64" at 626:46-626:53 (leading: Space)
+7571: RParen          ")" at 626:53-626:54
+7572: Arrow           "->" at 626:55-626:57 (leading: Space)
+7573: Ident           "bool" at 626:58-626:62 (leading: Space)
+7574: Semicolon       ";" at 626:62-626:63
+7575: At              "@" at 627:5-627:6 (leading: Newline, Space)
+7576: Ident           "intrinsic" at 627:6-627:15
+7577: KwFn            "fn" at 627:16-627:18 (leading: Space)
+7578: Ident           "__pos" at 627:19-627:24 (leading: Space)
+7579: LParen          "(" at 627:24-627:25
+7580: Ident           "self" at 627:25-627:29
+7581: Colon           ":" at 627:29-627:30
+7582: Ident           "float64" at 627:31-627:38 (leading: Space)
+7583: RParen          ")" at 627:38-627:39
+7584: Arrow           "->" at 627:40-627:42 (leading: Space)
+7585: Ident           "float64" at 627:43-627:50 (leading: Space)
+7586: Semicolon       ";" at 627:50-627:51
+7587: At              "@" at 628:5-628:6 (leading: Newline, Space)
+7588: Ident           "intrinsic" at 628:6-628:15
+7589: KwFn            "fn" at 628:16-628:18 (leading: Space)
+7590: Ident           "__neg" at 628:19-628:24 (leading: Space)
+7591: LParen          "(" at 628:24-628:25
+7592: Ident           "self" at 628:25-628:29
+7593: Colon           ":" at 628:29-628:30
+7594: Ident           "float64" at 628:31-628:38 (leading: Space)
+7595: RParen          ")" at 628:38-628:39
+7596: Arrow           "->" at 628:40-628:42 (leading: Space)
+7597: Ident           "float64" at 628:43-628:50 (leading: Space)
+7598: Semicolon       ";" at 628:50-628:51
+7599: At              "@" at 629:5-629:6 (leading: Newline, Space)
+7600: Ident           "intrinsic" at 629:6-629:15
+7601: KwFn            "fn" at 629:16-629:18 (leading: Space)
+7602: Ident           "__abs" at 629:19-629:24 (leading: Space)
+7603: LParen          "(" at 629:24-629:25
+7604: Ident           "self" at 629:25-629:29
+7605: Colon           ":" at 629:29-629:30
+7606: Ident           "float64" at 629:31-629:38 (leading: Space)
+7607: RParen          ")" at 629:38-629:39
+7608: Arrow           "->" at 629:40-629:42 (leading: Space)
+7609: Ident           "float64" at 629:43-629:50 (leading: Space)
+7610: Semicolon       ";" at 629:50-629:51
+7611: At              "@" at 630:5-630:6 (leading: Newline, Space)
+7612: Ident           "intrinsic" at 630:6-630:15
+7613: KwFn            "fn" at 630:16-630:18 (leading: Space)
+7614: Ident           "__to" at 630:19-630:23 (leading: Space)
+7615: LParen          "(" at 630:23-630:24
+7616: Ident           "self" at 630:24-630:28
+7617: Colon           ":" at 630:28-630:29
+7618: Ident           "float64" at 630:30-630:37 (leading: Space)
+7619: Comma           "," at 630:37-630:38
+7620: Ident           "target" at 630:39-630:45 (leading: Space)
+7621: Colon           ":" at 630:45-630:46
+7622: Ident           "float" at 630:47-630:52 (leading: Space)
+7623: RParen          ")" at 630:52-630:53
+7624: Arrow           "->" at 630:54-630:56 (leading: Space)
+7625: Ident           "float" at 630:57-630:62 (leading: Space)
+7626: Semicolon       ";" at 630:62-630:63
+7627: At              "@" at 631:5-631:6 (leading: Newline, Space)
+7628: Ident           "intrinsic" at 631:6-631:15
+7629: At              "@" at 631:16-631:17 (leading: Space)
+7630: Ident           "overload" at 631:17-631:25
+7631: KwFn            "fn" at 631:26-631:28 (leading: Space)
+7632: Ident           "__to" at 631:29-631:33 (leading: Space)
+7633: LParen          "(" at 631:33-631:34
+7634: Ident           "self" at 631:34-631:38
+7635: Colon           ":" at 631:38-631:39
+7636: Ident           "float64" at 631:40-631:47 (leading: Space)
+7637: Comma           "," at 631:47-631:48
+7638: Ident           "target" at 631:49-631:55 (leading: Space)
+7639: Colon           ":" at 631:55-631:56
+7640: Ident           "float16" at 631:57-631:64 (leading: Space)
+7641: RParen          ")" at 631:64-631:65
+7642: Arrow           "->" at 631:66-631:68 (leading: Space)
+7643: Ident           "float16" at 631:69-631:76 (leading: Space)
+7644: Semicolon       ";" at 631:76-631:77
+7645: At              "@" at 632:5-632:6 (leading: Newline, Space)
+7646: Ident           "intrinsic" at 632:6-632:15
+7647: At              "@" at 632:16-632:17 (leading: Space)
+7648: Ident           "overload" at 632:17-632:25
+7649: KwFn            "fn" at 632:26-632:28 (leading: Space)
+7650: Ident           "__to" at 632:29-632:33 (leading: Space)
+7651: LParen          "(" at 632:33-632:34
+7652: Ident           "self" at 632:34-632:38
+7653: Colon           ":" at 632:38-632:39
+7654: Ident           "float64" at 632:40-632:47 (leading: Space)
+7655: Comma           "," at 632:47-632:48
+7656: Ident           "target" at 632:49-632:55 (leading: Space)
+7657: Colon           ":" at 632:55-632:56
+7658: Ident           "float32" at 632:57-632:64 (leading: Space)
+7659: RParen          ")" at 632:64-632:65
+7660: Arrow           "->" at 632:66-632:68 (leading: Space)
+7661: Ident           "float32" at 632:69-632:76 (leading: Space)
+7662: Semicolon       ";" at 632:76-632:77
+7663: At              "@" at 633:5-633:6 (leading: Newline, Space)
+7664: Ident           "intrinsic" at 633:6-633:15
+7665: KwPub           "pub" at 633:16-633:19 (leading: Space)
+7666: KwFn            "fn" at 633:20-633:22 (leading: Space)
+7667: Ident           "from_str" at 633:23-633:31 (leading: Space)
+7668: LParen          "(" at 633:31-633:32
+7669: Ident           "s" at 633:32-633:33
+7670: Colon           ":" at 633:33-633:34
+7671: Amp             "&" at 633:35-633:36 (leading: Space)
+7672: Ident           "string" at 633:36-633:42
+7673: RParen          ")" at 633:42-633:43
+7674: Arrow           "->" at 633:44-633:46 (leading: Space)
+7675: Ident           "Erring" at 633:47-633:53 (leading: Space)
+7676: Lt              "<" at 633:53-633:54
+7677: Ident           "float64" at 633:54-633:61
+7678: Comma           "," at 633:61-633:62
+7679: Ident           "Error" at 633:63-633:68 (leading: Space)
+7680: Gt              ">" at 633:68-633:69
+7681: Semicolon       ";" at 633:69-633:70
+7682: RBrace          "}" at 634:1-634:2 (leading: Newline)
+7683: KwExtern        "extern" at 636:1-636:7 (leading: Newline)
+7684: Lt              "<" at 636:7-636:8
+7685: Ident           "float" at 636:8-636:13
+7686: Gt              ">" at 636:13-636:14
+7687: LBrace          "{" at 636:15-636:16 (leading: Space)
+7688: At              "@" at 637:5-637:6 (leading: Newline, Space)
+7689: Ident           "intrinsic" at 637:6-637:15
+7690: KwFn            "fn" at 637:16-637:18 (leading: Space)
+7691: Ident           "__add" at 637:19-637:24 (leading: Space)
+7692: LParen          "(" at 637:24-637:25
+7693: Ident           "self" at 637:25-637:29
+7694: Colon           ":" at 637:29-637:30
+7695: Ident           "float" at 637:31-637:36 (leading: Space)
+7696: Comma           "," at 637:36-637:37
+7697: Ident           "other" at 637:38-637:43 (leading: Space)
+7698: Colon           ":" at 637:43-637:44
+7699: Ident           "float" at 637:45-637:50 (leading: Space)
+7700: RParen          ")" at 637:50-637:51
+7701: Arrow           "->" at 637:52-637:54 (leading: Space)
+7702: Ident           "float" at 637:55-637:60 (leading: Space)
+7703: Semicolon       ";" at 637:60-637:61
+7704: At              "@" at 638:5-638:6 (leading: Newline, Space)
+7705: Ident           "intrinsic" at 638:6-638:15
+7706: KwFn            "fn" at 638:16-638:18 (leading: Space)
+7707: Ident           "__sub" at 638:19-638:24 (leading: Space)
+7708: LParen          "(" at 638:24-638:25
+7709: Ident           "self" at 638:25-638:29
+7710: Colon           ":" at 638:29-638:30
+7711: Ident           "float" at 638:31-638:36 (leading: Space)
+7712: Comma           "," at 638:36-638:37
+7713: Ident           "other" at 638:38-638:43 (leading: Space)
+7714: Colon           ":" at 638:43-638:44
+7715: Ident           "float" at 638:45-638:50 (leading: Space)
+7716: RParen          ")" at 638:50-638:51
+7717: Arrow           "->" at 638:52-638:54 (leading: Space)
+7718: Ident           "float" at 638:55-638:60 (leading: Space)
+7719: Semicolon       ";" at 638:60-638:61
+7720: At              "@" at 639:5-639:6 (leading: Newline, Space)
+7721: Ident           "intrinsic" at 639:6-639:15
+7722: KwFn            "fn" at 639:16-639:18 (leading: Space)
+7723: Ident           "__mul" at 639:19-639:24 (leading: Space)
+7724: LParen          "(" at 639:24-639:25
+7725: Ident           "self" at 639:25-639:29
+7726: Colon           ":" at 639:29-639:30
+7727: Ident           "float" at 639:31-639:36 (leading: Space)
+7728: Comma           "," at 639:36-639:37
+7729: Ident           "other" at 639:38-639:43 (leading: Space)
+7730: Colon           ":" at 639:43-639:44
+7731: Ident           "float" at 639:45-639:50 (leading: Space)
+7732: RParen          ")" at 639:50-639:51
+7733: Arrow           "->" at 639:52-639:54 (leading: Space)
+7734: Ident           "float" at 639:55-639:60 (leading: Space)
+7735: Semicolon       ";" at 639:60-639:61
+7736: At              "@" at 640:5-640:6 (leading: Newline, Space)
+7737: Ident           "intrinsic" at 640:6-640:15
+7738: KwFn            "fn" at 640:16-640:18 (leading: Space)
+7739: Ident           "__div" at 640:19-640:24 (leading: Space)
+7740: LParen          "(" at 640:24-640:25
+7741: Ident           "self" at 640:25-640:29
+7742: Colon           ":" at 640:29-640:30
+7743: Ident           "float" at 640:31-640:36 (leading: Space)
+7744: Comma           "," at 640:36-640:37
+7745: Ident           "other" at 640:38-640:43 (leading: Space)
+7746: Colon           ":" at 640:43-640:44
+7747: Ident           "float" at 640:45-640:50 (leading: Space)
+7748: RParen          ")" at 640:50-640:51
+7749: Arrow           "->" at 640:52-640:54 (leading: Space)
+7750: Ident           "float" at 640:55-640:60 (leading: Space)
+7751: Semicolon       ";" at 640:60-640:61
+7752: At              "@" at 641:5-641:6 (leading: Newline, Space)
+7753: Ident           "intrinsic" at 641:6-641:15
+7754: KwFn            "fn" at 641:16-641:18 (leading: Space)
+7755: Ident           "__mod" at 641:19-641:24 (leading: Space)
+7756: LParen          "(" at 641:24-641:25
+7757: Ident           "self" at 641:25-641:29
+7758: Colon           ":" at 641:29-641:30
+7759: Ident           "float" at 641:31-641:36 (leading: Space)
+7760: Comma           "," at 641:36-641:37
+7761: Ident           "other" at 641:38-641:43 (leading: Space)
+7762: Colon           ":" at 641:43-641:44
+7763: Ident           "float" at 641:45-641:50 (leading: Space)
+7764: RParen          ")" at 641:50-641:51
+7765: Arrow           "->" at 641:52-641:54 (leading: Space)
+7766: Ident           "float" at 641:55-641:60 (leading: Space)
+7767: Semicolon       ";" at 641:60-641:61
+7768: At              "@" at 642:5-642:6 (leading: Newline, Space)
+7769: Ident           "intrinsic" at 642:6-642:15
+7770: KwFn            "fn" at 642:16-642:18 (leading: Space)
+7771: Ident           "__lt" at 642:19-642:23 (leading: Space)
+7772: LParen          "(" at 642:23-642:24
+7773: Ident           "self" at 642:24-642:28
+7774: Colon           ":" at 642:28-642:29
+7775: Ident           "float" at 642:30-642:35 (leading: Space)
+7776: Comma           "," at 642:35-642:36
+7777: Ident           "other" at 642:37-642:42 (leading: Space)
+7778: Colon           ":" at 642:42-642:43
+7779: Ident           "float" at 642:44-642:49 (leading: Space)
+7780: RParen          ")" at 642:49-642:50
+7781: Arrow           "->" at 642:51-642:53 (leading: Space)
+7782: Ident           "bool" at 642:54-642:58 (leading: Space)
+7783: Semicolon       ";" at 642:58-642:59
+7784: At              "@" at 643:5-643:6 (leading: Newline, Space)
+7785: Ident           "intrinsic" at 643:6-643:15
+7786: KwFn            "fn" at 643:16-643:18 (leading: Space)
+7787: Ident           "__le" at 643:19-643:23 (leading: Space)
+7788: LParen          "(" at 643:23-643:24
+7789: Ident           "self" at 643:24-643:28
+7790: Colon           ":" at 643:28-643:29
+7791: Ident           "float" at 643:30-643:35 (leading: Space)
+7792: Comma           "," at 643:35-643:36
+7793: Ident           "other" at 643:37-643:42 (leading: Space)
+7794: Colon           ":" at 643:42-643:43
+7795: Ident           "float" at 643:44-643:49 (leading: Space)
+7796: RParen          ")" at 643:49-643:50
+7797: Arrow           "->" at 643:51-643:53 (leading: Space)
+7798: Ident           "bool" at 643:54-643:58 (leading: Space)
+7799: Semicolon       ";" at 643:58-643:59
+7800: At              "@" at 644:5-644:6 (leading: Newline, Space)
+7801: Ident           "intrinsic" at 644:6-644:15
+7802: KwFn            "fn" at 644:16-644:18 (leading: Space)
+7803: Ident           "__eq" at 644:19-644:23 (leading: Space)
+7804: LParen          "(" at 644:23-644:24
+7805: Ident           "self" at 644:24-644:28
+7806: Colon           ":" at 644:28-644:29
+7807: Ident           "float" at 644:30-644:35 (leading: Space)
+7808: Comma           "," at 644:35-644:36
+7809: Ident           "other" at 644:37-644:42 (leading: Space)
+7810: Colon           ":" at 644:42-644:43
+7811: Ident           "float" at 644:44-644:49 (leading: Space)
+7812: RParen          ")" at 644:49-644:50
+7813: Arrow           "->" at 644:51-644:53 (leading: Space)
+7814: Ident           "bool" at 644:54-644:58 (leading: Space)
+7815: Semicolon       ";" at 644:58-644:59
+7816: At              "@" at 645:5-645:6 (leading: Newline, Space)
+7817: Ident           "intrinsic" at 645:6-645:15
+7818: KwFn            "fn" at 645:16-645:18 (leading: Space)
+7819: Ident           "__ne" at 645:19-645:23 (leading: Space)
+7820: LParen          "(" at 645:23-645:24
+7821: Ident           "self" at 645:24-645:28
+7822: Colon           ":" at 645:28-645:29
+7823: Ident           "float" at 645:30-645:35 (leading: Space)
+7824: Comma           "," at 645:35-645:36
+7825: Ident           "other" at 645:37-645:42 (leading: Space)
+7826: Colon           ":" at 645:42-645:43
+7827: Ident           "float" at 645:44-645:49 (leading: Space)
+7828: RParen          ")" at 645:49-645:50
+7829: Arrow           "->" at 645:51-645:53 (leading: Space)
+7830: Ident           "bool" at 645:54-645:58 (leading: Space)
+7831: Semicolon       ";" at 645:58-645:59
+7832: At              "@" at 646:5-646:6 (leading: Newline, Space)
+7833: Ident           "intrinsic" at 646:6-646:15
+7834: KwFn            "fn" at 646:16-646:18 (leading: Space)
+7835: Ident           "__ge" at 646:19-646:23 (leading: Space)
+7836: LParen          "(" at 646:23-646:24
+7837: Ident           "self" at 646:24-646:28
+7838: Colon           ":" at 646:28-646:29
+7839: Ident           "float" at 646:30-646:35 (leading: Space)
+7840: Comma           "," at 646:35-646:36
+7841: Ident           "other" at 646:37-646:42 (leading: Space)
+7842: Colon           ":" at 646:42-646:43
+7843: Ident           "float" at 646:44-646:49 (leading: Space)
+7844: RParen          ")" at 646:49-646:50
+7845: Arrow           "->" at 646:51-646:53 (leading: Space)
+7846: Ident           "bool" at 646:54-646:58 (leading: Space)
+7847: Semicolon       ";" at 646:58-646:59
+7848: At              "@" at 647:5-647:6 (leading: Newline, Space)
+7849: Ident           "intrinsic" at 647:6-647:15
+7850: KwFn            "fn" at 647:16-647:18 (leading: Space)
+7851: Ident           "__gt" at 647:19-647:23 (leading: Space)
+7852: LParen          "(" at 647:23-647:24
+7853: Ident           "self" at 647:24-647:28
+7854: Colon           ":" at 647:28-647:29
+7855: Ident           "float" at 647:30-647:35 (leading: Space)
+7856: Comma           "," at 647:35-647:36
+7857: Ident           "other" at 647:37-647:42 (leading: Space)
+7858: Colon           ":" at 647:42-647:43
+7859: Ident           "float" at 647:44-647:49 (leading: Space)
+7860: RParen          ")" at 647:49-647:50
+7861: Arrow           "->" at 647:51-647:53 (leading: Space)
+7862: Ident           "bool" at 647:54-647:58 (leading: Space)
+7863: Semicolon       ";" at 647:58-647:59
+7864: At              "@" at 648:5-648:6 (leading: Newline, Space)
+7865: Ident           "intrinsic" at 648:6-648:15
+7866: KwFn            "fn" at 648:16-648:18 (leading: Space)
+7867: Ident           "__pos" at 648:19-648:24 (leading: Space)
+7868: LParen          "(" at 648:24-648:25
+7869: Ident           "self" at 648:25-648:29
+7870: Colon           ":" at 648:29-648:30
+7871: Ident           "float" at 648:31-648:36 (leading: Space)
+7872: RParen          ")" at 648:36-648:37
+7873: Arrow           "->" at 648:38-648:40 (leading: Space)
+7874: Ident           "float" at 648:41-648:46 (leading: Space)
+7875: Semicolon       ";" at 648:46-648:47
+7876: At              "@" at 649:5-649:6 (leading: Newline, Space)
+7877: Ident           "intrinsic" at 649:6-649:15
+7878: KwFn            "fn" at 649:16-649:18 (leading: Space)
+7879: Ident           "__neg" at 649:19-649:24 (leading: Space)
+7880: LParen          "(" at 649:24-649:25
+7881: Ident           "self" at 649:25-649:29
+7882: Colon           ":" at 649:29-649:30
+7883: Ident           "float" at 649:31-649:36 (leading: Space)
+7884: RParen          ")" at 649:36-649:37
+7885: Arrow           "->" at 649:38-649:40 (leading: Space)
+7886: Ident           "float" at 649:41-649:46 (leading: Space)
+7887: Semicolon       ";" at 649:46-649:47
+7888: At              "@" at 650:5-650:6 (leading: Newline, Space)
+7889: Ident           "intrinsic" at 650:6-650:15
+7890: KwFn            "fn" at 650:16-650:18 (leading: Space)
+7891: Ident           "__abs" at 650:19-650:24 (leading: Space)
+7892: LParen          "(" at 650:24-650:25
+7893: Ident           "self" at 650:25-650:29
+7894: Colon           ":" at 650:29-650:30
+7895: Ident           "float" at 650:31-650:36 (leading: Space)
+7896: RParen          ")" at 650:36-650:37
+7897: Arrow           "->" at 650:38-650:40 (leading: Space)
+7898: Ident           "float" at 650:41-650:46 (leading: Space)
+7899: Semicolon       ";" at 650:46-650:47
+7900: At              "@" at 651:5-651:6 (leading: Newline, Space)
+7901: Ident           "intrinsic" at 651:6-651:15
+7902: KwFn            "fn" at 651:16-651:18 (leading: Space)
+7903: Ident           "__to" at 651:19-651:23 (leading: Space)
+7904: LParen          "(" at 651:23-651:24
+7905: Ident           "self" at 651:24-651:28
+7906: Colon           ":" at 651:28-651:29
+7907: Ident           "float" at 651:30-651:35 (leading: Space)
+7908: Comma           "," at 651:35-651:36
+7909: Ident           "target" at 651:37-651:43 (leading: Space)
+7910: Colon           ":" at 651:43-651:44
+7911: Ident           "string" at 651:45-651:51 (leading: Space)
+7912: RParen          ")" at 651:51-651:52
+7913: Arrow           "->" at 651:53-651:55 (leading: Space)
+7914: Ident           "string" at 651:56-651:62 (leading: Space)
+7915: Semicolon       ";" at 651:62-651:63
+7916: At              "@" at 652:5-652:6 (leading: Newline, Space)
+7917: Ident           "overload" at 652:6-652:14
+7918: KwPub           "pub" at 652:15-652:18 (leading: Space)
+7919: KwFn            "fn" at 652:19-652:21 (leading: Space)
+7920: Ident           "__to" at 652:22-652:26 (leading: Space)
+7921: LParen          "(" at 652:26-652:27
+7922: Ident           "self" at 652:27-652:31
+7923: Colon           ":" at 652:31-652:32
+7924: Amp             "&" at 652:33-652:34 (leading: Space)
+7925: Ident           "float" at 652:34-652:39
+7926: Comma           "," at 652:39-652:40
+7927: Underscore      "_" at 652:41-652:42 (leading: Space)
+7928: Colon           ":" at 652:42-652:43
+7929: Ident           "string" at 652:44-652:50 (leading: Space)
+7930: RParen          ")" at 652:50-652:51
+7931: Arrow           "->" at 652:52-652:54 (leading: Space)
+7932: Ident           "string" at 652:55-652:61 (leading: Space)
+7933: LBrace          "{" at 652:62-652:63 (leading: Space)
+7934: KwReturn        "return" at 653:9-653:15 (leading: Newline, Space)
+7935: LParen          "(" at 653:16-653:17 (leading: Space)
+7936: Star            "*" at 653:17-653:18
+7937: Ident           "self" at 653:18-653:22
+7938: RParen          ")" at 653:22-653:23
+7939: KwTo            "to" at 653:24-653:26 (leading: Space)
+7940: Ident           "string" at 653:27-653:33 (leading: Space)
+7941: Semicolon       ";" at 653:33-653:34
+7942: RBrace          "}" at 654:5-654:6 (leading: Newline, Space)
+7943: At              "@" at 655:5-655:6 (leading: Newline, Space)
+7944: Ident           "intrinsic" at 655:6-655:15
+7945: At              "@" at 655:16-655:17 (leading: Space)
+7946: Ident           "overload" at 655:17-655:25
+7947: KwFn            "fn" at 655:26-655:28 (leading: Space)
+7948: Ident           "__to" at 655:29-655:33 (leading: Space)
+7949: LParen          "(" at 655:33-655:34
+7950: Ident           "self" at 655:34-655:38
+7951: Colon           ":" at 655:38-655:39
+7952: Ident           "float" at 655:40-655:45 (leading: Space)
+7953: Comma           "," at 655:45-655:46
+7954: Ident           "target" at 655:47-655:53 (leading: Space)
+7955: Colon           ":" at 655:53-655:54
+7956: Ident           "int" at 655:55-655:58 (leading: Space)
+7957: RParen          ")" at 655:58-655:59
+7958: Arrow           "->" at 655:60-655:62 (leading: Space)
+7959: Ident           "int" at 655:63-655:66 (leading: Space)
+7960: Semicolon       ";" at 655:66-655:67
+7961: At              "@" at 656:5-656:6 (leading: Newline, Space)
+7962: Ident           "intrinsic" at 656:6-656:15
+7963: At              "@" at 656:16-656:17 (leading: Space)
+7964: Ident           "overload" at 656:17-656:25
+7965: KwFn            "fn" at 656:26-656:28 (leading: Space)
+7966: Ident           "__to" at 656:29-656:33 (leading: Space)
+7967: LParen          "(" at 656:33-656:34
+7968: Ident           "self" at 656:34-656:38
+7969: Colon           ":" at 656:38-656:39
+7970: Ident           "float" at 656:40-656:45 (leading: Space)
+7971: Comma           "," at 656:45-656:46
+7972: Ident           "target" at 656:47-656:53 (leading: Space)
+7973: Colon           ":" at 656:53-656:54
+7974: Ident           "uint" at 656:55-656:59 (leading: Space)
+7975: RParen          ")" at 656:59-656:60
+7976: Arrow           "->" at 656:61-656:63 (leading: Space)
+7977: Ident           "uint" at 656:64-656:68 (leading: Space)
+7978: Semicolon       ";" at 656:68-656:69
+7979: At              "@" at 657:5-657:6 (leading: Newline, Space)
+7980: Ident           "intrinsic" at 657:6-657:15
+7981: At              "@" at 657:16-657:17 (leading: Space)
+7982: Ident           "overload" at 657:17-657:25
+7983: KwFn            "fn" at 657:26-657:28 (leading: Space)
+7984: Ident           "__to" at 657:29-657:33 (leading: Space)
+7985: LParen          "(" at 657:33-657:34
+7986: Ident           "self" at 657:34-657:38
+7987: Colon           ":" at 657:38-657:39
+7988: Ident           "float" at 657:40-657:45 (leading: Space)
+7989: Comma           "," at 657:45-657:46
+7990: Ident           "target" at 657:47-657:53 (leading: Space)
+7991: Colon           ":" at 657:53-657:54
+7992: Ident           "int8" at 657:55-657:59 (leading: Space)
+7993: RParen          ")" at 657:59-657:60
+7994: Arrow           "->" at 657:61-657:63 (leading: Space)
+7995: Ident           "int8" at 657:64-657:68 (leading: Space)
+7996: Semicolon       ";" at 657:68-657:69
+7997: At              "@" at 658:5-658:6 (leading: Newline, Space)
+7998: Ident           "intrinsic" at 658:6-658:15
+7999: At              "@" at 658:16-658:17 (leading: Space)
+8000: Ident           "overload" at 658:17-658:25
+8001: KwFn            "fn" at 658:26-658:28 (leading: Space)
+8002: Ident           "__to" at 658:29-658:33 (leading: Space)
+8003: LParen          "(" at 658:33-658:34
+8004: Ident           "self" at 658:34-658:38
+8005: Colon           ":" at 658:38-658:39
+8006: Ident           "float" at 658:40-658:45 (leading: Space)
+8007: Comma           "," at 658:45-658:46
+8008: Ident           "target" at 658:47-658:53 (leading: Space)
+8009: Colon           ":" at 658:53-658:54
+8010: Ident           "int16" at 658:55-658:60 (leading: Space)
+8011: RParen          ")" at 658:60-658:61
+8012: Arrow           "->" at 658:62-658:64 (leading: Space)
+8013: Ident           "int16" at 658:65-658:70 (leading: Space)
+8014: Semicolon       ";" at 658:70-658:71
+8015: At              "@" at 659:5-659:6 (leading: Newline, Space)
+8016: Ident           "intrinsic" at 659:6-659:15
+8017: At              "@" at 659:16-659:17 (leading: Space)
+8018: Ident           "overload" at 659:17-659:25
+8019: KwFn            "fn" at 659:26-659:28 (leading: Space)
+8020: Ident           "__to" at 659:29-659:33 (leading: Space)
+8021: LParen          "(" at 659:33-659:34
+8022: Ident           "self" at 659:34-659:38
+8023: Colon           ":" at 659:38-659:39
+8024: Ident           "float" at 659:40-659:45 (leading: Space)
+8025: Comma           "," at 659:45-659:46
+8026: Ident           "target" at 659:47-659:53 (leading: Space)
+8027: Colon           ":" at 659:53-659:54
+8028: Ident           "int32" at 659:55-659:60 (leading: Space)
+8029: RParen          ")" at 659:60-659:61
+8030: Arrow           "->" at 659:62-659:64 (leading: Space)
+8031: Ident           "int32" at 659:65-659:70 (leading: Space)
+8032: Semicolon       ";" at 659:70-659:71
+8033: At              "@" at 660:5-660:6 (leading: Newline, Space)
+8034: Ident           "intrinsic" at 660:6-660:15
+8035: At              "@" at 660:16-660:17 (leading: Space)
+8036: Ident           "overload" at 660:17-660:25
+8037: KwFn            "fn" at 660:26-660:28 (leading: Space)
+8038: Ident           "__to" at 660:29-660:33 (leading: Space)
+8039: LParen          "(" at 660:33-660:34
+8040: Ident           "self" at 660:34-660:38
+8041: Colon           ":" at 660:38-660:39
+8042: Ident           "float" at 660:40-660:45 (leading: Space)
+8043: Comma           "," at 660:45-660:46
+8044: Ident           "target" at 660:47-660:53 (leading: Space)
+8045: Colon           ":" at 660:53-660:54
+8046: Ident           "int64" at 660:55-660:60 (leading: Space)
+8047: RParen          ")" at 660:60-660:61
+8048: Arrow           "->" at 660:62-660:64 (leading: Space)
+8049: Ident           "int64" at 660:65-660:70 (leading: Space)
+8050: Semicolon       ";" at 660:70-660:71
+8051: At              "@" at 661:5-661:6 (leading: Newline, Space)
+8052: Ident           "intrinsic" at 661:6-661:15
+8053: At              "@" at 661:16-661:17 (leading: Space)
+8054: Ident           "overload" at 661:17-661:25
+8055: KwFn            "fn" at 661:26-661:28 (leading: Space)
+8056: Ident           "__to" at 661:29-661:33 (leading: Space)
+8057: LParen          "(" at 661:33-661:34
+8058: Ident           "self" at 661:34-661:38
+8059: Colon           ":" at 661:38-661:39
+8060: Ident           "float" at 661:40-661:45 (leading: Space)
+8061: Comma           "," at 661:45-661:46
+8062: Ident           "target" at 661:47-661:53 (leading: Space)
+8063: Colon           ":" at 661:53-661:54
+8064: Ident           "uint8" at 661:55-661:60 (leading: Space)
+8065: RParen          ")" at 661:60-661:61
+8066: Arrow           "->" at 661:62-661:64 (leading: Space)
+8067: Ident           "uint8" at 661:65-661:70 (leading: Space)
+8068: Semicolon       ";" at 661:70-661:71
+8069: At              "@" at 662:5-662:6 (leading: Newline, Space)
+8070: Ident           "intrinsic" at 662:6-662:15
+8071: At              "@" at 662:16-662:17 (leading: Space)
+8072: Ident           "overload" at 662:17-662:25
+8073: KwFn            "fn" at 662:26-662:28 (leading: Space)
+8074: Ident           "__to" at 662:29-662:33 (leading: Space)
+8075: LParen          "(" at 662:33-662:34
+8076: Ident           "self" at 662:34-662:38
+8077: Colon           ":" at 662:38-662:39
+8078: Ident           "float" at 662:40-662:45 (leading: Space)
+8079: Comma           "," at 662:45-662:46
+8080: Ident           "target" at 662:47-662:53 (leading: Space)
+8081: Colon           ":" at 662:53-662:54
+8082: Ident           "uint16" at 662:55-662:61 (leading: Space)
+8083: RParen          ")" at 662:61-662:62
+8084: Arrow           "->" at 662:63-662:65 (leading: Space)
+8085: Ident           "uint16" at 662:66-662:72 (leading: Space)
+8086: Semicolon       ";" at 662:72-662:73
+8087: At              "@" at 663:5-663:6 (leading: Newline, Space)
+8088: Ident           "intrinsic" at 663:6-663:15
+8089: At              "@" at 663:16-663:17 (leading: Space)
+8090: Ident           "overload" at 663:17-663:25
+8091: KwFn            "fn" at 663:26-663:28 (leading: Space)
+8092: Ident           "__to" at 663:29-663:33 (leading: Space)
+8093: LParen          "(" at 663:33-663:34
+8094: Ident           "self" at 663:34-663:38
+8095: Colon           ":" at 663:38-663:39
+8096: Ident           "float" at 663:40-663:45 (leading: Space)
+8097: Comma           "," at 663:45-663:46
+8098: Ident           "target" at 663:47-663:53 (leading: Space)
+8099: Colon           ":" at 663:53-663:54
+8100: Ident           "uint32" at 663:55-663:61 (leading: Space)
+8101: RParen          ")" at 663:61-663:62
+8102: Arrow           "->" at 663:63-663:65 (leading: Space)
+8103: Ident           "uint32" at 663:66-663:72 (leading: Space)
+8104: Semicolon       ";" at 663:72-663:73
+8105: At              "@" at 664:5-664:6 (leading: Newline, Space)
+8106: Ident           "intrinsic" at 664:6-664:15
+8107: At              "@" at 664:16-664:17 (leading: Space)
+8108: Ident           "overload" at 664:17-664:25
+8109: KwFn            "fn" at 664:26-664:28 (leading: Space)
+8110: Ident           "__to" at 664:29-664:33 (leading: Space)
+8111: LParen          "(" at 664:33-664:34
+8112: Ident           "self" at 664:34-664:38
+8113: Colon           ":" at 664:38-664:39
+8114: Ident           "float" at 664:40-664:45 (leading: Space)
+8115: Comma           "," at 664:45-664:46
+8116: Ident           "target" at 664:47-664:53 (leading: Space)
+8117: Colon           ":" at 664:53-664:54
+8118: Ident           "uint64" at 664:55-664:61 (leading: Space)
+8119: RParen          ")" at 664:61-664:62
+8120: Arrow           "->" at 664:63-664:65 (leading: Space)
+8121: Ident           "uint64" at 664:66-664:72 (leading: Space)
+8122: Semicolon       ";" at 664:72-664:73
+8123: At              "@" at 665:5-665:6 (leading: Newline, Space)
+8124: Ident           "intrinsic" at 665:6-665:15
+8125: At              "@" at 665:16-665:17 (leading: Space)
+8126: Ident           "overload" at 665:17-665:25
+8127: KwFn            "fn" at 665:26-665:28 (leading: Space)
+8128: Ident           "__to" at 665:29-665:33 (leading: Space)
+8129: LParen          "(" at 665:33-665:34
+8130: Ident           "self" at 665:34-665:38
+8131: Colon           ":" at 665:38-665:39
+8132: Ident           "float" at 665:40-665:45 (leading: Space)
+8133: Comma           "," at 665:45-665:46
+8134: Ident           "target" at 665:47-665:53 (leading: Space)
+8135: Colon           ":" at 665:53-665:54
+8136: Ident           "float16" at 665:55-665:62 (leading: Space)
+8137: RParen          ")" at 665:62-665:63
+8138: Arrow           "->" at 665:64-665:66 (leading: Space)
+8139: Ident           "float16" at 665:67-665:74 (leading: Space)
+8140: Semicolon       ";" at 665:74-665:75
+8141: At              "@" at 666:5-666:6 (leading: Newline, Space)
+8142: Ident           "intrinsic" at 666:6-666:15
+8143: At              "@" at 666:16-666:17 (leading: Space)
+8144: Ident           "overload" at 666:17-666:25
+8145: KwFn            "fn" at 666:26-666:28 (leading: Space)
+8146: Ident           "__to" at 666:29-666:33 (leading: Space)
+8147: LParen          "(" at 666:33-666:34
+8148: Ident           "self" at 666:34-666:38
+8149: Colon           ":" at 666:38-666:39
+8150: Ident           "float" at 666:40-666:45 (leading: Space)
+8151: Comma           "," at 666:45-666:46
+8152: Ident           "target" at 666:47-666:53 (leading: Space)
+8153: Colon           ":" at 666:53-666:54
+8154: Ident           "float32" at 666:55-666:62 (leading: Space)
+8155: RParen          ")" at 666:62-666:63
+8156: Arrow           "->" at 666:64-666:66 (leading: Space)
+8157: Ident           "float32" at 666:67-666:74 (leading: Space)
+8158: Semicolon       ";" at 666:74-666:75
+8159: At              "@" at 667:5-667:6 (leading: Newline, Space)
+8160: Ident           "intrinsic" at 667:6-667:15
+8161: At              "@" at 667:16-667:17 (leading: Space)
+8162: Ident           "overload" at 667:17-667:25
+8163: KwFn            "fn" at 667:26-667:28 (leading: Space)
+8164: Ident           "__to" at 667:29-667:33 (leading: Space)
+8165: LParen          "(" at 667:33-667:34
+8166: Ident           "self" at 667:34-667:38
+8167: Colon           ":" at 667:38-667:39
+8168: Ident           "float" at 667:40-667:45 (leading: Space)
+8169: Comma           "," at 667:45-667:46
+8170: Ident           "target" at 667:47-667:53 (leading: Space)
+8171: Colon           ":" at 667:53-667:54
+8172: Ident           "float64" at 667:55-667:62 (leading: Space)
+8173: RParen          ")" at 667:62-667:63
+8174: Arrow           "->" at 667:64-667:66 (leading: Space)
+8175: Ident           "float64" at 667:67-667:74 (leading: Space)
+8176: Semicolon       ";" at 667:74-667:75
+8177: At              "@" at 669:5-669:6 (leading: Newline, Space, LineComment, Newline, Space)
+8178: Ident           "intrinsic" at 669:6-669:15
+8179: KwPub           "pub" at 669:16-669:19 (leading: Space)
+8180: KwFn            "fn" at 669:20-669:22 (leading: Space)
+8181: Ident           "from_str" at 669:23-669:31 (leading: Space)
+8182: LParen          "(" at 669:31-669:32
+8183: Ident           "s" at 669:32-669:33
+8184: Colon           ":" at 669:33-669:34
+8185: Amp             "&" at 669:35-669:36 (leading: Space)
+8186: Ident           "string" at 669:36-669:42
+8187: RParen          ")" at 669:42-669:43
+8188: Arrow           "->" at 669:44-669:46 (leading: Space)
+8189: Ident           "Erring" at 669:47-669:53 (leading: Space)
+8190: Lt              "<" at 669:53-669:54
+8191: Ident           "float" at 669:54-669:59
+8192: Comma           "," at 669:59-669:60
+8193: Ident           "Error" at 669:61-669:66 (leading: Space)
+8194: Gt              ">" at 669:66-669:67
+8195: Semicolon       ";" at 669:67-669:68
+8196: RBrace          "}" at 670:1-670:2 (leading: Newline)
+8197: KwExtern        "extern" at 672:1-672:7 (leading: Newline)
+8198: Lt              "<" at 672:7-672:8
+8199: Ident           "string" at 672:8-672:14
+8200: Gt              ">" at 672:14-672:15
+8201: LBrace          "{" at 672:16-672:17 (leading: Space)
+8202: At              "@" at 673:5-673:6 (leading: Newline, Space)
+8203: Ident           "intrinsic" at 673:6-673:15
+8204: KwFn            "fn" at 673:16-673:18 (leading: Space)
+8205: Ident           "__add" at 673:19-673:24 (leading: Space)
+8206: LParen          "(" at 673:24-673:25
+8207: Ident           "self" at 673:25-673:29
+8208: Colon           ":" at 673:29-673:30
+8209: Amp             "&" at 673:31-673:32 (leading: Space)
+8210: Ident           "string" at 673:32-673:38
+8211: Comma           "," at 673:38-673:39
+8212: Ident           "other" at 673:40-673:45 (leading: Space)
+8213: Colon           ":" at 673:45-673:46
+8214: Amp             "&" at 673:47-673:48 (leading: Space)
+8215: Ident           "string" at 673:48-673:54
+8216: RParen          ")" at 673:54-673:55
+8217: Arrow           "->" at 673:56-673:58 (leading: Space)
+8218: Ident           "string" at 673:59-673:65 (leading: Space)
+8219: Semicolon       ";" at 673:65-673:66
+8220: At              "@" at 674:5-674:6 (leading: Newline, Space)
+8221: Ident           "intrinsic" at 674:6-674:15
+8222: KwFn            "fn" at 674:16-674:18 (leading: Space)
+8223: Ident           "__mul" at 674:19-674:24 (leading: Space)
+8224: LParen          "(" at 674:24-674:25
+8225: Ident           "self" at 674:25-674:29
+8226: Colon           ":" at 674:29-674:30
+8227: Amp             "&" at 674:31-674:32 (leading: Space)
+8228: Ident           "string" at 674:32-674:38
+8229: Comma           "," at 674:38-674:39
+8230: Ident           "other" at 674:40-674:45 (leading: Space)
+8231: Colon           ":" at 674:45-674:46
+8232: Ident           "int" at 674:47-674:50 (leading: Space)
+8233: RParen          ")" at 674:50-674:51
+8234: Arrow           "->" at 674:52-674:54 (leading: Space)
+8235: Ident           "string" at 674:55-674:61 (leading: Space)
+8236: Semicolon       ";" at 674:61-674:62
+8237: At              "@" at 675:5-675:6 (leading: Newline, Space)
+8238: Ident           "overload" at 675:6-675:14
+8239: KwPub           "pub" at 675:15-675:18 (leading: Space)
+8240: KwFn            "fn" at 675:19-675:21 (leading: Space)
+8241: Ident           "__mul" at 675:22-675:27 (leading: Space)
+8242: LParen          "(" at 675:27-675:28
+8243: Ident           "self" at 675:28-675:32
+8244: Colon           ":" at 675:32-675:33
+8245: Amp             "&" at 675:34-675:35 (leading: Space)
+8246: Ident           "string" at 675:35-675:41
+8247: Comma           "," at 675:41-675:42
+8248: Ident           "other" at 675:43-675:48 (leading: Space)
+8249: Colon           ":" at 675:48-675:49
+8250: Ident           "uint" at 675:50-675:54 (leading: Space)
+8251: RParen          ")" at 675:54-675:55
+8252: Arrow           "->" at 675:56-675:58 (leading: Space)
+8253: Ident           "string" at 675:59-675:65 (leading: Space)
+8254: LBrace          "{" at 675:66-675:67 (leading: Space)
+8255: KwReturn        "return" at 676:9-676:15 (leading: Newline, Space)
+8256: Ident           "self" at 676:16-676:20 (leading: Space)
+8257: Star            "*" at 676:21-676:22 (leading: Space)
+8258: LParen          "(" at 676:23-676:24 (leading: Space)
+8259: Ident           "other" at 676:24-676:29
+8260: KwTo            "to" at 676:30-676:32 (leading: Space)
+8261: Ident           "int" at 676:33-676:36 (leading: Space)
+8262: RParen          ")" at 676:36-676:37
+8263: Semicolon       ";" at 676:37-676:38
+8264: RBrace          "}" at 677:5-677:6 (leading: Newline, Space)
+8265: At              "@" at 678:5-678:6 (leading: Newline, Space)
+8266: Ident           "intrinsic" at 678:6-678:15
+8267: KwFn            "fn" at 678:16-678:18 (leading: Space)
+8268: Ident           "__eq" at 678:19-678:23 (leading: Space)
+8269: LParen          "(" at 678:23-678:24
+8270: Ident           "self" at 678:24-678:28
+8271: Colon           ":" at 678:28-678:29
+8272: Amp             "&" at 678:30-678:31 (leading: Space)
+8273: Ident           "string" at 678:31-678:37
+8274: Comma           "," at 678:37-678:38
+8275: Ident           "other" at 678:39-678:44 (leading: Space)
+8276: Colon           ":" at 678:44-678:45
+8277: Amp             "&" at 678:46-678:47 (leading: Space)
+8278: Ident           "string" at 678:47-678:53
+8279: RParen          ")" at 678:53-678:54
+8280: Arrow           "->" at 678:55-678:57 (leading: Space)
+8281: Ident           "bool" at 678:58-678:62 (leading: Space)
+8282: Semicolon       ";" at 678:62-678:63
+8283: At              "@" at 679:5-679:6 (leading: Newline, Space)
+8284: Ident           "intrinsic" at 679:6-679:15
+8285: KwFn            "fn" at 679:16-679:18 (leading: Space)
+8286: Ident           "__ne" at 679:19-679:23 (leading: Space)
+8287: LParen          "(" at 679:23-679:24
+8288: Ident           "self" at 679:24-679:28
+8289: Colon           ":" at 679:28-679:29
+8290: Amp             "&" at 679:30-679:31 (leading: Space)
+8291: Ident           "string" at 679:31-679:37
+8292: Comma           "," at 679:37-679:38
+8293: Ident           "other" at 679:39-679:44 (leading: Space)
+8294: Colon           ":" at 679:44-679:45
+8295: Amp             "&" at 679:46-679:47 (leading: Space)
+8296: Ident           "string" at 679:47-679:53
+8297: RParen          ")" at 679:53-679:54
+8298: Arrow           "->" at 679:55-679:57 (leading: Space)
+8299: Ident           "bool" at 679:58-679:62 (leading: Space)
+8300: Semicolon       ";" at 679:62-679:63
+8301: At              "@" at 680:5-680:6 (leading: Newline, Space)
+8302: Ident           "intrinsic" at 680:6-680:15
+8303: KwFn            "fn" at 680:16-680:18 (leading: Space)
+8304: Ident           "__to" at 680:19-680:23 (leading: Space)
+8305: LParen          "(" at 680:23-680:24
+8306: Ident           "self" at 680:24-680:28
+8307: Colon           ":" at 680:28-680:29
+8308: Amp             "&" at 680:30-680:31 (leading: Space)
+8309: Ident           "string" at 680:31-680:37
+8310: Comma           "," at 680:37-680:38
+8311: Ident           "target" at 680:39-680:45 (leading: Space)
+8312: Colon           ":" at 680:45-680:46
+8313: Ident           "int" at 680:47-680:50 (leading: Space)
+8314: RParen          ")" at 680:50-680:51
+8315: Arrow           "->" at 680:52-680:54 (leading: Space)
+8316: Ident           "int" at 680:55-680:58 (leading: Space)
+8317: Semicolon       ";" at 680:58-680:59
+8318: At              "@" at 681:5-681:6 (leading: Newline, Space)
+8319: Ident           "intrinsic" at 681:6-681:15
+8320: At              "@" at 681:16-681:17 (leading: Space)
+8321: Ident           "overload" at 681:17-681:25
+8322: KwFn            "fn" at 681:26-681:28 (leading: Space)
+8323: Ident           "__to" at 681:29-681:33 (leading: Space)
+8324: LParen          "(" at 681:33-681:34
+8325: Ident           "self" at 681:34-681:38
+8326: Colon           ":" at 681:38-681:39
+8327: Amp             "&" at 681:40-681:41 (leading: Space)
+8328: Ident           "string" at 681:41-681:47
+8329: Comma           "," at 681:47-681:48
+8330: Ident           "target" at 681:49-681:55 (leading: Space)
+8331: Colon           ":" at 681:55-681:56
+8332: Ident           "uint" at 681:57-681:61 (leading: Space)
+8333: RParen          ")" at 681:61-681:62
+8334: Arrow           "->" at 681:63-681:65 (leading: Space)
+8335: Ident           "uint" at 681:66-681:70 (leading: Space)
+8336: Semicolon       ";" at 681:70-681:71
+8337: At              "@" at 682:5-682:6 (leading: Newline, Space)
+8338: Ident           "intrinsic" at 682:6-682:15
+8339: At              "@" at 682:16-682:17 (leading: Space)
+8340: Ident           "overload" at 682:17-682:25
+8341: KwFn            "fn" at 682:26-682:28 (leading: Space)
+8342: Ident           "__to" at 682:29-682:33 (leading: Space)
+8343: LParen          "(" at 682:33-682:34
+8344: Ident           "self" at 682:34-682:38
+8345: Colon           ":" at 682:38-682:39
+8346: Amp             "&" at 682:40-682:41 (leading: Space)
+8347: Ident           "string" at 682:41-682:47
+8348: Comma           "," at 682:47-682:48
+8349: Ident           "target" at 682:49-682:55 (leading: Space)
+8350: Colon           ":" at 682:55-682:56
+8351: Ident           "float" at 682:57-682:62 (leading: Space)
+8352: RParen          ")" at 682:62-682:63
+8353: Arrow           "->" at 682:64-682:66 (leading: Space)
+8354: Ident           "float" at 682:67-682:72 (leading: Space)
+8355: Semicolon       ";" at 682:72-682:73
+8356: At              "@" at 683:5-683:6 (leading: Newline, Space)
+8357: Ident           "overload" at 683:6-683:14
+8358: KwPub           "pub" at 683:15-683:18 (leading: Space)
+8359: KwFn            "fn" at 683:19-683:21 (leading: Space)
+8360: Ident           "__to" at 683:22-683:26 (leading: Space)
+8361: LParen          "(" at 683:26-683:27
+8362: Ident           "self" at 683:27-683:31
+8363: Colon           ":" at 683:31-683:32
+8364: Amp             "&" at 683:33-683:34 (leading: Space)
+8365: Ident           "string" at 683:34-683:40
+8366: Comma           "," at 683:40-683:41
+8367: Underscore      "_" at 683:42-683:43 (leading: Space)
+8368: Colon           ":" at 683:43-683:44
+8369: Ident           "string" at 683:45-683:51 (leading: Space)
+8370: RParen          ")" at 683:51-683:52
+8371: Arrow           "->" at 683:53-683:55 (leading: Space)
+8372: Ident           "string" at 683:56-683:62 (leading: Space)
+8373: LBrace          "{" at 683:63-683:64 (leading: Space)
+8374: KwReturn        "return" at 684:9-684:15 (leading: Newline, Space)
+8375: Ident           "self" at 684:16-684:20 (leading: Space)
+8376: Dot             "." at 684:20-684:21
+8377: Ident           "__clone" at 684:21-684:28
+8378: LParen          "(" at 684:28-684:29
+8379: RParen          ")" at 684:29-684:30
+8380: Semicolon       ";" at 684:30-684:31
+8381: RBrace          "}" at 685:5-685:6 (leading: Newline, Space)
+8382: At              "@" at 686:5-686:6 (leading: Newline, Space)
+8383: Ident           "overload" at 686:6-686:14
+8384: KwPub           "pub" at 687:5-687:8 (leading: Newline, Space)
+8385: KwFn            "fn" at 687:9-687:11 (leading: Space)
+8386: Ident           "__to" at 687:12-687:16 (leading: Space)
+8387: LParen          "(" at 687:16-687:17
+8388: Ident           "self" at 687:17-687:21
+8389: Colon           ":" at 687:21-687:22
+8390: Amp             "&" at 687:23-687:24 (leading: Space)
+8391: Ident           "string" at 687:24-687:30
+8392: Comma           "," at 687:30-687:31
+8393: Underscore      "_" at 687:32-687:33 (leading: Space)
+8394: Colon           ":" at 687:33-687:34
+8395: Ident           "byte" at 687:35-687:39 (leading: Space)
+8396: LBracket        "[" at 687:39-687:40
+8397: RBracket        "]" at 687:40-687:41
+8398: RParen          ")" at 687:41-687:42
+8399: Arrow           "->" at 687:43-687:45 (leading: Space)
+8400: Ident           "byte" at 687:46-687:50 (leading: Space)
+8401: LBracket        "[" at 687:50-687:51
+8402: RBracket        "]" at 687:51-687:52
+8403: LBrace          "{" at 687:53-687:54 (leading: Space)
+8404: KwLet           "let" at 688:9-688:12 (leading: Newline, Space)
+8405: Ident           "view" at 688:13-688:17 (leading: Space)
+8406: Assign          "=" at 688:18-688:19 (leading: Space)
+8407: Ident           "self" at 688:20-688:24 (leading: Space)
+8408: Dot             "." at 688:24-688:25
+8409: Ident           "bytes" at 688:25-688:30
+8410: LParen          "(" at 688:30-688:31
+8411: RParen          ")" at 688:31-688:32
+8412: Semicolon       ";" at 688:32-688:33
+8413: KwLet           "let" at 689:9-689:12 (leading: Newline, Space)
+8414: Ident           "length" at 689:13-689:19 (leading: Space)
+8415: Colon           ":" at 689:19-689:20
+8416: Ident           "uint" at 689:21-689:25 (leading: Space)
+8417: Assign          "=" at 689:26-689:27 (leading: Space)
+8418: Ident           "view" at 689:28-689:32 (leading: Space)
+8419: Dot             "." at 689:32-689:33
+8420: Ident           "__len" at 689:33-689:38
+8421: LParen          "(" at 689:38-689:39
+8422: RParen          ")" at 689:39-689:40
+8423: Semicolon       ";" at 689:40-689:41
+8424: KwLet           "let" at 690:9-690:12 (leading: Newline, Space)
+8425: KwMut           "mut" at 690:13-690:16 (leading: Space)
+8426: Ident           "out" at 690:17-690:20 (leading: Space)
+8427: Colon           ":" at 690:20-690:21
+8428: Ident           "byte" at 690:22-690:26 (leading: Space)
+8429: LBracket        "[" at 690:26-690:27
+8430: RBracket        "]" at 690:27-690:28
+8431: Assign          "=" at 690:29-690:30 (leading: Space)
+8432: LBracket        "[" at 690:31-690:32 (leading: Space)
+8433: RBracket        "]" at 690:32-690:33
+8434: Semicolon       ";" at 690:33-690:34
+8435: Ident           "out" at 691:9-691:12 (leading: Newline, Space)
+8436: Dot             "." at 691:12-691:13
+8437: Ident           "reserve" at 691:13-691:20
+8438: LParen          "(" at 691:20-691:21
+8439: Ident           "length" at 691:21-691:27
+8440: RParen          ")" at 691:27-691:28
+8441: Semicolon       ";" at 691:28-691:29
+8442: KwLet           "let" at 692:9-692:12 (leading: Newline, Space)
+8443: Ident           "len_i" at 692:13-692:18 (leading: Space)
+8444: Colon           ":" at 692:18-692:19
+8445: Ident           "int" at 692:20-692:23 (leading: Space)
+8446: Assign          "=" at 692:24-692:25 (leading: Space)
+8447: Ident           "length" at 692:26-692:32 (leading: Space)
+8448: KwTo            "to" at 692:33-692:35 (leading: Space)
+8449: Ident           "int" at 692:36-692:39 (leading: Space)
+8450: Semicolon       ";" at 692:39-692:40
+8451: KwLet           "let" at 693:9-693:12 (leading: Newline, Space)
+8452: KwMut           "mut" at 693:13-693:16 (leading: Space)
+8453: Ident           "i" at 693:17-693:18 (leading: Space)
+8454: Colon           ":" at 693:18-693:19
+8455: Ident           "int" at 693:20-693:23 (leading: Space)
+8456: Assign          "=" at 693:24-693:25 (leading: Space)
+8457: IntLit          "0" at 693:26-693:27 (leading: Space)
+8458: Semicolon       ";" at 693:27-693:28
+8459: KwWhile         "while" at 694:9-694:14 (leading: Newline, Space)
+8460: Ident           "i" at 694:15-694:16 (leading: Space)
+8461: Lt              "<" at 694:17-694:18 (leading: Space)
+8462: Ident           "len_i" at 694:19-694:24 (leading: Space)
+8463: LBrace          "{" at 694:25-694:26 (leading: Space)
+8464: KwLet           "let" at 695:13-695:16 (leading: Newline, Space)
+8465: Ident           "b" at 695:17-695:18 (leading: Space)
+8466: Colon           ":" at 695:18-695:19
+8467: Ident           "byte" at 695:20-695:24 (leading: Space)
+8468: Assign          "=" at 695:25-695:26 (leading: Space)
+8469: Ident           "view" at 695:27-695:31 (leading: Space)
+8470: LBracket        "[" at 695:31-695:32
+8471: Ident           "i" at 695:32-695:33
+8472: RBracket        "]" at 695:33-695:34
+8473: Semicolon       ";" at 695:34-695:35
+8474: Ident           "out" at 696:13-696:16 (leading: Newline, Space)
+8475: Dot             "." at 696:16-696:17
+8476: Ident           "push" at 696:17-696:21
+8477: LParen          "(" at 696:21-696:22
+8478: Ident           "b" at 696:22-696:23
+8479: RParen          ")" at 696:23-696:24
+8480: Semicolon       ";" at 696:24-696:25
+8481: Ident           "i" at 697:13-697:14 (leading: Newline, Space)
+8482: Assign          "=" at 697:15-697:16 (leading: Space)
+8483: Ident           "i" at 697:17-697:18 (leading: Space)
+8484: Plus            "+" at 697:19-697:20 (leading: Space)
+8485: IntLit          "1" at 697:21-697:22 (leading: Space)
+8486: Semicolon       ";" at 697:22-697:23
+8487: RBrace          "}" at 698:9-698:10 (leading: Newline, Space)
+8488: KwReturn        "return" at 699:9-699:15 (leading: Newline, Space)
+8489: Ident           "out" at 699:16-699:19 (leading: Space)
+8490: Semicolon       ";" at 699:19-699:20
+8491: RBrace          "}" at 700:5-700:6 (leading: Newline, Space)
+8492: At              "@" at 701:5-701:6 (leading: Newline, Space)
+8493: Ident           "intrinsic" at 701:6-701:15
+8494: KwFn            "fn" at 701:16-701:18 (leading: Space)
+8495: Ident           "__len" at 701:19-701:24 (leading: Space)
+8496: LParen          "(" at 701:24-701:25
+8497: Ident           "self" at 701:25-701:29
+8498: Colon           ":" at 701:29-701:30
+8499: Amp             "&" at 701:31-701:32 (leading: Space)
+8500: Ident           "string" at 701:32-701:38
+8501: RParen          ")" at 701:38-701:39
+8502: Arrow           "->" at 701:40-701:42 (leading: Space)
+8503: Ident           "uint" at 701:43-701:47 (leading: Space)
+8504: Semicolon       ";" at 701:47-701:48
+8505: At              "@" at 702:5-702:6 (leading: Newline, Space)
+8506: Ident           "intrinsic" at 702:6-702:15
+8507: KwFn            "fn" at 702:16-702:18 (leading: Space)
+8508: Ident           "__clone" at 702:19-702:26 (leading: Space)
+8509: LParen          "(" at 702:26-702:27
+8510: Ident           "self" at 702:27-702:31
+8511: Colon           ":" at 702:31-702:32
+8512: Amp             "&" at 702:33-702:34 (leading: Space)
+8513: Ident           "string" at 702:34-702:40
+8514: RParen          ")" at 702:40-702:41
+8515: Arrow           "->" at 702:42-702:44 (leading: Space)
+8516: Ident           "string" at 702:45-702:51 (leading: Space)
+8517: Semicolon       ";" at 702:51-702:52
+8518: At              "@" at 703:5-703:6 (leading: Newline, Space)
+8519: Ident           "intrinsic" at 703:6-703:15
+8520: At              "@" at 703:16-703:17 (leading: Space)
+8521: Ident           "overload" at 703:17-703:25
+8522: KwFn            "fn" at 703:26-703:28 (leading: Space)
+8523: Ident           "__index" at 703:29-703:36 (leading: Space)
+8524: LParen          "(" at 703:36-703:37
+8525: Ident           "self" at 703:37-703:41
+8526: Colon           ":" at 703:41-703:42
+8527: Amp             "&" at 703:43-703:44 (leading: Space)
+8528: Ident           "string" at 703:44-703:50
+8529: Comma           "," at 703:50-703:51
+8530: Ident           "index" at 703:52-703:57 (leading: Space)
+8531: Colon           ":" at 703:57-703:58
+8532: Ident           "int" at 703:59-703:62 (leading: Space)
+8533: RParen          ")" at 703:62-703:63
+8534: Arrow           "->" at 703:64-703:66 (leading: Space)
+8535: Ident           "uint32" at 703:67-703:73 (leading: Space)
+8536: Semicolon       ";" at 703:73-703:74
+8537: At              "@" at 704:5-704:6 (leading: Newline, Space)
+8538: Ident           "intrinsic" at 704:6-704:15
+8539: At              "@" at 704:16-704:17 (leading: Space)
+8540: Ident           "overload" at 704:17-704:25
+8541: KwFn            "fn" at 704:26-704:28 (leading: Space)
+8542: Ident           "__index" at 704:29-704:36 (leading: Space)
+8543: LParen          "(" at 704:36-704:37
+8544: Ident           "self" at 704:37-704:41
+8545: Colon           ":" at 704:41-704:42
+8546: Amp             "&" at 704:43-704:44 (leading: Space)
+8547: Ident           "string" at 704:44-704:50
+8548: Comma           "," at 704:50-704:51
+8549: Ident           "index" at 704:52-704:57 (leading: Space)
+8550: Colon           ":" at 704:57-704:58
+8551: Ident           "Range" at 704:59-704:64 (leading: Space)
+8552: Lt              "<" at 704:64-704:65
+8553: Ident           "int" at 704:65-704:68
+8554: Gt              ">" at 704:68-704:69
+8555: RParen          ")" at 704:69-704:70
+8556: Arrow           "->" at 704:71-704:73 (leading: Space)
+8557: Ident           "string" at 704:74-704:80 (leading: Space)
+8558: Semicolon       ";" at 704:80-704:81
+8559: RBrace          "}" at 705:1-705:2 (leading: Newline)
+8560: At              "@" at 707:1-707:2 (leading: Newline)
+8561: Ident           "intrinsic" at 707:2-707:11
+8562: KwPub           "pub" at 708:1-708:4 (leading: Newline)
+8563: KwType          "type" at 708:5-708:9 (leading: Space)
+8564: Ident           "BytesView" at 708:10-708:19 (leading: Space)
+8565: Assign          "=" at 708:20-708:21 (leading: Space)
+8566: LBrace          "{" at 708:22-708:23 (leading: Space)
+8567: Ident           "owner" at 709:5-709:10 (leading: Newline, Space)
+8568: Colon           ":" at 709:10-709:11
+8569: Ident           "string" at 709:12-709:18 (leading: Space)
+8570: Comma           "," at 709:18-709:19
+8571: Ident           "ptr" at 710:5-710:8 (leading: Newline, Space)
+8572: Colon           ":" at 710:8-710:9
+8573: Star            "*" at 710:10-710:11 (leading: Space)
+8574: Ident           "byte" at 710:11-710:15
+8575: Comma           "," at 710:15-710:16
+8576: Ident           "len" at 711:5-711:8 (leading: Newline, Space)
+8577: Colon           ":" at 711:8-711:9
+8578: Ident           "uint" at 711:10-711:14 (leading: Space)
+8579: Comma           "," at 711:14-711:15
+8580: RBrace          "}" at 712:1-712:2 (leading: Newline)
+8581: Semicolon       ";" at 712:2-712:3
+8582: KwExtern        "extern" at 714:1-714:7 (leading: Newline)
+8583: Lt              "<" at 714:7-714:8
+8584: Ident           "BytesView" at 714:8-714:17
+8585: Gt              ">" at 714:17-714:18
+8586: LBrace          "{" at 714:19-714:20 (leading: Space)
+8587: At              "@" at 715:5-715:6 (leading: Newline, Space)
+8588: Ident           "intrinsic" at 715:6-715:15
+8589: KwFn            "fn" at 715:16-715:18 (leading: Space)
+8590: Ident           "__len" at 715:19-715:24 (leading: Space)
+8591: LParen          "(" at 715:24-715:25
+8592: Ident           "self" at 715:25-715:29
+8593: Colon           ":" at 715:29-715:30
+8594: Amp             "&" at 715:31-715:32 (leading: Space)
+8595: Ident           "BytesView" at 715:32-715:41
+8596: RParen          ")" at 715:41-715:42
+8597: Arrow           "->" at 715:43-715:45 (leading: Space)
+8598: Ident           "uint" at 715:46-715:50 (leading: Space)
+8599: Semicolon       ";" at 715:50-715:51
+8600: At              "@" at 716:5-716:6 (leading: Newline, Space)
+8601: Ident           "intrinsic" at 716:6-716:15
+8602: KwFn            "fn" at 716:16-716:18 (leading: Space)
+8603: Ident           "__index" at 716:19-716:26 (leading: Space)
+8604: LParen          "(" at 716:26-716:27
+8605: Ident           "self" at 716:27-716:31
+8606: Colon           ":" at 716:31-716:32
+8607: Amp             "&" at 716:33-716:34 (leading: Space)
+8608: Ident           "BytesView" at 716:34-716:43
+8609: Comma           "," at 716:43-716:44
+8610: Ident           "index" at 716:45-716:50 (leading: Space)
+8611: Colon           ":" at 716:50-716:51
+8612: Ident           "int" at 716:52-716:55 (leading: Space)
+8613: RParen          ")" at 716:55-716:56
+8614: Arrow           "->" at 716:57-716:59 (leading: Space)
+8615: Ident           "uint8" at 716:60-716:65 (leading: Space)
+8616: Semicolon       ";" at 716:65-716:66
+8617: RBrace          "}" at 717:1-717:2 (leading: Newline)
+8618: KwExtern        "extern" at 719:1-719:7 (leading: Newline)
+8619: Lt              "<" at 719:7-719:8
+8620: Ident           "bool" at 719:8-719:12
+8621: Gt              ">" at 719:12-719:13
+8622: LBrace          "{" at 719:14-719:15 (leading: Space)
+8623: At              "@" at 720:5-720:6 (leading: Newline, Space)
+8624: Ident           "intrinsic" at 720:6-720:15
+8625: KwFn            "fn" at 720:16-720:18 (leading: Space)
+8626: Ident           "__eq" at 720:19-720:23 (leading: Space)
+8627: LParen          "(" at 720:23-720:24
+8628: Ident           "self" at 720:24-720:28
+8629: Colon           ":" at 720:28-720:29
+8630: Ident           "bool" at 720:30-720:34 (leading: Space)
+8631: Comma           "," at 720:34-720:35
+8632: Ident           "other" at 720:36-720:41 (leading: Space)
+8633: Colon           ":" at 720:41-720:42
+8634: Ident           "bool" at 720:43-720:47 (leading: Space)
+8635: RParen          ")" at 720:47-720:48
+8636: Arrow           "->" at 720:49-720:51 (leading: Space)
+8637: Ident           "bool" at 720:52-720:56 (leading: Space)
+8638: Semicolon       ";" at 720:56-720:57
+8639: At              "@" at 721:5-721:6 (leading: Newline, Space)
+8640: Ident           "intrinsic" at 721:6-721:15
+8641: KwFn            "fn" at 721:16-721:18 (leading: Space)
+8642: Ident           "__ne" at 721:19-721:23 (leading: Space)
+8643: LParen          "(" at 721:23-721:24
+8644: Ident           "self" at 721:24-721:28
+8645: Colon           ":" at 721:28-721:29
+8646: Ident           "bool" at 721:30-721:34 (leading: Space)
+8647: Comma           "," at 721:34-721:35
+8648: Ident           "other" at 721:36-721:41 (leading: Space)
+8649: Colon           ":" at 721:41-721:42
+8650: Ident           "bool" at 721:43-721:47 (leading: Space)
+8651: RParen          ")" at 721:47-721:48
+8652: Arrow           "->" at 721:49-721:51 (leading: Space)
+8653: Ident           "bool" at 721:52-721:56 (leading: Space)
+8654: Semicolon       ";" at 721:56-721:57
+8655: At              "@" at 722:5-722:6 (leading: Newline, Space)
+8656: Ident           "intrinsic" at 722:6-722:15
+8657: KwFn            "fn" at 722:16-722:18 (leading: Space)
+8658: Ident           "__not" at 722:19-722:24 (leading: Space)
+8659: LParen          "(" at 722:24-722:25
+8660: Ident           "self" at 722:25-722:29
+8661: Colon           ":" at 722:29-722:30
+8662: Ident           "bool" at 722:31-722:35 (leading: Space)
+8663: RParen          ")" at 722:35-722:36
+8664: Arrow           "->" at 722:37-722:39 (leading: Space)
+8665: Ident           "bool" at 722:40-722:44 (leading: Space)
+8666: Semicolon       ";" at 722:44-722:45
+8667: At              "@" at 723:5-723:6 (leading: Newline, Space)
+8668: Ident           "intrinsic" at 723:6-723:15
+8669: KwFn            "fn" at 723:16-723:18 (leading: Space)
+8670: Ident           "__to" at 723:19-723:23 (leading: Space)
+8671: LParen          "(" at 723:23-723:24
+8672: Ident           "self" at 723:24-723:28
+8673: Colon           ":" at 723:28-723:29
+8674: Ident           "bool" at 723:30-723:34 (leading: Space)
+8675: Comma           "," at 723:34-723:35
+8676: Ident           "target" at 723:36-723:42 (leading: Space)
+8677: Colon           ":" at 723:42-723:43
+8678: Ident           "string" at 723:44-723:50 (leading: Space)
+8679: RParen          ")" at 723:50-723:51
+8680: Arrow           "->" at 723:52-723:54 (leading: Space)
+8681: Ident           "string" at 723:55-723:61 (leading: Space)
+8682: Semicolon       ";" at 723:61-723:62
+8683: At              "@" at 724:5-724:6 (leading: Newline, Space)
+8684: Ident           "overload" at 724:6-724:14
+8685: KwPub           "pub" at 724:15-724:18 (leading: Space)
+8686: KwFn            "fn" at 724:19-724:21 (leading: Space)
+8687: Ident           "__to" at 724:22-724:26 (leading: Space)
+8688: LParen          "(" at 724:26-724:27
+8689: Ident           "self" at 724:27-724:31
+8690: Colon           ":" at 724:31-724:32
+8691: Amp             "&" at 724:33-724:34 (leading: Space)
+8692: Ident           "bool" at 724:34-724:38
+8693: Comma           "," at 724:38-724:39
+8694: Underscore      "_" at 724:40-724:41 (leading: Space)
+8695: Colon           ":" at 724:41-724:42
+8696: Ident           "string" at 724:43-724:49 (leading: Space)
+8697: RParen          ")" at 724:49-724:50
+8698: Arrow           "->" at 724:51-724:53 (leading: Space)
+8699: Ident           "string" at 724:54-724:60 (leading: Space)
+8700: LBrace          "{" at 724:61-724:62 (leading: Space)
+8701: KwReturn        "return" at 725:9-725:15 (leading: Newline, Space)
+8702: LParen          "(" at 725:16-725:17 (leading: Space)
+8703: Star            "*" at 725:17-725:18
+8704: Ident           "self" at 725:18-725:22
+8705: RParen          ")" at 725:22-725:23
+8706: KwTo            "to" at 725:24-725:26 (leading: Space)
+8707: Ident           "string" at 725:27-725:33 (leading: Space)
+8708: Semicolon       ";" at 725:33-725:34
+8709: RBrace          "}" at 726:5-726:6 (leading: Newline, Space)
+8710: At              "@" at 727:5-727:6 (leading: Newline, Space)
+8711: Ident           "intrinsic" at 727:6-727:15
+8712: At              "@" at 727:16-727:17 (leading: Space)
+8713: Ident           "overload" at 727:17-727:25
+8714: KwFn            "fn" at 727:26-727:28 (leading: Space)
+8715: Ident           "__to" at 727:29-727:33 (leading: Space)
+8716: LParen          "(" at 727:33-727:34
+8717: Ident           "self" at 727:34-727:38
+8718: Colon           ":" at 727:38-727:39
+8719: Ident           "bool" at 727:40-727:44 (leading: Space)
+8720: Comma           "," at 727:44-727:45
+8721: Ident           "target" at 727:46-727:52 (leading: Space)
+8722: Colon           ":" at 727:52-727:53
+8723: Ident           "int" at 727:54-727:57 (leading: Space)
+8724: RParen          ")" at 727:57-727:58
+8725: Arrow           "->" at 727:59-727:61 (leading: Space)
+8726: Ident           "int" at 727:62-727:65 (leading: Space)
+8727: Semicolon       ";" at 727:65-727:66
+8728: At              "@" at 729:5-729:6 (leading: Newline, Space, LineComment, Newline, Space)
+8729: Ident           "intrinsic" at 729:6-729:15
+8730: KwPub           "pub" at 729:16-729:19 (leading: Space)
+8731: KwFn            "fn" at 729:20-729:22 (leading: Space)
+8732: Ident           "from_str" at 729:23-729:31 (leading: Space)
+8733: LParen          "(" at 729:31-729:32
+8734: Ident           "s" at 729:32-729:33
+8735: Colon           ":" at 729:33-729:34
+8736: Amp             "&" at 729:35-729:36 (leading: Space)
+8737: Ident           "string" at 729:36-729:42
+8738: RParen          ")" at 729:42-729:43
+8739: Arrow           "->" at 729:44-729:46 (leading: Space)
+8740: Ident           "Erring" at 729:47-729:53 (leading: Space)
+8741: Lt              "<" at 729:53-729:54
+8742: Ident           "bool" at 729:54-729:58
+8743: Comma           "," at 729:58-729:59
+8744: Ident           "Error" at 729:60-729:65 (leading: Space)
+8745: Gt              ">" at 729:65-729:66
+8746: Semicolon       ";" at 729:66-729:67
+8747: RBrace          "}" at 730:1-730:2 (leading: Newline)
+8748: KwExtern        "extern" at 732:1-732:7 (leading: Newline)
+8749: Lt              "<" at 732:7-732:8
+8750: Ident           "Array" at 732:8-732:13
+8751: Lt              "<" at 732:13-732:14
+8752: Ident           "T" at 732:14-732:15
+8753: Shr             ">>" at 732:15-732:17
+8754: LBrace          "{" at 732:18-732:19 (leading: Space)
+8755: At              "@" at 733:5-733:6 (leading: Newline, Space)
+8756: Ident           "intrinsic" at 733:6-733:15
+8757: KwFn            "fn" at 733:16-733:18 (leading: Space)
+8758: Ident           "__add" at 733:19-733:24 (leading: Space)
+8759: LParen          "(" at 733:24-733:25
+8760: Ident           "self" at 733:25-733:29
+8761: Colon           ":" at 733:29-733:30
+8762: Amp             "&" at 733:31-733:32 (leading: Space)
+8763: Ident           "Array" at 733:32-733:37
+8764: Lt              "<" at 733:37-733:38
+8765: Ident           "T" at 733:38-733:39
+8766: Gt              ">" at 733:39-733:40
+8767: Comma           "," at 733:40-733:41
+8768: Ident           "other" at 733:42-733:47 (leading: Space)
+8769: Colon           ":" at 733:47-733:48
+8770: Amp             "&" at 733:49-733:50 (leading: Space)
+8771: Ident           "Array" at 733:50-733:55
+8772: Lt              "<" at 733:55-733:56
+8773: Ident           "T" at 733:56-733:57
+8774: Gt              ">" at 733:57-733:58
+8775: RParen          ")" at 733:58-733:59
+8776: Arrow           "->" at 733:60-733:62 (leading: Space)
+8777: Ident           "Array" at 733:63-733:68 (leading: Space)
+8778: Lt              "<" at 733:68-733:69
+8779: Ident           "T" at 733:69-733:70
+8780: Gt              ">" at 733:70-733:71
+8781: Semicolon       ";" at 733:71-733:72
+8782: At              "@" at 734:5-734:6 (leading: Newline, Space)
+8783: Ident           "intrinsic" at 734:6-734:15
+8784: KwFn            "fn" at 734:16-734:18 (leading: Space)
+8785: Ident           "__index" at 734:19-734:26 (leading: Space)
+8786: LParen          "(" at 734:26-734:27
+8787: Ident           "self" at 734:27-734:31
+8788: Colon           ":" at 734:31-734:32
+8789: Amp             "&" at 734:33-734:34 (leading: Space)
+8790: Ident           "Array" at 734:34-734:39
+8791: Lt              "<" at 734:39-734:40
+8792: Ident           "T" at 734:40-734:41
+8793: Gt              ">" at 734:41-734:42
+8794: Comma           "," at 734:42-734:43
+8795: Ident           "index" at 734:44-734:49 (leading: Space)
+8796: Colon           ":" at 734:49-734:50
+8797: Ident           "int" at 734:51-734:54 (leading: Space)
+8798: RParen          ")" at 734:54-734:55
+8799: Arrow           "->" at 734:56-734:58 (leading: Space)
+8800: Amp             "&" at 734:59-734:60 (leading: Space)
+8801: Ident           "T" at 734:60-734:61
+8802: Semicolon       ";" at 734:61-734:62
 8803: At              "@" at 735:5-735:6 (leading: Newline, Space)
 8804: Ident           "intrinsic" at 735:6-735:15
-8805: KwFn            "fn" at 735:16-735:18 (leading: Space)
-8806: Ident           "__range" at 735:19-735:26 (leading: Space)
-8807: LParen          "(" at 735:26-735:27
-8808: Ident           "self" at 735:27-735:31
-8809: Colon           ":" at 735:31-735:32
-8810: Amp             "&" at 735:33-735:34 (leading: Space)
-8811: Ident           "Array" at 735:34-735:39
-8812: Lt              "<" at 735:39-735:40
-8813: Ident           "T" at 735:40-735:41
-8814: Gt              ">" at 735:41-735:42
-8815: RParen          ")" at 735:42-735:43
-8816: Arrow           "->" at 735:44-735:46 (leading: Space)
-8817: Ident           "Range" at 735:47-735:52 (leading: Space)
-8818: Lt              "<" at 735:52-735:53
-8819: Ident           "T" at 735:53-735:54
-8820: Gt              ">" at 735:54-735:55
-8821: Semicolon       ";" at 735:55-735:56
-8822: At              "@" at 736:5-736:6 (leading: Newline, Space)
-8823: Ident           "intrinsic" at 736:6-736:15
-8824: KwFn            "fn" at 736:16-736:18 (leading: Space)
-8825: Ident           "__len" at 736:19-736:24 (leading: Space)
-8826: LParen          "(" at 736:24-736:25
-8827: Ident           "self" at 736:25-736:29
-8828: Colon           ":" at 736:29-736:30
-8829: Amp             "&" at 736:31-736:32 (leading: Space)
-8830: Ident           "Array" at 736:32-736:37
-8831: Lt              "<" at 736:37-736:38
-8832: Ident           "T" at 736:38-736:39
-8833: Gt              ">" at 736:39-736:40
-8834: RParen          ")" at 736:40-736:41
-8835: Arrow           "->" at 736:42-736:44 (leading: Space)
-8836: Ident           "uint" at 736:45-736:49 (leading: Space)
-8837: Semicolon       ";" at 736:49-736:50
-8838: RBrace          "}" at 737:1-737:2 (leading: Newline)
-8839: KwExtern        "extern" at 739:1-739:7 (leading: Newline)
-8840: Lt              "<" at 739:7-739:8
-8841: Ident           "ArrayFixed" at 739:8-739:18
-8842: Lt              "<" at 739:18-739:19
-8843: Ident           "T" at 739:19-739:20
-8844: Comma           "," at 739:20-739:21
-8845: Ident           "N" at 739:22-739:23 (leading: Space)
-8846: Shr             ">>" at 739:23-739:25
-8847: LBrace          "{" at 739:26-739:27 (leading: Space)
-8848: At              "@" at 740:5-740:6 (leading: Newline, Space)
-8849: Ident           "intrinsic" at 740:6-740:15
-8850: KwFn            "fn" at 740:16-740:18 (leading: Space)
-8851: Ident           "__add" at 740:19-740:24 (leading: Space)
-8852: LParen          "(" at 740:24-740:25
-8853: Ident           "self" at 740:25-740:29
-8854: Colon           ":" at 740:29-740:30
-8855: Amp             "&" at 740:31-740:32 (leading: Space)
-8856: Ident           "ArrayFixed" at 740:32-740:42
-8857: Lt              "<" at 740:42-740:43
-8858: Ident           "T" at 740:43-740:44
-8859: Comma           "," at 740:44-740:45
-8860: Ident           "N" at 740:46-740:47 (leading: Space)
-8861: Gt              ">" at 740:47-740:48
-8862: Comma           "," at 740:48-740:49
-8863: Ident           "other" at 740:50-740:55 (leading: Space)
-8864: Colon           ":" at 740:55-740:56
-8865: Amp             "&" at 740:57-740:58 (leading: Space)
-8866: Ident           "ArrayFixed" at 740:58-740:68
-8867: Lt              "<" at 740:68-740:69
-8868: Ident           "T" at 740:69-740:70
-8869: Comma           "," at 740:70-740:71
-8870: Ident           "N" at 740:72-740:73 (leading: Space)
-8871: Gt              ">" at 740:73-740:74
-8872: RParen          ")" at 740:74-740:75
-8873: Arrow           "->" at 740:76-740:78 (leading: Space)
-8874: Ident           "ArrayFixed" at 740:79-740:89 (leading: Space)
-8875: Lt              "<" at 740:89-740:90
-8876: Ident           "T" at 740:90-740:91
-8877: Comma           "," at 740:91-740:92
-8878: Ident           "N" at 740:93-740:94 (leading: Space)
-8879: Gt              ">" at 740:94-740:95
-8880: Semicolon       ";" at 740:95-740:96
-8881: At              "@" at 741:5-741:6 (leading: Newline, Space)
-8882: Ident           "intrinsic" at 741:6-741:15
-8883: KwFn            "fn" at 741:16-741:18 (leading: Space)
-8884: Ident           "__index" at 741:19-741:26 (leading: Space)
-8885: LParen          "(" at 741:26-741:27
-8886: Ident           "self" at 741:27-741:31
-8887: Colon           ":" at 741:31-741:32
-8888: Amp             "&" at 741:33-741:34 (leading: Space)
-8889: Ident           "ArrayFixed" at 741:34-741:44
-8890: Lt              "<" at 741:44-741:45
-8891: Ident           "T" at 741:45-741:46
-8892: Comma           "," at 741:46-741:47
-8893: Ident           "N" at 741:48-741:49 (leading: Space)
-8894: Gt              ">" at 741:49-741:50
-8895: Comma           "," at 741:50-741:51
-8896: Ident           "index" at 741:52-741:57 (leading: Space)
-8897: Colon           ":" at 741:57-741:58
-8898: Ident           "int" at 741:59-741:62 (leading: Space)
-8899: RParen          ")" at 741:62-741:63
-8900: Arrow           "->" at 741:64-741:66 (leading: Space)
-8901: Amp             "&" at 741:67-741:68 (leading: Space)
-8902: Ident           "T" at 741:68-741:69
-8903: Semicolon       ";" at 741:69-741:70
-8904: At              "@" at 742:5-742:6 (leading: Newline, Space)
-8905: Ident           "intrinsic" at 742:6-742:15
-8906: At              "@" at 742:16-742:17 (leading: Space)
-8907: Ident           "overload" at 742:17-742:25
-8908: KwFn            "fn" at 742:26-742:28 (leading: Space)
-8909: Ident           "__index" at 742:29-742:36 (leading: Space)
-8910: LParen          "(" at 742:36-742:37
-8911: Ident           "self" at 742:37-742:41
-8912: Colon           ":" at 742:41-742:42
-8913: Amp             "&" at 742:43-742:44 (leading: Space)
-8914: Ident           "ArrayFixed" at 742:44-742:54
-8915: Lt              "<" at 742:54-742:55
-8916: Ident           "T" at 742:55-742:56
-8917: Comma           "," at 742:56-742:57
-8918: Ident           "N" at 742:58-742:59 (leading: Space)
-8919: Gt              ">" at 742:59-742:60
-8920: Comma           "," at 742:60-742:61
-8921: Ident           "index" at 742:62-742:67 (leading: Space)
-8922: Colon           ":" at 742:67-742:68
-8923: Ident           "Range" at 742:69-742:74 (leading: Space)
-8924: Lt              "<" at 742:74-742:75
-8925: Ident           "int" at 742:75-742:78
-8926: Gt              ">" at 742:78-742:79
-8927: RParen          ")" at 742:79-742:80
-8928: Arrow           "->" at 742:81-742:83 (leading: Space)
-8929: Ident           "Array" at 742:84-742:89 (leading: Space)
-8930: Lt              "<" at 742:89-742:90
-8931: Ident           "T" at 742:90-742:91
-8932: Gt              ">" at 742:91-742:92
-8933: Semicolon       ";" at 742:92-742:93
+8805: At              "@" at 735:16-735:17 (leading: Space)
+8806: Ident           "overload" at 735:17-735:25
+8807: KwFn            "fn" at 735:26-735:28 (leading: Space)
+8808: Ident           "__index" at 735:29-735:36 (leading: Space)
+8809: LParen          "(" at 735:36-735:37
+8810: Ident           "self" at 735:37-735:41
+8811: Colon           ":" at 735:41-735:42
+8812: Amp             "&" at 735:43-735:44 (leading: Space)
+8813: Ident           "Array" at 735:44-735:49
+8814: Lt              "<" at 735:49-735:50
+8815: Ident           "T" at 735:50-735:51
+8816: Gt              ">" at 735:51-735:52
+8817: Comma           "," at 735:52-735:53
+8818: Ident           "index" at 735:54-735:59 (leading: Space)
+8819: Colon           ":" at 735:59-735:60
+8820: Ident           "Range" at 735:61-735:66 (leading: Space)
+8821: Lt              "<" at 735:66-735:67
+8822: Ident           "int" at 735:67-735:70
+8823: Gt              ">" at 735:70-735:71
+8824: RParen          ")" at 735:71-735:72
+8825: Arrow           "->" at 735:73-735:75 (leading: Space)
+8826: Ident           "Array" at 735:76-735:81 (leading: Space)
+8827: Lt              "<" at 735:81-735:82
+8828: Ident           "T" at 735:82-735:83
+8829: Gt              ">" at 735:83-735:84
+8830: Semicolon       ";" at 735:84-735:85
+8831: At              "@" at 736:5-736:6 (leading: Newline, Space)
+8832: Ident           "intrinsic" at 736:6-736:15
+8833: KwFn            "fn" at 736:16-736:18 (leading: Space)
+8834: Ident           "__index_set" at 736:19-736:30 (leading: Space)
+8835: LParen          "(" at 736:30-736:31
+8836: Ident           "self" at 736:31-736:35
+8837: Colon           ":" at 736:35-736:36
+8838: Amp             "&" at 736:37-736:38 (leading: Space)
+8839: KwMut           "mut" at 736:38-736:41
+8840: Ident           "Array" at 736:42-736:47 (leading: Space)
+8841: Lt              "<" at 736:47-736:48
+8842: Ident           "T" at 736:48-736:49
+8843: Gt              ">" at 736:49-736:50
+8844: Comma           "," at 736:50-736:51
+8845: Ident           "index" at 736:52-736:57 (leading: Space)
+8846: Colon           ":" at 736:57-736:58
+8847: Ident           "int" at 736:59-736:62 (leading: Space)
+8848: Comma           "," at 736:62-736:63
+8849: Ident           "value" at 736:64-736:69 (leading: Space)
+8850: Colon           ":" at 736:69-736:70
+8851: Ident           "T" at 736:71-736:72 (leading: Space)
+8852: RParen          ")" at 736:72-736:73
+8853: Arrow           "->" at 736:74-736:76 (leading: Space)
+8854: NothingLit      "nothing" at 736:77-736:84 (leading: Space)
+8855: Semicolon       ";" at 736:84-736:85
+8856: At              "@" at 737:5-737:6 (leading: Newline, Space)
+8857: Ident           "intrinsic" at 737:6-737:15
+8858: KwFn            "fn" at 737:16-737:18 (leading: Space)
+8859: Ident           "__range" at 737:19-737:26 (leading: Space)
+8860: LParen          "(" at 737:26-737:27
+8861: Ident           "self" at 737:27-737:31
+8862: Colon           ":" at 737:31-737:32
+8863: Amp             "&" at 737:33-737:34 (leading: Space)
+8864: Ident           "Array" at 737:34-737:39
+8865: Lt              "<" at 737:39-737:40
+8866: Ident           "T" at 737:40-737:41
+8867: Gt              ">" at 737:41-737:42
+8868: RParen          ")" at 737:42-737:43
+8869: Arrow           "->" at 737:44-737:46 (leading: Space)
+8870: Ident           "Range" at 737:47-737:52 (leading: Space)
+8871: Lt              "<" at 737:52-737:53
+8872: Ident           "T" at 737:53-737:54
+8873: Gt              ">" at 737:54-737:55
+8874: Semicolon       ";" at 737:55-737:56
+8875: At              "@" at 738:5-738:6 (leading: Newline, Space)
+8876: Ident           "intrinsic" at 738:6-738:15
+8877: KwFn            "fn" at 738:16-738:18 (leading: Space)
+8878: Ident           "__len" at 738:19-738:24 (leading: Space)
+8879: LParen          "(" at 738:24-738:25
+8880: Ident           "self" at 738:25-738:29
+8881: Colon           ":" at 738:29-738:30
+8882: Amp             "&" at 738:31-738:32 (leading: Space)
+8883: Ident           "Array" at 738:32-738:37
+8884: Lt              "<" at 738:37-738:38
+8885: Ident           "T" at 738:38-738:39
+8886: Gt              ">" at 738:39-738:40
+8887: RParen          ")" at 738:40-738:41
+8888: Arrow           "->" at 738:42-738:44 (leading: Space)
+8889: Ident           "uint" at 738:45-738:49 (leading: Space)
+8890: Semicolon       ";" at 738:49-738:50
+8891: RBrace          "}" at 739:1-739:2 (leading: Newline)
+8892: KwExtern        "extern" at 741:1-741:7 (leading: Newline)
+8893: Lt              "<" at 741:7-741:8
+8894: Ident           "ArrayFixed" at 741:8-741:18
+8895: Lt              "<" at 741:18-741:19
+8896: Ident           "T" at 741:19-741:20
+8897: Comma           "," at 741:20-741:21
+8898: Ident           "N" at 741:22-741:23 (leading: Space)
+8899: Shr             ">>" at 741:23-741:25
+8900: LBrace          "{" at 741:26-741:27 (leading: Space)
+8901: At              "@" at 742:5-742:6 (leading: Newline, Space)
+8902: Ident           "intrinsic" at 742:6-742:15
+8903: KwFn            "fn" at 742:16-742:18 (leading: Space)
+8904: Ident           "__add" at 742:19-742:24 (leading: Space)
+8905: LParen          "(" at 742:24-742:25
+8906: Ident           "self" at 742:25-742:29
+8907: Colon           ":" at 742:29-742:30
+8908: Amp             "&" at 742:31-742:32 (leading: Space)
+8909: Ident           "ArrayFixed" at 742:32-742:42
+8910: Lt              "<" at 742:42-742:43
+8911: Ident           "T" at 742:43-742:44
+8912: Comma           "," at 742:44-742:45
+8913: Ident           "N" at 742:46-742:47 (leading: Space)
+8914: Gt              ">" at 742:47-742:48
+8915: Comma           "," at 742:48-742:49
+8916: Ident           "other" at 742:50-742:55 (leading: Space)
+8917: Colon           ":" at 742:55-742:56
+8918: Amp             "&" at 742:57-742:58 (leading: Space)
+8919: Ident           "ArrayFixed" at 742:58-742:68
+8920: Lt              "<" at 742:68-742:69
+8921: Ident           "T" at 742:69-742:70
+8922: Comma           "," at 742:70-742:71
+8923: Ident           "N" at 742:72-742:73 (leading: Space)
+8924: Gt              ">" at 742:73-742:74
+8925: RParen          ")" at 742:74-742:75
+8926: Arrow           "->" at 742:76-742:78 (leading: Space)
+8927: Ident           "ArrayFixed" at 742:79-742:89 (leading: Space)
+8928: Lt              "<" at 742:89-742:90
+8929: Ident           "T" at 742:90-742:91
+8930: Comma           "," at 742:91-742:92
+8931: Ident           "N" at 742:93-742:94 (leading: Space)
+8932: Gt              ">" at 742:94-742:95
+8933: Semicolon       ";" at 742:95-742:96
 8934: At              "@" at 743:5-743:6 (leading: Newline, Space)
 8935: Ident           "intrinsic" at 743:6-743:15
 8936: KwFn            "fn" at 743:16-743:18 (leading: Space)
-8937: Ident           "__index_set" at 743:19-743:30 (leading: Space)
-8938: LParen          "(" at 743:30-743:31
-8939: Ident           "self" at 743:31-743:35
-8940: Colon           ":" at 743:35-743:36
-8941: Amp             "&" at 743:37-743:38 (leading: Space)
-8942: KwMut           "mut" at 743:38-743:41
-8943: Ident           "ArrayFixed" at 743:42-743:52 (leading: Space)
-8944: Lt              "<" at 743:52-743:53
-8945: Ident           "T" at 743:53-743:54
-8946: Comma           "," at 743:54-743:55
-8947: Ident           "N" at 743:56-743:57 (leading: Space)
-8948: Gt              ">" at 743:57-743:58
-8949: Comma           "," at 743:58-743:59
-8950: Ident           "index" at 743:60-743:65 (leading: Space)
-8951: Colon           ":" at 743:65-743:66
-8952: Ident           "int" at 743:67-743:70 (leading: Space)
-8953: Comma           "," at 743:70-743:71
-8954: Ident           "value" at 743:72-743:77 (leading: Space)
-8955: Colon           ":" at 743:77-743:78
-8956: Ident           "T" at 743:79-743:80 (leading: Space)
-8957: RParen          ")" at 743:80-743:81
-8958: Arrow           "->" at 743:82-743:84 (leading: Space)
-8959: NothingLit      "nothing" at 743:85-743:92 (leading: Space)
-8960: Semicolon       ";" at 743:92-743:93
-8961: At              "@" at 744:5-744:6 (leading: Newline, Space)
-8962: Ident           "intrinsic" at 744:6-744:15
-8963: KwFn            "fn" at 744:16-744:18 (leading: Space)
-8964: Ident           "__range" at 744:19-744:26 (leading: Space)
-8965: LParen          "(" at 744:26-744:27
-8966: Ident           "self" at 744:27-744:31
-8967: Colon           ":" at 744:31-744:32
-8968: Amp             "&" at 744:33-744:34 (leading: Space)
-8969: Ident           "ArrayFixed" at 744:34-744:44
-8970: Lt              "<" at 744:44-744:45
-8971: Ident           "T" at 744:45-744:46
-8972: Comma           "," at 744:46-744:47
-8973: Ident           "N" at 744:48-744:49 (leading: Space)
-8974: Gt              ">" at 744:49-744:50
-8975: RParen          ")" at 744:50-744:51
-8976: Arrow           "->" at 744:52-744:54 (leading: Space)
-8977: Ident           "Range" at 744:55-744:60 (leading: Space)
-8978: Lt              "<" at 744:60-744:61
-8979: Ident           "T" at 744:61-744:62
-8980: Gt              ">" at 744:62-744:63
-8981: Semicolon       ";" at 744:63-744:64
-8982: At              "@" at 745:5-745:6 (leading: Newline, Space)
-8983: Ident           "intrinsic" at 745:6-745:15
-8984: KwFn            "fn" at 745:16-745:18 (leading: Space)
-8985: Ident           "__len" at 745:19-745:24 (leading: Space)
-8986: LParen          "(" at 745:24-745:25
-8987: Ident           "self" at 745:25-745:29
-8988: Colon           ":" at 745:29-745:30
-8989: Amp             "&" at 745:31-745:32 (leading: Space)
-8990: Ident           "ArrayFixed" at 745:32-745:42
-8991: Lt              "<" at 745:42-745:43
-8992: Ident           "T" at 745:43-745:44
-8993: Comma           "," at 745:44-745:45
-8994: Ident           "N" at 745:46-745:47 (leading: Space)
-8995: Gt              ">" at 745:47-745:48
-8996: RParen          ")" at 745:48-745:49
-8997: Arrow           "->" at 745:50-745:52 (leading: Space)
-8998: Ident           "uint" at 745:53-745:57 (leading: Space)
-8999: Semicolon       ";" at 745:57-745:58
-9000: RBrace          "}" at 746:1-746:2 (leading: Newline)
-9001: At              "@" at 748:1-748:2 (leading: Newline)
-9002: Ident           "intrinsic" at 748:2-748:11
-9003: KwPub           "pub" at 749:1-749:4 (leading: Newline)
-9004: KwFn            "fn" at 749:5-749:7 (leading: Space)
-9005: Ident           "default" at 749:8-749:15 (leading: Space)
-9006: Lt              "<" at 749:15-749:16
-9007: Ident           "T" at 749:16-749:17
-9008: Gt              ">" at 749:17-749:18
-9009: LParen          "(" at 749:18-749:19
-9010: RParen          ")" at 749:19-749:20
-9011: Arrow           "->" at 749:21-749:23 (leading: Space)
-9012: Ident           "T" at 749:24-749:25 (leading: Space)
-9013: Semicolon       ";" at 749:25-749:26
-9014: At              "@" at 751:1-751:2 (leading: Newline)
-9015: Ident           "intrinsic" at 751:2-751:11
-9016: KwPub           "pub" at 752:1-752:4 (leading: Newline)
-9017: KwFn            "fn" at 752:5-752:7 (leading: Space)
-9018: Ident           "size_of" at 752:8-752:15 (leading: Space)
-9019: Lt              "<" at 752:15-752:16
-9020: Ident           "T" at 752:16-752:17
-9021: Gt              ">" at 752:17-752:18
-9022: LParen          "(" at 752:18-752:19
-9023: RParen          ")" at 752:19-752:20
-9024: Arrow           "->" at 752:21-752:23 (leading: Space)
-9025: Ident           "uint" at 752:24-752:28 (leading: Space)
-9026: Semicolon       ";" at 752:28-752:29
-9027: At              "@" at 754:1-754:2 (leading: Newline)
-9028: Ident           "intrinsic" at 754:2-754:11
-9029: KwPub           "pub" at 755:1-755:4 (leading: Newline)
-9030: KwFn            "fn" at 755:5-755:7 (leading: Space)
-9031: Ident           "align_of" at 755:8-755:16 (leading: Space)
-9032: Lt              "<" at 755:16-755:17
-9033: Ident           "T" at 755:17-755:18
-9034: Gt              ">" at 755:18-755:19
-9035: LParen          "(" at 755:19-755:20
-9036: RParen          ")" at 755:20-755:21
-9037: Arrow           "->" at 755:22-755:24 (leading: Space)
-9038: Ident           "uint" at 755:25-755:29 (leading: Space)
-9039: Semicolon       ";" at 755:29-755:30
-9040: KwPub           "pub" at 757:1-757:4 (leading: Newline)
-9041: KwContract      "contract" at 757:5-757:13 (leading: Space)
-9042: Ident           "ErrorLike" at 757:14-757:23 (leading: Space)
-9043: LBrace          "{" at 757:23-757:24
-9044: KwField         "field" at 758:5-758:10 (leading: Newline, Space)
-9045: Ident           "message" at 758:11-758:18 (leading: Space)
-9046: Colon           ":" at 758:18-758:19
-9047: Ident           "string" at 758:20-758:26 (leading: Space)
-9048: Semicolon       ";" at 758:26-758:27
-9049: KwField         "field" at 759:5-759:10 (leading: Newline, Space)
-9050: Ident           "code" at 759:11-759:15 (leading: Space)
-9051: Colon           ":" at 759:15-759:16
-9052: Ident           "uint" at 759:17-759:21 (leading: Space)
-9053: Semicolon       ";" at 759:21-759:22
-9054: RBrace          "}" at 760:1-760:2 (leading: Newline)
-9055: At              "@" at 762:1-762:2 (leading: Newline)
-9056: Ident           "intrinsic" at 762:2-762:11
-9057: KwPub           "pub" at 763:1-763:4 (leading: Newline)
-9058: KwFn            "fn" at 763:5-763:7 (leading: Space)
-9059: Ident           "exit" at 763:8-763:12 (leading: Space)
-9060: Lt              "<" at 763:12-763:13
-9061: Ident           "E" at 763:13-763:14
-9062: Colon           ":" at 763:14-763:15
-9063: Ident           "ErrorLike" at 763:16-763:25 (leading: Space)
-9064: Gt              ">" at 763:25-763:26
-9065: LParen          "(" at 763:26-763:27
-9066: Ident           "e" at 763:27-763:28
-9067: Colon           ":" at 763:28-763:29
-9068: Ident           "E" at 763:30-763:31 (leading: Space)
-9069: RParen          ")" at 763:31-763:32
-9070: Arrow           "->" at 763:33-763:35 (leading: Space)
-9071: NothingLit      "nothing" at 763:36-763:43 (leading: Space)
-9072: Semicolon       ";" at 763:43-763:44
-9073: At              "@" at 765:1-765:2 (leading: Newline)
-9074: Ident           "intrinsic" at 765:2-765:11
-9075: KwPub           "pub" at 766:1-766:4 (leading: Newline)
-9076: KwFn            "fn" at 766:5-766:7 (leading: Space)
-9077: Ident           "rt_panic" at 766:8-766:16 (leading: Space)
-9078: LParen          "(" at 766:16-766:17
-9079: Ident           "ptr" at 766:17-766:20
-9080: Colon           ":" at 766:20-766:21
-9081: Star            "*" at 766:22-766:23 (leading: Space)
-9082: Ident           "byte" at 766:23-766:27
-9083: Comma           "," at 766:27-766:28
-9084: Ident           "length" at 766:29-766:35 (leading: Space)
-9085: Colon           ":" at 766:35-766:36
-9086: Ident           "uint" at 766:37-766:41 (leading: Space)
-9087: RParen          ")" at 766:41-766:42
-9088: Arrow           "->" at 766:43-766:45 (leading: Space)
-9089: NothingLit      "nothing" at 766:46-766:53 (leading: Space)
-9090: Semicolon       ";" at 766:53-766:54
-9091: KwPub           "pub" at 768:1-768:4 (leading: Newline)
-9092: KwFn            "fn" at 768:5-768:7 (leading: Space)
-9093: Ident           "panic" at 768:8-768:13 (leading: Space)
-9094: LParen          "(" at 768:13-768:14
-9095: Ident           "msg" at 768:14-768:17
-9096: Colon           ":" at 768:17-768:18
-9097: Ident           "string" at 768:19-768:25 (leading: Space)
-9098: RParen          ")" at 768:25-768:26
-9099: Arrow           "->" at 768:27-768:29 (leading: Space)
-9100: NothingLit      "nothing" at 768:30-768:37 (leading: Space)
-9101: LBrace          "{" at 768:38-768:39 (leading: Space)
-9102: KwLet           "let" at 769:5-769:8 (leading: Newline, Space)
-9103: Ident           "ptr" at 769:9-769:12 (leading: Space)
-9104: Assign          "=" at 769:13-769:14 (leading: Space)
-9105: Ident           "rt_string_ptr" at 769:15-769:28 (leading: Space)
-9106: LParen          "(" at 769:28-769:29
-9107: Amp             "&" at 769:29-769:30
-9108: Ident           "msg" at 769:30-769:33
-9109: RParen          ")" at 769:33-769:34
-9110: Semicolon       ";" at 769:34-769:35
-9111: KwLet           "let" at 770:5-770:8 (leading: Newline, Space)
-9112: Ident           "length" at 770:9-770:15 (leading: Space)
-9113: Assign          "=" at 770:16-770:17 (leading: Space)
-9114: Ident           "rt_string_len_bytes" at 770:18-770:37 (leading: Space)
-9115: LParen          "(" at 770:37-770:38
-9116: Amp             "&" at 770:38-770:39
-9117: Ident           "msg" at 770:39-770:42
-9118: RParen          ")" at 770:42-770:43
-9119: Semicolon       ";" at 770:43-770:44
-9120: Ident           "rt_panic" at 771:5-771:13 (leading: Newline, Space)
-9121: LParen          "(" at 771:13-771:14
-9122: Ident           "ptr" at 771:14-771:17
-9123: Comma           "," at 771:17-771:18
-9124: Ident           "length" at 771:19-771:25 (leading: Space)
-9125: RParen          ")" at 771:25-771:26
-9126: Semicolon       ";" at 771:26-771:27
-9127: RBrace          "}" at 772:1-772:2 (leading: Newline)
-9128: At              "@" at 774:1-774:2 (leading: Newline)
-9129: Ident           "intrinsic" at 774:2-774:11
-9130: KwPub           "pub" at 775:1-775:4 (leading: Newline)
-9131: KwType          "type" at 775:5-775:9 (leading: Space)
-9132: Ident           "RwLock" at 775:10-775:16 (leading: Space)
-9133: Assign          "=" at 775:17-775:18 (leading: Space)
-9134: LBrace          "{" at 775:19-775:20 (leading: Space)
-9135: Ident           "__opaque" at 776:5-776:13 (leading: Newline, Space)
-9136: Colon           ":" at 776:13-776:14
-9137: Star            "*" at 776:15-776:16 (leading: Space)
-9138: Ident           "byte" at 776:16-776:20
-9139: Comma           "," at 776:20-776:21
-9140: RBrace          "}" at 777:1-777:2 (leading: Newline)
-9141: Semicolon       ";" at 777:2-777:3
-9142: KwExtern        "extern" at 779:1-779:7 (leading: Newline)
-9143: Lt              "<" at 779:7-779:8
-9144: Ident           "RwLock" at 779:8-779:14
-9145: Gt              ">" at 779:14-779:15
-9146: LBrace          "{" at 779:16-779:17 (leading: Space)
-9147: At              "@" at 780:5-780:6 (leading: Newline, Space)
-9148: Ident           "intrinsic" at 780:6-780:15
-9149: KwPub           "pub" at 780:16-780:19 (leading: Space)
-9150: KwFn            "fn" at 780:20-780:22 (leading: Space)
-9151: Ident           "new" at 780:23-780:26 (leading: Space)
-9152: LParen          "(" at 780:26-780:27
-9153: RParen          ")" at 780:27-780:28
-9154: Arrow           "->" at 780:29-780:31 (leading: Space)
-9155: Ident           "RwLock" at 780:32-780:38 (leading: Space)
-9156: Semicolon       ";" at 780:38-780:39
-9157: At              "@" at 781:5-781:6 (leading: Newline, Space)
-9158: Ident           "intrinsic" at 781:6-781:15
-9159: KwPub           "pub" at 781:16-781:19 (leading: Space)
-9160: KwFn            "fn" at 781:20-781:22 (leading: Space)
-9161: Ident           "read_lock" at 781:23-781:32 (leading: Space)
-9162: LParen          "(" at 781:32-781:33
-9163: Ident           "self" at 781:33-781:37
-9164: Colon           ":" at 781:37-781:38
-9165: Amp             "&" at 781:39-781:40 (leading: Space)
-9166: KwMut           "mut" at 781:40-781:43
-9167: Ident           "RwLock" at 781:44-781:50 (leading: Space)
-9168: RParen          ")" at 781:50-781:51
-9169: Arrow           "->" at 781:52-781:54 (leading: Space)
-9170: NothingLit      "nothing" at 781:55-781:62 (leading: Space)
-9171: Semicolon       ";" at 781:62-781:63
-9172: At              "@" at 782:5-782:6 (leading: Newline, Space)
-9173: Ident           "intrinsic" at 782:6-782:15
-9174: KwPub           "pub" at 782:16-782:19 (leading: Space)
-9175: KwFn            "fn" at 782:20-782:22 (leading: Space)
-9176: Ident           "read_unlock" at 782:23-782:34 (leading: Space)
-9177: LParen          "(" at 782:34-782:35
-9178: Ident           "self" at 782:35-782:39
-9179: Colon           ":" at 782:39-782:40
-9180: Amp             "&" at 782:41-782:42 (leading: Space)
-9181: KwMut           "mut" at 782:42-782:45
-9182: Ident           "RwLock" at 782:46-782:52 (leading: Space)
-9183: RParen          ")" at 782:52-782:53
-9184: Arrow           "->" at 782:54-782:56 (leading: Space)
-9185: NothingLit      "nothing" at 782:57-782:64 (leading: Space)
-9186: Semicolon       ";" at 782:64-782:65
-9187: At              "@" at 783:5-783:6 (leading: Newline, Space)
-9188: Ident           "intrinsic" at 783:6-783:15
-9189: KwPub           "pub" at 783:16-783:19 (leading: Space)
-9190: KwFn            "fn" at 783:20-783:22 (leading: Space)
-9191: Ident           "write_lock" at 783:23-783:33 (leading: Space)
-9192: LParen          "(" at 783:33-783:34
-9193: Ident           "self" at 783:34-783:38
-9194: Colon           ":" at 783:38-783:39
-9195: Amp             "&" at 783:40-783:41 (leading: Space)
-9196: KwMut           "mut" at 783:41-783:44
-9197: Ident           "RwLock" at 783:45-783:51 (leading: Space)
-9198: RParen          ")" at 783:51-783:52
-9199: Arrow           "->" at 783:53-783:55 (leading: Space)
-9200: NothingLit      "nothing" at 783:56-783:63 (leading: Space)
-9201: Semicolon       ";" at 783:63-783:64
-9202: At              "@" at 784:5-784:6 (leading: Newline, Space)
-9203: Ident           "intrinsic" at 784:6-784:15
-9204: KwPub           "pub" at 784:16-784:19 (leading: Space)
-9205: KwFn            "fn" at 784:20-784:22 (leading: Space)
-9206: Ident           "write_unlock" at 784:23-784:35 (leading: Space)
-9207: LParen          "(" at 784:35-784:36
-9208: Ident           "self" at 784:36-784:40
-9209: Colon           ":" at 784:40-784:41
-9210: Amp             "&" at 784:42-784:43 (leading: Space)
-9211: KwMut           "mut" at 784:43-784:46
-9212: Ident           "RwLock" at 784:47-784:53 (leading: Space)
-9213: RParen          ")" at 784:53-784:54
-9214: Arrow           "->" at 784:55-784:57 (leading: Space)
-9215: NothingLit      "nothing" at 784:58-784:65 (leading: Space)
-9216: Semicolon       ";" at 784:65-784:66
-9217: At              "@" at 785:5-785:6 (leading: Newline, Space)
-9218: Ident           "intrinsic" at 785:6-785:15
-9219: KwPub           "pub" at 785:16-785:19 (leading: Space)
-9220: KwFn            "fn" at 785:20-785:22 (leading: Space)
-9221: Ident           "try_read_lock" at 785:23-785:36 (leading: Space)
-9222: LParen          "(" at 785:36-785:37
-9223: Ident           "self" at 785:37-785:41
-9224: Colon           ":" at 785:41-785:42
-9225: Amp             "&" at 785:43-785:44 (leading: Space)
-9226: KwMut           "mut" at 785:44-785:47
-9227: Ident           "RwLock" at 785:48-785:54 (leading: Space)
-9228: RParen          ")" at 785:54-785:55
-9229: Arrow           "->" at 785:56-785:58 (leading: Space)
-9230: Ident           "bool" at 785:59-785:63 (leading: Space)
-9231: Semicolon       ";" at 785:63-785:64
-9232: At              "@" at 786:5-786:6 (leading: Newline, Space)
-9233: Ident           "intrinsic" at 786:6-786:15
-9234: KwPub           "pub" at 786:16-786:19 (leading: Space)
-9235: KwFn            "fn" at 786:20-786:22 (leading: Space)
-9236: Ident           "try_write_lock" at 786:23-786:37 (leading: Space)
-9237: LParen          "(" at 786:37-786:38
-9238: Ident           "self" at 786:38-786:42
-9239: Colon           ":" at 786:42-786:43
-9240: Amp             "&" at 786:44-786:45 (leading: Space)
-9241: KwMut           "mut" at 786:45-786:48
-9242: Ident           "RwLock" at 786:49-786:55 (leading: Space)
-9243: RParen          ")" at 786:55-786:56
-9244: Arrow           "->" at 786:57-786:59 (leading: Space)
-9245: Ident           "bool" at 786:60-786:64 (leading: Space)
-9246: Semicolon       ";" at 786:64-786:65
-9247: RBrace          "}" at 787:1-787:2 (leading: Newline)
-9248: At              "@" at 795:1-795:2 (leading: Newline, LineComment, Newline, LineComment, Newline, LineComment, Newline, LineComment, Newline, LineComment, Newline)
-9249: Ident           "intrinsic" at 795:2-795:11
-9250: KwPub           "pub" at 796:1-796:4 (leading: Newline)
-9251: KwFn            "fn" at 796:5-796:7 (leading: Space)
-9252: Ident           "atomic_load" at 796:8-796:19 (leading: Space)
-9253: LParen          "(" at 796:19-796:20
-9254: Ident           "ptr" at 796:20-796:23
-9255: Colon           ":" at 796:23-796:24
-9256: Amp             "&" at 796:25-796:26 (leading: Space)
-9257: Ident           "int" at 796:26-796:29
-9258: RParen          ")" at 796:29-796:30
-9259: Arrow           "->" at 796:31-796:33 (leading: Space)
-9260: Ident           "int" at 796:34-796:37 (leading: Space)
-9261: Semicolon       ";" at 796:37-796:38
-9262: At              "@" at 798:1-798:2 (leading: Newline)
-9263: Ident           "intrinsic" at 798:2-798:11
-9264: At              "@" at 799:1-799:2 (leading: Newline)
-9265: Ident           "overload" at 799:2-799:10
-9266: KwPub           "pub" at 800:1-800:4 (leading: Newline)
-9267: KwFn            "fn" at 800:5-800:7 (leading: Space)
-9268: Ident           "atomic_load" at 800:8-800:19 (leading: Space)
-9269: LParen          "(" at 800:19-800:20
-9270: Ident           "ptr" at 800:20-800:23
-9271: Colon           ":" at 800:23-800:24
-9272: Amp             "&" at 800:25-800:26 (leading: Space)
-9273: Ident           "uint" at 800:26-800:30
-9274: RParen          ")" at 800:30-800:31
-9275: Arrow           "->" at 800:32-800:34 (leading: Space)
-9276: Ident           "uint" at 800:35-800:39 (leading: Space)
-9277: Semicolon       ";" at 800:39-800:40
-9278: At              "@" at 802:1-802:2 (leading: Newline)
-9279: Ident           "intrinsic" at 802:2-802:11
-9280: At              "@" at 803:1-803:2 (leading: Newline)
-9281: Ident           "overload" at 803:2-803:10
-9282: KwPub           "pub" at 804:1-804:4 (leading: Newline)
-9283: KwFn            "fn" at 804:5-804:7 (leading: Space)
-9284: Ident           "atomic_load" at 804:8-804:19 (leading: Space)
-9285: LParen          "(" at 804:19-804:20
-9286: Ident           "ptr" at 804:20-804:23
-9287: Colon           ":" at 804:23-804:24
-9288: Amp             "&" at 804:25-804:26 (leading: Space)
-9289: Ident           "bool" at 804:26-804:30
-9290: RParen          ")" at 804:30-804:31
-9291: Arrow           "->" at 804:32-804:34 (leading: Space)
-9292: Ident           "bool" at 804:35-804:39 (leading: Space)
-9293: Semicolon       ";" at 804:39-804:40
-9294: At              "@" at 807:1-807:2 (leading: Newline, LineComment, Newline)
-9295: Ident           "intrinsic" at 807:2-807:11
-9296: KwPub           "pub" at 808:1-808:4 (leading: Newline)
-9297: KwFn            "fn" at 808:5-808:7 (leading: Space)
-9298: Ident           "atomic_store" at 808:8-808:20 (leading: Space)
-9299: LParen          "(" at 808:20-808:21
-9300: Ident           "ptr" at 808:21-808:24
-9301: Colon           ":" at 808:24-808:25
-9302: Amp             "&" at 808:26-808:27 (leading: Space)
-9303: KwMut           "mut" at 808:27-808:30
-9304: Ident           "int" at 808:31-808:34 (leading: Space)
-9305: Comma           "," at 808:34-808:35
-9306: Ident           "value" at 808:36-808:41 (leading: Space)
-9307: Colon           ":" at 808:41-808:42
-9308: Ident           "int" at 808:43-808:46 (leading: Space)
-9309: RParen          ")" at 808:46-808:47
-9310: Arrow           "->" at 808:48-808:50 (leading: Space)
-9311: NothingLit      "nothing" at 808:51-808:58 (leading: Space)
-9312: Semicolon       ";" at 808:58-808:59
-9313: At              "@" at 810:1-810:2 (leading: Newline)
-9314: Ident           "intrinsic" at 810:2-810:11
-9315: At              "@" at 811:1-811:2 (leading: Newline)
-9316: Ident           "overload" at 811:2-811:10
-9317: KwPub           "pub" at 812:1-812:4 (leading: Newline)
-9318: KwFn            "fn" at 812:5-812:7 (leading: Space)
-9319: Ident           "atomic_store" at 812:8-812:20 (leading: Space)
-9320: LParen          "(" at 812:20-812:21
-9321: Ident           "ptr" at 812:21-812:24
-9322: Colon           ":" at 812:24-812:25
-9323: Amp             "&" at 812:26-812:27 (leading: Space)
-9324: KwMut           "mut" at 812:27-812:30
-9325: Ident           "uint" at 812:31-812:35 (leading: Space)
-9326: Comma           "," at 812:35-812:36
-9327: Ident           "value" at 812:37-812:42 (leading: Space)
-9328: Colon           ":" at 812:42-812:43
-9329: Ident           "uint" at 812:44-812:48 (leading: Space)
-9330: RParen          ")" at 812:48-812:49
-9331: Arrow           "->" at 812:50-812:52 (leading: Space)
-9332: NothingLit      "nothing" at 812:53-812:60 (leading: Space)
-9333: Semicolon       ";" at 812:60-812:61
-9334: At              "@" at 814:1-814:2 (leading: Newline)
-9335: Ident           "intrinsic" at 814:2-814:11
-9336: At              "@" at 815:1-815:2 (leading: Newline)
-9337: Ident           "overload" at 815:2-815:10
-9338: KwPub           "pub" at 816:1-816:4 (leading: Newline)
-9339: KwFn            "fn" at 816:5-816:7 (leading: Space)
-9340: Ident           "atomic_store" at 816:8-816:20 (leading: Space)
-9341: LParen          "(" at 816:20-816:21
-9342: Ident           "ptr" at 816:21-816:24
-9343: Colon           ":" at 816:24-816:25
-9344: Amp             "&" at 816:26-816:27 (leading: Space)
-9345: KwMut           "mut" at 816:27-816:30
-9346: Ident           "bool" at 816:31-816:35 (leading: Space)
-9347: Comma           "," at 816:35-816:36
-9348: Ident           "value" at 816:37-816:42 (leading: Space)
-9349: Colon           ":" at 816:42-816:43
-9350: Ident           "bool" at 816:44-816:48 (leading: Space)
-9351: RParen          ")" at 816:48-816:49
-9352: Arrow           "->" at 816:50-816:52 (leading: Space)
-9353: NothingLit      "nothing" at 816:53-816:60 (leading: Space)
-9354: Semicolon       ";" at 816:60-816:61
-9355: At              "@" at 819:1-819:2 (leading: Newline, LineComment, Newline)
-9356: Ident           "intrinsic" at 819:2-819:11
-9357: KwPub           "pub" at 820:1-820:4 (leading: Newline)
-9358: KwFn            "fn" at 820:5-820:7 (leading: Space)
-9359: Ident           "atomic_exchange" at 820:8-820:23 (leading: Space)
-9360: LParen          "(" at 820:23-820:24
-9361: Ident           "ptr" at 820:24-820:27
-9362: Colon           ":" at 820:27-820:28
-9363: Amp             "&" at 820:29-820:30 (leading: Space)
-9364: KwMut           "mut" at 820:30-820:33
-9365: Ident           "int" at 820:34-820:37 (leading: Space)
-9366: Comma           "," at 820:37-820:38
-9367: Ident           "new_val" at 820:39-820:46 (leading: Space)
-9368: Colon           ":" at 820:46-820:47
-9369: Ident           "int" at 820:48-820:51 (leading: Space)
-9370: RParen          ")" at 820:51-820:52
-9371: Arrow           "->" at 820:53-820:55 (leading: Space)
-9372: Ident           "int" at 820:56-820:59 (leading: Space)
-9373: Semicolon       ";" at 820:59-820:60
-9374: At              "@" at 822:1-822:2 (leading: Newline)
-9375: Ident           "intrinsic" at 822:2-822:11
-9376: At              "@" at 823:1-823:2 (leading: Newline)
-9377: Ident           "overload" at 823:2-823:10
-9378: KwPub           "pub" at 824:1-824:4 (leading: Newline)
-9379: KwFn            "fn" at 824:5-824:7 (leading: Space)
-9380: Ident           "atomic_exchange" at 824:8-824:23 (leading: Space)
-9381: LParen          "(" at 824:23-824:24
-9382: Ident           "ptr" at 824:24-824:27
-9383: Colon           ":" at 824:27-824:28
-9384: Amp             "&" at 824:29-824:30 (leading: Space)
-9385: KwMut           "mut" at 824:30-824:33
-9386: Ident           "uint" at 824:34-824:38 (leading: Space)
-9387: Comma           "," at 824:38-824:39
-9388: Ident           "new_val" at 824:40-824:47 (leading: Space)
-9389: Colon           ":" at 824:47-824:48
-9390: Ident           "uint" at 824:49-824:53 (leading: Space)
-9391: RParen          ")" at 824:53-824:54
-9392: Arrow           "->" at 824:55-824:57 (leading: Space)
-9393: Ident           "uint" at 824:58-824:62 (leading: Space)
-9394: Semicolon       ";" at 824:62-824:63
-9395: At              "@" at 826:1-826:2 (leading: Newline)
-9396: Ident           "intrinsic" at 826:2-826:11
-9397: At              "@" at 827:1-827:2 (leading: Newline)
-9398: Ident           "overload" at 827:2-827:10
-9399: KwPub           "pub" at 828:1-828:4 (leading: Newline)
-9400: KwFn            "fn" at 828:5-828:7 (leading: Space)
-9401: Ident           "atomic_exchange" at 828:8-828:23 (leading: Space)
-9402: LParen          "(" at 828:23-828:24
-9403: Ident           "ptr" at 828:24-828:27
-9404: Colon           ":" at 828:27-828:28
-9405: Amp             "&" at 828:29-828:30 (leading: Space)
-9406: KwMut           "mut" at 828:30-828:33
-9407: Ident           "bool" at 828:34-828:38 (leading: Space)
-9408: Comma           "," at 828:38-828:39
-9409: Ident           "new_val" at 828:40-828:47 (leading: Space)
-9410: Colon           ":" at 828:47-828:48
-9411: Ident           "bool" at 828:49-828:53 (leading: Space)
-9412: RParen          ")" at 828:53-828:54
-9413: Arrow           "->" at 828:55-828:57 (leading: Space)
-9414: Ident           "bool" at 828:58-828:62 (leading: Space)
-9415: Semicolon       ";" at 828:62-828:63
-9416: At              "@" at 832:1-832:2 (leading: Newline, LineComment, Newline, LineComment, Newline)
-9417: Ident           "intrinsic" at 832:2-832:11
-9418: KwPub           "pub" at 833:1-833:4 (leading: Newline)
-9419: KwFn            "fn" at 833:5-833:7 (leading: Space)
-9420: Ident           "atomic_compare_exchange" at 833:8-833:31 (leading: Space)
-9421: LParen          "(" at 833:31-833:32
-9422: Ident           "ptr" at 833:32-833:35
-9423: Colon           ":" at 833:35-833:36
-9424: Amp             "&" at 833:37-833:38 (leading: Space)
-9425: KwMut           "mut" at 833:38-833:41
-9426: Ident           "int" at 833:42-833:45 (leading: Space)
-9427: Comma           "," at 833:45-833:46
-9428: Ident           "expected" at 833:47-833:55 (leading: Space)
-9429: Colon           ":" at 833:55-833:56
-9430: Ident           "int" at 833:57-833:60 (leading: Space)
-9431: Comma           "," at 833:60-833:61
-9432: Ident           "desired" at 833:62-833:69 (leading: Space)
-9433: Colon           ":" at 833:69-833:70
-9434: Ident           "int" at 833:71-833:74 (leading: Space)
-9435: RParen          ")" at 833:74-833:75
-9436: Arrow           "->" at 833:76-833:78 (leading: Space)
-9437: Ident           "bool" at 833:79-833:83 (leading: Space)
-9438: Semicolon       ";" at 833:83-833:84
-9439: At              "@" at 835:1-835:2 (leading: Newline)
-9440: Ident           "intrinsic" at 835:2-835:11
-9441: At              "@" at 836:1-836:2 (leading: Newline)
-9442: Ident           "overload" at 836:2-836:10
-9443: KwPub           "pub" at 837:1-837:4 (leading: Newline)
-9444: KwFn            "fn" at 837:5-837:7 (leading: Space)
-9445: Ident           "atomic_compare_exchange" at 837:8-837:31 (leading: Space)
-9446: LParen          "(" at 837:31-837:32
-9447: Ident           "ptr" at 837:32-837:35
-9448: Colon           ":" at 837:35-837:36
-9449: Amp             "&" at 837:37-837:38 (leading: Space)
-9450: KwMut           "mut" at 837:38-837:41
-9451: Ident           "uint" at 837:42-837:46 (leading: Space)
-9452: Comma           "," at 837:46-837:47
-9453: Ident           "expected" at 837:48-837:56 (leading: Space)
-9454: Colon           ":" at 837:56-837:57
-9455: Ident           "uint" at 837:58-837:62 (leading: Space)
-9456: Comma           "," at 837:62-837:63
-9457: Ident           "desired" at 837:64-837:71 (leading: Space)
-9458: Colon           ":" at 837:71-837:72
-9459: Ident           "uint" at 837:73-837:77 (leading: Space)
-9460: RParen          ")" at 837:77-837:78
-9461: Arrow           "->" at 837:79-837:81 (leading: Space)
-9462: Ident           "bool" at 837:82-837:86 (leading: Space)
-9463: Semicolon       ";" at 837:86-837:87
-9464: At              "@" at 839:1-839:2 (leading: Newline)
-9465: Ident           "intrinsic" at 839:2-839:11
-9466: At              "@" at 840:1-840:2 (leading: Newline)
-9467: Ident           "overload" at 840:2-840:10
-9468: KwPub           "pub" at 841:1-841:4 (leading: Newline)
-9469: KwFn            "fn" at 841:5-841:7 (leading: Space)
-9470: Ident           "atomic_compare_exchange" at 841:8-841:31 (leading: Space)
-9471: LParen          "(" at 841:31-841:32
-9472: Ident           "ptr" at 841:32-841:35
-9473: Colon           ":" at 841:35-841:36
-9474: Amp             "&" at 841:37-841:38 (leading: Space)
-9475: KwMut           "mut" at 841:38-841:41
-9476: Ident           "bool" at 841:42-841:46 (leading: Space)
-9477: Comma           "," at 841:46-841:47
-9478: Ident           "expected" at 841:48-841:56 (leading: Space)
-9479: Colon           ":" at 841:56-841:57
-9480: Ident           "bool" at 841:58-841:62 (leading: Space)
-9481: Comma           "," at 841:62-841:63
-9482: Ident           "desired" at 841:64-841:71 (leading: Space)
-9483: Colon           ":" at 841:71-841:72
-9484: Ident           "bool" at 841:73-841:77 (leading: Space)
-9485: RParen          ")" at 841:77-841:78
-9486: Arrow           "->" at 841:79-841:81 (leading: Space)
-9487: Ident           "bool" at 841:82-841:86 (leading: Space)
-9488: Semicolon       ";" at 841:86-841:87
-9489: At              "@" at 844:1-844:2 (leading: Newline, LineComment, Newline)
-9490: Ident           "intrinsic" at 844:2-844:11
-9491: KwPub           "pub" at 845:1-845:4 (leading: Newline)
-9492: KwFn            "fn" at 845:5-845:7 (leading: Space)
-9493: Ident           "atomic_fetch_add" at 845:8-845:24 (leading: Space)
-9494: LParen          "(" at 845:24-845:25
-9495: Ident           "ptr" at 845:25-845:28
-9496: Colon           ":" at 845:28-845:29
-9497: Amp             "&" at 845:30-845:31 (leading: Space)
-9498: KwMut           "mut" at 845:31-845:34
-9499: Ident           "int" at 845:35-845:38 (leading: Space)
-9500: Comma           "," at 845:38-845:39
-9501: Ident           "delta" at 845:40-845:45 (leading: Space)
-9502: Colon           ":" at 845:45-845:46
-9503: Ident           "int" at 845:47-845:50 (leading: Space)
-9504: RParen          ")" at 845:50-845:51
-9505: Arrow           "->" at 845:52-845:54 (leading: Space)
-9506: Ident           "int" at 845:55-845:58 (leading: Space)
-9507: Semicolon       ";" at 845:58-845:59
-9508: At              "@" at 847:1-847:2 (leading: Newline)
-9509: Ident           "intrinsic" at 847:2-847:11
-9510: At              "@" at 848:1-848:2 (leading: Newline)
-9511: Ident           "overload" at 848:2-848:10
-9512: KwPub           "pub" at 849:1-849:4 (leading: Newline)
-9513: KwFn            "fn" at 849:5-849:7 (leading: Space)
-9514: Ident           "atomic_fetch_add" at 849:8-849:24 (leading: Space)
-9515: LParen          "(" at 849:24-849:25
-9516: Ident           "ptr" at 849:25-849:28
-9517: Colon           ":" at 849:28-849:29
-9518: Amp             "&" at 849:30-849:31 (leading: Space)
-9519: KwMut           "mut" at 849:31-849:34
-9520: Ident           "uint" at 849:35-849:39 (leading: Space)
-9521: Comma           "," at 849:39-849:40
-9522: Ident           "delta" at 849:41-849:46 (leading: Space)
-9523: Colon           ":" at 849:46-849:47
-9524: Ident           "uint" at 849:48-849:52 (leading: Space)
-9525: RParen          ")" at 849:52-849:53
-9526: Arrow           "->" at 849:54-849:56 (leading: Space)
-9527: Ident           "uint" at 849:57-849:61 (leading: Space)
-9528: Semicolon       ";" at 849:61-849:62
-9529: At              "@" at 852:1-852:2 (leading: Newline, LineComment, Newline)
-9530: Ident           "intrinsic" at 852:2-852:11
-9531: KwPub           "pub" at 853:1-853:4 (leading: Newline)
-9532: KwFn            "fn" at 853:5-853:7 (leading: Space)
-9533: Ident           "atomic_fetch_sub" at 853:8-853:24 (leading: Space)
-9534: LParen          "(" at 853:24-853:25
-9535: Ident           "ptr" at 853:25-853:28
-9536: Colon           ":" at 853:28-853:29
-9537: Amp             "&" at 853:30-853:31 (leading: Space)
-9538: KwMut           "mut" at 853:31-853:34
-9539: Ident           "int" at 853:35-853:38 (leading: Space)
-9540: Comma           "," at 853:38-853:39
-9541: Ident           "delta" at 853:40-853:45 (leading: Space)
-9542: Colon           ":" at 853:45-853:46
-9543: Ident           "int" at 853:47-853:50 (leading: Space)
-9544: RParen          ")" at 853:50-853:51
-9545: Arrow           "->" at 853:52-853:54 (leading: Space)
-9546: Ident           "int" at 853:55-853:58 (leading: Space)
-9547: Semicolon       ";" at 853:58-853:59
-9548: At              "@" at 855:1-855:2 (leading: Newline)
-9549: Ident           "intrinsic" at 855:2-855:11
-9550: At              "@" at 856:1-856:2 (leading: Newline)
-9551: Ident           "overload" at 856:2-856:10
-9552: KwPub           "pub" at 857:1-857:4 (leading: Newline)
-9553: KwFn            "fn" at 857:5-857:7 (leading: Space)
-9554: Ident           "atomic_fetch_sub" at 857:8-857:24 (leading: Space)
-9555: LParen          "(" at 857:24-857:25
-9556: Ident           "ptr" at 857:25-857:28
-9557: Colon           ":" at 857:28-857:29
-9558: Amp             "&" at 857:30-857:31 (leading: Space)
-9559: KwMut           "mut" at 857:31-857:34
-9560: Ident           "uint" at 857:35-857:39 (leading: Space)
-9561: Comma           "," at 857:39-857:40
-9562: Ident           "delta" at 857:41-857:46 (leading: Space)
-9563: Colon           ":" at 857:46-857:47
-9564: Ident           "uint" at 857:48-857:52 (leading: Space)
-9565: RParen          ")" at 857:52-857:53
-9566: Arrow           "->" at 857:54-857:56 (leading: Space)
-9567: Ident           "uint" at 857:57-857:61 (leading: Space)
-9568: Semicolon       ";" at 857:61-857:62
-9569: At              "@" at 862:1-862:2 (leading: Newline, LineComment, Newline, LineComment, Newline)
-9570: Ident           "intrinsic" at 862:2-862:11
-9571: KwPub           "pub" at 863:1-863:4 (leading: Newline)
-9572: KwFn            "fn" at 863:5-863:7 (leading: Space)
-9573: Ident           "rt_argv" at 863:8-863:15 (leading: Space)
-9574: LParen          "(" at 863:15-863:16
-9575: RParen          ")" at 863:16-863:17
-9576: Arrow           "->" at 863:18-863:20 (leading: Space)
-9577: Ident           "string" at 863:21-863:27 (leading: Space)
-9578: LBracket        "[" at 863:27-863:28
-9579: RBracket        "]" at 863:28-863:29
-9580: Semicolon       ";" at 863:29-863:30
-9581: At              "@" at 866:1-866:2 (leading: Newline, LineComment, Newline)
-9582: Ident           "intrinsic" at 866:2-866:11
-9583: KwPub           "pub" at 867:1-867:4 (leading: Newline)
-9584: KwFn            "fn" at 867:5-867:7 (leading: Space)
-9585: Ident           "rt_stdin_read_all" at 867:8-867:25 (leading: Space)
-9586: LParen          "(" at 867:25-867:26
-9587: RParen          ")" at 867:26-867:27
-9588: Arrow           "->" at 867:28-867:30 (leading: Space)
-9589: Ident           "string" at 867:31-867:37 (leading: Space)
-9590: Semicolon       ";" at 867:37-867:38
-9591: At              "@" at 870:1-870:2 (leading: Newline, LineComment, Newline)
-9592: Ident           "intrinsic" at 870:2-870:11
-9593: KwPub           "pub" at 871:1-871:4 (leading: Newline)
-9594: KwFn            "fn" at 871:5-871:7 (leading: Space)
-9595: Ident           "rt_exit" at 871:8-871:15 (leading: Space)
-9596: LParen          "(" at 871:15-871:16
-9597: Ident           "code" at 871:16-871:20
-9598: Colon           ":" at 871:20-871:21
-9599: Ident           "int" at 871:22-871:25 (leading: Space)
-9600: RParen          ")" at 871:25-871:26
-9601: Arrow           "->" at 871:27-871:29 (leading: Space)
-9602: NothingLit      "nothing" at 871:30-871:37 (leading: Space)
-9603: Semicolon       ";" at 871:37-871:38
-9604: EOF             at 872:1-872:1
+8937: Ident           "__index" at 743:19-743:26 (leading: Space)
+8938: LParen          "(" at 743:26-743:27
+8939: Ident           "self" at 743:27-743:31
+8940: Colon           ":" at 743:31-743:32
+8941: Amp             "&" at 743:33-743:34 (leading: Space)
+8942: Ident           "ArrayFixed" at 743:34-743:44
+8943: Lt              "<" at 743:44-743:45
+8944: Ident           "T" at 743:45-743:46
+8945: Comma           "," at 743:46-743:47
+8946: Ident           "N" at 743:48-743:49 (leading: Space)
+8947: Gt              ">" at 743:49-743:50
+8948: Comma           "," at 743:50-743:51
+8949: Ident           "index" at 743:52-743:57 (leading: Space)
+8950: Colon           ":" at 743:57-743:58
+8951: Ident           "int" at 743:59-743:62 (leading: Space)
+8952: RParen          ")" at 743:62-743:63
+8953: Arrow           "->" at 743:64-743:66 (leading: Space)
+8954: Amp             "&" at 743:67-743:68 (leading: Space)
+8955: Ident           "T" at 743:68-743:69
+8956: Semicolon       ";" at 743:69-743:70
+8957: At              "@" at 744:5-744:6 (leading: Newline, Space)
+8958: Ident           "intrinsic" at 744:6-744:15
+8959: At              "@" at 744:16-744:17 (leading: Space)
+8960: Ident           "overload" at 744:17-744:25
+8961: KwFn            "fn" at 744:26-744:28 (leading: Space)
+8962: Ident           "__index" at 744:29-744:36 (leading: Space)
+8963: LParen          "(" at 744:36-744:37
+8964: Ident           "self" at 744:37-744:41
+8965: Colon           ":" at 744:41-744:42
+8966: Amp             "&" at 744:43-744:44 (leading: Space)
+8967: Ident           "ArrayFixed" at 744:44-744:54
+8968: Lt              "<" at 744:54-744:55
+8969: Ident           "T" at 744:55-744:56
+8970: Comma           "," at 744:56-744:57
+8971: Ident           "N" at 744:58-744:59 (leading: Space)
+8972: Gt              ">" at 744:59-744:60
+8973: Comma           "," at 744:60-744:61
+8974: Ident           "index" at 744:62-744:67 (leading: Space)
+8975: Colon           ":" at 744:67-744:68
+8976: Ident           "Range" at 744:69-744:74 (leading: Space)
+8977: Lt              "<" at 744:74-744:75
+8978: Ident           "int" at 744:75-744:78
+8979: Gt              ">" at 744:78-744:79
+8980: RParen          ")" at 744:79-744:80
+8981: Arrow           "->" at 744:81-744:83 (leading: Space)
+8982: Ident           "Array" at 744:84-744:89 (leading: Space)
+8983: Lt              "<" at 744:89-744:90
+8984: Ident           "T" at 744:90-744:91
+8985: Gt              ">" at 744:91-744:92
+8986: Semicolon       ";" at 744:92-744:93
+8987: At              "@" at 745:5-745:6 (leading: Newline, Space)
+8988: Ident           "intrinsic" at 745:6-745:15
+8989: KwFn            "fn" at 745:16-745:18 (leading: Space)
+8990: Ident           "__index_set" at 745:19-745:30 (leading: Space)
+8991: LParen          "(" at 745:30-745:31
+8992: Ident           "self" at 745:31-745:35
+8993: Colon           ":" at 745:35-745:36
+8994: Amp             "&" at 745:37-745:38 (leading: Space)
+8995: KwMut           "mut" at 745:38-745:41
+8996: Ident           "ArrayFixed" at 745:42-745:52 (leading: Space)
+8997: Lt              "<" at 745:52-745:53
+8998: Ident           "T" at 745:53-745:54
+8999: Comma           "," at 745:54-745:55
+9000: Ident           "N" at 745:56-745:57 (leading: Space)
+9001: Gt              ">" at 745:57-745:58
+9002: Comma           "," at 745:58-745:59
+9003: Ident           "index" at 745:60-745:65 (leading: Space)
+9004: Colon           ":" at 745:65-745:66
+9005: Ident           "int" at 745:67-745:70 (leading: Space)
+9006: Comma           "," at 745:70-745:71
+9007: Ident           "value" at 745:72-745:77 (leading: Space)
+9008: Colon           ":" at 745:77-745:78
+9009: Ident           "T" at 745:79-745:80 (leading: Space)
+9010: RParen          ")" at 745:80-745:81
+9011: Arrow           "->" at 745:82-745:84 (leading: Space)
+9012: NothingLit      "nothing" at 745:85-745:92 (leading: Space)
+9013: Semicolon       ";" at 745:92-745:93
+9014: At              "@" at 746:5-746:6 (leading: Newline, Space)
+9015: Ident           "intrinsic" at 746:6-746:15
+9016: KwFn            "fn" at 746:16-746:18 (leading: Space)
+9017: Ident           "__range" at 746:19-746:26 (leading: Space)
+9018: LParen          "(" at 746:26-746:27
+9019: Ident           "self" at 746:27-746:31
+9020: Colon           ":" at 746:31-746:32
+9021: Amp             "&" at 746:33-746:34 (leading: Space)
+9022: Ident           "ArrayFixed" at 746:34-746:44
+9023: Lt              "<" at 746:44-746:45
+9024: Ident           "T" at 746:45-746:46
+9025: Comma           "," at 746:46-746:47
+9026: Ident           "N" at 746:48-746:49 (leading: Space)
+9027: Gt              ">" at 746:49-746:50
+9028: RParen          ")" at 746:50-746:51
+9029: Arrow           "->" at 746:52-746:54 (leading: Space)
+9030: Ident           "Range" at 746:55-746:60 (leading: Space)
+9031: Lt              "<" at 746:60-746:61
+9032: Ident           "T" at 746:61-746:62
+9033: Gt              ">" at 746:62-746:63
+9034: Semicolon       ";" at 746:63-746:64
+9035: At              "@" at 747:5-747:6 (leading: Newline, Space)
+9036: Ident           "intrinsic" at 747:6-747:15
+9037: KwFn            "fn" at 747:16-747:18 (leading: Space)
+9038: Ident           "__len" at 747:19-747:24 (leading: Space)
+9039: LParen          "(" at 747:24-747:25
+9040: Ident           "self" at 747:25-747:29
+9041: Colon           ":" at 747:29-747:30
+9042: Amp             "&" at 747:31-747:32 (leading: Space)
+9043: Ident           "ArrayFixed" at 747:32-747:42
+9044: Lt              "<" at 747:42-747:43
+9045: Ident           "T" at 747:43-747:44
+9046: Comma           "," at 747:44-747:45
+9047: Ident           "N" at 747:46-747:47 (leading: Space)
+9048: Gt              ">" at 747:47-747:48
+9049: RParen          ")" at 747:48-747:49
+9050: Arrow           "->" at 747:50-747:52 (leading: Space)
+9051: Ident           "uint" at 747:53-747:57 (leading: Space)
+9052: Semicolon       ";" at 747:57-747:58
+9053: RBrace          "}" at 748:1-748:2 (leading: Newline)
+9054: At              "@" at 750:1-750:2 (leading: Newline)
+9055: Ident           "intrinsic" at 750:2-750:11
+9056: KwPub           "pub" at 751:1-751:4 (leading: Newline)
+9057: KwFn            "fn" at 751:5-751:7 (leading: Space)
+9058: Ident           "default" at 751:8-751:15 (leading: Space)
+9059: Lt              "<" at 751:15-751:16
+9060: Ident           "T" at 751:16-751:17
+9061: Gt              ">" at 751:17-751:18
+9062: LParen          "(" at 751:18-751:19
+9063: RParen          ")" at 751:19-751:20
+9064: Arrow           "->" at 751:21-751:23 (leading: Space)
+9065: Ident           "T" at 751:24-751:25 (leading: Space)
+9066: Semicolon       ";" at 751:25-751:26
+9067: At              "@" at 753:1-753:2 (leading: Newline)
+9068: Ident           "intrinsic" at 753:2-753:11
+9069: KwPub           "pub" at 754:1-754:4 (leading: Newline)
+9070: KwFn            "fn" at 754:5-754:7 (leading: Space)
+9071: Ident           "size_of" at 754:8-754:15 (leading: Space)
+9072: Lt              "<" at 754:15-754:16
+9073: Ident           "T" at 754:16-754:17
+9074: Gt              ">" at 754:17-754:18
+9075: LParen          "(" at 754:18-754:19
+9076: RParen          ")" at 754:19-754:20
+9077: Arrow           "->" at 754:21-754:23 (leading: Space)
+9078: Ident           "uint" at 754:24-754:28 (leading: Space)
+9079: Semicolon       ";" at 754:28-754:29
+9080: At              "@" at 756:1-756:2 (leading: Newline)
+9081: Ident           "intrinsic" at 756:2-756:11
+9082: KwPub           "pub" at 757:1-757:4 (leading: Newline)
+9083: KwFn            "fn" at 757:5-757:7 (leading: Space)
+9084: Ident           "align_of" at 757:8-757:16 (leading: Space)
+9085: Lt              "<" at 757:16-757:17
+9086: Ident           "T" at 757:17-757:18
+9087: Gt              ">" at 757:18-757:19
+9088: LParen          "(" at 757:19-757:20
+9089: RParen          ")" at 757:20-757:21
+9090: Arrow           "->" at 757:22-757:24 (leading: Space)
+9091: Ident           "uint" at 757:25-757:29 (leading: Space)
+9092: Semicolon       ";" at 757:29-757:30
+9093: KwPub           "pub" at 759:1-759:4 (leading: Newline)
+9094: KwContract      "contract" at 759:5-759:13 (leading: Space)
+9095: Ident           "ErrorLike" at 759:14-759:23 (leading: Space)
+9096: LBrace          "{" at 759:23-759:24
+9097: KwField         "field" at 760:5-760:10 (leading: Newline, Space)
+9098: Ident           "message" at 760:11-760:18 (leading: Space)
+9099: Colon           ":" at 760:18-760:19
+9100: Ident           "string" at 760:20-760:26 (leading: Space)
+9101: Semicolon       ";" at 760:26-760:27
+9102: KwField         "field" at 761:5-761:10 (leading: Newline, Space)
+9103: Ident           "code" at 761:11-761:15 (leading: Space)
+9104: Colon           ":" at 761:15-761:16
+9105: Ident           "uint" at 761:17-761:21 (leading: Space)
+9106: Semicolon       ";" at 761:21-761:22
+9107: RBrace          "}" at 762:1-762:2 (leading: Newline)
+9108: At              "@" at 764:1-764:2 (leading: Newline)
+9109: Ident           "intrinsic" at 764:2-764:11
+9110: KwPub           "pub" at 765:1-765:4 (leading: Newline)
+9111: KwFn            "fn" at 765:5-765:7 (leading: Space)
+9112: Ident           "exit" at 765:8-765:12 (leading: Space)
+9113: Lt              "<" at 765:12-765:13
+9114: Ident           "E" at 765:13-765:14
+9115: Colon           ":" at 765:14-765:15
+9116: Ident           "ErrorLike" at 765:16-765:25 (leading: Space)
+9117: Gt              ">" at 765:25-765:26
+9118: LParen          "(" at 765:26-765:27
+9119: Ident           "e" at 765:27-765:28
+9120: Colon           ":" at 765:28-765:29
+9121: Ident           "E" at 765:30-765:31 (leading: Space)
+9122: RParen          ")" at 765:31-765:32
+9123: Arrow           "->" at 765:33-765:35 (leading: Space)
+9124: NothingLit      "nothing" at 765:36-765:43 (leading: Space)
+9125: Semicolon       ";" at 765:43-765:44
+9126: At              "@" at 767:1-767:2 (leading: Newline)
+9127: Ident           "intrinsic" at 767:2-767:11
+9128: KwPub           "pub" at 768:1-768:4 (leading: Newline)
+9129: KwFn            "fn" at 768:5-768:7 (leading: Space)
+9130: Ident           "rt_panic" at 768:8-768:16 (leading: Space)
+9131: LParen          "(" at 768:16-768:17
+9132: Ident           "ptr" at 768:17-768:20
+9133: Colon           ":" at 768:20-768:21
+9134: Star            "*" at 768:22-768:23 (leading: Space)
+9135: Ident           "byte" at 768:23-768:27
+9136: Comma           "," at 768:27-768:28
+9137: Ident           "length" at 768:29-768:35 (leading: Space)
+9138: Colon           ":" at 768:35-768:36
+9139: Ident           "uint" at 768:37-768:41 (leading: Space)
+9140: RParen          ")" at 768:41-768:42
+9141: Arrow           "->" at 768:43-768:45 (leading: Space)
+9142: NothingLit      "nothing" at 768:46-768:53 (leading: Space)
+9143: Semicolon       ";" at 768:53-768:54
+9144: KwPub           "pub" at 770:1-770:4 (leading: Newline)
+9145: KwFn            "fn" at 770:5-770:7 (leading: Space)
+9146: Ident           "panic" at 770:8-770:13 (leading: Space)
+9147: LParen          "(" at 770:13-770:14
+9148: Ident           "msg" at 770:14-770:17
+9149: Colon           ":" at 770:17-770:18
+9150: Ident           "string" at 770:19-770:25 (leading: Space)
+9151: RParen          ")" at 770:25-770:26
+9152: Arrow           "->" at 770:27-770:29 (leading: Space)
+9153: NothingLit      "nothing" at 770:30-770:37 (leading: Space)
+9154: LBrace          "{" at 770:38-770:39 (leading: Space)
+9155: KwLet           "let" at 771:5-771:8 (leading: Newline, Space)
+9156: Ident           "ptr" at 771:9-771:12 (leading: Space)
+9157: Assign          "=" at 771:13-771:14 (leading: Space)
+9158: Ident           "rt_string_ptr" at 771:15-771:28 (leading: Space)
+9159: LParen          "(" at 771:28-771:29
+9160: Amp             "&" at 771:29-771:30
+9161: Ident           "msg" at 771:30-771:33
+9162: RParen          ")" at 771:33-771:34
+9163: Semicolon       ";" at 771:34-771:35
+9164: KwLet           "let" at 772:5-772:8 (leading: Newline, Space)
+9165: Ident           "length" at 772:9-772:15 (leading: Space)
+9166: Assign          "=" at 772:16-772:17 (leading: Space)
+9167: Ident           "rt_string_len_bytes" at 772:18-772:37 (leading: Space)
+9168: LParen          "(" at 772:37-772:38
+9169: Amp             "&" at 772:38-772:39
+9170: Ident           "msg" at 772:39-772:42
+9171: RParen          ")" at 772:42-772:43
+9172: Semicolon       ";" at 772:43-772:44
+9173: Ident           "rt_panic" at 773:5-773:13 (leading: Newline, Space)
+9174: LParen          "(" at 773:13-773:14
+9175: Ident           "ptr" at 773:14-773:17
+9176: Comma           "," at 773:17-773:18
+9177: Ident           "length" at 773:19-773:25 (leading: Space)
+9178: RParen          ")" at 773:25-773:26
+9179: Semicolon       ";" at 773:26-773:27
+9180: RBrace          "}" at 774:1-774:2 (leading: Newline)
+9181: At              "@" at 776:1-776:2 (leading: Newline)
+9182: Ident           "intrinsic" at 776:2-776:11
+9183: KwPub           "pub" at 777:1-777:4 (leading: Newline)
+9184: KwType          "type" at 777:5-777:9 (leading: Space)
+9185: Ident           "RwLock" at 777:10-777:16 (leading: Space)
+9186: Assign          "=" at 777:17-777:18 (leading: Space)
+9187: LBrace          "{" at 777:19-777:20 (leading: Space)
+9188: Ident           "__opaque" at 778:5-778:13 (leading: Newline, Space)
+9189: Colon           ":" at 778:13-778:14
+9190: Star            "*" at 778:15-778:16 (leading: Space)
+9191: Ident           "byte" at 778:16-778:20
+9192: Comma           "," at 778:20-778:21
+9193: RBrace          "}" at 779:1-779:2 (leading: Newline)
+9194: Semicolon       ";" at 779:2-779:3
+9195: KwExtern        "extern" at 781:1-781:7 (leading: Newline)
+9196: Lt              "<" at 781:7-781:8
+9197: Ident           "RwLock" at 781:8-781:14
+9198: Gt              ">" at 781:14-781:15
+9199: LBrace          "{" at 781:16-781:17 (leading: Space)
+9200: At              "@" at 782:5-782:6 (leading: Newline, Space)
+9201: Ident           "intrinsic" at 782:6-782:15
+9202: KwPub           "pub" at 782:16-782:19 (leading: Space)
+9203: KwFn            "fn" at 782:20-782:22 (leading: Space)
+9204: Ident           "new" at 782:23-782:26 (leading: Space)
+9205: LParen          "(" at 782:26-782:27
+9206: RParen          ")" at 782:27-782:28
+9207: Arrow           "->" at 782:29-782:31 (leading: Space)
+9208: Ident           "RwLock" at 782:32-782:38 (leading: Space)
+9209: Semicolon       ";" at 782:38-782:39
+9210: At              "@" at 783:5-783:6 (leading: Newline, Space)
+9211: Ident           "intrinsic" at 783:6-783:15
+9212: KwPub           "pub" at 783:16-783:19 (leading: Space)
+9213: KwFn            "fn" at 783:20-783:22 (leading: Space)
+9214: Ident           "read_lock" at 783:23-783:32 (leading: Space)
+9215: LParen          "(" at 783:32-783:33
+9216: Ident           "self" at 783:33-783:37
+9217: Colon           ":" at 783:37-783:38
+9218: Amp             "&" at 783:39-783:40 (leading: Space)
+9219: KwMut           "mut" at 783:40-783:43
+9220: Ident           "RwLock" at 783:44-783:50 (leading: Space)
+9221: RParen          ")" at 783:50-783:51
+9222: Arrow           "->" at 783:52-783:54 (leading: Space)
+9223: NothingLit      "nothing" at 783:55-783:62 (leading: Space)
+9224: Semicolon       ";" at 783:62-783:63
+9225: At              "@" at 784:5-784:6 (leading: Newline, Space)
+9226: Ident           "intrinsic" at 784:6-784:15
+9227: KwPub           "pub" at 784:16-784:19 (leading: Space)
+9228: KwFn            "fn" at 784:20-784:22 (leading: Space)
+9229: Ident           "read_unlock" at 784:23-784:34 (leading: Space)
+9230: LParen          "(" at 784:34-784:35
+9231: Ident           "self" at 784:35-784:39
+9232: Colon           ":" at 784:39-784:40
+9233: Amp             "&" at 784:41-784:42 (leading: Space)
+9234: KwMut           "mut" at 784:42-784:45
+9235: Ident           "RwLock" at 784:46-784:52 (leading: Space)
+9236: RParen          ")" at 784:52-784:53
+9237: Arrow           "->" at 784:54-784:56 (leading: Space)
+9238: NothingLit      "nothing" at 784:57-784:64 (leading: Space)
+9239: Semicolon       ";" at 784:64-784:65
+9240: At              "@" at 785:5-785:6 (leading: Newline, Space)
+9241: Ident           "intrinsic" at 785:6-785:15
+9242: KwPub           "pub" at 785:16-785:19 (leading: Space)
+9243: KwFn            "fn" at 785:20-785:22 (leading: Space)
+9244: Ident           "write_lock" at 785:23-785:33 (leading: Space)
+9245: LParen          "(" at 785:33-785:34
+9246: Ident           "self" at 785:34-785:38
+9247: Colon           ":" at 785:38-785:39
+9248: Amp             "&" at 785:40-785:41 (leading: Space)
+9249: KwMut           "mut" at 785:41-785:44
+9250: Ident           "RwLock" at 785:45-785:51 (leading: Space)
+9251: RParen          ")" at 785:51-785:52
+9252: Arrow           "->" at 785:53-785:55 (leading: Space)
+9253: NothingLit      "nothing" at 785:56-785:63 (leading: Space)
+9254: Semicolon       ";" at 785:63-785:64
+9255: At              "@" at 786:5-786:6 (leading: Newline, Space)
+9256: Ident           "intrinsic" at 786:6-786:15
+9257: KwPub           "pub" at 786:16-786:19 (leading: Space)
+9258: KwFn            "fn" at 786:20-786:22 (leading: Space)
+9259: Ident           "write_unlock" at 786:23-786:35 (leading: Space)
+9260: LParen          "(" at 786:35-786:36
+9261: Ident           "self" at 786:36-786:40
+9262: Colon           ":" at 786:40-786:41
+9263: Amp             "&" at 786:42-786:43 (leading: Space)
+9264: KwMut           "mut" at 786:43-786:46
+9265: Ident           "RwLock" at 786:47-786:53 (leading: Space)
+9266: RParen          ")" at 786:53-786:54
+9267: Arrow           "->" at 786:55-786:57 (leading: Space)
+9268: NothingLit      "nothing" at 786:58-786:65 (leading: Space)
+9269: Semicolon       ";" at 786:65-786:66
+9270: At              "@" at 787:5-787:6 (leading: Newline, Space)
+9271: Ident           "intrinsic" at 787:6-787:15
+9272: KwPub           "pub" at 787:16-787:19 (leading: Space)
+9273: KwFn            "fn" at 787:20-787:22 (leading: Space)
+9274: Ident           "try_read_lock" at 787:23-787:36 (leading: Space)
+9275: LParen          "(" at 787:36-787:37
+9276: Ident           "self" at 787:37-787:41
+9277: Colon           ":" at 787:41-787:42
+9278: Amp             "&" at 787:43-787:44 (leading: Space)
+9279: KwMut           "mut" at 787:44-787:47
+9280: Ident           "RwLock" at 787:48-787:54 (leading: Space)
+9281: RParen          ")" at 787:54-787:55
+9282: Arrow           "->" at 787:56-787:58 (leading: Space)
+9283: Ident           "bool" at 787:59-787:63 (leading: Space)
+9284: Semicolon       ";" at 787:63-787:64
+9285: At              "@" at 788:5-788:6 (leading: Newline, Space)
+9286: Ident           "intrinsic" at 788:6-788:15
+9287: KwPub           "pub" at 788:16-788:19 (leading: Space)
+9288: KwFn            "fn" at 788:20-788:22 (leading: Space)
+9289: Ident           "try_write_lock" at 788:23-788:37 (leading: Space)
+9290: LParen          "(" at 788:37-788:38
+9291: Ident           "self" at 788:38-788:42
+9292: Colon           ":" at 788:42-788:43
+9293: Amp             "&" at 788:44-788:45 (leading: Space)
+9294: KwMut           "mut" at 788:45-788:48
+9295: Ident           "RwLock" at 788:49-788:55 (leading: Space)
+9296: RParen          ")" at 788:55-788:56
+9297: Arrow           "->" at 788:57-788:59 (leading: Space)
+9298: Ident           "bool" at 788:60-788:64 (leading: Space)
+9299: Semicolon       ";" at 788:64-788:65
+9300: RBrace          "}" at 789:1-789:2 (leading: Newline)
+9301: At              "@" at 797:1-797:2 (leading: Newline, LineComment, Newline, LineComment, Newline, LineComment, Newline, LineComment, Newline, LineComment, Newline)
+9302: Ident           "intrinsic" at 797:2-797:11
+9303: KwPub           "pub" at 798:1-798:4 (leading: Newline)
+9304: KwFn            "fn" at 798:5-798:7 (leading: Space)
+9305: Ident           "atomic_load" at 798:8-798:19 (leading: Space)
+9306: LParen          "(" at 798:19-798:20
+9307: Ident           "ptr" at 798:20-798:23
+9308: Colon           ":" at 798:23-798:24
+9309: Amp             "&" at 798:25-798:26 (leading: Space)
+9310: Ident           "int" at 798:26-798:29
+9311: RParen          ")" at 798:29-798:30
+9312: Arrow           "->" at 798:31-798:33 (leading: Space)
+9313: Ident           "int" at 798:34-798:37 (leading: Space)
+9314: Semicolon       ";" at 798:37-798:38
+9315: At              "@" at 800:1-800:2 (leading: Newline)
+9316: Ident           "intrinsic" at 800:2-800:11
+9317: At              "@" at 801:1-801:2 (leading: Newline)
+9318: Ident           "overload" at 801:2-801:10
+9319: KwPub           "pub" at 802:1-802:4 (leading: Newline)
+9320: KwFn            "fn" at 802:5-802:7 (leading: Space)
+9321: Ident           "atomic_load" at 802:8-802:19 (leading: Space)
+9322: LParen          "(" at 802:19-802:20
+9323: Ident           "ptr" at 802:20-802:23
+9324: Colon           ":" at 802:23-802:24
+9325: Amp             "&" at 802:25-802:26 (leading: Space)
+9326: Ident           "uint" at 802:26-802:30
+9327: RParen          ")" at 802:30-802:31
+9328: Arrow           "->" at 802:32-802:34 (leading: Space)
+9329: Ident           "uint" at 802:35-802:39 (leading: Space)
+9330: Semicolon       ";" at 802:39-802:40
+9331: At              "@" at 804:1-804:2 (leading: Newline)
+9332: Ident           "intrinsic" at 804:2-804:11
+9333: At              "@" at 805:1-805:2 (leading: Newline)
+9334: Ident           "overload" at 805:2-805:10
+9335: KwPub           "pub" at 806:1-806:4 (leading: Newline)
+9336: KwFn            "fn" at 806:5-806:7 (leading: Space)
+9337: Ident           "atomic_load" at 806:8-806:19 (leading: Space)
+9338: LParen          "(" at 806:19-806:20
+9339: Ident           "ptr" at 806:20-806:23
+9340: Colon           ":" at 806:23-806:24
+9341: Amp             "&" at 806:25-806:26 (leading: Space)
+9342: Ident           "bool" at 806:26-806:30
+9343: RParen          ")" at 806:30-806:31
+9344: Arrow           "->" at 806:32-806:34 (leading: Space)
+9345: Ident           "bool" at 806:35-806:39 (leading: Space)
+9346: Semicolon       ";" at 806:39-806:40
+9347: At              "@" at 809:1-809:2 (leading: Newline, LineComment, Newline)
+9348: Ident           "intrinsic" at 809:2-809:11
+9349: KwPub           "pub" at 810:1-810:4 (leading: Newline)
+9350: KwFn            "fn" at 810:5-810:7 (leading: Space)
+9351: Ident           "atomic_store" at 810:8-810:20 (leading: Space)
+9352: LParen          "(" at 810:20-810:21
+9353: Ident           "ptr" at 810:21-810:24
+9354: Colon           ":" at 810:24-810:25
+9355: Amp             "&" at 810:26-810:27 (leading: Space)
+9356: KwMut           "mut" at 810:27-810:30
+9357: Ident           "int" at 810:31-810:34 (leading: Space)
+9358: Comma           "," at 810:34-810:35
+9359: Ident           "value" at 810:36-810:41 (leading: Space)
+9360: Colon           ":" at 810:41-810:42
+9361: Ident           "int" at 810:43-810:46 (leading: Space)
+9362: RParen          ")" at 810:46-810:47
+9363: Arrow           "->" at 810:48-810:50 (leading: Space)
+9364: NothingLit      "nothing" at 810:51-810:58 (leading: Space)
+9365: Semicolon       ";" at 810:58-810:59
+9366: At              "@" at 812:1-812:2 (leading: Newline)
+9367: Ident           "intrinsic" at 812:2-812:11
+9368: At              "@" at 813:1-813:2 (leading: Newline)
+9369: Ident           "overload" at 813:2-813:10
+9370: KwPub           "pub" at 814:1-814:4 (leading: Newline)
+9371: KwFn            "fn" at 814:5-814:7 (leading: Space)
+9372: Ident           "atomic_store" at 814:8-814:20 (leading: Space)
+9373: LParen          "(" at 814:20-814:21
+9374: Ident           "ptr" at 814:21-814:24
+9375: Colon           ":" at 814:24-814:25
+9376: Amp             "&" at 814:26-814:27 (leading: Space)
+9377: KwMut           "mut" at 814:27-814:30
+9378: Ident           "uint" at 814:31-814:35 (leading: Space)
+9379: Comma           "," at 814:35-814:36
+9380: Ident           "value" at 814:37-814:42 (leading: Space)
+9381: Colon           ":" at 814:42-814:43
+9382: Ident           "uint" at 814:44-814:48 (leading: Space)
+9383: RParen          ")" at 814:48-814:49
+9384: Arrow           "->" at 814:50-814:52 (leading: Space)
+9385: NothingLit      "nothing" at 814:53-814:60 (leading: Space)
+9386: Semicolon       ";" at 814:60-814:61
+9387: At              "@" at 816:1-816:2 (leading: Newline)
+9388: Ident           "intrinsic" at 816:2-816:11
+9389: At              "@" at 817:1-817:2 (leading: Newline)
+9390: Ident           "overload" at 817:2-817:10
+9391: KwPub           "pub" at 818:1-818:4 (leading: Newline)
+9392: KwFn            "fn" at 818:5-818:7 (leading: Space)
+9393: Ident           "atomic_store" at 818:8-818:20 (leading: Space)
+9394: LParen          "(" at 818:20-818:21
+9395: Ident           "ptr" at 818:21-818:24
+9396: Colon           ":" at 818:24-818:25
+9397: Amp             "&" at 818:26-818:27 (leading: Space)
+9398: KwMut           "mut" at 818:27-818:30
+9399: Ident           "bool" at 818:31-818:35 (leading: Space)
+9400: Comma           "," at 818:35-818:36
+9401: Ident           "value" at 818:37-818:42 (leading: Space)
+9402: Colon           ":" at 818:42-818:43
+9403: Ident           "bool" at 818:44-818:48 (leading: Space)
+9404: RParen          ")" at 818:48-818:49
+9405: Arrow           "->" at 818:50-818:52 (leading: Space)
+9406: NothingLit      "nothing" at 818:53-818:60 (leading: Space)
+9407: Semicolon       ";" at 818:60-818:61
+9408: At              "@" at 821:1-821:2 (leading: Newline, LineComment, Newline)
+9409: Ident           "intrinsic" at 821:2-821:11
+9410: KwPub           "pub" at 822:1-822:4 (leading: Newline)
+9411: KwFn            "fn" at 822:5-822:7 (leading: Space)
+9412: Ident           "atomic_exchange" at 822:8-822:23 (leading: Space)
+9413: LParen          "(" at 822:23-822:24
+9414: Ident           "ptr" at 822:24-822:27
+9415: Colon           ":" at 822:27-822:28
+9416: Amp             "&" at 822:29-822:30 (leading: Space)
+9417: KwMut           "mut" at 822:30-822:33
+9418: Ident           "int" at 822:34-822:37 (leading: Space)
+9419: Comma           "," at 822:37-822:38
+9420: Ident           "new_val" at 822:39-822:46 (leading: Space)
+9421: Colon           ":" at 822:46-822:47
+9422: Ident           "int" at 822:48-822:51 (leading: Space)
+9423: RParen          ")" at 822:51-822:52
+9424: Arrow           "->" at 822:53-822:55 (leading: Space)
+9425: Ident           "int" at 822:56-822:59 (leading: Space)
+9426: Semicolon       ";" at 822:59-822:60
+9427: At              "@" at 824:1-824:2 (leading: Newline)
+9428: Ident           "intrinsic" at 824:2-824:11
+9429: At              "@" at 825:1-825:2 (leading: Newline)
+9430: Ident           "overload" at 825:2-825:10
+9431: KwPub           "pub" at 826:1-826:4 (leading: Newline)
+9432: KwFn            "fn" at 826:5-826:7 (leading: Space)
+9433: Ident           "atomic_exchange" at 826:8-826:23 (leading: Space)
+9434: LParen          "(" at 826:23-826:24
+9435: Ident           "ptr" at 826:24-826:27
+9436: Colon           ":" at 826:27-826:28
+9437: Amp             "&" at 826:29-826:30 (leading: Space)
+9438: KwMut           "mut" at 826:30-826:33
+9439: Ident           "uint" at 826:34-826:38 (leading: Space)
+9440: Comma           "," at 826:38-826:39
+9441: Ident           "new_val" at 826:40-826:47 (leading: Space)
+9442: Colon           ":" at 826:47-826:48
+9443: Ident           "uint" at 826:49-826:53 (leading: Space)
+9444: RParen          ")" at 826:53-826:54
+9445: Arrow           "->" at 826:55-826:57 (leading: Space)
+9446: Ident           "uint" at 826:58-826:62 (leading: Space)
+9447: Semicolon       ";" at 826:62-826:63
+9448: At              "@" at 828:1-828:2 (leading: Newline)
+9449: Ident           "intrinsic" at 828:2-828:11
+9450: At              "@" at 829:1-829:2 (leading: Newline)
+9451: Ident           "overload" at 829:2-829:10
+9452: KwPub           "pub" at 830:1-830:4 (leading: Newline)
+9453: KwFn            "fn" at 830:5-830:7 (leading: Space)
+9454: Ident           "atomic_exchange" at 830:8-830:23 (leading: Space)
+9455: LParen          "(" at 830:23-830:24
+9456: Ident           "ptr" at 830:24-830:27
+9457: Colon           ":" at 830:27-830:28
+9458: Amp             "&" at 830:29-830:30 (leading: Space)
+9459: KwMut           "mut" at 830:30-830:33
+9460: Ident           "bool" at 830:34-830:38 (leading: Space)
+9461: Comma           "," at 830:38-830:39
+9462: Ident           "new_val" at 830:40-830:47 (leading: Space)
+9463: Colon           ":" at 830:47-830:48
+9464: Ident           "bool" at 830:49-830:53 (leading: Space)
+9465: RParen          ")" at 830:53-830:54
+9466: Arrow           "->" at 830:55-830:57 (leading: Space)
+9467: Ident           "bool" at 830:58-830:62 (leading: Space)
+9468: Semicolon       ";" at 830:62-830:63
+9469: At              "@" at 834:1-834:2 (leading: Newline, LineComment, Newline, LineComment, Newline)
+9470: Ident           "intrinsic" at 834:2-834:11
+9471: KwPub           "pub" at 835:1-835:4 (leading: Newline)
+9472: KwFn            "fn" at 835:5-835:7 (leading: Space)
+9473: Ident           "atomic_compare_exchange" at 835:8-835:31 (leading: Space)
+9474: LParen          "(" at 835:31-835:32
+9475: Ident           "ptr" at 835:32-835:35
+9476: Colon           ":" at 835:35-835:36
+9477: Amp             "&" at 835:37-835:38 (leading: Space)
+9478: KwMut           "mut" at 835:38-835:41
+9479: Ident           "int" at 835:42-835:45 (leading: Space)
+9480: Comma           "," at 835:45-835:46
+9481: Ident           "expected" at 835:47-835:55 (leading: Space)
+9482: Colon           ":" at 835:55-835:56
+9483: Ident           "int" at 835:57-835:60 (leading: Space)
+9484: Comma           "," at 835:60-835:61
+9485: Ident           "desired" at 835:62-835:69 (leading: Space)
+9486: Colon           ":" at 835:69-835:70
+9487: Ident           "int" at 835:71-835:74 (leading: Space)
+9488: RParen          ")" at 835:74-835:75
+9489: Arrow           "->" at 835:76-835:78 (leading: Space)
+9490: Ident           "bool" at 835:79-835:83 (leading: Space)
+9491: Semicolon       ";" at 835:83-835:84
+9492: At              "@" at 837:1-837:2 (leading: Newline)
+9493: Ident           "intrinsic" at 837:2-837:11
+9494: At              "@" at 838:1-838:2 (leading: Newline)
+9495: Ident           "overload" at 838:2-838:10
+9496: KwPub           "pub" at 839:1-839:4 (leading: Newline)
+9497: KwFn            "fn" at 839:5-839:7 (leading: Space)
+9498: Ident           "atomic_compare_exchange" at 839:8-839:31 (leading: Space)
+9499: LParen          "(" at 839:31-839:32
+9500: Ident           "ptr" at 839:32-839:35
+9501: Colon           ":" at 839:35-839:36
+9502: Amp             "&" at 839:37-839:38 (leading: Space)
+9503: KwMut           "mut" at 839:38-839:41
+9504: Ident           "uint" at 839:42-839:46 (leading: Space)
+9505: Comma           "," at 839:46-839:47
+9506: Ident           "expected" at 839:48-839:56 (leading: Space)
+9507: Colon           ":" at 839:56-839:57
+9508: Ident           "uint" at 839:58-839:62 (leading: Space)
+9509: Comma           "," at 839:62-839:63
+9510: Ident           "desired" at 839:64-839:71 (leading: Space)
+9511: Colon           ":" at 839:71-839:72
+9512: Ident           "uint" at 839:73-839:77 (leading: Space)
+9513: RParen          ")" at 839:77-839:78
+9514: Arrow           "->" at 839:79-839:81 (leading: Space)
+9515: Ident           "bool" at 839:82-839:86 (leading: Space)
+9516: Semicolon       ";" at 839:86-839:87
+9517: At              "@" at 841:1-841:2 (leading: Newline)
+9518: Ident           "intrinsic" at 841:2-841:11
+9519: At              "@" at 842:1-842:2 (leading: Newline)
+9520: Ident           "overload" at 842:2-842:10
+9521: KwPub           "pub" at 843:1-843:4 (leading: Newline)
+9522: KwFn            "fn" at 843:5-843:7 (leading: Space)
+9523: Ident           "atomic_compare_exchange" at 843:8-843:31 (leading: Space)
+9524: LParen          "(" at 843:31-843:32
+9525: Ident           "ptr" at 843:32-843:35
+9526: Colon           ":" at 843:35-843:36
+9527: Amp             "&" at 843:37-843:38 (leading: Space)
+9528: KwMut           "mut" at 843:38-843:41
+9529: Ident           "bool" at 843:42-843:46 (leading: Space)
+9530: Comma           "," at 843:46-843:47
+9531: Ident           "expected" at 843:48-843:56 (leading: Space)
+9532: Colon           ":" at 843:56-843:57
+9533: Ident           "bool" at 843:58-843:62 (leading: Space)
+9534: Comma           "," at 843:62-843:63
+9535: Ident           "desired" at 843:64-843:71 (leading: Space)
+9536: Colon           ":" at 843:71-843:72
+9537: Ident           "bool" at 843:73-843:77 (leading: Space)
+9538: RParen          ")" at 843:77-843:78
+9539: Arrow           "->" at 843:79-843:81 (leading: Space)
+9540: Ident           "bool" at 843:82-843:86 (leading: Space)
+9541: Semicolon       ";" at 843:86-843:87
+9542: At              "@" at 846:1-846:2 (leading: Newline, LineComment, Newline)
+9543: Ident           "intrinsic" at 846:2-846:11
+9544: KwPub           "pub" at 847:1-847:4 (leading: Newline)
+9545: KwFn            "fn" at 847:5-847:7 (leading: Space)
+9546: Ident           "atomic_fetch_add" at 847:8-847:24 (leading: Space)
+9547: LParen          "(" at 847:24-847:25
+9548: Ident           "ptr" at 847:25-847:28
+9549: Colon           ":" at 847:28-847:29
+9550: Amp             "&" at 847:30-847:31 (leading: Space)
+9551: KwMut           "mut" at 847:31-847:34
+9552: Ident           "int" at 847:35-847:38 (leading: Space)
+9553: Comma           "," at 847:38-847:39
+9554: Ident           "delta" at 847:40-847:45 (leading: Space)
+9555: Colon           ":" at 847:45-847:46
+9556: Ident           "int" at 847:47-847:50 (leading: Space)
+9557: RParen          ")" at 847:50-847:51
+9558: Arrow           "->" at 847:52-847:54 (leading: Space)
+9559: Ident           "int" at 847:55-847:58 (leading: Space)
+9560: Semicolon       ";" at 847:58-847:59
+9561: At              "@" at 849:1-849:2 (leading: Newline)
+9562: Ident           "intrinsic" at 849:2-849:11
+9563: At              "@" at 850:1-850:2 (leading: Newline)
+9564: Ident           "overload" at 850:2-850:10
+9565: KwPub           "pub" at 851:1-851:4 (leading: Newline)
+9566: KwFn            "fn" at 851:5-851:7 (leading: Space)
+9567: Ident           "atomic_fetch_add" at 851:8-851:24 (leading: Space)
+9568: LParen          "(" at 851:24-851:25
+9569: Ident           "ptr" at 851:25-851:28
+9570: Colon           ":" at 851:28-851:29
+9571: Amp             "&" at 851:30-851:31 (leading: Space)
+9572: KwMut           "mut" at 851:31-851:34
+9573: Ident           "uint" at 851:35-851:39 (leading: Space)
+9574: Comma           "," at 851:39-851:40
+9575: Ident           "delta" at 851:41-851:46 (leading: Space)
+9576: Colon           ":" at 851:46-851:47
+9577: Ident           "uint" at 851:48-851:52 (leading: Space)
+9578: RParen          ")" at 851:52-851:53
+9579: Arrow           "->" at 851:54-851:56 (leading: Space)
+9580: Ident           "uint" at 851:57-851:61 (leading: Space)
+9581: Semicolon       ";" at 851:61-851:62
+9582: At              "@" at 854:1-854:2 (leading: Newline, LineComment, Newline)
+9583: Ident           "intrinsic" at 854:2-854:11
+9584: KwPub           "pub" at 855:1-855:4 (leading: Newline)
+9585: KwFn            "fn" at 855:5-855:7 (leading: Space)
+9586: Ident           "atomic_fetch_sub" at 855:8-855:24 (leading: Space)
+9587: LParen          "(" at 855:24-855:25
+9588: Ident           "ptr" at 855:25-855:28
+9589: Colon           ":" at 855:28-855:29
+9590: Amp             "&" at 855:30-855:31 (leading: Space)
+9591: KwMut           "mut" at 855:31-855:34
+9592: Ident           "int" at 855:35-855:38 (leading: Space)
+9593: Comma           "," at 855:38-855:39
+9594: Ident           "delta" at 855:40-855:45 (leading: Space)
+9595: Colon           ":" at 855:45-855:46
+9596: Ident           "int" at 855:47-855:50 (leading: Space)
+9597: RParen          ")" at 855:50-855:51
+9598: Arrow           "->" at 855:52-855:54 (leading: Space)
+9599: Ident           "int" at 855:55-855:58 (leading: Space)
+9600: Semicolon       ";" at 855:58-855:59
+9601: At              "@" at 857:1-857:2 (leading: Newline)
+9602: Ident           "intrinsic" at 857:2-857:11
+9603: At              "@" at 858:1-858:2 (leading: Newline)
+9604: Ident           "overload" at 858:2-858:10
+9605: KwPub           "pub" at 859:1-859:4 (leading: Newline)
+9606: KwFn            "fn" at 859:5-859:7 (leading: Space)
+9607: Ident           "atomic_fetch_sub" at 859:8-859:24 (leading: Space)
+9608: LParen          "(" at 859:24-859:25
+9609: Ident           "ptr" at 859:25-859:28
+9610: Colon           ":" at 859:28-859:29
+9611: Amp             "&" at 859:30-859:31 (leading: Space)
+9612: KwMut           "mut" at 859:31-859:34
+9613: Ident           "uint" at 859:35-859:39 (leading: Space)
+9614: Comma           "," at 859:39-859:40
+9615: Ident           "delta" at 859:41-859:46 (leading: Space)
+9616: Colon           ":" at 859:46-859:47
+9617: Ident           "uint" at 859:48-859:52 (leading: Space)
+9618: RParen          ")" at 859:52-859:53
+9619: Arrow           "->" at 859:54-859:56 (leading: Space)
+9620: Ident           "uint" at 859:57-859:61 (leading: Space)
+9621: Semicolon       ";" at 859:61-859:62
+9622: At              "@" at 864:1-864:2 (leading: Newline, LineComment, Newline, LineComment, Newline)
+9623: Ident           "intrinsic" at 864:2-864:11
+9624: KwPub           "pub" at 865:1-865:4 (leading: Newline)
+9625: KwFn            "fn" at 865:5-865:7 (leading: Space)
+9626: Ident           "rt_argv" at 865:8-865:15 (leading: Space)
+9627: LParen          "(" at 865:15-865:16
+9628: RParen          ")" at 865:16-865:17
+9629: Arrow           "->" at 865:18-865:20 (leading: Space)
+9630: Ident           "string" at 865:21-865:27 (leading: Space)
+9631: LBracket        "[" at 865:27-865:28
+9632: RBracket        "]" at 865:28-865:29
+9633: Semicolon       ";" at 865:29-865:30
+9634: At              "@" at 868:1-868:2 (leading: Newline, LineComment, Newline)
+9635: Ident           "intrinsic" at 868:2-868:11
+9636: KwPub           "pub" at 869:1-869:4 (leading: Newline)
+9637: KwFn            "fn" at 869:5-869:7 (leading: Space)
+9638: Ident           "rt_stdin_read_all" at 869:8-869:25 (leading: Space)
+9639: LParen          "(" at 869:25-869:26
+9640: RParen          ")" at 869:26-869:27
+9641: Arrow           "->" at 869:28-869:30 (leading: Space)
+9642: Ident           "string" at 869:31-869:37 (leading: Space)
+9643: Semicolon       ";" at 869:37-869:38
+9644: At              "@" at 872:1-872:2 (leading: Newline, LineComment, Newline)
+9645: Ident           "intrinsic" at 872:2-872:11
+9646: KwPub           "pub" at 873:1-873:4 (leading: Newline)
+9647: KwFn            "fn" at 873:5-873:7 (leading: Space)
+9648: Ident           "rt_exit" at 873:8-873:15 (leading: Space)
+9649: LParen          "(" at 873:15-873:16
+9650: Ident           "code" at 873:16-873:20
+9651: Colon           ":" at 873:20-873:21
+9652: Ident           "int" at 873:22-873:25 (leading: Space)
+9653: RParen          ")" at 873:25-873:26
+9654: Arrow           "->" at 873:27-873:29 (leading: Space)
+9655: NothingLit      "nothing" at 873:30-873:37 (leading: Space)
+9656: Semicolon       ";" at 873:37-873:38
+9657: EOF             at 874:1-874:1

--- a/testdata/golden/hir/allow_to_conversion.hir
+++ b/testdata/golden/hir/allow_to_conversion.hir
@@ -2,18 +2,18 @@
 == HIR ==
 module 
 
-type Foo <struct> (sym=1391, type=0)
+type Foo <struct> (sym=1395, type=0)
 
-fn __to(self: type#1484, _: string) -> string (id=1, sym=1392) {
+fn __to(self: type#1488, _: string) -> string (id=1, sym=1396) {
   return "\"Foo\""
 }
 
-fn takes_string(s: string) -> int (id=2, sym=1393) {
+fn takes_string(s: string) -> int (id=2, sym=1397) {
   return 0
 }
 
-fn test_allow_to() -> int (id=3, sym=1394) {
-  let f: type#1484 =  { value = 1 }: type#1484
+fn test_allow_to() -> int (id=3, sym=1398) {
+  let f: type#1488 =  { value = 1 }: type#1488
   return takes_string(__to(f, default())): int
 }
 

--- a/testdata/golden/hir/array_indexing.hir
+++ b/testdata/golden/hir/array_indexing.hir
@@ -2,7 +2,7 @@
 == HIR ==
 module 
 
-fn test() -> nothing (id=1, sym=1391) {
+fn test() -> nothing (id=1, sym=1395) {
   let a: type#76 = [1, 2, 3, 4]: type#76
   let x: &int [&] = a[1]: &int
   let y: &int [&] = a[__neg(1): int]: &int

--- a/testdata/golden/hir/arrays.hir
+++ b/testdata/golden/hir/arrays.hir
@@ -2,11 +2,11 @@
 == HIR ==
 module 
 
-fn first(arr: type#1485) -> int (id=1, sym=1391) {
+fn first(arr: type#1489) -> int (id=1, sym=1395) {
   return arr[0]: &int
 }
 
-fn make_array() -> type#1485 (id=2, sym=1392) {
-  return [1, 2, 3]: type#1485
+fn make_array() -> type#1489 (id=2, sym=1396) {
+  return [1, 2, 3]: type#1489
 }
 

--- a/testdata/golden/hir/async_spawn.hir
+++ b/testdata/golden/hir/async_spawn.hir
@@ -2,14 +2,14 @@
 == HIR ==
 module 
 
-async fn inc(x: int [copy]) -> int (id=1, sym=1391) {
+async fn inc(x: int [copy]) -> int (id=1, sym=1395) {
   return __add(x, 1): int
 }
 
-async fn test() -> int (id=2, sym=1392) {
-  let t: type#1484 = spawn inc(5): type#1484: type#1484
+async fn test() -> int (id=2, sym=1396) {
+  let t: type#1488 = spawn inc(5): type#1488: type#1488
   return {
-    let __cmp1: type#1487 = await(t): type#1487
+    let __cmp1: type#1491 = await(t): type#1491
     if tag_test(__cmp1, Success): bool {
       let v: int [copy] = tag_payload(__cmp1, Success, 0): int
       return v

--- a/testdata/golden/hir/bitwise.hir
+++ b/testdata/golden/hir/bitwise.hir
@@ -2,7 +2,7 @@
 == HIR ==
 module 
 
-fn bit_ops(a: int [copy], b: int [copy]) -> int (id=1, sym=1391) {
+fn bit_ops(a: int [copy], b: int [copy]) -> int (id=1, sym=1395) {
   let and_result: int [copy] = __bit_and(a, b): int
   let or_result: int [copy] = __bit_or(a, b): int
   let xor_result: int [copy] = __bit_xor(a, b): int
@@ -11,7 +11,7 @@ fn bit_ops(a: int [copy], b: int [copy]) -> int (id=1, sym=1391) {
   return __bit_or(and_result, or_result): int
 }
 
-fn logical_ops(a: bool [copy], b: bool [copy]) -> bool (id=2, sym=1392) {
+fn logical_ops(a: bool [copy], b: bool [copy]) -> bool (id=2, sym=1396) {
   return ((a && b) || __not(a)): bool
 }
 

--- a/testdata/golden/hir/block_expr.hir
+++ b/testdata/golden/hir/block_expr.hir
@@ -2,7 +2,7 @@
 == HIR ==
 module 
 
-fn block_scope() -> int (id=1, sym=1391) {
+fn block_scope() -> int (id=1, sym=1395) {
   let x: int [copy] = 1
   {
     let y: int [copy] = 2
@@ -11,11 +11,11 @@ fn block_scope() -> int (id=1, sym=1391) {
   return x
 }
 
-async fn with_async_block() -> nothing (id=2, sym=1392) {
-  let t: type#576 = async {
+async fn with_async_block() -> nothing (id=2, sym=1396) {
+  let t: type#581 = async {
     let x: int [copy] = 1
     let y: int [copy] = __add(x, 1): int
-  }: type#576
+  }: type#581
   return
 }
 

--- a/testdata/golden/hir/casts.hir
+++ b/testdata/golden/hir/casts.hir
@@ -2,11 +2,11 @@
 == HIR ==
 module 
 
-fn to_float(x: int [copy]) -> float (id=1, sym=1391) {
+fn to_float(x: int [copy]) -> float (id=1, sym=1395) {
   return x to ?: float
 }
 
-fn explicit_int(x: int [copy]) -> int (id=2, sym=1392) {
+fn explicit_int(x: int [copy]) -> int (id=2, sym=1396) {
   return x to ?: int
 }
 

--- a/testdata/golden/hir/compare.hir
+++ b/testdata/golden/hir/compare.hir
@@ -2,7 +2,7 @@
 == HIR ==
 module 
 
-fn classify(x: int [copy]) -> int (id=1, sym=1391) {
+fn classify(x: int [copy]) -> int (id=1, sym=1395) {
   return {
     let __cmp1: int [copy] = x
     if (__cmp1 == 0): bool {

--- a/testdata/golden/hir/compare_tag.hir
+++ b/testdata/golden/hir/compare_tag.hir
@@ -2,9 +2,9 @@
 == HIR ==
 module 
 
-fn unwrap_or_zero(x: type#1484) -> int (id=1, sym=1391) {
+fn unwrap_or_zero(x: type#1488) -> int (id=1, sym=1395) {
   return {
-    let __cmp1: type#1484 = x
+    let __cmp1: type#1488 = x
     if tag_test(__cmp1, Some): bool {
       let v: int [copy] = tag_payload(__cmp1, Some, 0): int
       return v

--- a/testdata/golden/hir/control_flow.hir
+++ b/testdata/golden/hir/control_flow.hir
@@ -2,7 +2,7 @@
 == HIR ==
 module 
 
-fn abs(x: int [copy]) -> int (id=1, sym=1391) {
+fn abs(x: int [copy]) -> int (id=1, sym=1395) {
   if __lt(x, 0): bool {
     return __neg(x): int
   } else {
@@ -10,7 +10,7 @@ fn abs(x: int [copy]) -> int (id=1, sym=1391) {
   }
 }
 
-fn countdown(n: int [copy]) -> int (id=2, sym=1392) {
+fn countdown(n: int [copy]) -> int (id=2, sym=1396) {
   let mut i: int [copy] = n
   while __gt(i, 0): bool {
     (i = __sub(i, 1)): int

--- a/testdata/golden/hir/for_classic.hir
+++ b/testdata/golden/hir/for_classic.hir
@@ -2,7 +2,7 @@
 == HIR ==
 module 
 
-fn sum_to(n: int [copy]) -> int (id=1, sym=1391) {
+fn sum_to(n: int [copy]) -> int (id=1, sym=1395) {
   let mut total: int [copy] = 0
   {
     let mut i: int [copy] = 0

--- a/testdata/golden/hir/for_iter.hir
+++ b/testdata/golden/hir/for_iter.hir
@@ -2,12 +2,12 @@
 == HIR ==
 module 
 
-fn sum(arr: type#1485) -> int (id=1, sym=1391) {
+fn sum(arr: type#1489) -> int (id=1, sym=1395) {
   let mut total: int [copy] = 0
   {
     let mut __iter1: type#187 = iter_init(arr): type#187
     while true {
-      let __next2: type#1487 = iter_next(__iter1): type#1487
+      let __next2: type#1491 = iter_next(__iter1): type#1491
       if tag_test(__next2, nothing): bool {
         break
       }

--- a/testdata/golden/hir/for_range.hir
+++ b/testdata/golden/hir/for_range.hir
@@ -2,7 +2,7 @@
 == HIR ==
 module 
 
-fn sum_range(n: int [copy]) -> int (id=1, sym=1391) {
+fn sum_range(n: int [copy]) -> int (id=1, sym=1395) {
   let mut total: int [copy] = 0
   {
     let mut i: int [copy] = 0

--- a/testdata/golden/hir/indexing_ranges.hir
+++ b/testdata/golden/hir/indexing_ranges.hir
@@ -2,10 +2,10 @@
 == HIR ==
 module 
 
-type Box <struct> (sym=1391, type=0)
+type Box <struct> (sym=1395, type=0)
 
-fn test() -> int (id=1, sym=1393) {
-  let b: type#1484 =  { value = 1 }: type#1484
+fn test() -> int (id=1, sym=1397) {
+  let b: type#1488 =  { value = 1 }: type#1488
   return __index(b, rt_range_int_new(1, 2, false)): int
 }
 

--- a/testdata/golden/hir/loops_control.hir
+++ b/testdata/golden/hir/loops_control.hir
@@ -2,7 +2,7 @@
 == HIR ==
 module 
 
-fn find_first_positive(arr: type#1485) -> int (id=1, sym=1391) {
+fn find_first_positive(arr: type#1489) -> int (id=1, sym=1395) {
   {
     let mut i: int [copy] = 0
     let __end1: int [copy] = 5
@@ -20,7 +20,7 @@ fn find_first_positive(arr: type#1485) -> int (id=1, sym=1391) {
   return 0
 }
 
-fn sum_until_zero(arr: type#1485) -> int (id=2, sym=1392) {
+fn sum_until_zero(arr: type#1489) -> int (id=2, sym=1396) {
   let mut total: int [copy] = 0
   {
     let mut i: int [copy] = 0

--- a/testdata/golden/hir/option_erring.hir
+++ b/testdata/golden/hir/option_erring.hir
@@ -2,14 +2,14 @@
 == HIR ==
 module 
 
-fn maybe(x: int [copy]) -> type#1484 (id=1, sym=1391) {
+fn maybe(x: int [copy]) -> type#1488 (id=1, sym=1395) {
   if __gt(x, 0): bool {
-    return Some(x): type#1484
+    return Some(x): type#1488
   }
   return nothing
 }
 
-fn get_value(opt: type#1484) -> int (id=2, sym=1392) {
+fn get_value(opt: type#1488) -> int (id=2, sym=1396) {
   return safe(opt): int
 }
 

--- a/testdata/golden/hir/range_literals.hir
+++ b/testdata/golden/hir/range_literals.hir
@@ -2,7 +2,7 @@
 == HIR ==
 module 
 
-fn make_ranges() -> nothing (id=1, sym=1391) {
+fn make_ranges() -> nothing (id=1, sym=1395) {
   let a: type#187 = rt_range_int_new(1, 3, false): type#187
   let b: type#187 = rt_range_int_new(1, 3, true): type#187
   let c: type#187 = rt_range_int_from_start(1, false): type#187

--- a/testdata/golden/hir/references.hir
+++ b/testdata/golden/hir/references.hir
@@ -2,12 +2,12 @@
 == HIR ==
 module 
 
-fn increment(x: &mut int [&mut]) -> nothing (id=1, sym=1391) {
+fn increment(x: &mut int [&mut]) -> nothing (id=1, sym=1395) {
   ((* x) = __add((* x), 1)): int
   return
 }
 
-fn read_ref(x: &int [&]) -> int (id=2, sym=1392) {
+fn read_ref(x: &int [&]) -> int (id=2, sym=1396) {
   return (* x): int
 }
 

--- a/testdata/golden/hir/simple_func.hir
+++ b/testdata/golden/hir/simple_func.hir
@@ -2,11 +2,11 @@
 == HIR ==
 module 
 
-fn add(a: int [copy], b: int [copy]) -> int (id=1, sym=1391) {
+fn add(a: int [copy], b: int [copy]) -> int (id=1, sym=1395) {
   return __add(a, b): int
 }
 
-fn main() -> nothing (id=2, sym=1392) {
+fn main() -> nothing (id=2, sym=1396) {
   let x: int [copy] = add(1, 2): int
   let y: int [copy] = __add(x, 3): int
   return

--- a/testdata/golden/hir/structs.hir
+++ b/testdata/golden/hir/structs.hir
@@ -2,13 +2,13 @@
 == HIR ==
 module 
 
-type Point <struct> (sym=1391, type=0)
+type Point <struct> (sym=1395, type=0)
 
-fn origin() -> type#1484 (id=1, sym=1392) {
-  return  { x = 0, y = 0 }: type#1484
+fn origin() -> type#1488 (id=1, sym=1396) {
+  return  { x = 0, y = 0 }: type#1488
 }
 
-fn move_point(p: type#1484, dx: int [copy], dy: int [copy]) -> type#1484 (id=2, sym=1393) {
-  return  { x = __add(p.x, dx): int, y = __add(p.y, dy): int }: type#1484
+fn move_point(p: type#1488, dx: int [copy], dy: int [copy]) -> type#1488 (id=2, sym=1397) {
+  return  { x = __add(p.x, dx): int, y = __add(p.y, dy): int }: type#1488
 }
 

--- a/testdata/golden/hir/tuples.hir
+++ b/testdata/golden/hir/tuples.hir
@@ -2,11 +2,11 @@
 == HIR ==
 module 
 
-fn swap(a: int [copy], b: int [copy]) -> type#1484 (id=1, sym=1391) {
-  return (b, a): type#1486
+fn swap(a: int [copy], b: int [copy]) -> type#1488 (id=1, sym=1395) {
+  return (b, a): type#1490
 }
 
-fn get_first(t: type#1487) -> int (id=2, sym=1392) {
+fn get_first(t: type#1491) -> int (id=2, sym=1396) {
   return t.0: int
 }
 

--- a/testdata/golden/hir_borrow/drop_releases_borrow.hir
+++ b/testdata/golden/hir_borrow/drop_releases_borrow.hir
@@ -2,7 +2,7 @@
 == HIR ==
 module 
 
-fn t() -> nothing (id=1, sym=1391) {
+fn t() -> nothing (id=1, sym=1395) {
   let mut x: int [copy] = 1
   let r: &int [&] = (& x): &int
   drop r
@@ -11,13 +11,13 @@ fn t() -> nothing (id=1, sym=1391) {
 }
 
 borrow edges:
-  L2783(r) (&) borrows L2782(x) at 0:51-53 scope=S3
+  L2791(r) (&) borrows L2790(x) at 0:51-53 scope=S3
 events:
-  borrow_start L2783(r) -> L2782(x) (&) at 0:51-53 scope=S3 note="B1"
-  drop L2783(r) -> L2782(x) at 0:59-67 scope=S3 note="B1"
-  borrow_end L2783(r) -> L2782(x) at 0:59-67 scope=S3 note="drop B1"
-  write L2782(x) at 0:72-77 scope=S3
+  borrow_start L2791(r) -> L2790(x) (&) at 0:51-53 scope=S3 note="B1"
+  drop L2791(r) -> L2790(x) at 0:59-67 scope=S3 note="B1"
+  borrow_end L2791(r) -> L2790(x) at 0:59-67 scope=S3 note="drop B1"
+  write L2790(x) at 0:72-77 scope=S3
 move plan:
-  L2782(x): MoveCopy (copy type)
-  L2783(r): MoveCopy (copy type)
+  L2790(x): MoveCopy (copy type)
+  L2791(r): MoveCopy (copy type)
 

--- a/testdata/golden/hir_borrow/drop_returned_borrow.hir
+++ b/testdata/golden/hir_borrow/drop_returned_borrow.hir
@@ -2,7 +2,7 @@
 == HIR ==
 module 
 
-@entrypoint fn main() -> nothing (id=1, sym=1391) {
+@entrypoint fn main() -> nothing (id=1, sym=1395) {
   let mut xs: type#76 = [1, 2, 3]: type#76
   let item: &mut int [&mut] = get_mut((&mut xs), 0): &mut int
   ((* item) = 10): int
@@ -13,17 +13,17 @@ module
 }
 
 borrow edges:
-  L2783(item) (&mut) borrows L2782(xs) at 0:95-97 scope=S3
-  L2784(shared) (&) borrows L2782(xs) at 0:167-170 scope=S3
+  L2791(item) (&mut) borrows L2790(xs) at 0:95-97 scope=S3
+  L2792(shared) (&) borrows L2790(xs) at 0:167-170 scope=S3
 events:
-  borrow_start L2783(item) -> L2782(xs) (&mut) at 0:95-97 scope=S3 note="B1"
-  write L2783(item) at 0:114-124 scope=S3 note="write_through_mut_ref"
-  drop L2783(item) -> L2782(xs) at 0:130-141 scope=S3 note="B1"
-  borrow_end L2783(item) -> L2782(xs) at 0:130-141 scope=S3 note="drop B1"
-  borrow_start L2784(shared) -> L2782(xs) (&) at 0:167-170 scope=S3 note="B2"
-  borrow_end L2784(shared) -> L2782(xs) scope=S3 note="scope_end B2"
+  borrow_start L2791(item) -> L2790(xs) (&mut) at 0:95-97 scope=S3 note="B1"
+  write L2791(item) at 0:114-124 scope=S3 note="write_through_mut_ref"
+  drop L2791(item) -> L2790(xs) at 0:130-141 scope=S3 note="B1"
+  borrow_end L2791(item) -> L2790(xs) at 0:130-141 scope=S3 note="drop B1"
+  borrow_start L2792(shared) -> L2790(xs) (&) at 0:167-170 scope=S3 note="B2"
+  borrow_end L2792(shared) -> L2790(xs) scope=S3 note="scope_end B2"
 move plan:
-  L2782(xs): MoveNeedsDrop (non-copy (drop))
-  L2783(item): MoveAllowed (non-copy reference)
-  L2784(shared): MoveCopy (copy type)
+  L2790(xs): MoveNeedsDrop (non-copy (drop))
+  L2791(item): MoveAllowed (non-copy reference)
+  L2792(shared): MoveCopy (copy type)
 

--- a/testdata/golden/hir_borrow/invalid/move_forbidden_when_borrowed.hir
+++ b/testdata/golden/hir_borrow/invalid/move_forbidden_when_borrowed.hir
@@ -3,7 +3,7 @@ error SEM3020 testdata/golden/hir_borrow/invalid/move_forbidden_when_borrowed.sg
 == HIR ==
 module 
 
-fn t() -> nothing (id=1, sym=1391) {
+fn t() -> nothing (id=1, sym=1395) {
   let x: string = "\"hi\""
   let r: &string [&] = (& x): &string
   let y: string = x
@@ -11,13 +11,13 @@ fn t() -> nothing (id=1, sym=1391) {
 }
 
 borrow edges:
-  L2783(r) (&) borrows L2782(x) at 0:56-58 scope=S3
+  L2791(r) (&) borrows L2790(x) at 0:56-58 scope=S3
 events:
-  borrow_start L2783(r) -> L2782(x) (&) at 0:56-58 scope=S3 note="B1"
-  move L2782(x) at 0:80-81 scope=S3 note="issue=frozen borrow=B1"
-  borrow_end L2783(r) -> L2782(x) scope=S3 note="scope_end B1"
+  borrow_start L2791(r) -> L2790(x) (&) at 0:56-58 scope=S3 note="B1"
+  move L2790(x) at 0:80-81 scope=S3 note="issue=frozen borrow=B1"
+  borrow_end L2791(r) -> L2790(x) scope=S3 note="scope_end B1"
 move plan:
-  L2782(x): MoveForbidden (move blocked by frozen (B1))
-  L2783(r): MoveCopy (copy type)
-  L2784(y): MoveNeedsDrop (non-copy (drop))
+  L2790(x): MoveForbidden (move blocked by frozen (B1))
+  L2791(r): MoveCopy (copy type)
+  L2792(y): MoveNeedsDrop (non-copy (drop))
 

--- a/testdata/golden/hir_borrow/invalid/mut_borrow_excludes_other.hir
+++ b/testdata/golden/hir_borrow/invalid/mut_borrow_excludes_other.hir
@@ -3,7 +3,7 @@ error SEM3018 testdata/golden/hir_borrow/invalid/mut_borrow_excludes_other.sg:4:
 == HIR ==
 module 
 
-fn t() -> nothing (id=1, sym=1391) {
+fn t() -> nothing (id=1, sym=1395) {
   let mut x: int [copy] = 1
   let m: &mut int [&mut] = (&mut x): &mut int
   let r: &int [&] = (& x): &int
@@ -11,13 +11,13 @@ fn t() -> nothing (id=1, sym=1391) {
 }
 
 borrow edges:
-  L2783(m) (&mut) borrows L2782(x) at 0:55-61 scope=S3
+  L2791(m) (&mut) borrows L2790(x) at 0:55-61 scope=S3
 events:
-  borrow_start L2783(m) -> L2782(x) (&mut) at 0:55-61 scope=S3 note="B1"
-  borrow_start _ -> L2782(x) at 0:81-83 scope=S3 note="issue=conflict_mut borrow=B1"
-  borrow_end L2783(m) -> L2782(x) scope=S3 note="scope_end B1"
+  borrow_start L2791(m) -> L2790(x) (&mut) at 0:55-61 scope=S3 note="B1"
+  borrow_start _ -> L2790(x) at 0:81-83 scope=S3 note="issue=conflict_mut borrow=B1"
+  borrow_end L2791(m) -> L2790(x) scope=S3 note="scope_end B1"
 move plan:
-  L2782(x): MoveCopy (copy type)
-  L2783(m): MoveAllowed (non-copy reference)
-  L2784(r): MoveCopy (copy type)
+  L2790(x): MoveCopy (copy type)
+  L2791(m): MoveAllowed (non-copy reference)
+  L2792(r): MoveCopy (copy type)
 

--- a/testdata/golden/hir_borrow/invalid/shared_borrow_blocks_mutation.hir
+++ b/testdata/golden/hir_borrow/invalid/shared_borrow_blocks_mutation.hir
@@ -3,7 +3,7 @@ error SEM3019 testdata/golden/hir_borrow/invalid/shared_borrow_blocks_mutation.s
 == HIR ==
 module 
 
-fn t() -> nothing (id=1, sym=1391) {
+fn t() -> nothing (id=1, sym=1395) {
   let mut x: int [copy] = 1
   let r: &int [&] = (& x): &int
   (x = 2): int
@@ -11,12 +11,12 @@ fn t() -> nothing (id=1, sym=1391) {
 }
 
 borrow edges:
-  L2783(r) (&) borrows L2782(x) at 0:51-53 scope=S3
+  L2791(r) (&) borrows L2790(x) at 0:51-53 scope=S3
 events:
-  borrow_start L2783(r) -> L2782(x) (&) at 0:51-53 scope=S3 note="B1"
-  write L2782(x) at 0:59-64 scope=S3 note="issue=frozen borrow=B1"
-  borrow_end L2783(r) -> L2782(x) scope=S3 note="scope_end B1"
+  borrow_start L2791(r) -> L2790(x) (&) at 0:51-53 scope=S3 note="B1"
+  write L2790(x) at 0:59-64 scope=S3 note="issue=frozen borrow=B1"
+  borrow_end L2791(r) -> L2790(x) scope=S3 note="scope_end B1"
 move plan:
-  L2782(x): MoveForbidden (write blocked by frozen (B1))
-  L2783(r): MoveCopy (copy type)
+  L2790(x): MoveForbidden (write blocked by frozen (B1))
+  L2791(r): MoveCopy (copy type)
 

--- a/testdata/golden/hir_borrow/invalid/spawn_escape.hir
+++ b/testdata/golden/hir_borrow/invalid/spawn_escape.hir
@@ -4,7 +4,7 @@ error SEM3021 testdata/golden/hir_borrow/invalid/spawn_escape.sg:6:27 cannot sen
 == HIR ==
 module 
 
-async fn use_ref(x: &int [&]) -> nothing (id=1, sym=1391) {
+async fn use_ref(x: &int [&]) -> nothing (id=1, sym=1395) {
 }
 
 borrow edges:
@@ -12,25 +12,25 @@ borrow edges:
 events:
   <none>
 move plan:
-  L2783(x): MoveCopy (copy type)
+  L2791(x): MoveCopy (copy type)
 
-async fn t() -> nothing (id=2, sym=1392) {
+async fn t() -> nothing (id=2, sym=1396) {
   let mut x: int [copy] = 1
   let r: &int [&] = (& x): &int
-  let t: type#576 = spawn use_ref(r): type#576: type#576
-  await(t): type#1485
+  let t: type#581 = spawn use_ref(r): type#581: type#581
+  await(t): type#1489
   return
 }
 
 borrow edges:
-  L2785(r) (&) borrows L2784(x) at 0:87-89 scope=S5
+  L2793(r) (&) borrows L2792(x) at 0:87-89 scope=S5
 events:
-  borrow_start L2785(r) -> L2784(x) (&) at 0:87-89 scope=S5 note="B1"
-  spawn_escape L2785(r) -> L2784(x) at 0:117-118 scope=S5 note="B1"
-  move L2786(t) at 0:125-126 scope=S5
-  borrow_end L2785(r) -> L2784(x) scope=S5 note="scope_end B1"
+  borrow_start L2793(r) -> L2792(x) (&) at 0:87-89 scope=S5 note="B1"
+  spawn_escape L2793(r) -> L2792(x) at 0:117-118 scope=S5 note="B1"
+  move L2794(t) at 0:125-126 scope=S5
+  borrow_end L2793(r) -> L2792(x) scope=S5 note="scope_end B1"
 move plan:
-  L2784(x): MoveCopy (copy type)
-  L2785(r): MoveForbidden (task escape)
-  L2786(t): MoveNeedsDrop (non-copy (drop))
+  L2792(x): MoveCopy (copy type)
+  L2793(r): MoveForbidden (task escape)
+  L2794(t): MoveNeedsDrop (non-copy (drop))
 

--- a/testdata/golden/mir/array_field_mut_ref_reborrow.mir
+++ b/testdata/golden/mir/array_field_mut_ref_reborrow.mir
@@ -6,7 +6,7 @@ funcs=2
 
 fn add_borrower:
   locals:
-    L0: &mut type#1484 [refmut] name=entry
+    L0: &mut type#1488 [refmut] name=entry
     L1: &string [copy,ref] name=client_id
     L2: bool [copy] name=tmp_call1
     L3: bool [copy] name=tmp_call2
@@ -24,14 +24,14 @@ fn add_borrower:
 
 fn main:
   locals:
-    L0: type#1484 name=entry
+    L0: type#1488 name=entry
     L1: type#80 name=tmp_arr1
-    L2: type#1484 name=tmp_struct2
+    L2: type#1488 name=tmp_struct2
     L3: uint [copy] name=tmp_call3
     L4: int [copy] name=tmp_cast4
   bb0:
     L1 = array_lit []
-    L2 = struct_lit type#1484 {borrowers=move L1}
+    L2 = struct_lit type#1488 {borrowers=move L1}
     L0 = move L2
     call add_borrower(addr_of_mut L0, addr_of G0)
     call add_borrower(addr_of_mut L0, addr_of G0)

--- a/testdata/golden/mir/array_fixed_struct.mir
+++ b/testdata/golden/mir/array_fixed_struct.mir
@@ -4,20 +4,20 @@ funcs=1
 
 fn main:
   locals:
-    L0: type#1487 name=pts
-    L1: type#1484 name=tmp_struct1
-    L2: type#1484 name=tmp_struct2
-    L3: type#1487 name=tmp_arr3
+    L0: type#1491 name=pts
+    L1: type#1488 name=tmp_struct1
+    L2: type#1488 name=tmp_struct2
+    L3: type#1491 name=tmp_arr3
     L4: int [copy] name=tmp_idx4
-    L5: type#1484 name=tmp_un5
+    L5: type#1488 name=tmp_un5
     L6: int [copy] name=tmp_field6
     L7: int [copy] name=tmp_idx7
-    L8: type#1484 name=tmp_un8
+    L8: type#1488 name=tmp_un8
     L9: int [copy] name=tmp_field9
     L10: int [copy] name=tmp_call10
   bb0:
-    L1 = struct_lit type#1484 {x=const 1, y=const 2}
-    L2 = struct_lit type#1484 {x=const 3, y=const 4}
+    L1 = struct_lit type#1488 {x=const 1, y=const 2}
+    L2 = struct_lit type#1488 {x=const 3, y=const 4}
     L3 = array_lit [move L1, move L2]
     L0 = move L3
     L4 = const 0

--- a/testdata/golden/mir/entrypoint_argv.mir
+++ b/testdata/golden/mir/entrypoint_argv.mir
@@ -9,7 +9,7 @@ fn __surge_start:
     L2: int [copy] name=x
     L3: bool [copy] name=has_arg0
     L4: string name=arg_str0
-    L5: type#765 name=arg_parsed0
+    L5: type#770 name=arg_parsed0
     L6: bool [copy] name=arg_ok0
     L7: type#48 name=entry_err
     L8: int name=entry_ret

--- a/testdata/golden/mir/entrypoint_returns_custom.mir
+++ b/testdata/golden/mir/entrypoint_returns_custom.mir
@@ -4,7 +4,7 @@ funcs=3
 
 fn __surge_start:
   locals:
-    L0: type#1484 name=entry_ret
+    L0: type#1488 name=entry_ret
     L1: int [copy] name=code
   bb0:
     L0 = call main()
@@ -14,7 +14,7 @@ fn __surge_start:
 
 fn __to:
   locals:
-    L0: type#1484 name=self
+    L0: type#1488 name=self
     L1: int [copy] name=_target
     L2: int [copy] name=tmp_field1
   bb0:
@@ -23,7 +23,7 @@ fn __to:
 
 fn main:
   locals:
-    L0: type#1484 name=tmp_struct1
+    L0: type#1488 name=tmp_struct1
   bb0:
-    L0 = struct_lit type#1484 {code=const 42}
+    L0 = struct_lit type#1488 {code=const 42}
     return move L0

--- a/testdata/golden/mir/entrypoint_stdin.mir
+++ b/testdata/golden/mir/entrypoint_stdin.mir
@@ -6,7 +6,7 @@ fn __surge_start:
   locals:
     L0: string name=stdin
     L1: int [copy] name=x
-    L2: type#765 name=stdin_parsed
+    L2: type#770 name=stdin_parsed
     L3: bool [copy] name=stdin_ok
     L4: int name=entry_ret
     L5: int [copy] name=code

--- a/testdata/golden/mir/erring_option_nested_tag.mir
+++ b/testdata/golden/mir/erring_option_nested_tag.mir
@@ -15,36 +15,36 @@ fn __surge_start:
 fn demo:
   locals:
     L0: bool [copy] name=flag
-    L1: type#1487 name=tmp_call1
-    L2: type#1488 name=tmp_call2
-    L3: type#1485 name=tmp_cast3
-    L4: type#1489 name=tmp_call4
-    L5: type#1485 name=tmp_cast5
+    L1: type#1491 name=tmp_call1
+    L2: type#1492 name=tmp_call2
+    L3: type#1489 name=tmp_cast3
+    L4: type#1493 name=tmp_call4
+    L5: type#1489 name=tmp_cast5
   bb0:
     if copy L0 then bb1 else bb2
   bb1:
     L1 = call Some(const "\"x\"")
     L2 = call Success(move L1)
-    L3 = cast move L2 to type#1485
+    L3 = cast move L2 to type#1489
     return move L3
   bb2:
     L4 = call Success(const nothing)
-    L5 = cast move L4 to type#1485
+    L5 = cast move L4 to type#1489
     return move L5
 
 fn main:
   locals:
-    L0: type#1485 name=v
-    L1: type#1485 name=tmp_call1
-    L2: type#1485 name=__cmp1
+    L0: type#1489 name=v
+    L1: type#1489 name=tmp_call1
+    L2: type#1489 name=__cmp1
     L3: bool [copy] name=tmp_tagtest2
-    L4: type#1484 name=tmp_payload3
+    L4: type#1488 name=tmp_payload3
     L5: bool [copy] name=tmp_tagtest4
     L6: string name=s
-    L7: type#1484 name=tmp_payload5
+    L7: type#1488 name=tmp_payload5
     L8: string name=tmp_payload6
     L9: bool [copy] name=tmp_tagtest7
-    L10: type#1484 name=tmp_payload8
+    L10: type#1488 name=tmp_payload8
     L11: bool [copy] name=tmp_tagtest9
     L12: type#48 name=err
   bb0:

--- a/testdata/golden/mir/imported_magic_methods.mir
+++ b/testdata/golden/mir/imported_magic_methods.mir
@@ -17,26 +17,26 @@ fn __surge_start:
 
 fn main:
   locals:
-    L0: type#1484 name=empty
-    L1: type#1484 name=tmp_struct1
+    L0: type#1488 name=empty
+    L1: type#1488 name=tmp_struct1
     L2: bool [copy] name=tmp_call2
     L3: int [copy] name=tmp_cast3
-    L4: type#1484 name=original
-    L5: type#1484 name=tmp_struct4
-    L6: type#1484 name=cloned
-    L7: type#1484 name=tmp_call5
+    L4: type#1488 name=original
+    L5: type#1488 name=tmp_struct4
+    L6: type#1488 name=cloned
+    L7: type#1488 name=tmp_call5
     L8: bool [copy] name=tmp_call6
-    L9: type#1485 name=flag
-    L10: type#1485 name=tmp_struct7
+    L9: type#1489 name=flag
+    L10: type#1489 name=tmp_struct7
     L11: bool [copy] name=tmp_call8
     L12: int [copy] name=tmp_cast9
     L13: int [copy] name=converted
     L14: int [copy] name=tmp_call10
     L15: int [copy] name=tmp_call11
     L16: bool [copy] name=tmp_call12
-    L17: type#1486 name=bag
+    L17: type#1490 name=bag
     L18: type#76 name=tmp_arr13
-    L19: type#1486 name=tmp_struct14
+    L19: type#1490 name=tmp_struct14
     L20: int [copy] name=tmp_call15
     L21: int [copy] name=tmp_call16
     L22: bool [copy] name=tmp_call17
@@ -44,8 +44,8 @@ fn main:
     L24: type#187 name=__iter1
     L25: type#187 name=tmp_call18
     L26: type#187 name=tmp_iter19
-    L27: type#1501 name=__next2
-    L28: type#1501 name=tmp_next20
+    L27: type#1505 name=__next2
+    L28: type#1505 name=tmp_next20
     L29: bool [copy] name=tmp_tagtest21
     L30: int [copy] name=v
     L31: int [copy] name=tmp_payload22
@@ -55,15 +55,15 @@ fn main:
     L35: type#187 name=__iter3
     L36: type#187 name=tmp_call25
     L37: type#187 name=tmp_iter26
-    L38: type#1501 name=__next4
-    L39: type#1501 name=tmp_next27
+    L38: type#1505 name=__next4
+    L39: type#1505 name=tmp_next27
     L40: bool [copy] name=tmp_tagtest28
     L41: int [copy] name=typed
     L42: int [copy] name=tmp_payload29
     L43: int [copy] name=tmp_call30
     L44: bool [copy] name=tmp_call31
   bb0:
-    L1 = struct_lit type#1484 {value=const "\"\""}
+    L1 = struct_lit type#1488 {value=const "\"\""}
     L0 = move L1
     L2 = call __not(addr_of L0)
     if copy L2 then bb1 else bb2
@@ -73,7 +73,7 @@ fn main:
   bb2:
     return const 1
   bb3:
-    L5 = struct_lit type#1484 {value=const "\"ok\""}
+    L5 = struct_lit type#1488 {value=const "\"ok\""}
     L4 = move L5
     L7 = call __clone(addr_of L4)
     L6 = move L7
@@ -82,7 +82,7 @@ fn main:
   bb4:
     return const 2
   bb5:
-    L10 = struct_lit type#1485 {value=const 1}
+    L10 = struct_lit type#1489 {value=const 1}
     L9 = move L10
     L11 = call __bool(addr_of L9)
     if copy L11 then bb6 else bb7
@@ -101,7 +101,7 @@ fn main:
     return const 4
   bb10:
     L18 = array_lit [const 1, const 2, const 3]
-    L19 = struct_lit type#1486 {values=move L18}
+    L19 = struct_lit type#1490 {values=move L18}
     L17 = move L19
     L20 = call __index_set(addr_of_mut L17, const 1, const 9)
     L21 = call __index(addr_of L17, const 1)

--- a/testdata/golden/mir/imported_operator_overload.mir
+++ b/testdata/golden/mir/imported_operator_overload.mir
@@ -14,19 +14,19 @@ fn __surge_start:
 
 fn main:
   locals:
-    L0: type#1484 [copy] name=digest
+    L0: type#1488 [copy] name=digest
     L1: uint64 [copy] name=tmp_cast1
-    L2: type#1484 [copy] name=tmp_struct2
-    L3: type#1484 [copy] name=same
+    L2: type#1488 [copy] name=tmp_struct2
+    L3: type#1488 [copy] name=same
     L4: uint64 [copy] name=tmp_cast3
-    L5: type#1484 [copy] name=tmp_struct4
+    L5: type#1488 [copy] name=tmp_struct4
     L6: bool [copy] name=tmp_call5
   bb0:
     L1 = cast const 42 to uint64
-    L2 = struct_lit type#1484 {value=copy L1}
+    L2 = struct_lit type#1488 {value=copy L1}
     L0 = copy L2
     L4 = cast const 42 to uint64
-    L5 = struct_lit type#1484 {value=copy L4}
+    L5 = struct_lit type#1488 {value=copy L4}
     L3 = copy L5
     L6 = call __ne(copy L0, copy L3)
     if copy L6 then bb1 else bb2

--- a/testdata/golden/mir/is_heir_ops.mir
+++ b/testdata/golden/mir/is_heir_ops.mir
@@ -14,19 +14,19 @@ fn __surge_start:
 
 fn main:
   locals:
-    L0: type#1485 name=x
-    L1: type#1485 name=tmp_struct1
+    L0: type#1489 name=x
+    L1: type#1489 name=tmp_struct1
     L2: bool [copy] name=a
     L3: bool [copy] name=tmp_is2
     L4: bool [copy] name=b
     L5: bool [copy] name=tmp_heir3
     L6: bool [copy] name=tmp_logic4
   bb0:
-    L1 = struct_lit type#1485 {x=const 1, y=const 2}
+    L1 = struct_lit type#1489 {x=const 1, y=const 2}
     L0 = move L1
-    L3 = type_test copy L0 is type#1485
+    L3 = type_test copy L0 is type#1489
     L2 = copy L3
-    L5 = heir_test copy L0 heir type#1484
+    L5 = heir_test copy L0 heir type#1488
     L4 = copy L5
     if copy L2 then bb1 else bb2
   bb1:

--- a/testdata/golden/mir/magic_methods_repro.mir
+++ b/testdata/golden/mir/magic_methods_repro.mir
@@ -6,8 +6,8 @@ funcs=7
 
 fn __bool:
   locals:
-    L0: &type#1485 [copy,ref] name=self
-    L1: type#1485 name=tmp_un1
+    L0: &type#1489 [copy,ref] name=self
+    L1: type#1489 name=tmp_un1
     L2: int [copy] name=tmp_field2
     L3: bool [copy] name=tmp_call3
   bb0:
@@ -18,17 +18,17 @@ fn __bool:
 
 fn __clone:
   locals:
-    L0: &type#1484 [copy,ref] name=self
+    L0: &type#1488 [copy,ref] name=self
     L1: string name=tmp_call1
-    L2: type#1484 name=tmp_struct2
+    L2: type#1488 name=tmp_struct2
   bb0:
     L1 = call __clone(addr_of (*L0).value)
-    L2 = struct_lit type#1484 {value=move L1}
+    L2 = struct_lit type#1488 {value=move L1}
     return move L2
 
 fn __index:
   locals:
-    L0: &type#1486 [copy,ref] name=self
+    L0: &type#1490 [copy,ref] name=self
     L1: int [copy] name=index
     L2: int [copy] name=tmp_idx1
     L3: int [copy] name=tmp_un2
@@ -39,7 +39,7 @@ fn __index:
 
 fn __index_set:
   locals:
-    L0: &mut type#1486 [refmut] name=self
+    L0: &mut type#1490 [refmut] name=self
     L1: int [copy] name=index
     L2: int [copy] name=value
     L3: int [copy] name=tmp_idx1
@@ -50,7 +50,7 @@ fn __index_set:
 
 fn __not:
   locals:
-    L0: &type#1484 [copy,ref] name=self
+    L0: &type#1488 [copy,ref] name=self
     L1: bool [copy] name=tmp_call1
   bb0:
     L1 = call __eq(addr_of (*L0).value, addr_of G0)
@@ -58,7 +58,7 @@ fn __not:
 
 fn __range:
   locals:
-    L0: &type#1486 [copy,ref] name=self
+    L0: &type#1490 [copy,ref] name=self
     L1: type#187 name=tmp_call1
   bb0:
     L1 = call __range::<int>(addr_of (*L0).values)
@@ -66,7 +66,7 @@ fn __range:
 
 fn __to:
   locals:
-    L0: &type#1484 [copy,ref] name=self
+    L0: &type#1488 [copy,ref] name=self
     L1: int [copy] name=_
   bb0:
     return const 7

--- a/testdata/golden/mir/magic_ops_call.mir
+++ b/testdata/golden/mir/magic_ops_call.mir
@@ -4,19 +4,19 @@ funcs=5
 
 fn __add:
   locals:
-    L0: &type#1484 [copy,ref] name=self
-    L1: &type#1484 [copy,ref] name=other
-    L2: type#1484 name=tmp_un1
+    L0: &type#1488 [copy,ref] name=self
+    L1: &type#1488 [copy,ref] name=other
+    L2: type#1488 name=tmp_un1
     L3: int [copy] name=tmp_field2
-    L4: type#1484 name=tmp_un3
+    L4: type#1488 name=tmp_un3
     L5: int [copy] name=tmp_field4
     L6: int [copy] name=tmp_call5
-    L7: type#1484 name=tmp_un6
+    L7: type#1488 name=tmp_un6
     L8: int [copy] name=tmp_field7
-    L9: type#1484 name=tmp_un8
+    L9: type#1488 name=tmp_un8
     L10: int [copy] name=tmp_field9
     L11: int [copy] name=tmp_call10
-    L12: type#1484 name=tmp_struct11
+    L12: type#1488 name=tmp_struct11
   bb0:
     L2 = (* copy L0)
     L3 = field copy L2.x
@@ -28,22 +28,22 @@ fn __add:
     L9 = (* copy L1)
     L10 = field copy L9.y
     L11 = call __add(copy L8, copy L10)
-    L12 = struct_lit type#1484 {x=copy L6, y=copy L11}
+    L12 = struct_lit type#1488 {x=copy L6, y=copy L11}
     return move L12
 
 fn __eq:
   locals:
-    L0: &type#1484 [copy,ref] name=self
-    L1: &type#1484 [copy,ref] name=other
+    L0: &type#1488 [copy,ref] name=self
+    L1: &type#1488 [copy,ref] name=other
     L2: bool [copy] name=tmp_logic1
-    L3: type#1484 name=tmp_un2
+    L3: type#1488 name=tmp_un2
     L4: int [copy] name=tmp_field3
-    L5: type#1484 name=tmp_un4
+    L5: type#1488 name=tmp_un4
     L6: int [copy] name=tmp_field5
     L7: bool [copy] name=tmp_call6
-    L8: type#1484 name=tmp_un7
+    L8: type#1488 name=tmp_un7
     L9: int [copy] name=tmp_field8
-    L10: type#1484 name=tmp_un9
+    L10: type#1488 name=tmp_un9
     L11: int [copy] name=tmp_field10
     L12: bool [copy] name=tmp_call11
   bb0:
@@ -69,11 +69,11 @@ fn __eq:
 
 fn __lt:
   locals:
-    L0: &type#1484 [copy,ref] name=self
-    L1: &type#1484 [copy,ref] name=other
-    L2: type#1484 name=tmp_un1
+    L0: &type#1488 [copy,ref] name=self
+    L1: &type#1488 [copy,ref] name=other
+    L2: type#1488 name=tmp_un1
     L3: int [copy] name=tmp_field2
-    L4: type#1484 name=tmp_un3
+    L4: type#1488 name=tmp_un3
     L5: int [copy] name=tmp_field4
     L6: bool [copy] name=tmp_call5
   bb0:
@@ -86,14 +86,14 @@ fn __lt:
 
 fn __neg:
   locals:
-    L0: &type#1484 [copy,ref] name=self
-    L1: type#1484 name=tmp_un1
+    L0: &type#1488 [copy,ref] name=self
+    L1: type#1488 name=tmp_un1
     L2: int [copy] name=tmp_field2
     L3: int [copy] name=tmp_call3
-    L4: type#1484 name=tmp_un4
+    L4: type#1488 name=tmp_un4
     L5: int [copy] name=tmp_field5
     L6: int [copy] name=tmp_call6
-    L7: type#1484 name=tmp_struct7
+    L7: type#1488 name=tmp_struct7
   bb0:
     L1 = (* copy L0)
     L2 = field copy L1.x
@@ -101,31 +101,31 @@ fn __neg:
     L4 = (* copy L0)
     L5 = field copy L4.y
     L6 = call __neg(copy L5)
-    L7 = struct_lit type#1484 {x=copy L3, y=copy L6}
+    L7 = struct_lit type#1488 {x=copy L3, y=copy L6}
     return move L7
 
 fn main:
   locals:
-    L0: type#1484 name=a
-    L1: type#1484 name=tmp_struct1
-    L2: type#1484 name=b
-    L3: type#1484 name=tmp_struct2
-    L4: type#1484 name=c
-    L5: type#1484 name=tmp_call3
+    L0: type#1488 name=a
+    L1: type#1488 name=tmp_struct1
+    L2: type#1488 name=b
+    L3: type#1488 name=tmp_struct2
+    L4: type#1488 name=c
+    L5: type#1488 name=tmp_call3
     L6: bool [copy] name=eq
     L7: bool [copy] name=tmp_call4
     L8: bool [copy] name=lt
     L9: bool [copy] name=tmp_call5
-    L10: type#1484 name=neg
-    L11: type#1484 name=tmp_call6
+    L10: type#1488 name=neg
+    L11: type#1488 name=tmp_call6
     L12: bool [copy] name=tmp_logic7
     L13: int [copy] name=tmp_field8
     L14: int [copy] name=tmp_field9
     L15: int [copy] name=tmp_call10
   bb0:
-    L1 = struct_lit type#1484 {x=const 1, y=const 2}
+    L1 = struct_lit type#1488 {x=const 1, y=const 2}
     L0 = move L1
-    L3 = struct_lit type#1484 {x=const 3, y=const 4}
+    L3 = struct_lit type#1488 {x=const 3, y=const 4}
     L2 = move L3
     L5 = call __add(addr_of L0, addr_of L2)
     L4 = move L5

--- a/testdata/golden/mir/magic_ops_call_nonplace.mir
+++ b/testdata/golden/mir/magic_ops_call_nonplace.mir
@@ -8,19 +8,19 @@ funcs=4
 
 fn __add:
   locals:
-    L0: &type#1484 [copy,ref] name=self
-    L1: &type#1484 [copy,ref] name=other
-    L2: type#1484 name=tmp_un1
+    L0: &type#1488 [copy,ref] name=self
+    L1: &type#1488 [copy,ref] name=other
+    L2: type#1488 name=tmp_un1
     L3: int [copy] name=tmp_field2
-    L4: type#1484 name=tmp_un3
+    L4: type#1488 name=tmp_un3
     L5: int [copy] name=tmp_field4
     L6: int [copy] name=tmp_call5
-    L7: type#1484 name=tmp_un6
+    L7: type#1488 name=tmp_un6
     L8: int [copy] name=tmp_field7
-    L9: type#1484 name=tmp_un8
+    L9: type#1488 name=tmp_un8
     L10: int [copy] name=tmp_field9
     L11: int [copy] name=tmp_call10
-    L12: type#1484 name=tmp_struct11
+    L12: type#1488 name=tmp_struct11
   bb0:
     L2 = (* copy L0)
     L3 = field copy L2.x
@@ -32,19 +32,19 @@ fn __add:
     L9 = (* copy L1)
     L10 = field copy L9.y
     L11 = call __add(copy L8, copy L10)
-    L12 = struct_lit type#1484 {x=copy L6, y=copy L11}
+    L12 = struct_lit type#1488 {x=copy L6, y=copy L11}
     return move L12
 
 fn __neg:
   locals:
-    L0: &type#1484 [copy,ref] name=self
-    L1: type#1484 name=tmp_un1
+    L0: &type#1488 [copy,ref] name=self
+    L1: type#1488 name=tmp_un1
     L2: int [copy] name=tmp_field2
     L3: int [copy] name=tmp_call3
-    L4: type#1484 name=tmp_un4
+    L4: type#1488 name=tmp_un4
     L5: int [copy] name=tmp_field5
     L6: int [copy] name=tmp_call6
-    L7: type#1484 name=tmp_struct7
+    L7: type#1488 name=tmp_struct7
   bb0:
     L1 = (* copy L0)
     L2 = field copy L1.x
@@ -52,16 +52,16 @@ fn __neg:
     L4 = (* copy L0)
     L5 = field copy L4.y
     L6 = call __neg(copy L5)
-    L7 = struct_lit type#1484 {x=copy L3, y=copy L6}
+    L7 = struct_lit type#1488 {x=copy L3, y=copy L6}
     return move L7
 
 fn __to:
   locals:
-    L0: &type#1484 [copy,ref] name=self
+    L0: &type#1488 [copy,ref] name=self
     L1: int [copy] name=target
-    L2: type#1484 name=tmp_un1
+    L2: type#1488 name=tmp_un1
     L3: int [copy] name=tmp_field2
-    L4: type#1484 name=tmp_un3
+    L4: type#1488 name=tmp_un3
     L5: int [copy] name=tmp_field4
     L6: int [copy] name=tmp_call5
   bb0:
@@ -74,14 +74,14 @@ fn __to:
 
 fn main:
   locals:
-    L0: type#1484 name=p1
-    L1: type#1484 name=tmp_struct1
-    L2: type#1484 name=p2
-    L3: type#1484 name=tmp_struct2
-    L4: type#1484 name=sum
-    L5: type#1484 name=tmp_call3
-    L6: type#1484 name=neg
-    L7: type#1484 name=tmp_call4
+    L0: type#1488 name=p1
+    L1: type#1488 name=tmp_struct1
+    L2: type#1488 name=p2
+    L3: type#1488 name=tmp_struct2
+    L4: type#1488 name=sum
+    L5: type#1488 name=tmp_call3
+    L6: type#1488 name=neg
+    L7: type#1488 name=tmp_call4
     L8: string name=s
     L9: string name=tmp_call5
     L10: string name=tmp_ref6
@@ -89,9 +89,9 @@ fn main:
     L12: int [copy] name=tmp_call8
     L13: int [copy] name=tmp_call9
   bb0:
-    L1 = struct_lit type#1484 {x=const 1, y=const 2}
+    L1 = struct_lit type#1488 {x=const 1, y=const 2}
     L0 = move L1
-    L3 = struct_lit type#1484 {x=const 3, y=const 4}
+    L3 = struct_lit type#1488 {x=const 3, y=const 4}
     L2 = move L3
     L5 = call __add(addr_of L0, addr_of L2)
     L4 = move L5

--- a/testdata/golden/mir/method_call.mir
+++ b/testdata/golden/mir/method_call.mir
@@ -4,19 +4,19 @@ funcs=2
 
 fn add:
   locals:
-    L0: &type#1484 [copy,ref] name=self
-    L1: &type#1484 [copy,ref] name=other
-    L2: type#1484 name=tmp_un1
+    L0: &type#1488 [copy,ref] name=self
+    L1: &type#1488 [copy,ref] name=other
+    L2: type#1488 name=tmp_un1
     L3: int [copy] name=tmp_field2
-    L4: type#1484 name=tmp_un3
+    L4: type#1488 name=tmp_un3
     L5: int [copy] name=tmp_field4
     L6: int [copy] name=tmp_call5
-    L7: type#1484 name=tmp_un6
+    L7: type#1488 name=tmp_un6
     L8: int [copy] name=tmp_field7
-    L9: type#1484 name=tmp_un8
+    L9: type#1488 name=tmp_un8
     L10: int [copy] name=tmp_field9
     L11: int [copy] name=tmp_call10
-    L12: type#1484 name=tmp_struct11
+    L12: type#1488 name=tmp_struct11
   bb0:
     L2 = (* copy L0)
     L3 = field copy L2.x
@@ -28,24 +28,24 @@ fn add:
     L9 = (* copy L1)
     L10 = field copy L9.y
     L11 = call __add(copy L8, copy L10)
-    L12 = struct_lit type#1484 {x=copy L6, y=copy L11}
+    L12 = struct_lit type#1488 {x=copy L6, y=copy L11}
     return move L12
 
 fn main:
   locals:
-    L0: type#1484 name=p1
-    L1: type#1484 name=tmp_struct1
-    L2: type#1484 name=p2
-    L3: type#1484 name=tmp_struct2
-    L4: type#1484 name=p3
-    L5: type#1484 name=tmp_call3
+    L0: type#1488 name=p1
+    L1: type#1488 name=tmp_struct1
+    L2: type#1488 name=p2
+    L3: type#1488 name=tmp_struct2
+    L4: type#1488 name=p3
+    L5: type#1488 name=tmp_call3
     L6: int [copy] name=tmp_field4
     L7: int [copy] name=tmp_field5
     L8: int [copy] name=tmp_call6
   bb0:
-    L1 = struct_lit type#1484 {x=const 1, y=const 2}
+    L1 = struct_lit type#1488 {x=const 1, y=const 2}
     L0 = move L1
-    L3 = struct_lit type#1484 {x=const 3, y=const 4}
+    L3 = struct_lit type#1488 {x=const 3, y=const 4}
     L2 = move L3
     L5 = call add(addr_of L0, addr_of L2)
     L4 = move L5

--- a/testdata/golden/mir/operator_repro.mir
+++ b/testdata/golden/mir/operator_repro.mir
@@ -4,8 +4,8 @@ funcs=2
 
 fn __eq:
   locals:
-    L0: type#1484 [copy] name=self
-    L1: type#1484 [copy] name=other
+    L0: type#1488 [copy] name=self
+    L1: type#1488 [copy] name=other
     L2: uint64 [copy] name=tmp_field1
     L3: uint64 [copy] name=tmp_field2
     L4: bool [copy] name=tmp_call3
@@ -17,8 +17,8 @@ fn __eq:
 
 fn __ne:
   locals:
-    L0: type#1484 [copy] name=self
-    L1: type#1484 [copy] name=other
+    L0: type#1488 [copy] name=self
+    L1: type#1488 [copy] name=other
     L2: uint64 [copy] name=tmp_field1
     L3: uint64 [copy] name=tmp_field2
     L4: bool [copy] name=tmp_call3

--- a/testdata/golden/mir/option_match.mir
+++ b/testdata/golden/mir/option_match.mir
@@ -4,9 +4,9 @@ funcs=1
 
 fn unwrap_or_zero:
   locals:
-    L0: type#1484 name=x
+    L0: type#1488 name=x
     L1: int [copy] name=tmp_block1
-    L2: type#1484 name=__cmp1
+    L2: type#1488 name=__cmp1
     L3: bool [copy] name=tmp_tagtest2
     L4: int [copy] name=v
     L5: int [copy] name=tmp_payload3

--- a/testdata/golden/mono/generic_type_ctor.mono
+++ b/testdata/golden/mono/generic_type_ctor.mono
@@ -2,9 +2,9 @@
 == MONO ==
 funcs=1 types=1
 fn main() -> nothing (id=2147483649, sym=2415919105) {
-  let b: type#1487 =  { v = 1 }: type#1487
+  let b: type#1491 =  { v = 1 }: type#1491
   return
 }
 
 types:
-  type Box::<int> = type#1487
+  type Box::<int> = type#1491

--- a/testdata/golden/mono/option_ctor_int.mono
+++ b/testdata/golden/mono/option_ctor_int.mono
@@ -2,11 +2,11 @@
 == MONO ==
 funcs=2 types=2
 fn main() -> nothing (id=2147483649, sym=2415919105) {
-  let x: type#1485 = Some(1): type#1486 to type#1485: type#1485
+  let x: type#1489 = Some(1): type#1490 to type#1489: type#1489
   return
 }
 fn Some::<int> (sym=2415919106)
 
 types:
-  type Option::<int> = type#1485
-  type Option::<int> = type#1485
+  type Option::<int> = type#1489
+  type Option::<int> = type#1489

--- a/testdata/golden/mono/option_implicit_wrap.mono
+++ b/testdata/golden/mono/option_implicit_wrap.mono
@@ -2,12 +2,12 @@
 == MONO ==
 funcs=2 types=2
 fn main() -> nothing (id=2147483649, sym=2415919105) {
-  let x: type#1485 = Some(1): type#1485
-  let y: type#1485 = Some(42): type#1485
+  let x: type#1489 = Some(1): type#1489
+  let y: type#1489 = Some(42): type#1489
   return
 }
 fn Some::<int> (sym=2415919106)
 
 types:
-  type Option::<int> = type#1485
-  type Option::<int> = type#1485
+  type Option::<int> = type#1489
+  type Option::<int> = type#1489


### PR DESCRIPTION
## Summary
- add byte-array net intrinsics for one native read/write per chunk
- update stdlib/net read_some/write_some/write_all to use buffered calls
- cover LLVM lowering and multi-byte PING/PONG smoke path

## Verification
- make check
- strace PING/PONG smoke: bulk_reads=20 bulk_writes=20 byte_reads=0 byte_writes=0

Closes #103

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added network byte array read/write operations for TCP connections, enabling efficient bulk data transfer instead of single-byte operations.

* **Improvements**
  * Enhanced async TCP read/write helpers to use bulk byte operations, improving performance and reducing memory allocation overhead.

* **Tests**
  * Added comprehensive test coverage for new network byte I/O functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->