### PR TITLE
Add native channel request/reply benchmark baseline

### DIFF
--- a/benchmarks/native/README.md
+++ b/benchmarks/native/README.md
@@ -1,0 +1,21 @@
+# Native Benchmarks
+
+Manual runtime probes live here. They are intentionally not part of `make check`
+because latency numbers are machine-dependent.
+
+Run the channel request/reply probe:
+
+```bash
+make build
+./scripts/bench_native_channels.sh
+```
+
+Useful overrides:
+
+```bash
+SURGE_CHANNEL_BENCH_MODES="1 2 4 8 default" ./scripts/bench_native_channels.sh
+SURGE_CHANNEL_BENCH_REPORT=/tmp/channel.md ./scripts/bench_native_channels.sh
+```
+
+Compare future runtime PRs against
+`benchmarks/native/channel-request-reply-baseline.md`.

--- a/benchmarks/native/channel-request-reply-baseline.md
+++ b/benchmarks/native/channel-request-reply-baseline.md
@@ -1,0 +1,42 @@
+# Native channel request/reply baseline
+
+Generated: 2026-06-18T11:32:58Z
+
+## Environment
+
+- compiler base commit: `e6b44148bb0e` (merged PR #115)
+- fixture: `benchmarks/native/channel_request_reply`
+- command: `./scripts/bench_native_channels.sh`
+- modes: `1 2 4 8 default`
+- machine: local developer workstation
+
+## Results
+
+| mode | probe | iterations | total us | ns/op |
+| --- | --- | ---: | ---: | ---: |
+| 1 | empty_loop | 20000 | 6159 | 307 |
+| 1 | response_bytes | 20000 | 454514 | 22725 |
+| 1 | channel_reused_reply | 20000 | 79565 | 3978 |
+| 1 | channel_new_reply | 20000 | 87077 | 4353 |
+| 2 | empty_loop | 20000 | 7892 | 394 |
+| 2 | response_bytes | 20000 | 448844 | 22442 |
+| 2 | channel_reused_reply | 20000 | 943410 | 47170 |
+| 2 | channel_new_reply | 20000 | 1059313 | 52965 |
+| 4 | empty_loop | 20000 | 7591 | 379 |
+| 4 | response_bytes | 20000 | 449635 | 22481 |
+| 4 | channel_reused_reply | 20000 | 2102557 | 105127 |
+| 4 | channel_new_reply | 20000 | 2163796 | 108189 |
+| 8 | empty_loop | 20000 | 7757 | 387 |
+| 8 | response_bytes | 20000 | 448600 | 22430 |
+| 8 | channel_reused_reply | 20000 | 2178635 | 108931 |
+| 8 | channel_new_reply | 20000 | 2234688 | 111734 |
+| default | empty_loop | 20000 | 7635 | 381 |
+| default | response_bytes | 20000 | 452752 | 22637 |
+| default | channel_reused_reply | 20000 | 2247712 | 112385 |
+| default | channel_new_reply | 20000 | 2319939 | 115996 |
+
+## Signal
+
+`channel_reused_reply` is the regression signal for the surgekv-style actor hop:
+single-worker baseline is about 4.0us/op, while multi-worker modes are about
+47-112us/op on this machine.

--- a/benchmarks/native/channel_request_reply/main.sg
+++ b/benchmarks/native/channel_request_reply/main.sg
@@ -1,0 +1,154 @@
+pragma module;
+
+import stdlib/time as time;
+
+tag Apply(int, Channel<int>);
+tag Stop();
+type Message = Apply(int, Channel<int>) | Stop();
+
+fn elapsed_us(start: time.Duration) -> int64 {
+    let now = time.monotonic_now();
+    let elapsed = now.sub(start);
+    return elapsed.as_micros();
+}
+
+fn print_row(name: string, iterations: int, total_us: int64) -> nothing {
+    let ns_op: int64 = (total_us * (1000):int64) / (iterations to int64);
+    print("| " + name
+        + " | " + (iterations to string)
+        + " | " + (total_us to string)
+        + " | " + (ns_op to string)
+        + " |");
+    return nothing;
+}
+
+fn bench_empty_loop(iterations: int) -> nothing {
+    let start = time.monotonic_now();
+    let mut sum: int = 0;
+    let mut i: int = 0;
+    while i < iterations {
+        sum = sum + i;
+        i = i + 1;
+    }
+    let total_us = elapsed_us(start);
+    if sum < 0 {
+        print("impossible");
+    }
+    print_row("empty_loop", iterations, total_us);
+    return nothing;
+}
+
+fn append_string_bytes(out: &mut byte[], s: &string) -> nothing {
+    let view = s.bytes();
+    let length: int = view.__len() to int;
+    let mut i: int = 0;
+    while i < length {
+        out.push(view[i]);
+        i = i + 1;
+    }
+    return nothing;
+}
+
+fn line_bytes(line: &string) -> byte[] {
+    let mut out: byte[] = [];
+    out.reserve(line.__len() + 1:uint);
+    append_string_bytes(&mut out, line);
+    out.push(10:byte);
+    return out;
+}
+
+fn bench_response_bytes(iterations: int) -> nothing {
+    let start = time.monotonic_now();
+    let mut total: uint = 0:uint;
+    let mut i: int = 0;
+    let line: string = "VALUE {\"v\":\"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\"}";
+    while i < iterations {
+        let bytes = line_bytes(&line);
+        total = total + bytes.__len();
+        i = i + 1;
+    }
+    let total_us = elapsed_us(start);
+    if total == 0:uint {
+        print("impossible");
+    }
+    print_row("response_bytes", iterations, total_us);
+    return nothing;
+}
+
+async fn echo_loop(requests: Channel<Message>) -> nothing {
+    let mut done: bool = false;
+    while !done {
+        compare requests.recv() {
+            Some(msg) => {
+                compare msg {
+                    Apply(value, reply) => {
+                        reply.send(own value);
+                    }
+                    Stop() => {
+                        done = true;
+                    }
+                };
+            }
+            nothing => {
+                done = true;
+            }
+        };
+    }
+    return nothing;
+}
+
+async fn bench_channel_reused_reply(iterations: int) -> nothing {
+    let requests = make_channel::<Message>(64:uint);
+    let reply = make_channel::<int>(1:uint);
+    let task = spawn echo_loop(requests);
+    let start = time.monotonic_now();
+    let mut i: int = 0;
+    while i < iterations {
+        let request: Message = Apply(i, reply);
+        requests.send(own request);
+        compare reply.recv() {
+            Some(_) => {}
+            nothing => {}
+        };
+        i = i + 1;
+    }
+    let total_us = elapsed_us(start);
+    let stop: Message = Stop();
+    requests.send(own stop);
+    let _ = task.await();
+    print_row("channel_reused_reply", iterations, total_us);
+    return nothing;
+}
+
+async fn bench_channel_new_reply(iterations: int) -> nothing {
+    let requests = make_channel::<Message>(64:uint);
+    let task = spawn echo_loop(requests);
+    let start = time.monotonic_now();
+    let mut i: int = 0;
+    while i < iterations {
+        let reply = make_channel::<int>(1:uint);
+        let request: Message = Apply(i, reply);
+        requests.send(own request);
+        compare reply.recv() {
+            Some(_) => {}
+            nothing => {}
+        };
+        i = i + 1;
+    }
+    let total_us = elapsed_us(start);
+    let stop: Message = Stop();
+    requests.send(own stop);
+    let _ = task.await();
+    print_row("channel_new_reply", iterations, total_us);
+    return nothing;
+}
+
+@entrypoint
+fn main() -> int {
+    let iterations: int = 20000;
+    bench_empty_loop(iterations);
+    bench_response_bytes(iterations);
+    let _ = bench_channel_reused_reply(iterations).await();
+    let _ = bench_channel_new_reply(iterations).await();
+    return 0;
+}

--- a/benchmarks/native/channel_request_reply/surge.toml
+++ b/benchmarks/native/channel_request_reply/surge.toml
@@ -1,0 +1,7 @@
+[package]
+name = "channel_request_reply"
+root = "."
+version = "0.1.0"
+
+[run]
+main = "main.sg"

--- a/scripts/bench_native_channels.sh
+++ b/scripts/bench_native_channels.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fixture="$root/benchmarks/native/channel_request_reply"
+report="${SURGE_CHANNEL_BENCH_REPORT:-$root/build/benchmarks/native-channel-request-reply.md}"
+modes="${SURGE_CHANNEL_BENCH_MODES:-1 2 4 8 default}"
+surge="${SURGE:-$root/surge}"
+
+fail() {
+	echo "bench_native_channels: $*" >&2
+	exit 1
+}
+
+if [[ ! -x "$surge" ]]; then
+	surge="$(command -v surge || true)"
+fi
+[[ -n "$surge" && -x "$surge" ]] || fail "surge binary not found; run 'make build' or set SURGE=/path/to/surge"
+
+export SURGE_STDLIB="${SURGE_STDLIB:-$root}"
+
+build_log="$(mktemp)"
+trap 'rm -f "$build_log"' EXIT
+
+if ! "$surge" build --release "$fixture" >"$build_log" 2>&1; then
+	cat "$build_log" >&2
+	fail "failed to build $fixture"
+fi
+
+built_path="$(awk '/^built / { print $2 }' "$build_log" | tail -n 1)"
+[[ -n "$built_path" ]] || fail "cannot find built binary in surge output"
+
+bench_bin="$built_path"
+if [[ "$bench_bin" != /* ]]; then
+	if [[ -x "$fixture/$bench_bin" ]]; then
+		bench_bin="$fixture/$bench_bin"
+	elif [[ -x "$root/$bench_bin" ]]; then
+		bench_bin="$root/$bench_bin"
+	else
+		bench_bin="$PWD/$bench_bin"
+	fi
+fi
+[[ -x "$bench_bin" ]] || fail "built binary not executable: $bench_bin"
+
+mkdir -p "$(dirname "$report")"
+{
+	echo "# Native channel request/reply benchmark"
+	echo
+	echo "Generated: $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+	echo
+	echo "## Environment"
+	echo
+	echo "- surge: $("$surge" version --full | tr '\n' ' ' | sed 's/[[:space:]]*$//')"
+	echo "- fixture: ${fixture#$root/}"
+	echo "- modes: $modes"
+	echo
+	echo "## Results"
+	echo
+	echo "| mode | probe | iterations | total us | ns/op |"
+	echo "| --- | --- | ---: | ---: | ---: |"
+} >"$report"
+
+for mode in $modes; do
+	if [[ "$mode" == "default" ]]; then
+		output="$(env -u SURGE_THREADS "$bench_bin")"
+	else
+		output="$(SURGE_THREADS="$mode" "$bench_bin")"
+	fi
+	while IFS= read -r line; do
+		[[ "$line" == \|* ]] || continue
+		printf '| %s |%s\n' "$mode" "${line#|}" >>"$report"
+	done <<<"$output"
+done
+
+cat >>"$report" <<'EOF'
+
+## Notes
+
+- `channel_reused_reply` approximates the state-manager request/reply hop used by surgekv.
+- `channel_new_reply` keeps the older per-request reply-channel shape visible.
+- This is a manual benchmark. Do not wire it into `make check`; use it for before/after runtime PRs.
+EOF
+
+echo "benchmark report: $report"


### PR DESCRIPTION
## Summary
- add a Surge-owned native channel request/reply benchmark fixture
- add a manual runner for the SURGE_THREADS matrix without wiring it into make check
- record the current baseline for the surgekv-style actor hop

## Verification
- make build
- ./scripts/bench_native_channels.sh
- make check
- bash -n scripts/bench_native_channels.sh
- git diff --check origin/main..HEAD
- sentrux session_end: pass, signal 6229 -> 6229

## Notes
- This covers the Phase 0 benchmark/baseline slice of the native async runtime epic.
- The benchmark is manual by design; no hard latency threshold is added to CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added native benchmark documentation with baseline performance metrics and execution instructions.

* **Tests**
  * Added channel request/reply benchmark module for performance measurement across multiple scenarios.

* **Chores**
  * Added benchmark build and execution script with configurable modes and custom report output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->