### PR TITLE
feat(runtime): break down trace tasks by status

### DIFF
--- a/STATS.md
+++ b/STATS.md
@@ -5,7 +5,7 @@
 ## 📊 Main code (without tests)
 
 - **Files:** 682 (Go: 652, C: 30)
-- **Lines of code:** 156256 (Go: 142236, C: 14020)
+- **Lines of code:** 156300 (Go: 142236, C: 14064)
 
 ## 📁 Directory breakdown
 
@@ -13,7 +13,7 @@
 |------------|--------|-------|
 | `cmd/` | 27 | 4669 |
 | `internal/` | 623 | 137120 |
-| `runtime/native/` (C code) | 30 | 14020 |
+| `runtime/native/` (C code) | 30 | 14064 |
 
 ## 🏆 Top 10 packages by size
 
@@ -38,7 +38,7 @@
 ## 📈 Total volume (code + tests)
 
 - **Files:** 857
-- **Lines of code:** 192145
+- **Lines of code:** 192189
 
 ## 📊 Percentage breakdown
 

--- a/runtime/native/rt_async_state.c
+++ b/runtime/native/rt_async_state.c
@@ -271,6 +271,12 @@ static void trace_exec_snapshot_dump(const char* reason) {
     uint64_t tasks_running = 0;
     uint64_t tasks_waiting = 0;
     uint64_t tasks_done = 0;
+    uint64_t tasks_ready_user = 0;
+    uint64_t tasks_ready_net = 0;
+    uint64_t tasks_waiting_user = 0;
+    uint64_t tasks_waiting_net = 0;
+    uint64_t tasks_done_user = 0;
+    uint64_t tasks_done_net = 0;
     uint64_t tasks_user = 0;
     uint64_t tasks_sleep = 0;
     uint64_t tasks_net_accept = 0;
@@ -300,7 +306,8 @@ static void trace_exec_snapshot_dump(const char* reason) {
         if (task == NULL) {
             continue;
         }
-        switch (task_status_load(task)) {
+        uint8_t status = task_status_load(task);
+        switch (status) {
             case TASK_READY:
                 tasks_ready++;
                 break;
@@ -314,6 +321,37 @@ static void trace_exec_snapshot_dump(const char* reason) {
             default:
                 tasks_done++;
                 break;
+        }
+        uint8_t net_task = task->kind == TASK_KIND_NET_ACCEPT || task->kind == TASK_KIND_NET_READ ||
+                           task->kind == TASK_KIND_NET_WRITE;
+        if (task->kind == TASK_KIND_USER) {
+            switch (status) {
+                case TASK_READY:
+                    tasks_ready_user++;
+                    break;
+                case TASK_WAITING:
+                    tasks_waiting_user++;
+                    break;
+                case TASK_DONE:
+                    tasks_done_user++;
+                    break;
+                default:
+                    break;
+            }
+        } else if (net_task) {
+            switch (status) {
+                case TASK_READY:
+                    tasks_ready_net++;
+                    break;
+                case TASK_WAITING:
+                    tasks_waiting_net++;
+                    break;
+                case TASK_DONE:
+                    tasks_done_net++;
+                    break;
+                default:
+                    break;
+            }
         }
         switch (task->kind) {
             case TASK_KIND_USER:
@@ -368,7 +406,7 @@ static void trace_exec_snapshot_dump(const char* reason) {
         }
     }
 
-    char buf[1400];
+    char buf[1800];
     size_t pos = 0;
     pos = trace_exec_append_literal(buf, pos, sizeof(buf), "TRACE_EXEC_SNAPSHOT");
     if (reason != NULL) {
@@ -397,6 +435,12 @@ static void trace_exec_snapshot_dump(const char* reason) {
     trace_exec_append_kv_u64(buf, &pos, sizeof(buf), "tasks_running", tasks_running);
     trace_exec_append_kv_u64(buf, &pos, sizeof(buf), "tasks_waiting", tasks_waiting);
     trace_exec_append_kv_u64(buf, &pos, sizeof(buf), "tasks_done", tasks_done);
+    trace_exec_append_kv_u64(buf, &pos, sizeof(buf), "tasks_ready_user", tasks_ready_user);
+    trace_exec_append_kv_u64(buf, &pos, sizeof(buf), "tasks_ready_net", tasks_ready_net);
+    trace_exec_append_kv_u64(buf, &pos, sizeof(buf), "tasks_waiting_user", tasks_waiting_user);
+    trace_exec_append_kv_u64(buf, &pos, sizeof(buf), "tasks_waiting_net", tasks_waiting_net);
+    trace_exec_append_kv_u64(buf, &pos, sizeof(buf), "tasks_done_user", tasks_done_user);
+    trace_exec_append_kv_u64(buf, &pos, sizeof(buf), "tasks_done_net", tasks_done_net);
     trace_exec_append_kv_u64(buf, &pos, sizeof(buf), "tasks_user", tasks_user);
     trace_exec_append_kv_u64(buf, &pos, sizeof(buf), "tasks_sleep", tasks_sleep);
     trace_exec_append_kv_u64(buf, &pos, sizeof(buf), "tasks_net_accept", tasks_net_accept);


### PR DESCRIPTION
## Summary
- adds user/net status breakdown fields to TRACE_EXEC_SNAPSHOT
- keeps existing task-kind totals and updates STATS.md
- no scheduler or runtime behavior changes

## Why
The previous task-kind counters showed high tasks_net_read, but not whether those tasks were ready, waiting, or already done. The PING tail investigation needs that distinction before changing scheduler behavior.

## Verification
- make check
- make c-warnings
- make ctidy
- git diff --check
- sentrux MCP scan/session_end: quality_signal 6224 -> 6224; stable
- local surgekv PING smoke with SURGE_THREADS=4 and live SIGUSR1 snapshots

## Research note
The new fields showed the PING backlog is not net wait tasks in ready state: observed tasks_ready_user=29..30, tasks_ready_net=0, tasks_done_net=28..29. That points the next runtime work at user async wrapper/join scheduling around stdlib/net read/write, not at initial net wait-task polling.