### PR TITLE
fix(runtime): keep channel fanout progressing

### DIFF
--- a/internal/vm/mt_executor_test.go
+++ b/internal/vm/mt_executor_test.go
@@ -607,6 +607,117 @@ fn main() -> int {
 	}
 }
 
+func TestMTBlockingChannelHelpersDoNotParkWorkers(t *testing.T) {
+	requireLLVMBackend(t)
+	ensureLLVMToolchain(t)
+
+	source := `tag Request(Channel<int>);
+type Message = Request(Channel<int>);
+
+fn apply(requests: &Channel<Message>) -> int {
+    let reply = make_channel::<int>(0:uint);
+    let request: Message = Request(reply);
+    requests.send(own request);
+    return compare reply.recv() {
+        Some(v) => v;
+        nothing => -1;
+    };
+}
+
+async fn manager(requests: Channel<Message>, expected: int) -> int {
+    let mut handled = 0;
+    while handled < expected {
+        compare requests.recv() {
+            Some(msg) => {
+                compare msg {
+                    Request(reply) => {
+                        checkpoint().await();
+                        reply.send(1);
+                        handled = handled + 1;
+                    }
+                };
+            }
+            nothing => {
+                return -1;
+            }
+        };
+    }
+    return handled;
+}
+
+async fn client(requests: Channel<Message>, rounds: int) -> int {
+    let mut i = 0;
+    let mut sum = 0;
+    while i < rounds {
+        sum = sum + apply(&requests);
+        i = i + 1;
+    }
+    return sum;
+}
+
+@entrypoint
+fn main() -> int {
+    if rt_worker_count() <= 1:uint {
+        return 90;
+    }
+
+    let clients = 8;
+    let rounds = 25;
+    let expected = clients * rounds;
+    let requests = make_channel::<Message>(0:uint);
+    let manager_requests = requests;
+    let manager_task = spawn manager(manager_requests, expected);
+    let mut tasks: Task<int>[] = Array::<Task<int>>::with_len(clients to uint);
+
+    let mut i = 0;
+    while i < clients {
+        let client_requests = requests;
+        tasks[i] = spawn client(client_requests, rounds);
+        i = i + 1;
+    }
+
+    let mut total = 0;
+    for task in tasks {
+        let res = task.await();
+        let ok = compare res {
+            Success(v) => {
+                total = total + v;
+                true;
+            }
+            Cancelled() => false;
+        };
+        if !ok {
+            return 1;
+        }
+    }
+
+    let manager_res = manager_task.await();
+    let manager_ok = compare manager_res {
+        Success(v) => v == expected;
+        Cancelled() => false;
+    };
+    if !manager_ok || total != expected {
+        return 2;
+    }
+
+    print("ok");
+    return 0;
+}
+`
+
+	outputPath := buildLLVMProgramFromSource(t, source)
+	baseEnv := envWithStdlib(repoRoot(t))
+	env := overrideEnv(baseEnv, "2")
+	dur, res := runBinaryWithTimeout(t, outputPath, env, 10*time.Second)
+	if res.exitCode != 0 {
+		t.Fatalf("run failed (exit=%d, dur=%s)\nstdout:\n%s\nstderr:\n%s",
+			res.exitCode, dur, res.stdout, res.stderr)
+	}
+	if !strings.Contains(res.stdout, "ok") {
+		t.Fatalf("unexpected stdout: %q", res.stdout)
+	}
+}
+
 func TestMTWorkStealing(t *testing.T) {
 	requireLLVMBackend(t)
 	ensureLLVMToolchain(t)

--- a/internal/vm/mt_executor_test.go
+++ b/internal/vm/mt_executor_test.go
@@ -718,6 +718,71 @@ fn main() -> int {
 	}
 }
 
