### PR TITLE
Document runtime scheduler invariants

### DIFF
--- a/STATS.md
+++ b/STATS.md
@@ -5,7 +5,7 @@
 ## 📊 Main code (without tests)
 
 - **Files:** 682 (Go: 652, C: 30)
-- **Lines of code:** 156130 (Go: 142227, C: 13903)
+- **Lines of code:** 156163 (Go: 142227, C: 13936)
 
 ## 📁 Directory breakdown
 
@@ -13,7 +13,7 @@
 |------------|--------|-------|
 | `cmd/` | 27 | 4669 |
 | `internal/` | 623 | 137111 |
-| `runtime/native/` (C code) | 30 | 13903 |
+| `runtime/native/` (C code) | 30 | 13936 |
 
 ## 🏆 Top 10 packages by size
 
@@ -38,7 +38,7 @@
 ## 📈 Total volume (code + tests)
 
 - **Files:** 857
-- **Lines of code:** 191981
+- **Lines of code:** 192014
 
 ## 📊 Percentage breakdown
 

--- a/runtime/native/rt_async_internal.h
+++ b/runtime/native/rt_async_internal.h
@@ -13,9 +13,13 @@
 // Async runtime internals shared across modules.
 
 typedef enum {
+    // READY tasks must be in exactly one ready queue or about to be queued.
     TASK_READY = 0,
+    // RUNNING tasks are being polled by one worker and counted in running_count.
     TASK_RUNNING = 1,
+    // WAITING tasks are parked behind at least one waker_key until wake_task runs.
     TASK_WAITING = 2,
+    // DONE is terminal; tasks may remain in tasks[] until the last handle is released.
     TASK_DONE = 3,
 } task_status;
 
@@ -188,6 +192,25 @@ typedef struct {
     struct rt_blocking_job* blocking_head;
     struct rt_blocking_job* blocking_tail;
 } rt_executor;
+
+// Executor invariants:
+// - ex->lock owns tasks[], scopes[], waiters, inject/local queues, running_count,
+//   channel_blocked_workers, compensation_count, timer state, and shutdown flags.
+// - task status is atomic so external helpers can observe it, but transitions that
+//   touch queues or waiters still happen under ex->lock.
+// - waiters is a FIFO-by-key registration list. prepare_park may pre-register a
+//   waiter before the task stores TASK_WAITING; wake_task uses wake_token to close
+//   wake-before-park races.
+// - ready queues hold task ids whose enqueued flag is set. Worker threads pop local
+//   queues first, then inject, then steal; non-worker threads inject globally.
+// - running_count counts tasks currently being polled. User tasks may poll without
+//   ex->lock, but the increment/decrement around that poll is protected by ex->lock.
+// - channel_blocked_workers counts executor workers parked inside sync channel
+//   helpers after temporarily leaving running_count. Compensation workers are a
+//   fallback for that path, not a normal async parking mechanism.
+// - The I/O thread is signaled when the executor becomes idle, when net waiters are
+//   registered, or when shutdown changes. Workers sleep on ready_cv only after they
+//   fail to find local, injected, or stealable ready work.
 
 typedef struct rt_channel rt_channel;
 

