### PR TITLE
feat(runtime): trace task-context channel blocking

### DIFF
--- a/STATS.md
+++ b/STATS.md
@@ -5,7 +5,7 @@
 ## 📊 Main code (without tests)
 
 - **Files:** 682 (Go: 652, C: 30)
-- **Lines of code:** 156340 (Go: 142236, C: 14104)
+- **Lines of code:** 156366 (Go: 142236, C: 14130)
 
 ## 📁 Directory breakdown
 
@@ -13,7 +13,7 @@
 |------------|--------|-------|
 | `cmd/` | 27 | 4669 |
 | `internal/` | 623 | 137120 |
-| `runtime/native/` (C code) | 30 | 14104 |
+| `runtime/native/` (C code) | 30 | 14130 |
 
 ## 🏆 Top 10 packages by size
 
@@ -33,12 +33,12 @@
 ## 🧪 Test files
 
 - **Files:** 175
-- **Lines of code:** 35889
+- **Lines of code:** 35894
 
 ## 📈 Total volume (code + tests)
 
 - **Files:** 857
-- **Lines of code:** 192229
+- **Lines of code:** 192260
 
 ## 📊 Percentage breakdown
 

--- a/internal/vm/mt_executor_test.go
+++ b/internal/vm/mt_executor_test.go
@@ -659,7 +659,8 @@ fn main() -> int {
 		t.Fatalf("unexpected stdout: %q", res.stdout)
 	}
 	trace := parseExecTrace(t, res.stderr)
