### PR TITLE
fix(sema): diagnose blocking channel calls in nonblocking functions

### DIFF
--- a/STATS.md
+++ b/STATS.md
@@ -5,21 +5,21 @@
 ## 📊 Main code (without tests)
 
 - **Files:** 682 (Go: 652, C: 30)
-- **Lines of code:** 156163 (Go: 142227, C: 13936)
+- **Lines of code:** 156172 (Go: 142236, C: 13936)
 
 ## 📁 Directory breakdown
 
 | Directory | Files | Lines |
 |------------|--------|-------|
 | `cmd/` | 27 | 4669 |
-| `internal/` | 623 | 137111 |
+| `internal/` | 623 | 137120 |
 | `runtime/native/` (C code) | 30 | 13936 |
 
 ## 🏆 Top 10 packages by size
 
 | # | Package | Lines |
 |---|-------|-------|
-| 1 | `internal/sema` | 28562 |
+| 1 | `internal/sema` | 28571 |
 | 2 | `internal/vm` | 23197 |
 | 3 | `internal/backend/llvm` | 12022 |
 | 4 | `internal/mir` | 10281 |
@@ -38,7 +38,7 @@
 ## 📈 Total volume (code + tests)
 
 - **Files:** 857
-- **Lines of code:** 192023
+- **Lines of code:** 192032
 
 ## 📊 Percentage breakdown
 

