### PR TITLE
feat(runtime): add channel wake placement experiment

### DIFF
--- a/STATS.md
+++ b/STATS.md
@@ -5,7 +5,7 @@
 ## 📊 Main code (without tests)
 
 - **Files:** 682 (Go: 652, C: 30)
-- **Lines of code:** 156178 (Go: 142236, C: 13942)
+- **Lines of code:** 156205 (Go: 142236, C: 13969)
 
 ## 📁 Directory breakdown
 
@@ -13,7 +13,7 @@
 |------------|--------|-------|
 | `cmd/` | 27 | 4669 |
 | `internal/` | 623 | 137120 |
-| `runtime/native/` (C code) | 30 | 13942 |
+| `runtime/native/` (C code) | 30 | 13969 |
 
 ## 🏆 Top 10 packages by size
 
@@ -38,7 +38,7 @@
 ## 📈 Total volume (code + tests)
 
 - **Files:** 857
-- **Lines of code:** 192039
+- **Lines of code:** 192066
 
 ## 📊 Percentage breakdown
 

--- a/benchmarks/native/README.md
+++ b/benchmarks/native/README.md
@@ -15,6 +15,7 @@ Useful overrides:
 ```bash
 SURGE_CHANNEL_BENCH_MODES="1 2 4 8 default" ./scripts/bench_native_channels.sh
 SURGE_CHANNEL_BENCH_REPORT=/tmp/channel.md ./scripts/bench_native_channels.sh
+SURGE_CHANNEL_WAKE_INJECT=1 SURGE_CHANNEL_BENCH_REPORT=/tmp/channel-inject.md ./scripts/bench_native_channels.sh
 ```
 
 Compare future runtime PRs against
@@ -24,3 +25,5 @@ The fixture also prints scheduler-shape rows:
 
 - `channel_ping_pong`: direct async send/recv handoff between two tasks.
 - `channel_sync_new_reply`: sync wrapper fallback called from an async task.
+
+Use `SURGE_CHANNEL_WAKE_INJECT=1` only for A/B placement experiments.

--- a/runtime/native/rt_async_channel.c
+++ b/runtime/native/rt_async_channel.c
@@ -57,7 +57,7 @@ static void refill_buffer_from_sender(rt_executor* ex, rt_channel* ch) {
     }
     sender->resume_kind = RESUME_CHAN_SEND_ACK;
     sender->resume_bits = 0;
-    wake_task(ex, sender_id, 1);
+    wake_channel_task(ex, sender_id, 1);
 }
 
 void* rt_channel_new(uint64_t capacity) {
@@ -131,7 +131,7 @@ bool rt_channel_send(void* channel, uint64_t value_bits) {
         if (recv_task != NULL && task_status_load(recv_task) != TASK_DONE) {
             recv_task->resume_kind = RESUME_CHAN_RECV_VALUE;
             recv_task->resume_bits = value_bits;
-            wake_task(ex, recv_id, 1);
+            wake_channel_task(ex, recv_id, 1);
         }
         rt_unlock(ex);
         return 1;
@@ -207,7 +207,7 @@ uint8_t rt_channel_recv(void* channel, uint64_t* out_bits) {
             }
             sender->resume_kind = RESUME_CHAN_SEND_ACK;
             sender->resume_bits = 0;
-            wake_task(ex, sender_id, 1);
+            wake_channel_task(ex, sender_id, 1);
         }
         rt_unlock(ex);
         return 1;
@@ -238,7 +238,7 @@ bool rt_channel_try_send(void* channel, uint64_t value_bits) {
         if (recv_task != NULL && task_status_load(recv_task) != TASK_DONE) {
             recv_task->resume_kind = RESUME_CHAN_RECV_VALUE;
             recv_task->resume_bits = value_bits;
-            wake_task(ex, recv_id, 1);
+            wake_channel_task(ex, recv_id, 1);
         }
         rt_unlock(ex);
         return 1;
@@ -278,7 +278,7 @@ bool rt_channel_try_recv(void* channel, uint64_t* out_bits) {
             }
             sender->resume_kind = RESUME_CHAN_SEND_ACK;
             sender->resume_bits = 0;
-            wake_task(ex, sender_id, 1);
+            wake_channel_task(ex, sender_id, 1);
         }
         rt_unlock(ex);
         return 1;
@@ -311,7 +311,7 @@ uint8_t rt_channel_try_recv_status_locked(rt_executor* ex, void* channel, uint64
             }
             sender->resume_kind = RESUME_CHAN_SEND_ACK;
             sender->resume_bits = 0;
-            wake_task(ex, sender_id, 1);
+            wake_channel_task(ex, sender_id, 1);
         }
         return 1;
     }
