### PR TITLE
feat(runtime): hint channel request handoffs

### DIFF
--- a/STATS.md
+++ b/STATS.md
@@ -5,15 +5,15 @@
 ## 📊 Main code (without tests)
 
 - **Files:** 682 (Go: 652, C: 30)
-- **Lines of code:** 156366 (Go: 142236, C: 14130)
+- **Lines of code:** 156467 (Go: 142279, C: 14188)
 
 ## 📁 Directory breakdown
 
 | Directory | Files | Lines |
 |------------|--------|-------|
 | `cmd/` | 27 | 4669 |
-| `internal/` | 623 | 137120 |
-| `runtime/native/` (C code) | 30 | 14130 |
+| `internal/` | 623 | 137163 |
+| `runtime/native/` (C code) | 30 | 14188 |
 
 ## 🏆 Top 10 packages by size
 
@@ -21,8 +21,8 @@
 |---|-------|-------|
 | 1 | `internal/sema` | 28571 |
 | 2 | `internal/vm` | 23197 |
-| 3 | `internal/backend/llvm` | 12022 |
-| 4 | `internal/mir` | 10281 |
+| 3 | `internal/backend/llvm` | 12027 |
+| 4 | `internal/mir` | 10319 |
 | 5 | `internal/parser` | 8960 |
 | 6 | `internal/hir` | 7162 |
 | 7 | `internal/driver` | 6039 |
@@ -33,12 +33,12 @@
 ## 🧪 Test files
 
 - **Files:** 175
-- **Lines of code:** 35996
+- **Lines of code:** 36004
 
 ## 📈 Total volume (code + tests)
 
 - **Files:** 857
-- **Lines of code:** 192362
+- **Lines of code:** 192471
 
 ## 📊 Percentage breakdown
 

--- a/internal/backend/llvm/builtins.go
+++ b/internal/backend/llvm/builtins.go
@@ -156,6 +156,7 @@ func runtimeDecls() []builtinDecl {
 		{name: "rt_async_return_cancelled", ret: "void", params: []string{"ptr"}},
 		{name: "rt_channel_new", ret: "ptr", params: []string{"i64"}},
 		{name: "rt_channel_send", ret: "i1", params: []string{"ptr", "i64"}},
+		{name: "rt_channel_send_yield", ret: "i1", params: []string{"ptr", "i64"}},
 		{name: "rt_channel_recv", ret: "i8", params: []string{"ptr", "ptr"}},
 		{name: "rt_channel_send_blocking", ret: "void", params: []string{"ptr", "i64"}},
 		{name: "rt_channel_recv_blocking", ret: "i8", params: []string{"ptr", "ptr"}},

--- a/internal/backend/llvm/emit_channel.go
+++ b/internal/backend/llvm/emit_channel.go
@@ -337,8 +337,12 @@ func (fe *funcEmitter) emitInstrChanSend(ins *mir.Instr) error {
 	if err != nil {
 		return err
 	}
+	callee := "rt_channel_send"
+	if ins.ChanSend.YieldAfterHandoff {
+		callee = "rt_channel_send_yield"
+	}
 	okVal := fe.nextTemp()
-	fmt.Fprintf(&fe.emitter.buf, "  %s = call i1 @rt_channel_send(ptr %s, i64 %s)\n", okVal, chVal, bitsVal)
+	fmt.Fprintf(&fe.emitter.buf, "  %s = call i1 @%s(ptr %s, i64 %s)\n", okVal, callee, chVal, bitsVal)
 	fmt.Fprintf(&fe.emitter.buf, "  br i1 %s, label %%bb%d, label %%bb%d\n", okVal, ins.ChanSend.ReadyBB, ins.ChanSend.PendBB)
 	fe.blockTerminated = true
 	return nil

--- a/internal/mir/async_normalize.go
+++ b/internal/mir/async_normalize.go
@@ -143,7 +143,44 @@ func splitAsyncAwaits(f *Func) ([]awaitSite, error) {
 		}
 	}
 
+	markChannelSendHandoffYields(f)
 	return sites, nil
+}
+
+func markChannelSendHandoffYields(f *Func) {
+	if f == nil {
+		return
+	}
+	// A send whose ready path immediately polls a recv is the request/reply
+	// shape. The runtime may yield after a completed handoff so the receiver
+	// gets a turn before this task parks for the reply.
+	for bi := range f.Blocks {
+		bb := &f.Blocks[bi]
+		for ii := range bb.Instrs {
+			ins := &bb.Instrs[ii]
+			if ins.Kind != InstrChanSend {
+				continue
+			}
+			ins.ChanSend.YieldAfterHandoff = readyPathStartsWithChanRecv(f, ins.ChanSend.ReadyBB)
+		}
+	}
+}
+
+func readyPathStartsWithChanRecv(f *Func, bbID BlockID) bool {
+	for steps := 0; bbID != NoBlockID && steps < len(f.Blocks); steps++ {
+		if int(bbID) < 0 || int(bbID) >= len(f.Blocks) {
+			return false
+		}
+		bb := &f.Blocks[bbID]
+		if len(bb.Instrs) > 0 {
+			return bb.Instrs[0].Kind == InstrChanRecv
+		}
+		if bb.Term.Kind != TermGoto {
+			return false
+		}
+		bbID = bb.Term.Goto.Target
+	}
+	return false
 }
 
 // collectSuspendSites scans for poll/join_all instructions in block order.