--- a/internal/sema/nonblocking_check.go
+++ b/internal/sema/nonblocking_check.go
@@ -210,6 +210,11 @@ func (tc *typeChecker) checkBlockingCall(call *ast.ExprCallData, callSpan, _ sou
 
 	// Check for blocking method calls (e.g., mutex.lock())
 	if methodName, typeName, isBlocking := tc.isBlockingMethodCall(call); isBlocking {
+		if typeName == "Channel" {
+			tc.report(diag.SemaChannelBlockingInNonblocking, callSpan,
+				"@nonblocking function cannot call blocking channel method %s.%s", typeName, methodName)
+			return
+		}
 		tc.report(diag.SemaLockNonblockingCallsWait, callSpan,
 			"@nonblocking function cannot call blocking method %s.%s", typeName, methodName)
 		return
@@ -252,9 +257,13 @@ func (tc *typeChecker) isBlockingMethodCall(call *ast.ExprCallData) (methodName,
 	if receiverType == types.NoTypeID {
 		return methodName, "", false
 	}
+	if tc.isChannelType(receiverType) {
+		typeName = "Channel"
+	} else {
+		// Get the base type name (stripping references)
+		typeName = tc.baseTypeName(receiverType)
+	}
 
-	// Get the base type name (stripping references)
-	typeName = tc.baseTypeName(receiverType)
 	if typeName == "" {
 		return methodName, "", false
 	}

--- a/testdata/golden/sema/invalid/concurrency/nonblocking_calls_channel.ast
+++ b/testdata/golden/sema/invalid/concurrency/nonblocking_calls_channel.ast
@@ -1,0 +1,16 @@
+nonblocking_calls_channel.sg (span: 2:1-8:1)
+└─ Item[0]: Fn (span: 2:1-7:2)
+   ├─ Name: bad_channel
+   ├─ Params: (ch: &Channel<int>)
+   ├─ Return: nothing
+   └─ Body:
+      └─ Stmt[0]: Block (span: 3:50-7:2)
+         ├─ Stmt[0]: Expr (span: 4:5-4:16)
+         │  └─ Expr: expr#4: ch.send(1)
+         ├─ Stmt[1]: Let (span: 5:5-5:23)
+         │  ├─ Name: _
+         │  ├─ Mutable: false
+         │  ├─ Type: <inferred>
+         │  └─ Value: expr#7: ch.recv()
+         └─ Stmt[2]: Expr (span: 6:5-6:16)
+            └─ Expr: expr#10: ch.close()

--- a/testdata/golden/sema/invalid/concurrency/nonblocking_calls_channel.diag
+++ b/testdata/golden/sema/invalid/concurrency/nonblocking_calls_channel.diag
@@ -1,0 +1,3 @@
+error SEM3106 testdata/golden/sema/invalid/concurrency/nonblocking_calls_channel.sg:4:5 @nonblocking function cannot call blocking channel method Channel.send
+error SEM3106 testdata/golden/sema/invalid/concurrency/nonblocking_calls_channel.sg:5:13 @nonblocking function cannot call blocking channel method Channel.recv
+error SEM3106 testdata/golden/sema/invalid/concurrency/nonblocking_calls_channel.sg:6:5 @nonblocking function cannot call blocking channel method Channel.close

--- a/testdata/golden/sema/invalid/concurrency/nonblocking_calls_channel.fmt
+++ b/testdata/golden/sema/invalid/concurrency/nonblocking_calls_channel.fmt
@@ -1,0 +1,7 @@
+// Invalid: @nonblocking function calls blocking channel methods
+@nonblocking
+pub fn bad_channel(ch: &Channel<int>) -> nothing {
+    ch.send(1);
+    let _ = ch.recv();
+    ch.close();
+}

--- a/testdata/golden/sema/invalid/concurrency/nonblocking_calls_channel.sg
+++ b/testdata/golden/sema/invalid/concurrency/nonblocking_calls_channel.sg
@@ -1,0 +1,7 @@
+// Invalid: @nonblocking function calls blocking channel methods
+@nonblocking
+pub fn bad_channel(ch: &Channel<int>) -> nothing {
+    ch.send(1);
+    let _ = ch.recv();
+    ch.close();
+}

--- a/testdata/golden/sema/invalid/concurrency/nonblocking_calls_channel.tokens
+++ b/testdata/golden/sema/invalid/concurrency/nonblocking_calls_channel.tokens
@@ -1,0 +1,41 @@
+  1: At              "@" at 2:1-2:2 (leading: LineComment, Newline)
+  2: Ident           "nonblocking" at 2:2-2:13
+  3: KwPub           "pub" at 3:1-3:4 (leading: Newline)
+  4: KwFn            "fn" at 3:5-3:7 (leading: Space)
+  5: Ident           "bad_channel" at 3:8-3:19 (leading: Space)
+  6: LParen          "(" at 3:19-3:20
+  7: Ident           "ch" at 3:20-3:22
+  8: Colon           ":" at 3:22-3:23
+  9: Amp             "&" at 3:24-3:25 (leading: Space)
+ 10: Ident           "Channel" at 3:25-3:32
+ 11: Lt              "<" at 3:32-3:33
+ 12: Ident           "int" at 3:33-3:36
+ 13: Gt              ">" at 3:36-3:37
+ 14: RParen          ")" at 3:37-3:38
+ 15: Arrow           "->" at 3:39-3:41 (leading: Space)
+ 16: NothingLit      "nothing" at 3:42-3:49 (leading: Space)
+ 17: LBrace          "{" at 3:50-3:51 (leading: Space)
+ 18: Ident           "ch" at 4:5-4:7 (leading: Newline, Space)
+ 19: Dot             "." at 4:7-4:8
+ 20: Ident           "send" at 4:8-4:12
+ 21: LParen          "(" at 4:12-4:13
+ 22: IntLit          "1" at 4:13-4:14
+ 23: RParen          ")" at 4:14-4:15
+ 24: Semicolon       ";" at 4:15-4:16
+ 25: KwLet           "let" at 5:5-5:8 (leading: Newline, Space)
+ 26: Underscore      "_" at 5:9-5:10 (leading: Space)
+ 27: Assign          "=" at 5:11-5:12 (leading: Space)
+ 28: Ident           "ch" at 5:13-5:15 (leading: Space)
+ 29: Dot             "." at 5:15-5:16
+ 30: Ident           "recv" at 5:16-5:20
+ 31: LParen          "(" at 5:20-5:21
+ 32: RParen          ")" at 5:21-5:22
+ 33: Semicolon       ";" at 5:22-5:23
+ 34: Ident           "ch" at 6:5-6:7 (leading: Newline, Space)
+ 35: Dot             "." at 6:7-6:8
+ 36: Ident           "close" at 6:8-6:13
+ 37: LParen          "(" at 6:13-6:14
+ 38: RParen          ")" at 6:14-6:15
+ 39: Semicolon       ";" at 6:15-6:16
+ 40: RBrace          "}" at 7:1-7:2 (leading: Newline)
+ 41: EOF             at 8:1-8:1


### PR DESCRIPTION
## Summary

- make the `@nonblocking` checker recognize `Channel<T>` receivers through the existing channel type detector
- report blocking `Channel.send` / `recv` / `close` as `SEM3106` instead of the generic lock/waits diagnostic
- add a golden concurrency case covering all three blocking channel methods
- update `STATS.md`

## Context

This is a small RNT-032 guardrail. It does not enable a noisy global warning for every sync channel wrapper; it only fixes the existing opt-in `@nonblocking` contract so channel waits are diagnosed explicitly.

The surgekv API ownership finding remains tracked separately at https://github.com/vovakirdan/surgekv/issues/1.

## Validation

- `go test ./internal/sema -count=1`
- `make golden-check`
- `make check`
- sentrux MCP: `quality_signal 6226`, session gate passed before this branch and rescan stayed stable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved semantic analysis so blocking channel methods (`send`, `recv`, `close`) called inside `@nonblocking` functions are identified and reported with the correct `SEM3106` diagnostics.

* **Tests**
  * Added new semantic-analysis golden fixtures (AST, formatted source, tokens, and expected diagnostics) covering invalid nonblocking channel calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->