### PR TITLE
perf(runtime): avoid signal on buffered channel refill

### DIFF
--- a/STATS.md
+++ b/STATS.md
@@ -33,12 +33,12 @@
 ## 🧪 Test files
 
 - **Files:** 175
-- **Lines of code:** 36091
+- **Lines of code:** 36188
 
 ## 📈 Total volume (code + tests)
 
 - **Files:** 857
-- **Lines of code:** 192566
+- **Lines of code:** 192663
 
 ## 📊 Percentage breakdown
 

--- a/internal/vm/mt_executor_test.go
+++ b/internal/vm/mt_executor_test.go
@@ -620,6 +620,103 @@ fn main() -> int {
 	}
 }
 
+func TestMTBufferedRecvRefillCompletesSenderAfterNonYieldingReceiver(t *testing.T) {
+	requireLLVMBackend(t)
+	ensureLLVMToolchain(t)
+	if runtime.NumCPU() < 2 {
+		t.Skip("buffered recv refill handoff test needs >=2 CPUs")
+	}
+	t.Parallel()
+
+	source := `async fn sender(ch: own Channel<int>) -> int {
+    ch.send(200);
+    return 7;
+}
+
+async fn receiver(ch: own Channel<int>, spins: int) -> int {
+    let first = ch.recv();
+    let first_ok = compare first {
+        Some(v) => v == 100;
+        nothing => false;
+    };
+    if !first_ok {
+        return 2;
+    }
+
+    let mut i: int = 0;
+    let mut total: int = 0;
+    while i < spins {
+        total = total + i;
+        i = i + 1;
+    }
+    if total < 0 {
+        return 3;
+    }
+
+    let second = ch.recv();
+    let second_ok = compare second {
+        Some(v) => v == 200;
+        nothing => false;
+    };
+    if !second_ok {
+        return 4;
+    }
+    return 5;
+}
+
+async fn run() -> int {
+    if rt_worker_count() <= 1:uint {
+        return 6;
+    }
+    let ch = make_channel::<int>(1:uint);
+    ch.send(100);
+    let send_ch = ch;
+    let recv_ch = ch;
+    let send_task = spawn sender(send_ch);
+    checkpoint().await();
+    checkpoint().await();
+    let recv_task = spawn receiver(recv_ch, 200000);
+
+    let recv_res = recv_task.await();
+    let send_res = send_task.await();
+    let recv_ok = compare recv_res {
+        Success(v) => v == 5;
+        Cancelled() => false;
+    };
+    let send_ok = compare send_res {
+        Success(v) => v == 7;
+        Cancelled() => false;
+    };
+    if !recv_ok || !send_ok {
+        return 8;
+    }
+    print("ok");
+    return 0;
+}
+
+@entrypoint
+fn main() -> int {
+    let res = run().await();
+    return compare res {
+        Success(v) => v;
+        Cancelled() => 1;
+    };
+}
+`
+
+	outputPath := buildLLVMProgramFromSource(t, source)
+	baseEnv := envWithStdlib(repoRoot(t))
+	env := overrideEnv(baseEnv, "2")
+	dur, res := runBinaryWithTimeout(t, outputPath, env, 10*time.Second)
+	if res.exitCode != 0 {
+		t.Fatalf("run failed (exit=%d, dur=%s)\nstdout:\n%s\nstderr:\n%s",
+			res.exitCode, dur, res.stdout, res.stderr)
+	}
+	if !strings.Contains(res.stdout, "ok") {
+		t.Fatalf("unexpected stdout: %q", res.stdout)
+	}
+}
+
 func TestMTChannelParkUnpark(t *testing.T) {
 	requireLLVMBackend(t)
 	ensureLLVMToolchain(t)

--- a/runtime/native/rt_async_channel.c
+++ b/runtime/native/rt_async_channel.c
@@ -57,7 +57,7 @@ static void refill_buffer_from_sender(rt_executor* ex, rt_channel* ch) {
     }
     sender->resume_kind = RESUME_CHAN_SEND_ACK;
     sender->resume_bits = 0;
-    wake_channel_task(ex, sender_id, 1);
+    wake_channel_task_no_signal(ex, sender_id, 1);
 }
 
 static int prepare_channel_send_yield(rt_task* task) {


### PR DESCRIPTION
## Summary
- use `wake_channel_task_no_signal` when buffered recv refills from a blocked sender
- mirror the recv-ack handoff policy already used for unbuffered channel receives
- add an LLVM MT regression test for a full buffered channel, blocked sender, and non-yielding receiver
- update `STATS.md`

## Verification
- `SURGE_BACKEND=llvm go test ./internal/vm -run 'TestMT(RecvAckHandoffCompletesSenderAfterNonYieldingReceiver|BufferedRecvRefillCompletesSenderAfterNonYieldingReceiver)' -count=1 -v`\n- `make cfmt-check && make c-warnings && make build && git diff --check`\n- `make check`\n- sentrux MCP scan: `quality_signal=6220`; rule failures are pre-existing outside this diff (`max_cc`, `no_god_files`)\n