### PR TITLE
fix(runtime): make live trace snapshots reliable

### DIFF
--- a/STATS.md
+++ b/STATS.md
@@ -5,7 +5,7 @@
 ## 📊 Main code (without tests)
 
 - **Files:** 682 (Go: 652, C: 30)
-- **Lines of code:** 156234 (Go: 142236, C: 13998)
+- **Lines of code:** 156218 (Go: 142236, C: 13982)
 
 ## 📁 Directory breakdown
 
@@ -13,7 +13,7 @@
 |------------|--------|-------|
 | `cmd/` | 27 | 4669 |
 | `internal/` | 623 | 137120 |
-| `runtime/native/` (C code) | 30 | 13998 |
+| `runtime/native/` (C code) | 30 | 13982 |
 
 ## 🏆 Top 10 packages by size
 
@@ -38,7 +38,7 @@
 ## 📈 Total volume (code + tests)
 
 - **Files:** 857
-- **Lines of code:** 192123
+- **Lines of code:** 192107
 
 ## 📊 Percentage breakdown
 

--- a/runtime/native/rt_async_state.c
+++ b/runtime/native/rt_async_state.c
@@ -278,23 +278,7 @@ static void trace_exec_snapshot_dump(const char* reason) {
     uint64_t waiters_net = 0;
     uint64_t waiters_other = 0;
 
-    // Snapshot reads executor-owned fields, so it is intentionally exit-only and best-effort.
-    if (pthread_mutex_trylock(&ex->lock) != 0) {
-        char busy_buf[128];
-        size_t busy_pos = 0;
-        busy_pos =
-            trace_exec_append_literal(busy_buf, busy_pos, sizeof(busy_buf), "TRACE_EXEC_SNAPSHOT");
-        if (reason != NULL) {
-            busy_pos = trace_exec_append_literal(busy_buf, busy_pos, sizeof(busy_buf), " reason=");
-            busy_pos = trace_exec_append_literal(busy_buf, busy_pos, sizeof(busy_buf), reason);
-        }
-        trace_exec_append_kv_u64(busy_buf, &busy_pos, sizeof(busy_buf), "lock_busy", 1);
-        if (busy_pos + 1 < sizeof(busy_buf)) {
-            busy_buf[busy_pos++] = '\n';
-        }
-        (void)write(STDERR_FILENO, busy_buf, busy_pos);
-        return;
-    }
+    rt_lock(ex);
     if (ex->local_queues != NULL) {
         for (uint32_t i = 0; i < ex->worker_count; i++) {
             uint64_t len = (uint64_t)ex->local_queues[i].len;
@@ -385,7 +369,7 @@ static void trace_exec_snapshot_dump(const char* reason) {
     if (pos + 1 < sizeof(buf)) {
         buf[pos++] = '\n';
     }
-    pthread_mutex_unlock(&ex->lock);
+    rt_unlock(ex);
     (void)write(STDERR_FILENO, buf, pos);
 }
 


### PR DESCRIPTION
## Summary

- remove the best-effort `trylock` snapshot fallback now that live dumps are drained outside the signal handler
- make `TRACE_EXEC_SNAPSHOT reason=sigusr1` wait for executor state instead of returning `lock_busy=1`
- update generated `STATS.md`

## Why

The Phase 5 PING-tail investigation needs usable live snapshots. In the first PING matrix, multi-worker samples often produced only `TRACE_EXEC_SNAPSHOT reason=sigusr1 lock_busy=1`, hiding the ready/waiting queue state.

## Verification

- `go test ./internal/vm -run TestMTNetWaiterWakeupLatency -count=1 -timeout 90s`
- `make cfmt-check && make c-warnings`
- `make check`
- `git diff --check`
- manual `surgekv` PING smoke with 5 `SIGUSR1` samples: `snapshots=5`, `trace_net=5`, `lock_busy=0`
- sentrux MCP: `quality_signal=6224`, session delta `0`; existing rule failures remain `max_cc` and `no_god_files`
