### PR TITLE
fix(runtime): keep channel fanout progressing under small thread counts

### DIFF
--- a/internal/vm/mt_executor_test.go
+++ b/internal/vm/mt_executor_test.go
@@ -783,6 +783,136 @@ fn main() -> int {
 	}
 }
 
+func TestMTBlockingChannelHelpersDrainReadyWorkAtCompensationLimit(t *testing.T) {
+	requireLLVMBackend(t)
+	ensureLLVMToolchain(t)
+
+	source := `tag Request(Channel<int>);
+type Message = Request(Channel<int>);
+
+fn apply(requests: &Channel<Message>) -> int {
+    let reply = make_channel::<int>(0:uint);
+    let request: Message = Request(reply);
+    requests.send(own request);
+    return compare reply.recv() {
+        Some(v) => v;
+        nothing => -1;
+    };
+}
+
+async fn manager(requests: Channel<Message>, expected: int) -> int {
+    let mut handled = 0;
+    while handled < expected {
+        compare requests.recv() {
+            Some(msg) => {
+                compare msg {
+                    Request(reply) => {
+                        checkpoint().await();
+                        reply.send(1);
+                        handled = handled + 1;
+                    }
+                };
+            }
+            nothing => {
+                return -1;
+            }
+        };
+    }
+    return handled;
+}
+
+async fn client(requests: Channel<Message>, rounds: int) -> int {
+    let mut i = 0;
+    let mut sum = 0;
+    while i < rounds {
+        sum = sum + apply(&requests);
+        i = i + 1;
+    }
+    return sum;
+}
+
+@entrypoint
+fn main() -> int {
+    if rt_worker_count() <= 1:uint {
+        return 90;
+    }
+
+    let manager_count = 4;
+    let clients_per_manager = 8;
+    let rounds = 8;
+    let expected_per_manager = clients_per_manager * rounds;
+    let expected_total = manager_count * expected_per_manager;
+    let mut managers: Task<int>[] = [];
+    let mut clients: Task<int>[] = [];
+    managers.reserve(manager_count to uint);
+    clients.reserve(expected_total to uint);
+
+    let mut manager_idx = 0;
+    while manager_idx < manager_count {
+        let requests = make_channel::<Message>(0:uint);
+        let manager_requests = requests;
+        managers.push(spawn manager(manager_requests, expected_per_manager));
+        let mut client_idx = 0;
+        while client_idx < clients_per_manager {
+            let client_requests = requests;
+            clients.push(spawn client(client_requests, rounds));
+            client_idx = client_idx + 1;
+        }
+        manager_idx = manager_idx + 1;
+    }
+
+    let mut client_total = 0;
+    for task in clients {
+        let client_res = task.await();
+        let client_ok = compare client_res {
+            Success(v) => {
+                client_total = client_total + v;
+                true;
+            }
+            Cancelled() => false;
+        };
+        if !client_ok {
+            return 1;
+        }
+    }
+
+    let mut manager_total = 0;
+    for task in managers {
+        let manager_res = task.await();
+        let manager_ok = compare manager_res {
+            Success(v) => {
+                manager_total = manager_total + v;
+                true;
+            }
+            Cancelled() => false;
+        };
+        if !manager_ok {
+            return 1;
+        }
+    }
+
+    if client_total != expected_total || manager_total != expected_total {
+        return 2;
+    }
+
+    print("ok");
+    return 0;
+}
+`
+
+	outputPath := buildLLVMProgramFromSource(t, source)
+	baseEnv := envWithStdlib(repoRoot(t))
+	env := overrideEnv(baseEnv, "2")
+	dur, res := runBinaryWithTimeout(t, outputPath, env, 10*time.Second)
+	if res.exitCode != 0 {
+		t.Fatalf("run failed (exit=%d, dur=%s)\nstdout:\n%s\nstderr:\n%s",
+			res.exitCode, dur, res.stdout, res.stderr)
+	}
+	if !strings.Contains(res.stdout, "ok") {
+		t.Fatalf("unexpected stdout: %q", res.stdout)
+	}
+}
+
 func TestMTWorkStealing(t *testing.T) {
 	requireLLVMBackend(t)
 	ensureLLVMToolchain(t)

--- a/runtime/native/rt_async_state.c
+++ b/runtime/native/rt_async_state.c
@@ -1139,6 +1139,9 @@ static int ready_push_inner(rt_executor* ex, uint64_t id, int force_inject) {
     }
     task_enqueued_store(task, 1);
     task_status_store(task, TASK_READY);
+    if (ex->channel_blocked_workers > 0) {
+        maybe_start_compensation_worker_locked(ex);
+    }
     pthread_cond_signal(&ex->ready_cv);
     return 1;
 }
@@ -1705,7 +1708,8 @@ static void maybe_start_compensation_worker_locked(rt_executor* ex) {
     if (ex->channel_blocked_workers < total_workers) {
         return;
     }
-    uint32_t limit = ex->worker_count > UINT32_MAX / 4U ? UINT32_MAX : ex->worker_count * 4U;
+    // Stateful channel fanout can park many workers behind sync request/reply chains.
+    uint32_t limit = ex->worker_count > UINT32_MAX / 32U ? UINT32_MAX : ex->worker_count * 32U;
     if (ex->compensation_count >= limit) {
         return;
     }


### PR DESCRIPTION
## What changed

- Start a compensation worker when ready work is queued while runtime workers are blocked in synchronous channel waits.
- Raise the bounded compensation limit from 4x to 32x worker count for stateful request/reply fanout workloads.
- Add an MT regression test with multiple manager channels and 32 client tasks.

## Why

Issue #113 reproduced with all runtime workers channel-blocked while stateful TCP work still had ready request/reply tasks to run. The old compensation path only reacted when a worker entered channel wait, so work queued after that point could stall at small `SURGE_THREADS` values.

## Validation

- `SURGE_BACKEND=llvm SURGE_SKIP_TIMEOUT_TESTS=0 go test ./internal/vm -run 'TestMTBlockingChannelHelpers(DoNotParkWorkers|AllowTimersToAdvance|DrainReadyWorkAtCompensationLimit)|TestMTChannelParkUnpark|TestMTCorrectnessWakeups|TestNativeNetSingleThreadBlockingChannelInAsyncServer' -count=1 -timeout 90s`
- `make build`
- `make c-warnings`
- `make cfmt-check`
- `git diff --check`
- `surgekv` release, `SURGE_THREADS=2`, GET clients=32 requests=500: `errors=0`, fresh `PING` returned `PONG`
- `surgekv` release, `SURGE_THREADS=4`, GET clients=32 requests=500: `errors=0`, fresh `PING` returned `PONG`
- `surgekv` release, `SURGE_THREADS=2`, GET clients=32 requests=5000: `errors=0`, fresh `PING` returned `PONG`

Closes #113


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of concurrent task execution with channel blocking, enabling more compensation workers to be spawned when needed for better performance.

* **Tests**
  * Added test coverage for compensation worker behavior under specific channel-blocking scenarios with LLVM backend.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->