### PR TITLE
perf(runtime): avoid wake signal on yielded tasks

### DIFF
--- a/STATS.md
+++ b/STATS.md
@@ -5,7 +5,7 @@
 ## 📊 Main code (without tests)
 
 - **Files:** 682 (Go: 652, C: 30)
-- **Lines of code:** 156469 (Go: 142279, C: 14190)
+- **Lines of code:** 156475 (Go: 142279, C: 14196)
 
 ## 📁 Directory breakdown
 
@@ -13,7 +13,7 @@
 |------------|--------|-------|
 | `cmd/` | 27 | 4669 |
 | `internal/` | 623 | 137163 |
-| `runtime/native/` (C code) | 30 | 14190 |
+| `runtime/native/` (C code) | 30 | 14196 |
 
 ## 🏆 Top 10 packages by size
 
@@ -38,7 +38,7 @@
 ## 📈 Total volume (code + tests)
 
 - **Files:** 857
-- **Lines of code:** 192473
+- **Lines of code:** 192479
 
 ## 📊 Percentage breakdown
 

--- a/runtime/native/rt_async_state.c
+++ b/runtime/native/rt_async_state.c
@@ -1486,6 +1486,12 @@ void ready_push(rt_executor* ex, uint64_t id) {
     (void)ready_push_inner(ex, id, 0);
 }
 
+static int ready_push_yielded_task(rt_executor* ex, uint64_t id) {
+    // A yielding worker immediately re-enters the scheduler loop, so waking another
+    // worker here mostly creates condvar churn for task-to-task handoffs.
+    return ready_push_with_policy(ex, id, 1, 0, 0);
+}
+
 int ready_pop(rt_executor* ex, uint64_t* out_id) {
     // Caller holds ex->lock; worker_next_ready adds local and steal paths.
     return pop_task_from_deque(ex, &ex->inject, 0, out_id, SCHED_SRC_INJECT);
@@ -2059,7 +2065,7 @@ static void apply_poll_outcome(rt_executor* ex, rt_task* task, poll_outcome outc
             task->state = outcome.state;
             task_status_store(task, TASK_READY);
             // Yielded tasks go through the inject queue to avoid local LIFO starvation.
-            (void)ready_push_inner(ex, task->id, 1);
+            (void)ready_push_yielded_task(ex, task->id);
             tick_virtual(ex);
             break;
         case POLL_PARKED:


### PR DESCRIPTION
## Summary

- requeue yielded tasks on the inject queue without signaling `ready_cv`
- keep the worker that just yielded on the scheduler loop instead of waking extra workers for task-to-task handoffs
- update `STATS.md` from the normal pre-commit stats hook

## Why

After #135, isolated `channel_reused_reply` still showed high multi-worker latency with heavy worker sleep/wake churn. A local reused-only trace showed roughly 23k worker sleep/wake events for 20k operations at `SURGE_THREADS=4`. With this change, the same reused-only shape dropped to about 11 worker sleeps and about 10us/op.

## Benchmarks

Full matrix after this change:

- mode 4 `channel_reused_reply`: `8923 ns/op` (was `82185 ns/op` after #135)
- default `channel_reused_reply`: `10181 ns/op` (was `103193 ns/op` after #135)
- mode 4 `channel_new_reply`: `11429 ns/op`
- mode 4 `channel_sync_new_reply`: `139763 ns/op`

`channel_ping_pong` also improved versus #135 mode 4 (`106812 ns/op` here vs around `136452 ns/op` in the #135 full matrix).

## Validation

- `make build`
- `SURGE_BACKEND=llvm go test ./internal/vm -run 'TestMT(ChannelParkUnpark|NonYieldingTrySendHandoffWakesReceiver|BlockingChannelHelpersDoNotParkWorkers|BlockingChannelHelpersAllowTimersToAdvance|BlockingChannelHelpersDrainReadyWorkAtCompensationLimit)' -count=1 -timeout 120s -v`\n- `SURGE_CHANNEL_BENCH_REPORT=/tmp/native-channel-yield-nosignal-final.md ./scripts/bench_native_channels.sh`\n- `make cfmt-check`\n- `make c-warnings`\n- `git diff --check`\n- `make check`\n- sentrux `session_end`: pass, quality signal `6220 -> 6220`\n\nSentrux `check_rules` still reports existing unrelated complexity/fan-out violations outside this diff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated codebase statistics and internal task scheduling optimizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->