### PR TITLE
Runtime trace diagnostics for channel fallback paths

### DIFF
--- a/STATS.md
+++ b/STATS.md
@@ -4,24 +4,24 @@
 
 ## 📊 Main code (without tests)
 
-- **Files:** 680 (Go: 650, C: 30)
-- **Lines of code:** 154705 (Go: 141506, C: 13199)
+- **Files:** 682 (Go: 652, C: 30)
+- **Lines of code:** 155959 (Go: 142226, C: 13733)
 
 ## 📁 Directory breakdown
 
 | Directory | Files | Lines |
 |------------|--------|-------|
 | `cmd/` | 27 | 4669 |
-| `internal/` | 622 | 136822 |
-| `runtime/native/` (C code) | 30 | 13199 |
+| `internal/` | 623 | 137110 |
+| `runtime/native/` (C code) | 30 | 13733 |
 
 ## 🏆 Top 10 packages by size
 
 | # | Package | Lines |
 |---|-------|-------|
 | 1 | `internal/sema` | 28562 |
-| 2 | `internal/vm` | 22982 |
-| 3 | `internal/backend/llvm` | 11948 |
+| 2 | `internal/vm` | 23197 |
+| 3 | `internal/backend/llvm` | 12021 |
 | 4 | `internal/mir` | 10281 |
 | 5 | `internal/parser` | 8960 |
 | 6 | `internal/hir` | 7162 |
@@ -32,15 +32,15 @@
 
 ## 🧪 Test files
 
-- **Files:** 172
-- **Lines of code:** 34971
+- **Files:** 174
+- **Lines of code:** 35795
 
 ## 📈 Total volume (code + tests)
 
-- **Files:** 852
-- **Lines of code:** 189676
+- **Files:** 856
+- **Lines of code:** 191754
 
 ## 📊 Percentage breakdown
 
-- **Main code (Go + C):** 81% (Go: 74%, C: 6%)
+- **Main code (Go + C):** 81% (Go: 74%, C: 7%)
 - **Tests:** 18%