-	if trace["channel_blocking_wait"] != 0 || trace["compensation_started"] != 0 {
+	if trace["channel_blocking_wait"] != 0 || trace["channel_task_blocking_send"] != 0 ||
+		trace["channel_task_blocking_recv"] != 0 || trace["compensation_started"] != 0 {
 		t.Fatalf("async channel path should not pin workers, got %+v\nstderr:\n%s", trace, res.stderr)
 	}
 	snapshot := parseExecSnapshot(t, res.stderr)
@@ -781,6 +782,10 @@ fn main() -> int {
 	trace := parseExecTrace(t, res.stderr)
 	if trace["channel_blocking_wait"] == 0 {
 		t.Fatalf("expected task-context blocking channel waits in TRACE_EXEC, got %+v\nstderr:\n%s",
+			trace, res.stderr)
+	}
+	if trace["channel_task_blocking_send"] == 0 || trace["channel_task_blocking_recv"] == 0 {
+		t.Fatalf("expected task-context blocking channel helper counters in TRACE_EXEC, got %+v\nstderr:\n%s",
 			trace, res.stderr)
 	}
 	if trace["compensation_started"] == 0 {

--- a/runtime/native/rt_async_channel.c
+++ b/runtime/native/rt_async_channel.c
@@ -369,6 +369,7 @@ void rt_channel_send_blocking(void* channel, uint64_t value_bits) {
     rt_async_debug_printf(
         "async chan send start ch=%p bits=%llu\n", (void*)ch, (unsigned long long)value_bits);
     if (rt_current_task() != NULL) {
+        rt_trace_channel_task_blocking_send();
         while (!rt_channel_send(channel, value_bits)) {
             if (current_task_cancelled(ex)) {
                 pending_key = waker_none();
@@ -405,6 +406,7 @@ uint8_t rt_channel_recv_blocking(void* channel, uint64_t* out_bits) {
     }
     rt_async_debug_printf("async chan recv start ch=%p\n", (void*)ch);
     if (rt_current_task() != NULL) {
+        rt_trace_channel_task_blocking_recv();
         for (;;) {
             uint8_t status = rt_channel_recv(channel, out_bits);
             if (status != 0) {

--- a/runtime/native/rt_async_internal.h
+++ b/runtime/native/rt_async_internal.h
@@ -239,6 +239,8 @@ void panic_msg(const char* msg);
 int rt_async_debug_enabled(void);
 void rt_async_debug_printf(const char* fmt, ...);
 int rt_exec_trace_enabled(void);
+void rt_trace_channel_task_blocking_send(void);
+void rt_trace_channel_task_blocking_recv(void);
 
 static inline uint8_t task_status_load(const rt_task* task) {
     return task == NULL ? TASK_DONE : atomic_load_explicit(&task->status, memory_order_acquire);

--- a/runtime/native/rt_async_state.c
+++ b/runtime/native/rt_async_state.c
@@ -54,6 +54,8 @@ static _Atomic uint64_t trace_park_committed_total;
 static _Atomic uint64_t trace_worker_sleep_total;
 static _Atomic uint64_t trace_worker_wake_total;
 static _Atomic uint64_t trace_channel_blocking_wait_total;
+static _Atomic uint64_t trace_channel_task_blocking_send_total;
+static _Atomic uint64_t trace_channel_task_blocking_recv_total;
 static _Atomic uint64_t trace_compensation_started_total;
 static uint64_t trace_sched_hash;
 static uint64_t trace_sched_events;
@@ -122,6 +124,14 @@ static void trace_exec_inc(_Atomic uint64_t* counter) {
         return;
     }
     (void)atomic_fetch_add_explicit(counter, 1, memory_order_relaxed);
+}
+
+void rt_trace_channel_task_blocking_send(void) {
+    trace_exec_inc(&trace_channel_task_blocking_send_total);
+}
+
+void rt_trace_channel_task_blocking_recv(void) {
+    trace_exec_inc(&trace_channel_task_blocking_recv_total);
 }
 
 static void
@@ -210,6 +220,18 @@ static void trace_exec_dump(const char* reason) {
         pos,
         sizeof(buf),
         atomic_load_explicit(&trace_channel_blocking_wait_total, memory_order_relaxed));
+    pos = trace_exec_append_literal(buf, pos, sizeof(buf), " channel_task_blocking_send=");
+    pos = trace_exec_append_u64(
+        buf,
+        pos,
+        sizeof(buf),
+        atomic_load_explicit(&trace_channel_task_blocking_send_total, memory_order_relaxed));
+    pos = trace_exec_append_literal(buf, pos, sizeof(buf), " channel_task_blocking_recv=");
+    pos = trace_exec_append_u64(
+        buf,
+        pos,
+        sizeof(buf),
+        atomic_load_explicit(&trace_channel_task_blocking_recv_total, memory_order_relaxed));
     pos = trace_exec_append_literal(buf, pos, sizeof(buf), " compensation_started=");
     pos = trace_exec_append_u64(
         buf,

--- a/scripts/bench_native_channels.sh
+++ b/scripts/bench_native_channels.sh
@@ -98,9 +98,11 @@ for mode in $modes; do
 		[[ "$line" == \|* ]] || continue
 		printf '| %s |%s\n' "$mode" "${line#|}" >>"$report"
 	done <<<"$output"
-	printf '| %s | %s | %s | %s |\n' \
+	printf '| %s | %s | %s | %s | %s | %s |\n' \
 		"$mode" \
 		"$(trace_value "$trace_log" TRACE_EXEC channel_blocking_wait)" \
+		"$(trace_value "$trace_log" TRACE_EXEC channel_task_blocking_send)" \
+		"$(trace_value "$trace_log" TRACE_EXEC channel_task_blocking_recv)" \
 		"$(trace_value "$trace_log" TRACE_EXEC compensation_started)" \
 		"$(trace_value "$trace_log" TRACE_EXEC_SNAPSHOT compensation_high_water)" >>"$trace_rows"
 	rm -f "$trace_log"
@@ -110,8 +112,8 @@ cat >>"$report" <<'EOF'
 
 ## Runtime Trace
 
-| mode | channel blocking waits | compensation started | compensation high-water |
-| --- | ---: | ---: | ---: |
+| mode | channel blocking waits | task-context blocking sends | task-context blocking recvs | compensation started | compensation high-water |
+| --- | ---: | ---: | ---: | ---: | ---: |
 EOF
 cat "$trace_rows" >>"$report"
 


### PR DESCRIPTION
## Summary

- Add `TRACE_EXEC` counters for sync channel helpers entered from task context.
- Report `channel_task_blocking_send` and `channel_task_blocking_recv` alongside existing `channel_blocking_wait`.
- Extend MT trace checks so direct async channel paths stay at zero and sync-wrapper channel paths report both counters.
- Update generated `STATS.md`.

## Why

This is the next runtime-refactor measurement step after rejecting #131. It lets us measure how much `surgekv` and similar actor request/reply paths still rely on sync-in-async channel helpers before changing scheduler policy again.

## Evidence

`benchmarks/native/channel_request_reply` with `SURGE_THREADS=4 SURGE_TRACE_EXEC=1` now reports the sync-wrapper row as:

```
channel_task_blocking_send=5000 channel_task_blocking_recv=5000
```

The direct async channel MT path remains zero for these counters.

## Checks

- `SURGE_BACKEND=llvm go test ./internal/vm -run 'TestMT(ChannelParkUnpark|BlockingChannelHelpersDoNotParkWorkers)' -count=1 -timeout 90s -v`\n- `make build`\n- `make cfmt-check`\n- `make c-warnings`\n- `make ctidy`\n- `git diff --check`\n- `make check`\n- sentrux MCP `session_end`: pass, no new violations, quality signal 6224 -> 6222\n