--- a/runtime/native/rt_async_state.c
+++ b/runtime/native/rt_async_state.c
@@ -1109,6 +1109,7 @@ static void ensure_wait_keys_cap(rt_task* task, size_t want) {
 }
 
 void remove_waiter(rt_executor* ex, waker_key key, uint64_t task_id) {
+    // Caller holds ex->lock; compaction preserves relative order of other waiters.
     if (ex == NULL || ex->waiters_len == 0) {
         return;
     }
@@ -1124,6 +1125,7 @@ void remove_waiter(rt_executor* ex, waker_key key, uint64_t task_id) {
 }
 
 void add_waiter(rt_executor* ex, waker_key key, uint64_t task_id) {
+    // Caller holds ex->lock; waiters are consumed FIFO per key by pop_waiter.
     if (ex == NULL || !waker_valid(key)) {
         return;
     }
@@ -1193,6 +1195,7 @@ void prepare_park(rt_executor* ex, rt_task* task, waker_key key, int already_add
 }
 
 int pop_waiter(rt_executor* ex, waker_key key, uint64_t* out_id) {
+    // Caller holds ex->lock; stale/done/cancelled waiters are dropped while scanning.
     if (ex == NULL || !waker_valid(key) || ex->waiters_len == 0) {
         return 0;
     }
@@ -1268,6 +1271,7 @@ pop_task_from_deque(rt_executor* ex, rt_deque* dq, int lifo, uint64_t* out_id, u
 }
 
 static int ready_push_inner(rt_executor* ex, uint64_t id, int force_inject) {
+    // Caller holds ex->lock; enqueued prevents duplicate ready-queue entries.
     if (ex == NULL) {
         return 0;
     }
@@ -1313,10 +1317,12 @@ static int ready_push_inner(rt_executor* ex, uint64_t id, int force_inject) {
 }
 
 void ready_push(rt_executor* ex, uint64_t id) {
+    // Caller holds ex->lock.
     (void)ready_push_inner(ex, id, 0);
 }
 
 int ready_pop(rt_executor* ex, uint64_t* out_id) {
+    // Caller holds ex->lock; worker_next_ready adds local and steal paths.
     return pop_task_from_deque(ex, &ex->inject, 0, out_id, SCHED_SRC_INJECT);
 }
 
@@ -1434,6 +1440,7 @@ static int worker_next_ready(rt_executor* ex, uint32_t worker_id, uint64_t* out_
 }
 
 void wake_task(rt_executor* ex, uint64_t id, int remove_waiter_flag) {
+    // Caller holds ex->lock; wake_token handles a wake that races with park_current.
     if (ex == NULL) {
         return;
     }
@@ -1931,6 +1938,7 @@ int rt_wait_current_worker_wakeup(rt_executor* ex, rt_task* task) {
     trace_exec_inc(&trace_channel_blocking_wait_total);
     rt_lock(ex);
     move_current_local_to_inject_locked(ex);
+    // This sync helper parks the OS worker, so it stops contributing to scheduler progress.
     ex->channel_blocked_workers++;
     int dropped_running = 0;
     if (ex->running_count > 0) {
@@ -1968,6 +1976,7 @@ static void* rt_worker_main(void* arg) {
         rt_lock(ex);
         uint64_t id = 0;
         while (!ex->shutdown && !worker_next_ready(ex, worker_id, &id)) {
+            // Sleep only after local, inject, and steal queues have been checked under ex->lock.
             trace_exec_inc(&trace_worker_sleep_total);
             pthread_cond_wait(&ex->ready_cv, &ex->lock);
             trace_exec_inc(&trace_worker_wake_total);
@@ -1983,6 +1992,7 @@ static void* rt_worker_main(void* arg) {
         }
         task_status_store(task, TASK_RUNNING);
         (void)task_wake_token_exchange(task, 0);
+        // running_count is changed only while holding ex->lock.
         ex->running_count++;
         rt_set_current_task(task);
 


### PR DESCRIPTION
## Summary
- Document native async task state and executor locking invariants in `rt_async_internal.h`.
- Add short invariant comments around waiter, ready-queue, wake, sync channel wait, and worker sleep paths.
- Update generated `STATS.md`.

## Validation
- `make check`
- `make build`
- `make cfmt-check`
- `make c-warnings`
- `make ctidy`
- `make cppcheck`
- `git diff --check origin/main..HEAD`
- sentrux MCP: `signal_before=6226`, `signal_after=6226`, `signal_delta=0`, `pass=true`

Notes: `mcp__sentrux.check_rules` still reports existing repo-level `max_cc`/`no_god_files` violations outside this diff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced inline documentation for async runtime scheduler components, clarifying concurrency patterns, executor behavior, task state definitions, and worker synchronization expectations.

* **Chores**
  * Updated internal code metrics documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->