### PR TITLE
Expose native heap stats

### DIFF
--- a/STATS.md
+++ b/STATS.md
@@ -5,15 +5,15 @@
 ## 📊 Main code (without tests)
 
 - **Files:** 682 (Go: 652, C: 30)
-- **Lines of code:** 156050 (Go: 142226, C: 13824)
+- **Lines of code:** 156130 (Go: 142227, C: 13903)
 
 ## 📁 Directory breakdown
 
 | Directory | Files | Lines |
 |------------|--------|-------|
 | `cmd/` | 27 | 4669 |
-| `internal/` | 623 | 137110 |
-| `runtime/native/` (C code) | 30 | 13824 |
+| `internal/` | 623 | 137111 |
+| `runtime/native/` (C code) | 30 | 13903 |
 
 ## 🏆 Top 10 packages by size
 
@@ -21,7 +21,7 @@
 |---|-------|-------|
 | 1 | `internal/sema` | 28562 |
 | 2 | `internal/vm` | 23197 |
-| 3 | `internal/backend/llvm` | 12021 |
+| 3 | `internal/backend/llvm` | 12022 |
 | 4 | `internal/mir` | 10281 |
 | 5 | `internal/parser` | 8960 |
 | 6 | `internal/hir` | 7162 |
@@ -32,13 +32,13 @@
 
 ## 🧪 Test files
 
-- **Files:** 174
-- **Lines of code:** 35821
+- **Files:** 175
+- **Lines of code:** 35851
 
 ## 📈 Total volume (code + tests)
 
-- **Files:** 856
-- **Lines of code:** 191871
+- **Files:** 857
+- **Lines of code:** 191981
 
 ## 📊 Percentage breakdown
 