@@ -337,7 +337,7 @@ uint8_t rt_channel_try_send_status_locked(rt_executor* ex, void* channel, uint64
         if (recv_task != NULL && task_status_load(recv_task) != TASK_DONE) {
             recv_task->resume_kind = RESUME_CHAN_RECV_VALUE;
             recv_task->resume_bits = value_bits;
-            wake_task(ex, recv_id, 1);
+            wake_channel_task(ex, recv_id, 1);
         }
         return 1;
     }
@@ -469,7 +469,7 @@ void rt_channel_close(void* channel) {
         }
         task->resume_kind = RESUME_CHAN_RECV_CLOSED;
         task->resume_bits = 0;
-        wake_task(ex, task_id, 1);
+        wake_channel_task(ex, task_id, 1);
     }
 
     waker_key send_key = channel_send_key(ch);
@@ -480,7 +480,7 @@ void rt_channel_close(void* channel) {
         }
         task->resume_kind = RESUME_CHAN_SEND_CLOSED;
         task->resume_bits = 0;
-        wake_task(ex, task_id, 1);
+        wake_channel_task(ex, task_id, 1);
     }
     rt_unlock(ex);
 }

--- a/runtime/native/rt_async_internal.h
+++ b/runtime/native/rt_async_internal.h
@@ -350,6 +350,7 @@ void clear_select_timers(rt_executor* ex, rt_task* task);
 void ready_push(rt_executor* ex, uint64_t id);
 int ready_pop(rt_executor* ex, uint64_t* out_id);
 void wake_task(rt_executor* ex, uint64_t id, int remove_waiter_flag);
+void wake_channel_task(rt_executor* ex, uint64_t id, int remove_waiter_flag);
 void wake_key_all(rt_executor* ex, waker_key key);
 void park_current(rt_executor* ex, waker_key key);
 void tick_virtual(rt_executor* ex);

--- a/runtime/native/rt_async_state.c
+++ b/runtime/native/rt_async_state.c
@@ -60,6 +60,7 @@ static uint64_t trace_sched_events;
 static uint64_t trace_sched_local_pops;
 static uint64_t trace_sched_inject_pops;
 static uint64_t trace_sched_steal_pops;
+static uint8_t channel_wake_force_inject;
 
 static int async_debug_enabled_cached = -1;
 
@@ -583,6 +584,14 @@ static uint64_t rt_env_sched_seed(void) {
     return (uint64_t)parsed;
 }
 