--- a/internal/mir/instr.go
+++ b/internal/mir/instr.go
@@ -184,10 +184,11 @@ type JoinAllInstr struct {
 
 // ChanSendInstr represents a channel send instruction.
 type ChanSendInstr struct {
-	Channel Operand
-	Value   Operand
-	ReadyBB BlockID
-	PendBB  BlockID
+	Channel           Operand
+	Value             Operand
+	ReadyBB           BlockID
+	PendBB            BlockID
+	YieldAfterHandoff bool
 }
 
 // ChanRecvInstr represents a channel receive instruction.

--- a/internal/vm/mt_executor_test.go
+++ b/internal/vm/mt_executor_test.go
@@ -765,6 +765,10 @@ fn main() -> int {
 		trace["channel_task_blocking_recv"] != 0 || trace["compensation_started"] != 0 {
 		t.Fatalf("async channel path should not pin workers, got %+v\nstderr:\n%s", trace, res.stderr)
 	}
+	if trace["channel_handoff_yield"] == 0 {
+		t.Fatalf("expected async channel handoff yields in TRACE_EXEC, got %+v\nstderr:\n%s",
+			trace, res.stderr)
+	}
 	snapshot := parseExecSnapshot(t, res.stderr)
 	if snapshot["compensation"] != 0 || snapshot["channel_blocked"] != 0 {
 		t.Fatalf("unexpected async channel snapshot %+v\nstderr:\n%s", snapshot, res.stderr)
@@ -888,6 +892,10 @@ fn main() -> int {
 	}
 	if trace["channel_task_blocking_send"] == 0 || trace["channel_task_blocking_recv"] == 0 {
 		t.Fatalf("expected task-context blocking channel helper counters in TRACE_EXEC, got %+v\nstderr:\n%s",
+			trace, res.stderr)
+	}
+	if trace["channel_handoff_yield"] != 0 {
+		t.Fatalf("sync channel helper path should not use async handoff yields, got %+v\nstderr:\n%s",
 			trace, res.stderr)
 	}
 	if trace["compensation_started"] == 0 {

--- a/runtime/native/rt.h
+++ b/runtime/native/rt.h
@@ -183,6 +183,7 @@ void rt_async_return_cancelled(void* state);
 
 void* rt_channel_new(uint64_t capacity);
 bool rt_channel_send(void* channel, uint64_t value_bits);
+bool rt_channel_send_yield(void* channel, uint64_t value_bits);
 uint8_t rt_channel_recv(void* channel, uint64_t* out_bits);
 void rt_channel_send_blocking(void* channel, uint64_t value_bits);
 uint8_t rt_channel_recv_blocking(void* channel, uint64_t* out_bits);

--- a/runtime/native/rt_async_channel.c
+++ b/runtime/native/rt_async_channel.c
@@ -60,6 +60,20 @@ static void refill_buffer_from_sender(rt_executor* ex, rt_channel* ch) {
     wake_channel_task(ex, sender_id, 1);
 }
 
+static int prepare_channel_send_yield(rt_task* task) {
+    if (task == NULL) {
+        return 0;
+    }
+    // The compiler emits this helper only when the ready path immediately
+    // reaches a recv suspend point. Re-polling consumes this ack without
+    // repeating the already completed send.
+    task->resume_kind = RESUME_CHAN_SEND_ACK;
+    task->resume_bits = 0;
+    pending_key = waker_none();
+    rt_trace_channel_handoff_yield();
+    return 1;
+}
+
 void* rt_channel_new(uint64_t capacity) {
     rt_channel* ch = (rt_channel*)rt_alloc(sizeof(rt_channel), _Alignof(rt_channel));
     if (ch == NULL) {
@@ -82,7 +96,7 @@ void* rt_channel_new(uint64_t capacity) {
     return ch;
 }
 
-bool rt_channel_send(void* channel, uint64_t value_bits) {
+static bool rt_channel_send_inner(void* channel, uint64_t value_bits, int yield_after_handoff) {
     rt_executor* ex = ensure_exec();
     rt_channel* ch = channel_from_handle(channel);
     if (ex == NULL || ch == NULL) {
@@ -131,7 +145,15 @@ bool rt_channel_send(void* channel, uint64_t value_bits) {
         if (recv_task != NULL && task_status_load(recv_task) != TASK_DONE) {
             recv_task->resume_kind = RESUME_CHAN_RECV_VALUE;
             recv_task->resume_bits = value_bits;
-            wake_channel_task(ex, recv_id, 1);
+            if (yield_after_handoff) {
+                wake_channel_task_no_signal(ex, recv_id, 1);
+            } else {
+                wake_channel_task(ex, recv_id, 1);
+            }
+            if (yield_after_handoff && prepare_channel_send_yield(task)) {
+                rt_unlock(ex);
+                return 0;
+            }
         }
         rt_unlock(ex);
         return 1;
@@ -147,6 +169,14 @@ bool rt_channel_send(void* channel, uint64_t value_bits) {
     pending_key = send_key;
     rt_unlock(ex);
     return 0;
+}
+
+bool rt_channel_send(void* channel, uint64_t value_bits) {
+    return rt_channel_send_inner(channel, value_bits, 0);
+}
+
+bool rt_channel_send_yield(void* channel, uint64_t value_bits) {
+    return rt_channel_send_inner(channel, value_bits, 1);
 }
 
 uint8_t rt_channel_recv(void* channel, uint64_t* out_bits) {

--- a/runtime/native/rt_async_internal.h
+++ b/runtime/native/rt_async_internal.h
@@ -241,6 +241,7 @@ void rt_async_debug_printf(const char* fmt, ...);
 int rt_exec_trace_enabled(void);
 void rt_trace_channel_task_blocking_send(void);
 void rt_trace_channel_task_blocking_recv(void);
+void rt_trace_channel_handoff_yield(void);
 
 static inline uint8_t task_status_load(const rt_task* task) {
     return task == NULL ? TASK_DONE : atomic_load_explicit(&task->status, memory_order_acquire);
@@ -353,6 +354,7 @@ void ready_push(rt_executor* ex, uint64_t id);
 int ready_pop(rt_executor* ex, uint64_t* out_id);
 void wake_task(rt_executor* ex, uint64_t id, int remove_waiter_flag);
 void wake_channel_task(rt_executor* ex, uint64_t id, int remove_waiter_flag);
+void wake_channel_task_no_signal(rt_executor* ex, uint64_t id, int remove_waiter_flag);
 void wake_key_all(rt_executor* ex, waker_key key);
 void park_current(rt_executor* ex, waker_key key);
 void tick_virtual(rt_executor* ex);
@@ -374,6 +376,7 @@ void task_release(rt_executor* ex, rt_task* task);
 
 void* rt_channel_new(uint64_t capacity);
 bool rt_channel_send(void* channel, uint64_t value_bits);
+bool rt_channel_send_yield(void* channel, uint64_t value_bits);
 uint8_t rt_channel_recv(void* channel, uint64_t* out_bits);
 bool rt_channel_try_send(void* channel, uint64_t value_bits);
 bool rt_channel_try_recv(void* channel, uint64_t* out_bits);

--- a/runtime/native/rt_async_state.c
+++ b/runtime/native/rt_async_state.c
@@ -56,6 +56,7 @@ static _Atomic uint64_t trace_worker_wake_total;
 static _Atomic uint64_t trace_channel_blocking_wait_total;
 static _Atomic uint64_t trace_channel_task_blocking_send_total;
 static _Atomic uint64_t trace_channel_task_blocking_recv_total;
+static _Atomic uint64_t trace_channel_handoff_yield_total;
 static _Atomic uint64_t trace_compensation_started_total;
 static uint64_t trace_sched_hash;
 static uint64_t trace_sched_events;
@@ -132,6 +133,10 @@ void rt_trace_channel_task_blocking_send(void) {
 
 void rt_trace_channel_task_blocking_recv(void) {
     trace_exec_inc(&trace_channel_task_blocking_recv_total);
+}
+
+void rt_trace_channel_handoff_yield(void) {
+    trace_exec_inc(&trace_channel_handoff_yield_total);
 }
 
 static void
@@ -232,6 +237,12 @@ static void trace_exec_dump(const char* reason) {
         pos,
         sizeof(buf),
         atomic_load_explicit(&trace_channel_task_blocking_recv_total, memory_order_relaxed));
+    pos = trace_exec_append_literal(buf, pos, sizeof(buf), " channel_handoff_yield=");
+    pos = trace_exec_append_u64(
+        buf,
+        pos,
+        sizeof(buf),
+        atomic_load_explicit(&trace_channel_handoff_yield_total, memory_order_relaxed));
     pos = trace_exec_append_literal(buf, pos, sizeof(buf), " compensation_started=");
     pos = trace_exec_append_u64(
         buf,
@@ -1410,7 +1421,8 @@ pop_task_from_deque(rt_executor* ex, rt_deque* dq, int lifo, uint64_t* out_id, u
     return 0;
 }
 
-static int ready_push_with_policy(rt_executor* ex, uint64_t id, int force_inject, int front) {
+static int ready_push_with_policy(
+    rt_executor* ex, uint64_t id, int force_inject, int front, int signal_ready) {
     // Caller holds ex->lock; enqueued prevents duplicate ready-queue entries.
     if (ex == NULL) {
         return 0;
@@ -1459,12 +1471,14 @@ static int ready_push_with_policy(rt_executor* ex, uint64_t id, int force_inject
     if (ex->channel_blocked_workers > 0) {
         maybe_start_compensation_worker_locked(ex);
     }
-    pthread_cond_signal(&ex->ready_cv);
+    if (signal_ready) {
+        pthread_cond_signal(&ex->ready_cv);
+    }
     return 1;
 }
 
 static int ready_push_inner(rt_executor* ex, uint64_t id, int force_inject) {
-    return ready_push_with_policy(ex, id, force_inject, 0);
+    return ready_push_with_policy(ex, id, force_inject, 0, 1);
 }
 
 void ready_push(rt_executor* ex, uint64_t id) {
@@ -1590,8 +1604,12 @@ static int worker_next_ready(rt_executor* ex, uint32_t worker_id, uint64_t* out_
     return 0;
 }
 
-static void wake_task_with_policy(
-    rt_executor* ex, uint64_t id, int remove_waiter_flag, int force_inject, int front) {
+static void wake_task_with_policy(rt_executor* ex,
+                                  uint64_t id,
+                                  int remove_waiter_flag,
+                                  int force_inject,
+                                  int front,
+                                  int signal_ready) {
     // Caller holds ex->lock; wake_token handles a wake that races with park_current.
     if (ex == NULL) {
         return;
@@ -1608,7 +1626,7 @@ static void wake_task_with_policy(
     task->park_key = waker_none();
     task->park_prepared = 0;
     (void)task_wake_token_exchange(task, 1);
-    if (ready_push_with_policy(ex, id, force_inject, front)) {
+    if (ready_push_with_policy(ex, id, force_inject, front, signal_ready)) {
         trace_exec_inc(&trace_wake_enqueued_total);
     } else if (ex->channel_blocked_workers > 0) {
         pthread_cond_broadcast(&ex->ready_cv);
@@ -1616,11 +1634,17 @@ static void wake_task_with_policy(
 }
 
 void wake_task(rt_executor* ex, uint64_t id, int remove_waiter_flag) {
-    wake_task_with_policy(ex, id, remove_waiter_flag, 0, 0);
+    wake_task_with_policy(ex, id, remove_waiter_flag, 0, 0, 1);
 }
 
 void wake_channel_task(rt_executor* ex, uint64_t id, int remove_waiter_flag) {
-    wake_task_with_policy(ex, id, remove_waiter_flag, channel_wake_force_inject != 0, 0);
+    wake_task_with_policy(ex, id, remove_waiter_flag, channel_wake_force_inject != 0, 0, 1);
+}
+
+void wake_channel_task_no_signal(rt_executor* ex, uint64_t id, int remove_waiter_flag) {
+    // Only use when the current task is about to yield before running user code.
+    // Generic channel wakes must signal so non-yielding producers cannot starve waiters.
+    wake_task_with_policy(ex, id, remove_waiter_flag, channel_wake_force_inject != 0, 0, 0);
 }
 
 static void ready_push_for_waker_key(rt_executor* ex, uint64_t id, waker_key key) {
@@ -1638,7 +1662,7 @@ static void wake_key_all_with_policy(rt_executor* ex, waker_key key, int front) 
     for (size_t i = 0; i < ex->waiters_len; i++) {
         waiter w = ex->waiters[i];
         if (w.key.kind == key.kind && w.key.id == key.id) {
-            wake_task_with_policy(ex, w.task_id, 0, 0, front);
+            wake_task_with_policy(ex, w.task_id, 0, 0, front, 1);
             continue;
         }
         ex->waiters[out++] = w;

--- a/scripts/bench_native_channels.sh
+++ b/scripts/bench_native_channels.sh
@@ -98,11 +98,12 @@ for mode in $modes; do
 		[[ "$line" == \|* ]] || continue
 		printf '| %s |%s\n' "$mode" "${line#|}" >>"$report"
 	done <<<"$output"
-	printf '| %s | %s | %s | %s | %s | %s |\n' \
+	printf '| %s | %s | %s | %s | %s | %s | %s |\n' \
 		"$mode" \
 		"$(trace_value "$trace_log" TRACE_EXEC channel_blocking_wait)" \
 		"$(trace_value "$trace_log" TRACE_EXEC channel_task_blocking_send)" \
 		"$(trace_value "$trace_log" TRACE_EXEC channel_task_blocking_recv)" \
+		"$(trace_value "$trace_log" TRACE_EXEC channel_handoff_yield)" \
 		"$(trace_value "$trace_log" TRACE_EXEC compensation_started)" \
 		"$(trace_value "$trace_log" TRACE_EXEC_SNAPSHOT compensation_high_water)" >>"$trace_rows"
 	rm -f "$trace_log"
@@ -112,8 +113,8 @@ cat >>"$report" <<'EOF'
 
 ## Runtime Trace
 
-| mode | channel blocking waits | task-context blocking sends | task-context blocking recvs | compensation started | compensation high-water |
-| --- | ---: | ---: | ---: | ---: | ---: |
+| mode | channel blocking waits | task-context blocking sends | task-context blocking recvs | handoff yields | compensation started | compensation high-water |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
 EOF
 cat "$trace_rows" >>"$report"
 


### PR DESCRIPTION
## Summary
- mark async channel sends whose ready continuation immediately reaches a recv suspend point
- lower that narrow request/reply shape to `rt_channel_send_yield`
- let that helper enqueue the receiver without an immediate ready-cv signal, then yield the sender with a saved send ack
- expose `channel_handoff_yield` in TRACE_EXEC and the native channel benchmark report

## Evidence
- rejected broader handoff-yield spike: mode=4 `channel_reused_reply` regressed to ~133us/op
- with the compiler hint + no-signal handoff: mode=4 `channel_reused_reply` repeated at ~101us/op, `channel_new_reply` ~103-105us/op, `channel_ping_pong` stayed ~137-138us/op
- benchmark report: `/tmp/native-channel-hinted-yield-nosignal-matrix.md`
- IR check confirms sync wrappers still use `rt_channel_send_blocking` / `rt_channel_recv_blocking`

## Checks
- `SURGE_BACKEND=llvm go test ./internal/vm -run 'TestMT(ChannelParkUnpark|NonYieldingTrySendHandoffWakesReceiver|BlockingChannelHelpersDoNotParkWorkers)' -count=1 -timeout 90s -v`
- `SURGE_BACKEND=llvm go test ./internal/mir ./internal/backend/llvm ./internal/vm -run 'TestMT(ChannelParkUnpark|NonYieldingTrySendHandoffWakesReceiver|BlockingChannelHelpersDoNotParkWorkers)' -count=1 -timeout 120s`
- `make build`
- `make cfmt-check`
- `make c-warnings`
- `make ctidy`
- `git diff --check`
- `make check`
- sentrux MCP: `scan`, `session_start`, `rescan`, `check_rules`, `session_end` (`session_end pass=true`, quality 6223 -> 6220; existing global rules still report max_cc/no_god_files outside this diff)
