### PR TITLE
fix(runtime): reuse native listener addresses

### DIFF
--- a/STATS.md
+++ b/STATS.md
@@ -5,7 +5,7 @@
 ## 📊 Main code (without tests)
 
 - **Files:** 682 (Go: 652, C: 30)
-- **Lines of code:** 156502 (Go: 142279, C: 14223)
+- **Lines of code:** 156508 (Go: 142279, C: 14229)
 
 ## 📁 Directory breakdown
 
@@ -13,7 +13,7 @@
 |------------|--------|-------|
 | `cmd/` | 27 | 4669 |
 | `internal/` | 623 | 137163 |
-| `runtime/native/` (C code) | 30 | 14223 |
+| `runtime/native/` (C code) | 30 | 14229 |
 
 ## 🏆 Top 10 packages by size
 
@@ -33,12 +33,12 @@
 ## 🧪 Test files
 
 - **Files:** 175
-- **Lines of code:** 36227
+- **Lines of code:** 36234
 
 ## 📈 Total volume (code + tests)
 
 - **Files:** 857
-- **Lines of code:** 192729
+- **Lines of code:** 192742
 
 ## 📊 Percentage breakdown
 

--- a/internal/vm/llvm_parity_test.go
+++ b/internal/vm/llvm_parity_test.go
@@ -95,6 +95,13 @@ func TestLLVMParity(t *testing.T) {
 			},
 		},
 		{name: "net_listen_close", file: "net_listen_close.sg"},
+		{
+			name: "net_listen_reuseaddr",
+			file: "net_listen_reuseaddr.sg",
+			setup: func(t *testing.T) []string {
+				return []string{strconv.Itoa(pickFreePort(t))}
+			},
+		},
 		{name: "net_echo", file: "net_echo.sg"},
 		{name: "http_parse_request", file: "http_parse_request.sg"},
 		{name: "http_parse_request_strict", file: "http_parse_request_strict.sg"},

--- a/runtime/native/rt_net.c
+++ b/runtime/native/rt_net.c
@@ -463,6 +463,12 @@ void* rt_net_listen(void* addr, uint64_t port) {
     if (fd < 0) {
         return net_make_error(net_error_code_from_errno(errno));
     }
+    int reuse = 1;
+    if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &reuse, (socklen_t)sizeof(reuse)) != 0) {
+        uint64_t code = net_error_code_from_errno(errno);
+        close(fd);
+        return net_make_error(code);
+    }
     if (!net_set_nonblocking(fd, &err_code)) {
         close(fd);
         return net_make_error(err_code == 0 ? NET_ERR_IO : err_code);

--- a/testdata/llvm_parity/net_listen_reuseaddr.sg
+++ b/testdata/llvm_parity/net_listen_reuseaddr.sg
@@ -1,0 +1,74 @@
+import stdlib/net as net;
+
+async fn accept_and_close(listener: TcpListener) -> int {
+    let accept_task = net.accept(&listener).await();
+    compare accept_task {
+        Success(conn_res) => {
+            compare conn_res {
+                Success(conn) => {
+                    let _ = net.close_conn(own conn);
+                    let _ = net.close_listener(own listener);
+                    return 0;
+                }
+                err => {
+                    print("accept_err=" + (err.code to string));
+                    let _ = net.close_listener(own listener);
+                    return 1;
+                }
+            };
+        }
+        Cancelled() => {
+            print("accept_cancelled");
+            let _ = net.close_listener(own listener);
+            return 1;
+        }
+    };
+    return 1;
+}
+
+@entrypoint("argv")
+fn main(port: uint) -> int {
+    let listen_res = net.listen("127.0.0.1", port);
+    compare listen_res {
+        Success(listener) => {
+            let task: Task<int> = @local spawn accept_and_close(listener);
+            let conn_res = net.connect("127.0.0.1", port);
+            compare conn_res {
+                Success(conn) => {
+                    let accept_res = task.await();
+                    let _ = net.close_conn(own conn);
+                    let accept_ok: bool = compare accept_res {
+                        Success(code) => code == 0;
+                        Cancelled() => false;
+                    };
+                    if !accept_ok {
+                        return 1;
+                    }
+                }
+                err => {
+                    print("connect_err=" + (err.code to string));
+                    let _ = task.await();
+                    return 1;
+                }
+            };
+        }
+        err => {
+            print("listen_err=" + (err.code to string));
+            return 1;
+        }
+    };
+
+    let second = net.listen("127.0.0.1", port);
+    compare second {
+        Success(listener) => {
+            let _ = net.close_listener(own listener);
+            print("reuse_ok");
+            return 0;
+        }
+        err => {
+            print("reuse_err=" + (err.code to string));
+            return 1;
+        }
+    };
+    return 1;
+}


### PR DESCRIPTION
## Summary

- set `SO_REUSEADDR` on native TCP listener sockets before `bind`
- add LLVM parity coverage for immediate same-port listener reuse after a short connection
- refresh `STATS.md`

## Root Cause

The VM backend already enables `SO_REUSEADDR` in `rt_net_listen`, but the native C runtime did not. Short TCP benchmark runs can leave the server port in `TIME-WAIT`, causing immediate follow-up listens to fail with `AddrInUse` in native builds.

## Validation

- `SURGE_BACKEND=llvm go test ./internal/vm -run 'TestLLVMParity/net_listen_reuseaddr' -count=1`
- `make c-check`
- `make check`
- rebuilt local `surge` and `surgekv`; same-port `surgekv` restart passed
- `SURGEKV_LAYER_MODES='8' ./scripts/layer_probe.sh` passed after the fix on the previously failing fixed port
- sentrux MCP scan: quality signal `6220`; rule failures are pre-existing `max_cc` / `no_god_files` outside this diff


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network socket handling to support address reuse, preventing binding errors when restarting listeners on previously used addresses and ports.

* **Tests**
  * Added test coverage for TCP listener address reuse behavior following connection closure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->