### PR TITLE
fix(runtime): enable TCP_NODELAY on TCP sockets

### DIFF
--- a/internal/vm/intrinsic_net.go
+++ b/internal/vm/intrinsic_net.go
@@ -167,7 +167,7 @@ func (vm *VM) handleNetConnect(frame *Frame, call *mir.CallInstr, writes *[]Loca
 		closeNetFD(fd)
 		return vm.netWriteError(frame, dstLocal, errType, netErrorCodeFromErr(err), writes)
 	}
-	if err := syscall.SetNonblock(fd, true); err != nil {
+	if err := netPrepareConnFD(fd); err != nil {
 		closeNetFD(fd)
 		return vm.netWriteError(frame, dstLocal, errType, netErrorCodeFromErr(err), writes)
 	}
@@ -327,7 +327,7 @@ func (vm *VM) handleNetAccept(frame *Frame, call *mir.CallInstr, writes *[]Local
 	if err != nil {
 		return vm.netWriteError(frame, dstLocal, errType, netErrorCodeFromErr(err), writes)
 	}
-	if err := syscall.SetNonblock(fd, true); err != nil {
+	if err := netPrepareConnFD(fd); err != nil {
 		closeNetFD(fd)
 		return vm.netWriteError(frame, dstLocal, errType, netErrorCodeFromErr(err), writes)
 	}

--- a/internal/vm/intrinsic_net_helpers.go
+++ b/internal/vm/intrinsic_net_helpers.go
@@ -96,6 +96,17 @@ func netErrorCodeFromErrno(errno syscall.Errno) uint64 {
 	}
 }
 
+func netSetNoDelay(fd int) error {
+	return syscall.SetsockoptInt(fd, syscall.IPPROTO_TCP, syscall.TCP_NODELAY, 1)
+}
+
+func netPrepareConnFD(fd int) error {
+	if err := netSetNoDelay(fd); err != nil {
+		return err
+	}
+	return syscall.SetNonblock(fd, true)
+}
+
 func (vm *VM) netErrorValue(errType types.TypeID, code uint64) (Value, *VMError) {
 	return vm.makeErrorLikeValue(errType, netErrorMessage(code), code)
 }

--- a/internal/vm/intrinsic_net_helpers_test.go
+++ b/internal/vm/intrinsic_net_helpers_test.go
@@ -1,0 +1,25 @@
+package vm
+
+import (
+	"syscall"
+	"testing"
+)
+
+func TestNetSetNoDelay(t *testing.T) {
+	fd, err := syscall.Socket(syscall.AF_INET, syscall.SOCK_STREAM, 0)
+	if err != nil {
+		t.Fatalf("socket: %v", err)
+	}
+	defer closeNetFD(fd)
+
+	if noDelayErr := netSetNoDelay(fd); noDelayErr != nil {
+		t.Fatalf("set TCP_NODELAY: %v", noDelayErr)
+	}
+	got, err := syscall.GetsockoptInt(fd, syscall.IPPROTO_TCP, syscall.TCP_NODELAY)
+	if err != nil {
+		t.Fatalf("get TCP_NODELAY: %v", err)
+	}
+	if got != 1 {
+		t.Fatalf("TCP_NODELAY = %d, want 1", got)
+	}
+}

--- a/runtime/native/rt_net.c
+++ b/runtime/native/rt_net.c
@@ -9,6 +9,7 @@
 #include <fcntl.h>
 #include <limits.h>
 #include <netinet/in.h>
+#include <netinet/tcp.h>
 #include <poll.h>
 #include <stdbool.h>
 #include <stddef.h>
@@ -318,6 +319,27 @@ static int net_set_nonblocking(int fd, uint64_t* out_code) {
     return 1;
 }
 
+static int net_set_tcp_nodelay(int fd, uint64_t* out_code) {
+    if (out_code != NULL) {
+        *out_code = 0;
+    }
+    int enabled = 1;
+    if (setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &enabled, (socklen_t)sizeof(enabled)) != 0) {
+        if (out_code != NULL) {
+            *out_code = net_error_code_from_errno(errno);
+        }
+        return 0;
+    }
+    return 1;
+}
+
+static int net_prepare_conn_fd(int fd, uint64_t* out_code) {
+    if (!net_set_tcp_nodelay(fd, out_code)) {
+        return 0;
+    }
+    return net_set_nonblocking(fd, out_code);
+}
+
 static const NetListener* net_listener_from_borrowed(const void* listener) {
     if (listener == NULL) {
         return NULL;
@@ -420,7 +442,6 @@ void* rt_net_connect(void* addr, uint64_t port) {
     if (fd < 0) {
         return net_make_error(net_error_code_from_errno(errno));
     }
-
     struct sockaddr_in sa;
     memset(&sa, 0, sizeof(sa));
     sa.sin_family = AF_INET;
@@ -436,7 +457,7 @@ void* rt_net_connect(void* addr, uint64_t port) {
         return net_make_error(code);
     }
 
-    if (!net_set_nonblocking(fd, &err_code)) {
+    if (!net_prepare_conn_fd(fd, &err_code)) {
         close(fd);
         return net_make_error(err_code == 0 ? NET_ERR_IO : err_code);
     }
@@ -492,7 +513,7 @@ void* rt_net_accept(const void* listener) {
         return net_make_error(net_error_code_from_errno(errno));
     }
     uint64_t err_code = 0;
-    if (!net_set_nonblocking(fd, &err_code)) {
+    if (!net_prepare_conn_fd(fd, &err_code)) {
         close(fd);
         return net_make_error(err_code == 0 ? NET_ERR_IO : err_code);
     }


### PR DESCRIPTION
## Summary
- set TCP_NODELAY on native TCP connections after connect and accept
- mirror the same behavior in the VM net runtime
- add a small VM socket option test

## Verification
- make check
- accepted socket strace: setsockopt(... TCP_NODELAY, [1], 4) = 0
- outbound connect strace: setsockopt(... TCP_NODELAY, [1], 4) = 0
- sentrux session_end: quality stable, signal_delta=0

Closes #104

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Newly established TCP connections (both inbound and outbound) now automatically enable TCP_NODELAY for reduced network latency and improved responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->