### PR TITLE
perf(runtime): defer channel recv ack wake signals

### DIFF
--- a/STATS.md
+++ b/STATS.md
@@ -33,12 +33,12 @@
 ## 🧪 Test files
 
 - **Files:** 175
-- **Lines of code:** 36004
+- **Lines of code:** 36091
 
 ## 📈 Total volume (code + tests)
 
 - **Files:** 857
-- **Lines of code:** 192479
+- **Lines of code:** 192566
 
 ## 📊 Percentage breakdown
 

--- a/internal/vm/mt_executor_test.go
+++ b/internal/vm/mt_executor_test.go
@@ -533,6 +533,93 @@ fn main() -> int {
 	}
 }
 
+func TestMTRecvAckHandoffCompletesSenderAfterNonYieldingReceiver(t *testing.T) {
+	requireLLVMBackend(t)
+	ensureLLVMToolchain(t)
+	if runtime.NumCPU() < 2 {
+		t.Skip("recv ack handoff test needs >=2 CPUs")
+	}
+	t.Parallel()
+
+	source := `async fn sender(ch: own Channel<nothing>) -> int {
+    ch.send(nothing);
+    return 7;
+}
+
+async fn receiver(ch: own Channel<nothing>, spins: int) -> int {
+    let value = ch.recv();
+    let ok = compare value {
+        Some(_) => true;
+        nothing => false;
+    };
+    if !ok {
+        return 2;
+    }
+
+    let mut i: int = 0;
+    let mut total: int = 0;
+    while i < spins {
+        total = total + i;
+        i = i + 1;
+    }
+    if total < 0 {
+        return 3;
+    }
+    return 5;
+}
+
+async fn run() -> int {
+    if rt_worker_count() <= 1:uint {
+        return 4;
+    }
+    let ch = make_channel::<nothing>(0:uint);
+    let send_ch = ch;
+    let recv_ch = ch;
+    let send_task = spawn sender(send_ch);
+    checkpoint().await();
+    checkpoint().await();
+    let recv_task = spawn receiver(recv_ch, 200000);
+
+    let recv_res = recv_task.await();
+    let send_res = send_task.await();
+    let recv_ok = compare recv_res {
+        Success(v) => v == 5;
+        Cancelled() => false;
+    };
+    let send_ok = compare send_res {
+        Success(v) => v == 7;
+        Cancelled() => false;
+    };
+    if !recv_ok || !send_ok {
+        return 6;
+    }
+    print("ok");
+    return 0;
+}
+
+@entrypoint
+fn main() -> int {
+    let res = run().await();
+    return compare res {
+        Success(v) => v;
+        Cancelled() => 1;
+    };
+}
+`
+
+	outputPath := buildLLVMProgramFromSource(t, source)
+	baseEnv := envWithStdlib(repoRoot(t))
+	env := overrideEnv(baseEnv, "2")
+	dur, res := runBinaryWithTimeout(t, outputPath, env, 10*time.Second)
+	if res.exitCode != 0 {
+		t.Fatalf("run failed (exit=%d, dur=%s)\nstdout:\n%s\nstderr:\n%s",
+			res.exitCode, dur, res.stdout, res.stderr)
+	}
+	if !strings.Contains(res.stdout, "ok") {
+		t.Fatalf("unexpected stdout: %q", res.stdout)
+	}
+}
+
 func TestMTChannelParkUnpark(t *testing.T) {
 	requireLLVMBackend(t)
 	ensureLLVMToolchain(t)

--- a/runtime/native/rt_async_channel.c
+++ b/runtime/native/rt_async_channel.c
@@ -237,7 +237,7 @@ uint8_t rt_channel_recv(void* channel, uint64_t* out_bits) {
             }
             sender->resume_kind = RESUME_CHAN_SEND_ACK;
             sender->resume_bits = 0;
-            wake_channel_task(ex, sender_id, 1);
+            wake_channel_task_no_signal(ex, sender_id, 1);
         }
         rt_unlock(ex);
         return 1;

--- a/runtime/native/rt_async_state.c
+++ b/runtime/native/rt_async_state.c
@@ -1648,10 +1648,10 @@ void wake_channel_task(rt_executor* ex, uint64_t id, int remove_waiter_flag) {
 }
 
 void wake_channel_task_no_signal(rt_executor* ex, uint64_t id, int remove_waiter_flag) {
-    // Only use when the current task is about to yield before running user code.
-    // Generic channel wakes must signal so non-yielding producers cannot starve waiters.
-    // The yielding sender is injected after poll returns, so FIFO inject order keeps
-    // this handoff receiver ahead of it without leaving the receiver in a local queue.
+    // Use only for cooperative channel handoffs where the current worker is still
+    // active and can drain the injected continuation after the current poll yields,
+    // parks, or completes. Generic external/net/timer wakes must signal sleepers.
+    // Force inject keeps handoff order predictable and avoids local LIFO ping-pong.
     wake_task_with_policy(ex, id, remove_waiter_flag, 1, 0, 0);
 }
 


### PR DESCRIPTION
## Summary

- defer ready-worker signaling when `recv` completes a waiting sender handoff
- keep the sender continuation in the injected queue so the active worker can drain it without condvar wake churn
- add a targeted MT test covering a blocked sender resumed after a non-yielding receiver

## Measurements

Native channel matrix after the change (`/tmp/native-channel-recv-ack-nosignal-full.md`):

- `channel_ping_pong`: mode 4 `12024 ns/op`, mode 8 `12319 ns/op`, default `10691 ns/op`
- `channel_reused_reply`: mode 4 `10786 ns/op`, mode 8 `10804 ns/op`, default `9800 ns/op`

`surgekv` smoke was neutral as expected because its main reply path already uses send-yield handoff:

- threads=4 GET `2631 rps`, SET `1550 rps`, mixed `1873 rps`, zero errors

## Verification

- `go test ./internal/vm -run 'TestMTNonYieldingTrySendHandoffWakesReceiver|TestMTRecvAckHandoffCompletesSenderAfterNonYieldingReceiver|TestMTChannelParkUnpark|TestMTCorrectnessChannels|TestMTBlockingChannelHelpersDoNotParkWorkers' -count=1`
- `make build`
- `./scripts/bench_native_channels.sh`
- `surge build --release .` in `surgekv`
- `surgekv/scripts/bench.sh` 32-client threads=4 smoke
- `git diff --check`
- `make cfmt-check`
- `make c-warnings`
- `make check`
- sentrux MCP `session_end`: pass, signal `6220 -> 6220`

Note: sentrux rules still report pre-existing violations outside this diff (`max_cc`, `internal/driver/diagnose.go` fan-out).
