### PR TITLE
perf(runtime): coallocate buffered channel storage

### DIFF
--- a/STATS.md
+++ b/STATS.md
@@ -5,7 +5,7 @@
 ## 📊 Main code (without tests)
 
 - **Files:** 682 (Go: 652, C: 30)
-- **Lines of code:** 156475 (Go: 142279, C: 14196)
+- **Lines of code:** 156502 (Go: 142279, C: 14223)
 
 ## 📁 Directory breakdown
 
@@ -13,7 +13,7 @@
 |------------|--------|-------|
 | `cmd/` | 27 | 4669 |
 | `internal/` | 623 | 137163 |
-| `runtime/native/` (C code) | 30 | 14196 |
+| `runtime/native/` (C code) | 30 | 14223 |
 
 ## 🏆 Top 10 packages by size
 
@@ -33,12 +33,12 @@
 ## 🧪 Test files
 
 - **Files:** 175
-- **Lines of code:** 36091
+- **Lines of code:** 36130
 
 ## 📈 Total volume (code + tests)
 
 - **Files:** 857
-- **Lines of code:** 192566
+- **Lines of code:** 192632
 
 ## 📊 Percentage breakdown
 

--- a/internal/vm/llvm_native_heap_stats_test.go
+++ b/internal/vm/llvm_native_heap_stats_test.go
@@ -28,3 +28,42 @@ fn main() -> int {
 		t.Fatalf("heap stats smoke failed with exit=%d\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr)
 	}
 }
+
+func TestLLVMNativeBufferedChannelAllocatesSingleBlock(t *testing.T) {
+	ensureLLVMToolchain(t)
+
+	// The public LLVM path includes fixed HeapStats/native wrapper allocations around
+	// make_channel. With the native buffer co-allocated into rt_channel, capacity=1
+	// should add three more allocations than capacity=0; a separate buffer would add four.
+	source := `@entrypoint
+fn main() -> int {
+    let s0: HeapStats = rt_heap_stats();
+    let ch0 = make_channel::<int>(0:uint);
+    let s1: HeapStats = rt_heap_stats();
+    let ch1 = make_channel::<int>(1:uint);
+    let s2: HeapStats = rt_heap_stats();
+    let unbuffered_delta = s1.alloc_count - s0.alloc_count;
+    let buffered_delta = s2.alloc_count - s1.alloc_count;
+    let expected_buffered_delta = unbuffered_delta + 3:uint;
+    if buffered_delta != expected_buffered_delta { return 1; }
+    if ch0.try_send(1) { return 2; }
+    let sent1 = ch1.try_send(42);
+    if !sent1 { return 3; }
+    compare ch1.try_recv() {
+        Some(v) => {
+            if v != 42 { return 4; }
+        }
+        nothing => {
+            return 5;
+        }
+    };
+    return 0;
+}
+`
+
+	outputPath := buildLLVMProgramFromSource(t, source)
+	stdout, stderr, code := runBinary(t, outputPath)
+	if code != 0 {
+		t.Fatalf("buffered channel allocation smoke failed with exit=%d\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr)
+	}
+}

--- a/runtime/native/rt_async_channel.c
+++ b/runtime/native/rt_async_channel.c
@@ -10,6 +10,38 @@ struct rt_channel {
     size_t buf_head;
 };
 
+static uint64_t channel_align_up(uint64_t size, uint64_t align) {
+    if (align == 0) {
+        return size;
+    }
+    uint64_t rem = size % align;
+    if (rem == 0) {
+        return size;
+    }
+    uint64_t add = align - rem;
+    if (size > UINT64_MAX - add) {
+        panic_msg("async: channel allocation overflow");
+        return 0;
+    }
+    return size + add;
+}
+
+static uint64_t channel_buffer_offset(void) {
+    return channel_align_up((uint64_t)sizeof(rt_channel), (uint64_t) _Alignof(uint64_t));
+}
+
+static uint64_t channel_alloc_size(uint64_t capacity) {
+    if (capacity == 0) {
+        return (uint64_t)sizeof(rt_channel);
+    }
+    uint64_t offset = channel_buffer_offset();
+    if (capacity > (UINT64_MAX - offset) / (uint64_t)sizeof(uint64_t)) {
+        panic_msg("async: channel allocation overflow");
+        return 0;
+    }
+    return offset + capacity * (uint64_t)sizeof(uint64_t);
+}
+
 static rt_channel* channel_from_handle(void* handle) {
     if (handle == NULL) {
         panic_msg("async: null channel handle");
@@ -75,7 +107,8 @@ static int prepare_channel_send_yield(rt_task* task) {
 }
 
 void* rt_channel_new(uint64_t capacity) {
-    rt_channel* ch = (rt_channel*)rt_alloc(sizeof(rt_channel), _Alignof(rt_channel));
+    uint64_t bytes = channel_alloc_size(capacity);
+    rt_channel* ch = (rt_channel*)rt_alloc(bytes, _Alignof(rt_channel));
     if (ch == NULL) {
         panic_msg("async: channel allocation failed");
         return NULL;
@@ -83,13 +116,7 @@ void* rt_channel_new(uint64_t capacity) {
     memset(ch, 0, sizeof(rt_channel));
     ch->capacity = capacity;
     if (capacity > 0) {
-        uint64_t bytes = capacity * sizeof(uint64_t);
-        ch->buf = (uint64_t*)rt_alloc(bytes, _Alignof(uint64_t));
-        if (ch->buf == NULL) {
-            panic_msg("async: channel buffer allocation failed");
-            rt_free((uint8_t*)ch, sizeof(rt_channel), _Alignof(rt_channel));
-            return NULL;
-        }
+        ch->buf = (uint64_t*)((uint8_t*)ch + channel_buffer_offset());
     }
     rt_async_debug_printf(
         "async chan new ch=%p cap=%llu\n", (void*)ch, (unsigned long long)capacity);


### PR DESCRIPTION
## Summary
- co-allocate buffered channel ring storage with the `rt_channel` header
- keep unbuffered channel allocation unchanged
- add an LLVM native heap-stats regression test for the public `make_channel(1)` path
- update `STATS.md`

## Verification
- `make check`
- targeted `go test ./internal/vm -run 'TestLLVMNative(HeapStats|BufferedChannelAllocatesSingleBlock)|TestMTChannelParkUnpark|TestMTRecvAckHandoffCompletesSenderAfterNonYieldingReceiver' -count=1`\n- `SURGE=... ./scripts/bench_native_channels.sh` A/B against `runtime-refactor-epic` (allocation count improvement is stable; ns/op remains noisy, so this PR does not claim a scheduler-speed win)\n- sentrux MCP scan: current `quality_signal=6220`, same as base; rule failures are pre-existing outside this diff (`max_cc`, `no_god_files`)\n