### PR TITLE
feat(runtime): trace compensation high-water mark

### DIFF
--- a/STATS.md
+++ b/STATS.md
@@ -5,7 +5,7 @@
 ## 📊 Main code (without tests)
 
 - **Files:** 682 (Go: 652, C: 30)
-- **Lines of code:** 156163 (Go: 142227, C: 13936)
+- **Lines of code:** 156169 (Go: 142227, C: 13942)
 
 ## 📁 Directory breakdown
 
@@ -13,7 +13,7 @@
 |------------|--------|-------|
 | `cmd/` | 27 | 4669 |
 | `internal/` | 623 | 137111 |
-| `runtime/native/` (C code) | 30 | 13936 |
+| `runtime/native/` (C code) | 30 | 13942 |
 
 ## 🏆 Top 10 packages by size
 
@@ -33,12 +33,12 @@
 ## 🧪 Test files
 
 - **Files:** 175
-- **Lines of code:** 35860
+- **Lines of code:** 35861
 
 ## 📈 Total volume (code + tests)
 
 - **Files:** 857
-- **Lines of code:** 192023
+- **Lines of code:** 192030
 
 ## 📊 Percentage breakdown
 

--- a/internal/vm/mt_executor_test.go
+++ b/internal/vm/mt_executor_test.go
@@ -788,7 +788,8 @@ fn main() -> int {
 			trace, res.stderr)
 	}
 	snapshot := parseExecSnapshot(t, res.stderr)
-	if snapshot["worker_count"] != 2 || snapshot["compensation"] == 0 || snapshot["channel_blocked"] != 0 {
+	if snapshot["worker_count"] != 2 || snapshot["compensation"] == 0 ||
+		snapshot["compensation_high_water"] == 0 || snapshot["channel_blocked"] != 0 {
 		t.Fatalf("unexpected TRACE_EXEC_SNAPSHOT %+v\nstderr:\n%s", snapshot, res.stderr)
 	}
 }

--- a/runtime/native/rt_async_internal.h
+++ b/runtime/native/rt_async_internal.h
@@ -174,6 +174,7 @@ typedef struct {
     uint32_t running_count;
     uint32_t channel_blocked_workers;
     uint32_t compensation_count;
+    uint32_t compensation_high_water;
     uint8_t sched_mode;
     uint8_t initialized;
     uint8_t io_started;
@@ -195,7 +196,7 @@ typedef struct {
 
 // Executor invariants:
 // - ex->lock owns tasks[], scopes[], waiters, inject/local queues, running_count,
-//   channel_blocked_workers, compensation_count, timer state, and shutdown flags.
+//   channel_blocked_workers, compensation_count/high-water, timer state, and shutdown flags.
 // - task status is atomic so external helpers can observe it, but transitions that
 //   touch queues or waiters still happen under ex->lock.
 // - waiters is a FIFO-by-key registration list. prepare_park may pre-register a

--- a/runtime/native/rt_async_state.c
+++ b/runtime/native/rt_async_state.c
@@ -364,6 +364,8 @@ static void trace_exec_snapshot_dump(const char* reason) {
         buf, &pos, sizeof(buf), "channel_blocked", (uint64_t)ex->channel_blocked_workers);
     trace_exec_append_kv_u64(
         buf, &pos, sizeof(buf), "compensation", (uint64_t)ex->compensation_count);
+    trace_exec_append_kv_u64(
+        buf, &pos, sizeof(buf), "compensation_high_water", (uint64_t)ex->compensation_high_water);
     trace_exec_append_kv_u64(buf, &pos, sizeof(buf), "inject_len", (uint64_t)ex->inject.len);
     trace_exec_append_kv_u64(buf, &pos, sizeof(buf), "local_total", local_total);
     trace_exec_append_kv_u64(buf, &pos, sizeof(buf), "local_max", local_max);
@@ -1908,6 +1910,9 @@ static void maybe_start_compensation_worker_locked(rt_executor* ex) {
     (void)pthread_detach(thread);
     trace_exec_inc(&trace_compensation_started_total);
     ex->compensation_count++;
+    if (ex->compensation_count > ex->compensation_high_water) {
+        ex->compensation_high_water = ex->compensation_count;
+    }
 }
 
 static void move_current_local_to_inject_locked(rt_executor* ex) {


### PR DESCRIPTION
## Summary

- add `compensation_high_water` to native executor state
- include `compensation_high_water` in `TRACE_EXEC_SNAPSHOT`
- extend the blocking channel helper MT test to assert the snapshot exposes compensation growth
- update `STATS.md`

## Notes

The surgekv sync wrapper/API finding is tracked separately for the surgekv team: https://github.com/vovakirdan/surgekv/issues/1. This PR does not touch surgekv APIs or the nested surgekv worktree.

## Validation

- `SURGE_BACKEND=llvm SURGE_SKIP_TIMEOUT_TESTS=0 go test ./internal/vm -run TestMTBlockingChannelHelpersDoNotParkWorkers -count=1 -v`
- `SURGE_BACKEND=llvm SURGE_SKIP_TIMEOUT_TESTS=0 go test ./internal/vm -run 'TestMT(ChannelParkUnpark|BlockingChannelHelpers)' -count=1 -v`
- `make check`
- sentrux MCP: `quality_signal 6226 -> 6226`, session gate passed

`sentrux check_rules` still reports pre-existing complexity/god-file violations outside the changed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated code metrics documentation with latest statistics.

* **Tests**
  * Enhanced test assertions to validate new executor metrics.

* **Chores**
  * Improved runtime system monitoring with new high-water mark metric collection for better executor performance visibility and tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->