+static uint8_t rt_env_channel_wake_force_inject(void) {
+    const char* value = getenv("SURGE_CHANNEL_WAKE_INJECT");
+    if (value == NULL || value[0] == '\0' || (value[0] == '0' && value[1] == '\0')) {
+        return 0;
+    }
+    return 1;
+}
+
 static uint32_t rt_detect_cpu_count(void) {
     long cpus = sysconf(_SC_NPROCESSORS_ONLN);
     if (cpus <= 0) {
@@ -637,6 +646,7 @@ static void exec_init_once(void) {
     ex->worker_count = threads;
     ex->sched_mode = rt_env_sched_mode();
     ex->sched_seed = rt_env_sched_seed();
+    channel_wake_force_inject = rt_env_channel_wake_force_inject();
     uint32_t blocking_threads = rt_env_blocking_count();
     if (blocking_threads == 0) {
         blocking_threads = rt_default_blocking_count(ex->worker_count);
@@ -1441,7 +1451,8 @@ static int worker_next_ready(rt_executor* ex, uint32_t worker_id, uint64_t* out_
     return 0;
 }
 
-void wake_task(rt_executor* ex, uint64_t id, int remove_waiter_flag) {
+static void
+wake_task_with_policy(rt_executor* ex, uint64_t id, int remove_waiter_flag, int force_inject) {
     // Caller holds ex->lock; wake_token handles a wake that races with park_current.
     if (ex == NULL) {
         return;
@@ -1458,11 +1469,26 @@ void wake_task(rt_executor* ex, uint64_t id, int remove_waiter_flag) {
     task->park_key = waker_none();
     task->park_prepared = 0;
     (void)task_wake_token_exchange(task, 1);
-    if (ready_push_inner(ex, id, 0)) {
+    if (ready_push_inner(ex, id, force_inject)) {
         trace_exec_inc(&trace_wake_enqueued_total);
     } else if (ex->channel_blocked_workers > 0) {
         pthread_cond_broadcast(&ex->ready_cv);
     }
+}
+
+void wake_task(rt_executor* ex, uint64_t id, int remove_waiter_flag) {
+    wake_task_with_policy(ex, id, remove_waiter_flag, 0);
+}
+
+void wake_channel_task(rt_executor* ex, uint64_t id, int remove_waiter_flag) {
+    wake_task_with_policy(ex, id, remove_waiter_flag, channel_wake_force_inject != 0);
+}
+
+static void ready_push_for_waker_key(rt_executor* ex, uint64_t id, waker_key key) {
+    waker_kind kind = (waker_kind)key.kind;
+    int force_inject =
+        channel_wake_force_inject != 0 && (kind == WAKER_CHAN_SEND || kind == WAKER_CHAN_RECV);
+    (void)ready_push_inner(ex, id, force_inject);
 }
 
 void wake_key_all(rt_executor* ex, waker_key key) {
@@ -1494,7 +1520,7 @@ void park_current(rt_executor* ex, waker_key key) {
         task->park_prepared = 0;
         task->park_key = waker_none();
         task_status_store(task, TASK_READY);
-        ready_push(ex, task->id);
+        ready_push_for_waker_key(ex, task->id, key);
         return;
     }
     task_status_store(task, TASK_WAITING);
@@ -1507,7 +1533,7 @@ void park_current(rt_executor* ex, waker_key key) {
         remove_waiter(ex, key, task->id);
         task->park_key = waker_none();
         task_status_store(task, TASK_READY);
-        ready_push(ex, task->id);
+        ready_push_for_waker_key(ex, task->id, key);
         return;
     }
     trace_exec_inc(&trace_park_committed_total);

--- a/scripts/bench_native_channels.sh
+++ b/scripts/bench_native_channels.sh
@@ -6,6 +6,10 @@ fixture="$root/benchmarks/native/channel_request_reply"
 report="${SURGE_CHANNEL_BENCH_REPORT:-$root/build/benchmarks/native-channel-request-reply.md}"
 modes="${SURGE_CHANNEL_BENCH_MODES:-1 2 4 8 default}"
 surge="${SURGE:-$root/surge}"
+channel_wake_policy="local-first"
+if [[ -n "${SURGE_CHANNEL_WAKE_INJECT:-}" && "${SURGE_CHANNEL_WAKE_INJECT:-}" != "0" ]]; then
+	channel_wake_policy="force-inject"
+fi
 
 fail() {
 	echo "bench_native_channels: $*" >&2
@@ -72,6 +76,7 @@ mkdir -p "$(dirname "$report")"
 	echo "- surge: $("$surge" version --full | tr '\n' ' ' | sed 's/[[:space:]]*$//')"
 	echo "- fixture: ${fixture#$root/}"
 	echo "- modes: $modes"
+	echo "- channel wake policy: $channel_wake_policy"
 	echo "- trace: separate SURGE_TRACE_EXEC=1 pass"
 	echo
 	echo "## Results"


### PR DESCRIPTION
## Summary

- add `SURGE_CHANNEL_WAKE_INJECT=1` to force channel wakeups through the global inject queue
- keep default channel wake placement unchanged
- label the channel wake policy in native benchmark reports and document the A/B command

## Findings

Full local matrix does not justify changing the default policy. Force-inject is mixed: small wins on some 2-worker actor rows, but regressions at 4/8/default and on sync-wrapper fallback. Keep it as an experiment only.

Selected ns/op from the local full run:

| mode | probe | local-first | force-inject |
| --- | --- | ---: | ---: |
| 2 | channel_reused_reply | 55984 | 54641 |
| 4 | channel_reused_reply | 101664 | 105033 |
| 8 | channel_reused_reply | 108039 | 112097 |
| default | channel_sync_new_reply | 749539 | 769732 |

`SURGE_SCHED_TRACE=1` confirms the flag changes placement: default `local=107140 inject=3114`, force-inject `local=2179 inject=119307` on the 2-worker benchmark binary.

## Verification

- `make build`
- `make check`
- `make c-warnings`
- `make cfmt-check`
- `git diff --check`
- `bash -n scripts/bench_native_channels.sh`
- `SURGE_CHANNEL_BENCH_MODES="1 2" ... ./scripts/bench_native_channels.sh`
- `SURGE_CHANNEL_WAKE_INJECT=1 SURGE_CHANNEL_BENCH_MODES="1 2" ... ./scripts/bench_native_channels.sh`
- full local matrix default vs force-inject
- sentrux MCP: `quality_signal=6225`, `signal_delta=-1`, no new violations


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable async channel wake policy controlled by `SURGE_CHANNEL_WAKE_INJECT`, enabling local-first scheduling by default or forced injection for placement experiments.

* **Documentation**
  * Expanded native channel benchmark README with an additional request/reply probe example using `SURGE_CHANNEL_WAKE_INJECT=1`, including clarification it’s intended for A/B placement experiments.
  * Benchmark reports now document the selected channel wake policy.

* **Chores**
  * Updated repository line-of-code metrics in `STATS.md`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->