--- a/internal/backend/llvm/builtins.go
+++ b/internal/backend/llvm/builtins.go
@@ -64,6 +64,7 @@ func runtimeDecls() []builtinDecl {
 		{name: "rt_panic_bounds", ret: "void", params: []string{"i64", "i64", "i64"}},
 		{name: "rt_monotonic_now", ret: "i64", params: nil},
 		{name: "rt_worker_count", ret: "i64", params: nil},
+		{name: "rt_heap_stats", ret: "ptr", params: nil},
 		{name: "rt_string_from_bytes", ret: "ptr", params: []string{"ptr", "i64"}},
 		{name: "rt_string_from_utf16", ret: "ptr", params: []string{"ptr", "i64"}},
 		{name: "rt_utf8_valid", ret: "i1", params: []string{"ptr", "i64"}},

--- a/internal/vm/llvm_native_heap_stats_test.go
+++ b/internal/vm/llvm_native_heap_stats_test.go
@@ -1,0 +1,30 @@
+package vm_test
+
+import (
+	"testing"
+)
+
+func TestLLVMNativeHeapStats(t *testing.T) {
+	ensureLLVMToolchain(t)
+
+	source := `@entrypoint
+fn main() -> int {
+    let s0: HeapStats = rt_heap_stats();
+    let p = rt_alloc(32:uint, 1:uint);
+    let s1: HeapStats = rt_heap_stats();
+    if s1.alloc_count <= s0.alloc_count { return 1; }
+    if s1.live_blocks <= s0.live_blocks { return 2; }
+    if s1.live_bytes <= s0.live_bytes { return 3; }
+    rt_free(p, 32:uint, 1:uint);
+    let s2: HeapStats = rt_heap_stats();
+    if s2.free_count <= s1.free_count { return 4; }
+    return 0;
+}
+`
+
+	outputPath := buildLLVMProgramFromSource(t, source)
+	stdout, stderr, code := runBinary(t, outputPath)
+	if code != 0 {
+		t.Fatalf("heap stats smoke failed with exit=%d\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr)
+	}
+}

--- a/runtime/native/rt.h
+++ b/runtime/native/rt.h
@@ -36,6 +36,7 @@ void rt_panic_numeric(const uint8_t* ptr, uint64_t length);
 void rt_panic_bounds(uint64_t kind, int64_t index, int64_t length);
 int64_t rt_monotonic_now(void);
 uint64_t rt_worker_count(void);
+void* rt_heap_stats(void);
 void rt_exec_trace_dump(void);
 void rt_sched_trace_dump(void);
 

--- a/runtime/native/rt_alloc.c
+++ b/runtime/native/rt_alloc.c
@@ -4,30 +4,80 @@
 
 #include "rt.h"
 
+#include <stdatomic.h>
 #include <stdlib.h>
 #include <string.h>
+
+typedef struct SurgeHeapStats {
+    void* alloc_count;
+    void* free_count;
+    void* live_blocks;
+    void* live_bytes;
+    void* rc_increments;
+    void* rc_decrements;
+} SurgeHeapStats;
+
+static _Atomic uint64_t heap_alloc_count;
+static _Atomic uint64_t heap_free_count;
+static _Atomic uint64_t heap_live_blocks;
+static _Atomic uint64_t heap_live_bytes;
 
 static uint64_t min_u64(uint64_t a, uint64_t b) {
     return a < b ? a : b;
 }
 
+static uint64_t alloc_size(uint64_t size) {
+    return size == 0 ? 1 : size;
+}
+
+static void record_alloc(uint64_t size) {
+    (void)atomic_fetch_add_explicit(&heap_alloc_count, 1, memory_order_relaxed);
+    (void)atomic_fetch_add_explicit(&heap_live_blocks, 1, memory_order_relaxed);
+    (void)atomic_fetch_add_explicit(&heap_live_bytes, alloc_size(size), memory_order_relaxed);
+}
+
+static void record_free(uint64_t size) {
+    (void)atomic_fetch_add_explicit(&heap_free_count, 1, memory_order_relaxed);
+    (void)atomic_fetch_sub_explicit(&heap_live_blocks, 1, memory_order_relaxed);
+    (void)atomic_fetch_sub_explicit(&heap_live_bytes, alloc_size(size), memory_order_relaxed);
+}
+
+static void record_realloc(uint64_t old_size, uint64_t new_size) {
+    uint64_t old_actual = alloc_size(old_size);
+    uint64_t new_actual = alloc_size(new_size);
+    (void)atomic_fetch_add_explicit(&heap_alloc_count, 1, memory_order_relaxed);
+    (void)atomic_fetch_add_explicit(&heap_free_count, 1, memory_order_relaxed);
+    if (new_actual >= old_actual) {
+        (void)atomic_fetch_add_explicit(
+            &heap_live_bytes, new_actual - old_actual, memory_order_relaxed);
+    } else {
+        (void)atomic_fetch_sub_explicit(
+            &heap_live_bytes, old_actual - new_actual, memory_order_relaxed);
+    }
+}
+
 void* rt_alloc(uint64_t size, uint64_t align) {
-    if (size == 0) {
-        size = 1;
-    }
-    if (align <= sizeof(void*)) {
-        return malloc((size_t)size);
-    }
+    size = alloc_size(size);
     void* ptr = NULL;
+    if (align <= sizeof(void*)) {
+        ptr = malloc((size_t)size);
+        if (ptr != NULL) {
+            record_alloc(size);
+        }
+        return ptr;
+    }
     if (posix_memalign(&ptr, (size_t)align, (size_t)size) != 0) {
         return NULL;
     }
+    record_alloc(size);
     return ptr;
 }
 
 void rt_free(uint8_t* ptr, uint64_t size, uint64_t align) {
-    (void)size;
     (void)align;
+    if (ptr != NULL) {
+        record_free(size);
+    }
     free(ptr);
 }
 
@@ -37,7 +87,15 @@ void* rt_realloc(uint8_t* ptr, uint64_t old_size, uint64_t new_size, uint64_t al
         return NULL;
     }
     if (align <= sizeof(void*)) {
-        return realloc(ptr, (size_t)new_size);
+        void* next = realloc(ptr, (size_t)alloc_size(new_size));
+        if (next != NULL) {
+            if (ptr == NULL) {
+                record_alloc(new_size);
+            } else {
+                record_realloc(old_size, new_size);
+            }
+        }
+        return next;
     }
     void* next = rt_alloc(new_size, align);
     if (next == NULL) {
@@ -48,6 +106,26 @@ void* rt_realloc(uint8_t* ptr, uint64_t old_size, uint64_t new_size, uint64_t al
         rt_free(ptr, old_size, align);
     }
     return next;
+}
+
+void* rt_heap_stats(void) {
+    uint64_t alloc_count = atomic_load_explicit(&heap_alloc_count, memory_order_relaxed);
+    uint64_t free_count = atomic_load_explicit(&heap_free_count, memory_order_relaxed);
+    uint64_t live_blocks = atomic_load_explicit(&heap_live_blocks, memory_order_relaxed);
+    uint64_t live_bytes = atomic_load_explicit(&heap_live_bytes, memory_order_relaxed);
+
+    SurgeHeapStats* stats = (SurgeHeapStats*)rt_alloc((uint64_t)sizeof(SurgeHeapStats),
+                                                      (uint64_t) _Alignof(SurgeHeapStats));
+    if (stats == NULL) {
+        return NULL;
+    }
+    stats->alloc_count = rt_biguint_from_u64(alloc_count);
+    stats->free_count = rt_biguint_from_u64(free_count);
+    stats->live_blocks = rt_biguint_from_u64(live_blocks);
+    stats->live_bytes = rt_biguint_from_u64(live_bytes);
+    stats->rc_increments = rt_biguint_from_u64(0);
+    stats->rc_decrements = rt_biguint_from_u64(0);
+    return stats;
 }
 
 void rt_memcpy(uint8_t* dst, const uint8_t* src, uint64_t n) {


### PR DESCRIPTION
## Summary
- implement LLVM/native `rt_heap_stats()` for the existing `HeapStats` shape
- count native `rt_alloc`, `rt_free`, and successful `rt_realloc` as alloc/free/live block and byte counters
- add an LLVM-only smoke test that verifies allocation/free deltas through `HeapStats`

## Notes
- RC counters stay zero for native runtime, matching the current RNT-012 scope
- counters cover the native runtime allocator surface, not direct libc `malloc` calls used in a few local temporary buffers

## Checks
- `make check`
- `make build`
- `make cfmt-check`
- `make c-warnings`
- `make ctidy`
- `make cppcheck`
- `SURGE_BACKEND=llvm go test ./internal/vm -run TestLLVMNativeHeapStats -count=1 -v`
- `go test ./internal/backend/llvm -count=1`
- `git diff --check origin/main..HEAD`
- sentrux MCP: `pass=true`, no violations


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added heap statistics inspection capability to the runtime, enabling monitoring of allocation and deallocation activity.

* **Tests**
  * Added validation test to verify heap statistics tracking accuracy across allocation and free cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->