+func TestMTBlockingChannelHelpersAllowTimersToAdvance(t *testing.T) {
+	requireLLVMBackend(t)
+	ensureLLVMToolchain(t)
+
+	source := `fn recv_sync(ch: &Channel<int>) -> int {
+    return compare ch.recv() {
+        Some(v) => v;
+        nothing => -1;
+    };
+}
+
+async fn receiver(ch: Channel<int>) -> int {
+    return recv_sync(&ch);
+}
+
+async fn sender(ch: Channel<int>) -> int {
+    sleep(10:uint).await();
+    ch.send(7);
+    return 0;
+}
+
+@entrypoint
+fn main() -> int {
+    if rt_worker_count() <= 1:uint {
+        return 90;
+    }
+
+    let ch = make_channel::<int>(0:uint);
+    let recv_ch = ch;
+    let send_ch = ch;
+    let recv_task = spawn receiver(recv_ch);
+    let send_task = spawn sender(send_ch);
+
+    let recv_res = recv_task.await();
+    let send_res = send_task.await();
+    let recv_ok = compare recv_res {
+        Success(v) => v == 7;
+        Cancelled() => false;
+    };
+    let send_ok = compare send_res {
+        Success(v) => v == 0;
+        Cancelled() => false;
+    };
+    if !recv_ok || !send_ok {
+        return 1;
+    }
+
+    print("ok");
+    return 0;
+}
+`
+
+	outputPath := buildLLVMProgramFromSource(t, source)
+	baseEnv := envWithStdlib(repoRoot(t))
+	env := overrideEnv(baseEnv, "2")
+	dur, res := runBinaryWithTimeout(t, outputPath, env, 10*time.Second)
+	if res.exitCode != 0 {
+		t.Fatalf("run failed (exit=%d, dur=%s)\nstdout:\n%s\nstderr:\n%s",
+			res.exitCode, dur, res.stdout, res.stderr)
+	}
+	if !strings.Contains(res.stdout, "ok") {
+		t.Fatalf("unexpected stdout: %q", res.stdout)
+	}
+}
+
 func TestMTWorkStealing(t *testing.T) {
 	requireLLVMBackend(t)
 	ensureLLVMToolchain(t)

--- a/runtime/native/rt_async_channel.c
+++ b/runtime/native/rt_async_channel.c
@@ -348,6 +348,11 @@ uint8_t rt_channel_try_send_status_locked(rt_executor* ex, void* channel, uint64
 }
 
 static void channel_blocking_yield(void) {
+    rt_executor* ex = ensure_exec();
+    rt_task* current = rt_current_task();
+    if (rt_wait_current_worker_wakeup(ex, current)) {
+        return;
+    }
     void* task = checkpoint();
     if (task == NULL) {
         return;
@@ -363,6 +368,18 @@ void rt_channel_send_blocking(void* channel, uint64_t value_bits) {
     }
     rt_async_debug_printf(
         "async chan send start ch=%p bits=%llu\n", (void*)ch, (unsigned long long)value_bits);
+    if (rt_current_task() != NULL) {
+        while (!rt_channel_send(channel, value_bits)) {
+            if (current_task_cancelled(ex)) {
+                pending_key = waker_none();
+                return;
+            }
+            channel_blocking_yield();
+        }
+        pending_key = waker_none();
+        rt_async_debug_printf("async chan send ok ch=%p\n", (void*)ch);
+        return;
+    }
     for (;;) {
         rt_lock(ex);
         uint8_t status = rt_channel_try_send_status_locked(ex, channel, value_bits);
@@ -387,6 +404,27 @@ uint8_t rt_channel_recv_blocking(void* channel, uint64_t* out_bits) {
         return 2;
     }
     rt_async_debug_printf("async chan recv start ch=%p\n", (void*)ch);
+    if (rt_current_task() != NULL) {
+        for (;;) {
+            uint8_t status = rt_channel_recv(channel, out_bits);
+            if (status != 0) {
+                pending_key = waker_none();
+                if (status == 1 && out_bits != NULL) {
+                    rt_async_debug_printf("async chan recv ok ch=%p bits=%llu\n",
+                                          (void*)ch,
+                                          (unsigned long long)*out_bits);
+                } else if (status == 2) {
+                    rt_async_debug_printf("async chan recv closed ch=%p\n", (void*)ch);
+                }
+                return status;
+            }
+            if (current_task_cancelled(ex)) {
+                pending_key = waker_none();
+                return 2;
+            }
+            channel_blocking_yield();
+        }
+    }
     for (;;) {
         rt_lock(ex);
         uint8_t status = rt_channel_try_recv_status_locked(ex, channel, out_bits);

--- a/runtime/native/rt_async_internal.h
+++ b/runtime/native/rt_async_internal.h
@@ -168,6 +168,8 @@ typedef struct {
     rt_worker_ctx* worker_ctxs;
     uint32_t worker_count;
     uint32_t running_count;
+    uint32_t channel_blocked_workers;
+    uint32_t compensation_count;
     uint8_t sched_mode;
     uint8_t initialized;
     uint8_t io_started;
@@ -360,5 +362,6 @@ int poll_net_waiters(rt_executor* ex, int timeout_ms);
 void rt_net_wake_poll(void);
 int run_ready_one(rt_executor* ex);
 void run_until_done(rt_executor* ex, const rt_task* task, uint8_t* out_kind, uint64_t* out_bits);
+int rt_wait_current_worker_wakeup(rt_executor* ex, rt_task* task);
 
 #endif

--- a/runtime/native/rt_async_state.c
+++ b/runtime/native/rt_async_state.c
@@ -1760,10 +1760,21 @@ int rt_wait_current_worker_wakeup(rt_executor* ex, rt_task* task) {
     rt_lock(ex);
     move_current_local_to_inject_locked(ex);
     ex->channel_blocked_workers++;
+    int dropped_running = 0;
+    if (ex->running_count > 0) {
+        ex->running_count--;
+        dropped_running = 1;
+        if (ex->running_count == 0 && runnable_is_empty(ex)) {
+            pthread_cond_signal(&ex->io_cv);
+        }
+    }
     maybe_start_compensation_worker_locked(ex);
     while (!ex->shutdown && task->resume_kind == RESUME_NONE &&
            task_wake_token_exchange(task, 0) == 0) {
         pthread_cond_wait(&ex->ready_cv, &ex->lock);
+    }
+    if (dropped_running) {
+        ex->running_count++;
     }
     if (ex->channel_blocked_workers > 0) {
         ex->channel_blocked_workers--;

--- a/runtime/native/rt_async_state.c
+++ b/runtime/native/rt_async_state.c
@@ -447,6 +447,8 @@ static void* rt_io_main(void* arg);
 static void apply_poll_outcome(rt_executor* ex, rt_task* task, poll_outcome outcome);
 static int runnable_is_empty(const rt_executor* ex);
 static int worker_next_ready(rt_executor* ex, uint32_t worker_id, uint64_t* out_id);
+static void maybe_start_compensation_worker_locked(rt_executor* ex);
+static void move_current_local_to_inject_locked(rt_executor* ex);
 static void trace_exec_init(void);
 
 static void exec_init_once(void) {
@@ -1280,6 +1282,8 @@ void wake_task(rt_executor* ex, uint64_t id, int remove_waiter_flag) {
     (void)task_wake_token_exchange(task, 1);
     if (ready_push_inner(ex, id, 0)) {
         trace_exec_inc(&trace_wake_enqueued_total);
+    } else if (ex->channel_blocked_workers > 0) {
+        pthread_cond_broadcast(&ex->ready_cv);
     }
 }
 
@@ -1691,6 +1695,81 @@ static void apply_poll_outcome(rt_executor* ex, rt_task* task, poll_outcome outc
             panic_msg("async: unknown poll outcome");
             break;
     }
+}
+
+static void maybe_start_compensation_worker_locked(rt_executor* ex) {
+    if (ex == NULL || ex->worker_count <= 1) {
+        return;
+    }
+    uint32_t total_workers = ex->worker_count + ex->compensation_count;
+    if (ex->channel_blocked_workers < total_workers) {
+        return;
+    }
+    uint32_t limit = ex->worker_count > UINT32_MAX / 4U ? UINT32_MAX : ex->worker_count * 4U;
+    if (ex->compensation_count >= limit) {
+        return;
+    }
+    // Compensation workers live until executor shutdown; their context is process-lifetime.
+    rt_worker_ctx* ctx = (rt_worker_ctx*)rt_alloc(sizeof(rt_worker_ctx), _Alignof(rt_worker_ctx));
+    if (ctx == NULL) {
+        panic_msg("async: compensation worker context allocation failed");
+        return;
+    }
+    memset(ctx, 0, sizeof(rt_worker_ctx));
+    ctx->ex = ex;
+    ctx->worker_id = ex->compensation_count % ex->worker_count;
+    ctx->sched_rng =
+        ex->sched_seed +
+        UINT64_C(0x9e3779b97f4a7c15) * (uint64_t)(ex->worker_count + ex->compensation_count + 1U);
+
+    pthread_t thread;
+    if (pthread_create(&thread, NULL, rt_worker_main, ctx) != 0) {
+        rt_free((uint8_t*)ctx, sizeof(rt_worker_ctx), _Alignof(rt_worker_ctx));
+        panic_msg("async: compensation worker start failed");
+        return;
+    }
+    (void)pthread_detach(thread);
+    ex->compensation_count++;
+}
+
+static void move_current_local_to_inject_locked(rt_executor* ex) {
+    if (ex == NULL || tls_worker_id < 0 || (uint32_t)tls_worker_id >= ex->worker_count ||
+        ex->local_queues == NULL) {
+        return;
+    }
+    rt_deque* local = &ex->local_queues[(uint32_t)tls_worker_id];
+    uint64_t id = 0;
+    int moved = 0;
+    while (deque_pop_head(local, &id)) {
+        if (deque_push_tail(&ex->inject,
+                            id,
+                            "async: inject queue overflow",
+                            "async: inject queue allocation failed")) {
+            moved = 1;
+        }
+    }
+    if (moved) {
+        pthread_cond_broadcast(&ex->ready_cv);
+    }
+}
+
+int rt_wait_current_worker_wakeup(rt_executor* ex, rt_task* task) {
+    if (ex == NULL || task == NULL || tls_worker_id < 0) {
+        return 0;
+    }
+    rt_lock(ex);
+    move_current_local_to_inject_locked(ex);
+    ex->channel_blocked_workers++;
+    maybe_start_compensation_worker_locked(ex);
+    while (!ex->shutdown && task->resume_kind == RESUME_NONE &&
+           task_wake_token_exchange(task, 0) == 0) {
+        pthread_cond_wait(&ex->ready_cv, &ex->lock);
+    }
+    if (ex->channel_blocked_workers > 0) {
+        ex->channel_blocked_workers--;
+    }
+    rt_unlock(ex);
+    return 1;
 }
 
 static void* rt_worker_main(void* arg) {


### PR DESCRIPTION
## Summary

- route task-context blocking channel send/recv through the normal async channel waiter path
- add bounded compensation workers when synchronous channel waits occupy all runtime workers
- flush a blocking worker's local ready queue to the global inject queue before it sleeps
- add an LLVM MT regression for synchronous channel fanout from async tasks

## Root Cause

`rt_channel_send_blocking` / `rt_channel_recv_blocking` used polling plus `checkpoint().await()` when called from a task. Under multi-thread runtime pressure, enough socket/client tasks could occupy all executor workers while synchronously waiting on channel fanout. Ready work could also remain stranded in a blocked worker's local queue.

## Validation

- `SURGE_BACKEND=llvm SURGE_SKIP_TIMEOUT_TESTS=0 go test ./internal/vm -run 'TestMTBlockingChannelHelpersDoNotParkWorkers|TestMTChannelParkUnpark|TestMTCorrectnessWakeups|TestNativeNetSingleThreadBlockingChannelInAsyncServer' -count=1 -timeout 90s`
- `make c-warnings && make cfmt-check`
- external `surgekv` repro from #110, clean checkout at `8cce470`, `SURGE_THREADS=2`, PING 8 clients / 200 requests: `errors=0`, `total_ms=62`
- `sentrux session_end`: pass, quality signal unchanged

Note: `TestMTCorrectnessChannels` still times out intermittently; I reproduced that on clean `origin/main` as well, so it is not introduced by this branch.

Closes #110

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved blocking channel send/receive behavior in multi-threaded mode to avoid unnecessary worker parking.
  * Enhanced wake/scheduling handling so blocked workers and timers progress reliably, especially under concurrent request-reply patterns.
* **Tests**
  * Added multi-threaded regression tests covering blocking channel helper behavior, including scenarios involving bounded channels and delayed sends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->