--- a/check_file_sizes.sh
+++ b/check_file_sizes.sh
@@ -240,13 +240,18 @@ check_directory() {
     echo -e "(≤575 строк): ${GREEN}$ok_files${NC}"
     echo -e "(576-675 строк): ${YELLOW}$acceptable_files${NC}"
     echo -e "(>675 строк): ${RED}$bad_files${NC}"
+
+    if [ $total_files -eq 0 ]; then
+        echo ""
+        echo "После фильтрации файлов для проверки не осталось."
+        echo -e "Общая оценка: ${GREEN}ОТЛИЧНО${NC} (нет применимых файлов)"
+        exit 0
+    fi
     
     # Рассчитываем процент "хороших" файлов (OK + ACCEPTABLE)
     local good_files=$((ok_files + acceptable_files))
     local percentage=0
-    if [ $total_files -gt 0 ]; then
-        percentage=$((good_files * 100 / total_files))
-    fi
+    percentage=$((good_files * 100 / total_files))
     
     echo ""
     echo "Процент хороших файлов: $percentage%"

--- a/internal/vm/mt_executor_test.go
+++ b/internal/vm/mt_executor_test.go
@@ -76,6 +76,58 @@ type schedTrace struct {
 	hash   uint64
 }
 
+type execTrace map[string]uint64
+
+func parseExecTrace(t *testing.T, stderr string) execTrace {
+	t.Helper()
+	for _, line := range strings.Split(stderr, "\n") {
+		if !strings.HasPrefix(line, "TRACE_EXEC ") {
+			continue
+		}
+		out := execTrace{}
+		fields := strings.Fields(line)
+		for _, field := range fields[1:] {
+			kv := strings.SplitN(field, "=", 2)
+			if len(kv) != 2 || kv[0] == "reason" {
+				continue
+			}
+			v, err := strconv.ParseUint(kv[1], 10, 64)
+			if err != nil {
+				t.Fatalf("parse TRACE_EXEC %s: %v", kv[0], err)
+			}
+			out[kv[0]] = v
+		}
+		return out
+	}
+	t.Fatalf("missing TRACE_EXEC in stderr:\n%s", stderr)
+	return nil
+}
+
+func parseExecSnapshot(t *testing.T, stderr string) execTrace {
+	t.Helper()
+	for _, line := range strings.Split(stderr, "\n") {
+		if !strings.HasPrefix(line, "TRACE_EXEC_SNAPSHOT ") {
+			continue
+		}
+		out := execTrace{}
+		fields := strings.Fields(line)
+		for _, field := range fields[1:] {
+			kv := strings.SplitN(field, "=", 2)
+			if len(kv) != 2 || kv[0] == "reason" {
+				continue
+			}
+			v, err := strconv.ParseUint(kv[1], 10, 64)
+			if err != nil {
+				t.Fatalf("parse TRACE_EXEC_SNAPSHOT %s: %v", kv[0], err)
+			}
+			out[kv[0]] = v
+		}
+		return out
+	}
+	t.Fatalf("missing TRACE_EXEC_SNAPSHOT in stderr:\n%s", stderr)
+	return nil
+}
+
 func parseSchedTrace(t *testing.T, stderr string) schedTrace {
 	t.Helper()
 	for _, line := range strings.Split(stderr, "\n") {
@@ -708,6 +760,7 @@ fn main() -> int {
 	outputPath := buildLLVMProgramFromSource(t, source)
 	baseEnv := envWithStdlib(repoRoot(t))
 	env := overrideEnv(baseEnv, "2")
+	env = overrideEnvVar(env, "SURGE_TRACE_EXEC", "1")
 	dur, res := runBinaryWithTimeout(t, outputPath, env, 10*time.Second)
 	if res.exitCode != 0 {
 		t.Fatalf("run failed (exit=%d, dur=%s)\nstdout:\n%s\nstderr:\n%s",
@@ -715,6 +768,19 @@ fn main() -> int {
 	}
 	if !strings.Contains(res.stdout, "ok") {
 		t.Fatalf("unexpected stdout: %q", res.stdout)
+	}
+	trace := parseExecTrace(t, res.stderr)
+	if trace["channel_blocking_wait"] == 0 {
+		t.Fatalf("expected task-context blocking channel waits in TRACE_EXEC, got %+v\nstderr:\n%s",
+			trace, res.stderr)
+	}
+	if trace["compensation_started"] == 0 {
+		t.Fatalf("expected compensation workers in TRACE_EXEC, got %+v\nstderr:\n%s",
+			trace, res.stderr)
+	}
+	snapshot := parseExecSnapshot(t, res.stderr)
+	if snapshot["worker_count"] != 2 || snapshot["compensation"] == 0 {
+		t.Fatalf("unexpected TRACE_EXEC_SNAPSHOT %+v\nstderr:\n%s", snapshot, res.stderr)
 	}
 }
 

--- a/runtime/native/rt.h
+++ b/runtime/native/rt.h
@@ -36,6 +36,7 @@ void rt_panic_numeric(const uint8_t* ptr, uint64_t length);
 void rt_panic_bounds(uint64_t kind, int64_t index, int64_t length);
 int64_t rt_monotonic_now(void);
 uint64_t rt_worker_count(void);
+void rt_exec_trace_dump(void);
 void rt_sched_trace_dump(void);
 
 void* rt_argv(void);

--- a/runtime/native/rt_async_state.c
+++ b/runtime/native/rt_async_state.c
@@ -53,6 +53,8 @@ static _Atomic uint64_t trace_park_attempt_total;
 static _Atomic uint64_t trace_park_committed_total;
 static _Atomic uint64_t trace_worker_sleep_total;
 static _Atomic uint64_t trace_worker_wake_total;
+static _Atomic uint64_t trace_channel_blocking_wait_total;
+static _Atomic uint64_t trace_compensation_started_total;
 static uint64_t trace_sched_hash;
 static uint64_t trace_sched_events;
 static uint64_t trace_sched_local_pops;
@@ -147,7 +149,7 @@ static void trace_exec_dump(const char* reason) {
     if (!trace_exec_enabled()) {
         return;
     }
-    char buf[512];
+    char buf[768];
     size_t pos = 0;
     pos = trace_exec_append_literal(buf, pos, sizeof(buf), "TRACE_EXEC ");
     if (reason != NULL) {
@@ -197,6 +199,18 @@ static void trace_exec_dump(const char* reason) {
                               pos,
                               sizeof(buf),
                               atomic_load_explicit(&trace_worker_wake_total, memory_order_relaxed));
+    pos = trace_exec_append_literal(buf, pos, sizeof(buf), " channel_blocking_wait=");
+    pos = trace_exec_append_u64(
+        buf,
+        pos,
+        sizeof(buf),
+        atomic_load_explicit(&trace_channel_blocking_wait_total, memory_order_relaxed));
+    pos = trace_exec_append_literal(buf, pos, sizeof(buf), " compensation_started=");
+    pos = trace_exec_append_u64(
+        buf,
+        pos,
+        sizeof(buf),
+        atomic_load_explicit(&trace_compensation_started_total, memory_order_relaxed));
     pos = trace_exec_append_literal(buf, pos, sizeof(buf), " blocking_submitted=");
     pos = trace_exec_append_u64(
         buf,
@@ -227,6 +241,147 @@ static void trace_exec_dump(const char* reason) {
     (void)write(STDERR_FILENO, buf, pos);
 }
 
+static void
+trace_exec_append_kv_u64(char* buf, size_t* pos, size_t cap, const char* name, uint64_t value) {
+    if (buf == NULL || pos == NULL || name == NULL) {
+        return;
+    }
+    *pos = trace_exec_append_literal(buf, *pos, cap, " ");
+    *pos = trace_exec_append_literal(buf, *pos, cap, name);
+    *pos = trace_exec_append_literal(buf, *pos, cap, "=");
+    *pos = trace_exec_append_u64(buf, *pos, cap, value);
+}
+
+static void trace_exec_snapshot_dump(const char* reason) {
+    if (!trace_exec_enabled()) {
+        return;
+    }
+    rt_executor* ex = &exec_state;
+    if (!ex->initialized) {
+        return;
+    }
+    uint64_t local_total = 0;
+    uint64_t local_max = 0;
+    uint64_t tasks_ready = 0;
+    uint64_t tasks_running = 0;
+    uint64_t tasks_waiting = 0;
+    uint64_t tasks_done = 0;
+    uint64_t waiters_join = 0;
+    uint64_t waiters_timer = 0;
+    uint64_t waiters_chan_send = 0;
+    uint64_t waiters_chan_recv = 0;
+    uint64_t waiters_net = 0;
+    uint64_t waiters_other = 0;
+
+    // Snapshot reads executor-owned fields, so it is intentionally exit-only and best-effort.
+    if (pthread_mutex_trylock(&ex->lock) != 0) {
+        char busy_buf[128];
+        size_t busy_pos = 0;
+        busy_pos =
+            trace_exec_append_literal(busy_buf, busy_pos, sizeof(busy_buf), "TRACE_EXEC_SNAPSHOT");
+        if (reason != NULL) {
+            busy_pos = trace_exec_append_literal(busy_buf, busy_pos, sizeof(busy_buf), " reason=");
+            busy_pos = trace_exec_append_literal(busy_buf, busy_pos, sizeof(busy_buf), reason);
+        }
+        trace_exec_append_kv_u64(busy_buf, &busy_pos, sizeof(busy_buf), "lock_busy", 1);
+        if (busy_pos + 1 < sizeof(busy_buf)) {
+            busy_buf[busy_pos++] = '\n';
+        }
+        (void)write(STDERR_FILENO, busy_buf, busy_pos);
+        return;
+    }
+    if (ex->local_queues != NULL) {
+        for (uint32_t i = 0; i < ex->worker_count; i++) {
+            uint64_t len = (uint64_t)ex->local_queues[i].len;
+            local_total += len;
+            if (len > local_max) {
+                local_max = len;
+            }
+        }
+    }
+    for (size_t i = 1; i < ex->tasks_cap; i++) {
+        const rt_task* task = ex->tasks[i];
+        if (task == NULL) {
+            continue;
+        }
+        switch (task_status_load(task)) {
+            case TASK_READY:
+                tasks_ready++;
+                break;
+            case TASK_RUNNING:
+                tasks_running++;
+                break;
+            case TASK_WAITING:
+                tasks_waiting++;
+                break;
+            case TASK_DONE:
+            default:
+                tasks_done++;
+                break;
+        }
+    }
+    for (size_t i = 0; i < ex->waiters_len; i++) {
+        switch ((waker_kind)ex->waiters[i].key.kind) {
+            case WAKER_JOIN:
+            case WAKER_SCOPE:
+            case WAKER_BLOCKING:
+                waiters_join++;
+                break;
+            case WAKER_TIMER:
+                waiters_timer++;
+                break;
+            case WAKER_CHAN_SEND:
+                waiters_chan_send++;
+                break;
+            case WAKER_CHAN_RECV:
+                waiters_chan_recv++;
+                break;
+            case WAKER_NET_ACCEPT:
+            case WAKER_NET_READ:
+            case WAKER_NET_WRITE:
+                waiters_net++;
+                break;
+            case WAKER_NONE:
+            default:
+                waiters_other++;
+                break;
+        }
+    }
+
+    char buf[1024];
+    size_t pos = 0;
+    pos = trace_exec_append_literal(buf, pos, sizeof(buf), "TRACE_EXEC_SNAPSHOT");
+    if (reason != NULL) {
+        pos = trace_exec_append_literal(buf, pos, sizeof(buf), " reason=");
+        pos = trace_exec_append_literal(buf, pos, sizeof(buf), reason);
+    }
+    trace_exec_append_kv_u64(buf, &pos, sizeof(buf), "worker_count", (uint64_t)ex->worker_count);
+    trace_exec_append_kv_u64(buf, &pos, sizeof(buf), "running", (uint64_t)ex->running_count);
+    trace_exec_append_kv_u64(
+        buf, &pos, sizeof(buf), "channel_blocked", (uint64_t)ex->channel_blocked_workers);
+    trace_exec_append_kv_u64(
+        buf, &pos, sizeof(buf), "compensation", (uint64_t)ex->compensation_count);
+    trace_exec_append_kv_u64(buf, &pos, sizeof(buf), "inject_len", (uint64_t)ex->inject.len);
+    trace_exec_append_kv_u64(buf, &pos, sizeof(buf), "local_total", local_total);
+    trace_exec_append_kv_u64(buf, &pos, sizeof(buf), "local_max", local_max);
+    trace_exec_append_kv_u64(buf, &pos, sizeof(buf), "waiters", (uint64_t)ex->waiters_len);
+    trace_exec_append_kv_u64(buf, &pos, sizeof(buf), "waiters_join", waiters_join);
+    trace_exec_append_kv_u64(buf, &pos, sizeof(buf), "waiters_timer", waiters_timer);
+    trace_exec_append_kv_u64(buf, &pos, sizeof(buf), "waiters_chan_send", waiters_chan_send);
+    trace_exec_append_kv_u64(buf, &pos, sizeof(buf), "waiters_chan_recv", waiters_chan_recv);
+    trace_exec_append_kv_u64(buf, &pos, sizeof(buf), "waiters_net", waiters_net);
+    trace_exec_append_kv_u64(buf, &pos, sizeof(buf), "waiters_other", waiters_other);
+    trace_exec_append_kv_u64(buf, &pos, sizeof(buf), "tasks_ready", tasks_ready);
+    trace_exec_append_kv_u64(buf, &pos, sizeof(buf), "tasks_running", tasks_running);
+    trace_exec_append_kv_u64(buf, &pos, sizeof(buf), "tasks_waiting", tasks_waiting);
+    trace_exec_append_kv_u64(buf, &pos, sizeof(buf), "tasks_done", tasks_done);
+    if (pos + 1 < sizeof(buf)) {
+        buf[pos++] = '\n';
+    }
+    pthread_mutex_unlock(&ex->lock);
+    (void)write(STDERR_FILENO, buf, pos);
+}
+
 static void trace_sched_record(uint8_t source, uint64_t id) {
     if (!trace_sched_enabled()) {
         return;
@@ -247,6 +402,11 @@ static void trace_sched_record(uint8_t source, uint64_t id) {
 static void trace_exec_signal_handler(int sig) {
     (void)sig;
     trace_exec_dump("sigusr1");
+}
+
+void rt_exec_trace_dump(void) {
+    trace_exec_dump("exit");
+    trace_exec_snapshot_dump("exit");
 }
 
 static void trace_sched_init(void) {
@@ -1733,6 +1893,7 @@ static void maybe_start_compensation_worker_locked(rt_executor* ex) {
         return;
     }
     (void)pthread_detach(thread);
+    trace_exec_inc(&trace_compensation_started_total);
     ex->compensation_count++;
 }
 
@@ -1761,6 +1922,7 @@ int rt_wait_current_worker_wakeup(rt_executor* ex, rt_task* task) {
     if (ex == NULL || task == NULL || tls_worker_id < 0) {
         return 0;
     }
+    trace_exec_inc(&trace_channel_blocking_wait_total);
     rt_lock(ex);
     move_current_local_to_inject_locked(ex);
     ex->channel_blocked_workers++;

--- a/runtime/native/rt_io.c
+++ b/runtime/native/rt_io.c
@@ -159,6 +159,7 @@ void* rt_stdin_read_all(void) {
 }
 
 void rt_exit(int64_t code) {
+    rt_exec_trace_dump();
     rt_sched_trace_dump();
     exit((int)code);
 }


### PR DESCRIPTION
## Summary
- dump SURGE_TRACE_EXEC counters on normal native runtime exit
- add an exit-only TRACE_EXEC_SNAPSHOT for executor queues, waiters, and task states
- count task-context blocking channel waits and compensation workers
- let the file-size check pass when no files remain after its filters

## Verification
- make check
- make build
- git diff --check HEAD~2..HEAD
- sentrux session_end: pass, signal 6229 -> 6229

## Notes
- This is the first execution slice of the native async runtime refactor epic.
- Benchmark harness work and async surgekv migration remain separate follow-up slices after this diagnostic baseline lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Features**
  * Enhanced execution tracing with additional runtime metrics including channel blocking diagnostics and worker compensation events.
  * Improved diagnostics output on process exit.

* **Tests**
  * Added test validation for execution tracing and runtime state snapshots.

* **Chores**
  * Updated codebase metrics documentation.
  * Improved edge-case handling in file checking utility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->