### PR TITLE
Cover runtime compensation scheduler counters

### DIFF
--- a/STATS.md
+++ b/STATS.md
@@ -33,12 +33,12 @@
 ## 🧪 Test files
 
 - **Files:** 175
-- **Lines of code:** 35851
+- **Lines of code:** 35860
 
 ## 📈 Total volume (code + tests)
 
 - **Files:** 857
-- **Lines of code:** 192014
+- **Lines of code:** 192023
 
 ## 📊 Percentage breakdown
 

--- a/internal/vm/mt_executor_test.go
+++ b/internal/vm/mt_executor_test.go
@@ -649,6 +649,7 @@ fn main() -> int {
 	outputPath := buildLLVMProgramFromSource(t, source)
 	baseEnv := envWithStdlib(repoRoot(t))
 	env := overrideEnv(baseEnv, "2")
+	env = overrideEnvVar(env, "SURGE_TRACE_EXEC", "1")
 	dur, res := runBinaryWithTimeout(t, outputPath, env, 20*time.Second)
 	if res.exitCode != 0 {
 		t.Fatalf("run failed (exit=%d, dur=%s)\nstdout:\n%s\nstderr:\n%s",
@@ -656,6 +657,14 @@ fn main() -> int {
 	}
 	if !strings.Contains(res.stdout, "ok") {
 		t.Fatalf("unexpected stdout: %q", res.stdout)
+	}
+	trace := parseExecTrace(t, res.stderr)
+	if trace["channel_blocking_wait"] != 0 || trace["compensation_started"] != 0 {
+		t.Fatalf("async channel path should not pin workers, got %+v\nstderr:\n%s", trace, res.stderr)
+	}
+	snapshot := parseExecSnapshot(t, res.stderr)
+	if snapshot["compensation"] != 0 || snapshot["channel_blocked"] != 0 {
+		t.Fatalf("unexpected async channel snapshot %+v\nstderr:\n%s", snapshot, res.stderr)
 	}
 }
 
@@ -779,7 +788,7 @@ fn main() -> int {
 			trace, res.stderr)
 	}
 	snapshot := parseExecSnapshot(t, res.stderr)
-	if snapshot["worker_count"] != 2 || snapshot["compensation"] == 0 {
+	if snapshot["worker_count"] != 2 || snapshot["compensation"] == 0 || snapshot["channel_blocked"] != 0 {
 		t.Fatalf("unexpected TRACE_EXEC_SNAPSHOT %+v\nstderr:\n%s", snapshot, res.stderr)
 	}
 }


### PR DESCRIPTION
## Summary
- Assert normal async channel stress does not use sync-channel worker pinning or compensation workers.
- Assert the existing sync-channel compensation scenario exits with no workers left in `channel_blocked`.
- Update generated `STATS.md`.

## Validation
- `SURGE_BACKEND=llvm SURGE_SKIP_TIMEOUT_TESTS=0 go test ./internal/vm -run 'TestMTChannelParkUnpark|TestMTBlockingChannelHelpersDoNotParkWorkers|TestMTBlockingChannelHelpersAllowTimersToAdvance|TestMTBlockingChannelHelpersDrainReadyWorkAtCompensationLimit' -count=1 -v`
- `make check`
- `make build`
- `make cfmt-check`
- `make c-warnings`
- `make ctidy`
- `make cppcheck`
- `git diff --check origin/main..HEAD`
- sentrux MCP: `signal_before=6226`, `signal_after=6226`, `signal_delta=0`, `pass=true`

Notes: sentrux rules still report existing repo-level `max_cc`/`no_god_files` violations outside this diff.