### PR TITLE
perf(runtime): inject channel handoff receivers

### DIFF
--- a/STATS.md
+++ b/STATS.md
@@ -5,7 +5,7 @@
 ## 📊 Main code (without tests)
 
 - **Files:** 682 (Go: 652, C: 30)
-- **Lines of code:** 156467 (Go: 142279, C: 14188)
+- **Lines of code:** 156469 (Go: 142279, C: 14190)
 
 ## 📁 Directory breakdown
 
@@ -13,7 +13,7 @@
 |------------|--------|-------|
 | `cmd/` | 27 | 4669 |
 | `internal/` | 623 | 137163 |
-| `runtime/native/` (C code) | 30 | 14188 |
+| `runtime/native/` (C code) | 30 | 14190 |
 
 ## 🏆 Top 10 packages by size
 
@@ -38,7 +38,7 @@
 ## 📈 Total volume (code + tests)
 
 - **Files:** 857
-- **Lines of code:** 192471
+- **Lines of code:** 192473
 
 ## 📊 Percentage breakdown
 

--- a/benchmarks/native/README.md
+++ b/benchmarks/native/README.md
@@ -26,4 +26,6 @@ The fixture also prints scheduler-shape rows:
 - `channel_ping_pong`: direct async send/recv handoff between two tasks.
 - `channel_sync_new_reply`: sync wrapper fallback called from an async task.
 
-Use `SURGE_CHANNEL_WAKE_INJECT=1` only for A/B placement experiments.
+Default channel placement keeps generic wakes local-first, while no-signal
+handoff wakes use inject placement. Use `SURGE_CHANNEL_WAKE_INJECT=1` only for
+A/B experiments that force all channel wakes through inject.

--- a/runtime/native/rt_async_state.c
+++ b/runtime/native/rt_async_state.c
@@ -1644,7 +1644,9 @@ void wake_channel_task(rt_executor* ex, uint64_t id, int remove_waiter_flag) {
 void wake_channel_task_no_signal(rt_executor* ex, uint64_t id, int remove_waiter_flag) {
     // Only use when the current task is about to yield before running user code.
     // Generic channel wakes must signal so non-yielding producers cannot starve waiters.
-    wake_task_with_policy(ex, id, remove_waiter_flag, channel_wake_force_inject != 0, 0, 0);
+    // The yielding sender is injected after poll returns, so FIFO inject order keeps
+    // this handoff receiver ahead of it without leaving the receiver in a local queue.
+    wake_task_with_policy(ex, id, remove_waiter_flag, 1, 0, 0);
 }
 
 static void ready_push_for_waker_key(rt_executor* ex, uint64_t id, waker_key key) {

--- a/scripts/bench_native_channels.sh
+++ b/scripts/bench_native_channels.sh
@@ -6,7 +6,7 @@ fixture="$root/benchmarks/native/channel_request_reply"
 report="${SURGE_CHANNEL_BENCH_REPORT:-$root/build/benchmarks/native-channel-request-reply.md}"
 modes="${SURGE_CHANNEL_BENCH_MODES:-1 2 4 8 default}"
 surge="${SURGE:-$root/surge}"
-channel_wake_policy="local-first"
+channel_wake_policy="handoff-inject"
 if [[ -n "${SURGE_CHANNEL_WAKE_INJECT:-}" && "${SURGE_CHANNEL_WAKE_INJECT:-}" != "0" ]]; then
 	channel_wake_policy="force-inject"
 fi


### PR DESCRIPTION
## Summary

- put no-signal channel handoff receivers on the inject queue so they stay ahead of the yielding sender
- keep generic channel wakes local-first; `SURGE_CHANNEL_WAKE_INJECT=1` remains the all-inject A/B mode
- update the native channel benchmark policy label/docs

## Benchmarks

Mode 4 `channel_reused_reply` improved from local-first `100960 ns/op` to handoff-inject `82185 ns/op` in the full matrix run. Default mode improved from `113524 ns/op` to `103193 ns/op`.

The rejected global force-inject variant improved async request/reply too, but regressed the sync fallback and made `TestMTBlockingChannelHelpersDoNotParkWorkers` time out, so this PR keeps the policy scoped to no-signal handoffs only.

## Validation

- `SURGE_BACKEND=llvm go test ./internal/vm -run 'TestMT(ChannelParkUnpark|NonYieldingTrySendHandoffWakesReceiver|BlockingChannelHelpersDoNotParkWorkers)' -count=1 -timeout 90s -v`\n- `make build`\n- `SURGE_CHANNEL_BENCH_REPORT=/tmp/native-channel-nosignal-inject-full.md ./scripts/bench_native_channels.sh`\n- `SURGE_CHANNEL_BENCH_MODES=4 SURGE_CHANNEL_BENCH_REPORT=/tmp/native-channel-handoff-inject-mode4.md ./scripts/bench_native_channels.sh`\n- `make cfmt-check`\n- `make c-warnings`\n- `git diff --check`\n- `make check`\n- sentrux `session_end`: pass, quality signal `6220 -> 6220`\n\nSentrux `check_rules` still reports existing unrelated complexity/fan-out violations outside this diff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated native benchmark documentation to clarify channel wake placement behavior and configuration usage.

* **Chores**
  * Updated code size statistics.
  * Modified default benchmark channel wake policy behavior.
  * Refined channel handoff implementation for improved ordering consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->