### PR TITLE
Trace native net poll counters

### DIFF
--- a/STATS.md
+++ b/STATS.md
@@ -5,7 +5,7 @@
 ## 📊 Main code (without tests)
 
 - **Files:** 682 (Go: 652, C: 30)
-- **Lines of code:** 155959 (Go: 142226, C: 13733)
+- **Lines of code:** 156050 (Go: 142226, C: 13824)
 
 ## 📁 Directory breakdown
 
@@ -13,7 +13,7 @@
 |------------|--------|-------|
 | `cmd/` | 27 | 4669 |
 | `internal/` | 623 | 137110 |
-| `runtime/native/` (C code) | 30 | 13733 |
+| `runtime/native/` (C code) | 30 | 13824 |
 
 ## 🏆 Top 10 packages by size
 
@@ -33,12 +33,12 @@
 ## 🧪 Test files
 
 - **Files:** 174
-- **Lines of code:** 35795
+- **Lines of code:** 35821
 
 ## 📈 Total volume (code + tests)
 
 - **Files:** 856
-- **Lines of code:** 191754
+- **Lines of code:** 191871
 
 ## 📊 Percentage breakdown
 

--- a/internal/vm/mt_correctness_test.go
+++ b/internal/vm/mt_correctness_test.go
@@ -830,7 +830,7 @@ fn main(port: uint, count: uint) -> int {
 	port := pickFreePort(t)
 	count := 20
 	cmd := exec.Command(outputPath, strconv.Itoa(port), strconv.Itoa(count))
-	cmd.Env = mtEnv(t)
+	cmd.Env = overrideEnvVar(mtEnv(t), "SURGE_TRACE_EXEC", "1")
 	var outBuf, errBuf bytes.Buffer
 	cmd.Stdout = &outBuf
 	cmd.Stderr = &errBuf
@@ -894,6 +894,32 @@ fn main(port: uint, count: uint) -> int {
 
 	if elapsed > 800*time.Millisecond {
 		t.Fatalf("persistent ping loop too slow: %s for %d requests", elapsed, count)
+	}
+	requireNetTracePollCounters(t, errBuf.String())
+}
+
+func requireNetTracePollCounters(t *testing.T, stderr string) {
+	t.Helper()
+	if !strings.Contains(stderr, "TRACE_NET ") {
+		t.Fatalf("missing TRACE_NET in stderr:\n%s", stderr)
+	}
+	if strings.Contains(stderr, "io_poll_calls=0 ") {
+		t.Fatalf("expected non-zero io_poll_calls in TRACE_NET\nstderr:\n%s", stderr)
+	}
+	if strings.Contains(stderr, "io_poll_net_ready=0 ") {
+		t.Fatalf("expected non-zero io_poll_net_ready in TRACE_NET\nstderr:\n%s", stderr)
+	}
+	if strings.Contains(stderr, "io_poll_waiters_last=0 ") {
+		t.Fatalf("expected non-zero io_poll_waiters_last in TRACE_NET\nstderr:\n%s", stderr)
+	}
+	if strings.Contains(stderr, "io_poll_waiters_max=0 ") {
+		t.Fatalf("expected non-zero io_poll_waiters_max in TRACE_NET\nstderr:\n%s", stderr)
+	}
+	if !strings.Contains(stderr, "io_poll_timeouts=") {
+		t.Fatalf("missing IO timeout counter in TRACE_NET\nstderr:\n%s", stderr)
+	}
+	if !strings.Contains(stderr, "io_poll_timeout_max_ms=") {
+		t.Fatalf("missing IO timeout max counter in TRACE_NET\nstderr:\n%s", stderr)
 	}
 }
 

--- a/runtime/native/rt_async_internal.h
+++ b/runtime/native/rt_async_internal.h
@@ -214,6 +214,7 @@ typedef struct rt_blocking_job {
 void panic_msg(const char* msg);
 int rt_async_debug_enabled(void);
 void rt_async_debug_printf(const char* fmt, ...);
+int rt_exec_trace_enabled(void);
 
 static inline uint8_t task_status_load(const rt_task* task) {
     return task == NULL ? TASK_DONE : atomic_load_explicit(&task->status, memory_order_acquire);
@@ -360,6 +361,7 @@ poll_outcome poll_blocking_task(rt_executor* ex, rt_task* task);
 poll_outcome poll_net_task(const rt_executor* ex, const rt_task* task);
 int poll_net_waiters(rt_executor* ex, int timeout_ms);
 void rt_net_wake_poll(void);
+void rt_net_trace_dump(void);
 int run_ready_one(rt_executor* ex);
 void run_until_done(rt_executor* ex, const rt_task* task, uint8_t* out_kind, uint64_t* out_bits);
 int rt_wait_current_worker_wakeup(rt_executor* ex, rt_task* task);

--- a/runtime/native/rt_async_state.c
+++ b/runtime/native/rt_async_state.c
@@ -107,7 +107,7 @@ void rt_async_debug_printf(const char* fmt, ...) {
     rt_write_stderr((const uint8_t*)buf, len);
 }
 
-static int trace_exec_enabled(void) {
+int rt_exec_trace_enabled(void) {
     return trace_exec_enabled_flag != 0;
 }
 
@@ -116,11 +116,14 @@ static int trace_sched_enabled(void) {
 }
 
 static void trace_exec_inc(_Atomic uint64_t* counter) {
-    if (!trace_exec_enabled() || counter == NULL) {
+    if (!rt_exec_trace_enabled() || counter == NULL) {
         return;
     }
     (void)atomic_fetch_add_explicit(counter, 1, memory_order_relaxed);
 }
+
+static void
+trace_exec_append_kv_u64(char* buf, size_t* pos, size_t cap, const char* name, uint64_t value);
 
 static size_t trace_exec_append_literal(char* buf, size_t pos, size_t cap, const char* lit) {
     if (buf == NULL || lit == NULL) {
@@ -146,7 +149,7 @@ static size_t trace_exec_append_u64(char* buf, size_t pos, size_t cap, uint64_t 
 }
 
 static void trace_exec_dump(const char* reason) {
-    if (!trace_exec_enabled()) {
+    if (!rt_exec_trace_enabled()) {
         return;
     }
     char buf[768];
@@ -253,7 +256,7 @@ trace_exec_append_kv_u64(char* buf, size_t* pos, size_t cap, const char* name, u
 }
 
 static void trace_exec_snapshot_dump(const char* reason) {
-    if (!trace_exec_enabled()) {
+    if (!rt_exec_trace_enabled()) {
         return;
     }
     rt_executor* ex = &exec_state;
@@ -406,6 +409,9 @@ static void trace_exec_signal_handler(int sig) {
 
 void rt_exec_trace_dump(void) {
     trace_exec_dump("exit");
+    if (rt_exec_trace_enabled()) {
+        rt_net_trace_dump();
+    }
     trace_exec_snapshot_dump("exit");
 }
 

--- a/runtime/native/rt_net.c
+++ b/runtime/native/rt_net.c
@@ -14,6 +14,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/socket.h>
@@ -64,6 +65,76 @@ typedef struct SurgeArrayHeader {
 
 static int net_poll_wake_read_fd = -1;
 static int net_poll_wake_write_fd = -1;
+static _Atomic uint64_t net_poll_calls_total;
+static _Atomic uint64_t net_poll_timeouts_total;
+static _Atomic uint64_t net_poll_wake_fd_total;
+static _Atomic uint64_t net_poll_ready_total;
+static _Atomic uint64_t net_poll_errors_total;
+static _Atomic uint64_t net_poll_timeout_last_ms;
+static _Atomic uint64_t net_poll_timeout_max_ms;
+static _Atomic uint64_t net_poll_waiters_last;
+static _Atomic uint64_t net_poll_waiters_max;
+static _Atomic uint64_t net_poll_waiters_total;
+
+#define NET_TRACE_DUMP_FORMAT                                                                      \
+    "TRACE_NET reason=exit io_poll_calls=%llu io_poll_timeouts=%llu "                              \
+    "io_poll_wake_fd=%llu io_poll_net_ready=%llu io_poll_errors=%llu "                             \
+    "io_poll_timeout_last_ms=%llu io_poll_timeout_max_ms=%llu "                                    \
+    "io_poll_waiters_last=%llu io_poll_waiters_max=%llu "                                          \
+    "io_poll_waiters_total=%llu\n"
+#define NET_TRACE_DUMP_ARGS                                                                        \
+    net_trace_load(&net_poll_calls_total), net_trace_load(&net_poll_timeouts_total),               \
+        net_trace_load(&net_poll_wake_fd_total), net_trace_load(&net_poll_ready_total),            \
+        net_trace_load(&net_poll_errors_total), net_trace_load(&net_poll_timeout_last_ms),         \
+        net_trace_load(&net_poll_timeout_max_ms), net_trace_load(&net_poll_waiters_last),          \
+        net_trace_load(&net_poll_waiters_max), net_trace_load(&net_poll_waiters_total)
+
+static unsigned long long net_trace_load(const _Atomic uint64_t* counter) {
+    return (unsigned long long)atomic_load_explicit(counter, memory_order_relaxed);
+}
+
+static void net_trace_inc(_Atomic uint64_t* counter) {
+    if (!rt_exec_trace_enabled()) {
+        return;
+    }
+    (void)atomic_fetch_add_explicit(counter, 1, memory_order_relaxed);
+}
+
+static void net_trace_add(_Atomic uint64_t* counter, uint64_t value) {
+    if (!rt_exec_trace_enabled()) {
+        return;
+    }
+    (void)atomic_fetch_add_explicit(counter, value, memory_order_relaxed);
+}
+
+static void net_trace_store(_Atomic uint64_t* counter, uint64_t value) {
+    if (!rt_exec_trace_enabled()) {
+        return;
+    }
+    atomic_store_explicit(counter, value, memory_order_relaxed);
+}
+
+void rt_net_trace_dump(void) {
+    (void)dprintf(STDERR_FILENO, NET_TRACE_DUMP_FORMAT, NET_TRACE_DUMP_ARGS);
+}
+
+static uint64_t net_trace_timeout_ms(int timeout_ms) {
+    if (timeout_ms <= 0) {
+        return 0;
+    }
+    return (uint64_t)timeout_ms;
+}
+
+static void net_trace_max(_Atomic uint64_t* counter, uint64_t value) {
+    if (!rt_exec_trace_enabled()) {
+        return;
+    }
+    uint64_t current = atomic_load_explicit(counter, memory_order_relaxed);
+    while (current < value &&
+           !atomic_compare_exchange_weak_explicit(
+               counter, &current, value, memory_order_relaxed, memory_order_relaxed)) {
+    }
+}
 
 static int net_set_nonblocking_cloexec(int fd) {
     int flags = fcntl(fd, F_GETFL, 0);
@@ -813,13 +884,20 @@ int poll_net_waiters(rt_executor* ex, int timeout_ms) {
         rt_free((uint8_t*)fds, (uint64_t)cap * (uint64_t)sizeof(NetPollFd), _Alignof(NetPollFd));
         return 0;
     }
-
     struct pollfd* pfds = (struct pollfd*)rt_alloc(
         (uint64_t)poll_count * (uint64_t)sizeof(struct pollfd), _Alignof(struct pollfd));
     if (pfds == NULL) {
         rt_free((uint8_t*)fds, (uint64_t)cap * (uint64_t)sizeof(NetPollFd), _Alignof(NetPollFd));
         return 0;
     }
+    net_trace_inc(&net_poll_calls_total);
+    uint64_t requested_timeout_ms = net_trace_timeout_ms(timeout_ms);
+    net_trace_store(&net_poll_timeout_last_ms, requested_timeout_ms);
+    net_trace_max(&net_poll_timeout_max_ms, requested_timeout_ms);
+    net_trace_store(&net_poll_waiters_last, (uint64_t)count);
+    net_trace_max(&net_poll_waiters_max, (uint64_t)count);
+    net_trace_add(&net_poll_waiters_total, (uint64_t)count);
+
     size_t offset = 0;
     if (wake_fd >= 0) {
         pfds[0].fd = wake_fd;
@@ -848,6 +926,7 @@ int poll_net_waiters(rt_executor* ex, int timeout_ms) {
     } while (n < 0 && errno == EINTR);
     rt_lock(ex);
     if (n < 0) {
+        net_trace_inc(&net_poll_errors_total);
         for (size_t i = 0; i < count; i++) {
             if (fds[i].want_read) {
                 complete_net_waiters(ex, net_read_key(fds[i].fd));
@@ -864,6 +943,7 @@ int poll_net_waiters(rt_executor* ex, int timeout_ms) {
         return 1;
     }
     if (n == 0) {
+        net_trace_inc(&net_poll_timeouts_total);
         rt_free((uint8_t*)pfds,
                 (uint64_t)poll_count * (uint64_t)sizeof(struct pollfd),
                 _Alignof(struct pollfd));
@@ -874,6 +954,7 @@ int poll_net_waiters(rt_executor* ex, int timeout_ms) {
     int woke = 0;
     if (wake_fd >= 0 && pfds[0].revents != 0) {
         net_poll_wake_drain();
+        net_trace_inc(&net_poll_wake_fd_total);
         woke = 1;
     }
     for (size_t i = 0; i < count; i++) {
@@ -884,11 +965,13 @@ int poll_net_waiters(rt_executor* ex, int timeout_ms) {
         bool read_ready = (pfds[poll_idx].revents & (POLLIN | POLLERR | POLLHUP)) != 0;
         bool write_ready = (pfds[poll_idx].revents & (POLLOUT | POLLERR | POLLHUP)) != 0;
         if (read_ready) {
+            net_trace_inc(&net_poll_ready_total);
             complete_net_waiters(ex, net_read_key(fds[i].fd));
             complete_net_waiters(ex, net_accept_key(fds[i].fd));
             woke = 1;
         }
         if (write_ready) {
+            net_trace_inc(&net_poll_ready_total);
             complete_net_waiters(ex, net_write_key(fds[i].fd));
             woke = 1;
         }


### PR DESCRIPTION
## Summary
- add a `TRACE_NET` exit dump under `SURGE_TRACE_EXEC` for native IO polling
- track poll calls, timeouts, wake-fd wakeups, net readiness, errors, timeout last/max, and waiter last/max/total
- cover the TCP waiter path in `TestMTNetWaiterWakeupLatency` without asserting scheduler-sensitive timeout counts

## Checks
- `make check`
- `make build`
- `make cfmt-check`
- `make c-warnings`
- `make ctidy`
- `make cppcheck`
- `SURGE_BACKEND=llvm go test ./internal/vm -run 'TestMTNetWaiterWakeupLatency|TestMTBlockingChannelHelpersDoNotParkWorkers' -count=1 -v`\n- `git diff --check origin/main..HEAD`\n- sentrux MCP: `pass=true`, signal `6229 -> 6226`, no violations\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive tracing diagnostics for network operations with counter-based tracking of poll calls, timeouts, wake-ups, and readiness events.

* **Tests**
  * Enhanced performance validation tests with improved trace output inspection for network operations.

* **Chores**
  * Refactored internal tracing infrastructure for better maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->