### PR TITLE
feat(cli): add surge doctor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,145 +1,119 @@
 # Changelog
 
-This changelog is curated manually.
-It currently starts with the `ret` block-values work and does not backfill older project history yet.
+This changelog is generated with `scripts/update_changelog.sh`.
+It keeps the latest release notes; older sections may be replaced.
 
 ## [0.1.12] - 2026-06-19
 
-### 🚀 Features
+### CLI / Tooling
 
-- *(install)* Add release archive installer
-- *(cli)* Add surge doctor
+- Add release archive installer
+- Add surge doctor
 
-### 📚 Documentation
+### Documentation
 
-- *(readme)* Use installed surge in Russian quickstart
+- Use installed surge in Russian quickstart
 
 ## [0.1.11] - 2026-06-19
 
-### 🚀 Features
-
-- *(module)* Implement git module synchronization and update functionality
-- *(stdlib)* Add safe random helpers
-- Add Surge Issue Fixer skill and agent configuration
-- *(stdlib)* Add stable hash module
-- *(runtime)* Trace native net poll counters
-- *(runtime)* Expose native heap stats
-- *(runtime)* Trace compensation high-water mark
-- *(runtime)* Add channel wake placement experiment
-- *(runtime)* Support live async trace dumps
-- *(runtime)* Include task kind counts in trace snapshots
-- *(runtime)* Break down trace tasks by status
-- *(runtime)* Trace task-context channel blocking
-- *(runtime)* Hint channel request handoffs
-
-### 🐛 Bug Fixes
-
-- *(result)* Change exit function return type from nothing to T
-- *(attrs)* Standardize spacing in attribute declarations
-- *(sema)* Accept exhaustive compare return blocks
-- *(runtime)* Prune completed async scope children
-- *(llvm)* Load task handles before runtime task calls
-- *(sema)* Surface channel send diagnostics correctly
-- *(compiler)* Restore Erring<Option<T>, E> pipeline
-- *(sema)* Resolve imported JsonValue method params
-- *(frontend)* Handle shorthand casts consistently
-- *(mir)* Discard control-flow results in side-effect contexts
-- *(sema)* Diagnose compare scrutinee reuse
-- *(mir)* Preserve typed default arg lowering (#76)
-- *(vm)* Reborrow shared calls from map mut refs
-- *(llvm)* Lower time monotonic_now
-- *(llvm)* Tighten monotonic_now follow-up
-- *(vm)* Preserve borrowed async frame locals
-- *(vm)* Retain async borrow backing selectively
-- *(vm)* Address review follow-ups
-- *(vm)* Roll back task-state pin collection safely
-- *(mir)* Avoid double deref for field reborrows
-- Lower duration intrinsics (closes #82)
-- *(llvm)* Lower concrete clone methods (closes #85) (#86)
-- *(lsp)* Resolve shadowed call targets (#89)
-- *(driver)* Reject wrong explicit module import paths (#90)
-- *(mir)* Short-circuit logical operators (closes #87)
-- *(llvm)* Lower fields through array element refs (closes #88)
-- *(sema)* Lower imported magic methods (closes #98)
-- *(stdlib)* Address hash review feedback
-- *(runtime)* Wake net poller on new waiters
-- *(stdlib/net)* Buffer tcp reads and writes
-- *(runtime)* Enable TCP_NODELAY on TCP sockets
-- *(runtime)* Preserve poll context for single-thread awaits
-- *(runtime)* Keep channel fanout progressing
-- *(runtime)* Exclude channel waits from running workers
-- *(runtime)* Keep channel fanout progressing under small thread counts
-- *(sema)* Diagnose blocking channel calls in nonblocking functions
-- *(runtime)* Make live trace snapshots reliable
-- *(runtime)* Prioritize net join continuations
-- *(runtime)* Reuse native listener addresses
-- *(runtime)* Address async scheduler review
-
-### 💼 Other
-
-- *(tooling)* Unify version metadata and checks
-- *(runtime)* Add native channel request-reply baseline
-- *(runtime)* Include trace counters in channel benchmark
-- *(runtime)* Add channel scheduler matrix
-
-### 🚜 Refactor
-
-- *(sema)* Split method call checking units
-- *(target-selection)* Consolidate command target resolution logic
-
-### 📚 Documentation
-
-- *(stdlib)* Remove hash planning drafts
-- *(runtime)* Document scheduler invariants
-- *(runtime)* Document async runtime diagnostics
-- *(runtime)* Document native async runtime
-
-### ⚡ Performance
-
-- *(runtime)* Inject channel handoff receivers
-- *(runtime)* Avoid wake signal on yielded tasks
-- *(runtime)* Defer channel recv ack wake signals
-- *(runtime)* Avoid signal on buffered channel refill
-- *(runtime)* Coallocate buffered channel storage
-
-### 🧪 Testing
-
-- *(vm)* Cover async borrow capture rejection
-- Update golden files
-- Allow empty file-size check set
-- *(runtime)* Add native executor trace diagnostics
-- *(runtime)* Cover compensation scheduler counters
-- *(runtime)* Cover non-yielding channel handoffs
-
-### ⚙️ Miscellaneous Tasks
-
-- Update .gitignore to include scribe/
-- Ignore local skvc package
-
-## Unreleased
-
 ### Language
 
-- Added explicit `ret` block exits for brace-block expressions.
-- Accepted both `ret;` and `ret nothing;` as `nothing`-valued block exits.
-- Kept short `=> expr` compare arms unchanged while introducing explicit block-local exits for brace blocks.
+- Change exit function return type from nothing to T
+- Standardize spacing in attribute declarations
+- Accept exhaustive compare return blocks
+- Handle shorthand casts consistently
+- Diagnose compare scrutinee reuse
 
 ### Diagnostics
 
-- Added migration warnings for legacy implicit block values, with a fix-it that inserts `ret`.
-- Added diagnostics for block expressions that can fall through without producing a required value.
-- Added diagnostics for conflicting block-result types collected through `ret`.
-- Tightened compare-arm diagnostics so consumed compare values still require a consistent result type, while discarded control-flow compares remain valid.
-- Propagated return-path checks through `ret` blocks so task-return and trivial-recursion diagnostics still fire on nested value paths.
+- Surface channel send diagnostics correctly
+- Diagnose blocking channel calls in nonblocking functions
 
 ### Compiler
 
-- Fixed expected-type propagation for `ret` payloads and nested compare/block expressions.
-- Distinguished explicit function `return` from synthetic block-value tails during sema flow analysis.
-- Refined abrupt-exit and reachability analysis for compare arms and block expressions.
-- Hardened block-result collection so discarded block tails do not leak false value-flow requirements into surrounding control-flow code.
+- Load task handles before runtime task calls
+- Restore Erring<Option<T>, E> pipeline
+- Resolve imported JsonValue method params
+- Split method call checking units
+- Consolidate command target resolution logic
+- Discard control-flow results in side-effect contexts
+- Preserve typed default arg lowering (#76)
+- Lower time monotonic_now
+- Tighten monotonic_now follow-up
+- Avoid double deref for field reborrows
+- Lower concrete clone methods (closes #85) (#86)
+- Reject wrong explicit module import paths (#90)
+- Short-circuit logical operators (closes #87)
+- Lower fields through array element refs (closes #88)
+- Lower imported magic methods (closes #98)
+
+### Runtime
+
+- Prune completed async scope children
+- VM async exit poll
+- Preserve borrowed async frame locals
+- Reborrow shared calls from map mut refs
+- Retain async borrow backing selectively
+- Address review follow-ups
+- Roll back task-state pin collection safely
+- Wake net poller on new waiters
+- Enable TCP_NODELAY on TCP sockets
+- Preserve poll context for single-thread awaits
+- Keep channel fanout progressing
+- Exclude channel waits from running workers
+- Keep channel fanout progressing under small thread counts
+- Add native channel request-reply baseline
+- Trace native net poll counters
+- Expose native heap stats
+- Trace compensation high-water mark
+- Include trace counters in channel benchmark
+- Add channel scheduler matrix
+- Add channel wake placement experiment
+- Support live async trace dumps
+- Make live trace snapshots reliable
+- Include task kind counts in trace snapshots
+- Break down trace tasks by status
+- Prioritize net join continuations
+- Trace task-context channel blocking
+- Hint channel request handoffs
+- Inject channel handoff receivers
+- Avoid wake signal on yielded tasks
+- Defer channel recv ack wake signals
+- Coallocate buffered channel storage
+- Avoid signal on buffered channel refill
+- Reuse native listener addresses
+- Address async scheduler review
+
+### Standard Library
+
+- Entropy random UUID
+- Add safe random helpers
+- Lower duration intrinsics (closes #82)
+- Add stable hash module
+- Address hash review feedback
+- Buffer tcp reads and writes
+
+### CLI / Tooling
+
+- Implement git module synchronization and update functionality
+- Unify version metadata and checks
+- Add Surge Issue Fixer skill and agent configuration
+- Update .gitignore to include scribe/
+- Resolve shadowed call targets (#89)
+- Ignore local skvc package
+
+### Documentation
+
+- Remove hash planning drafts
+- Document scheduler invariants
+- Document async runtime diagnostics
+- Document native async runtime
 
 ### Tests
 
-- Added regression coverage for `ret` across parser, sema, HIR, MIR, driver, VM, and golden snapshots.
-- Refreshed older block-expression golden cases to use `ret` where they depended on the old implicit block-value style.
+- Cover async borrow capture rejection
+- Update golden files
+- Allow empty file-size check set
+- Add native executor trace diagnostics
+- Cover compensation scheduler counters
+- Cover non-yielding channel handoffs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 This changelog is curated manually.
 It currently starts with the `ret` block-values work and does not backfill older project history yet.
 
+## [0.1.12] - 2026-06-19
+
+### 🚀 Features
+
+- *(install)* Add release archive installer
+- *(cli)* Add surge doctor
+
+### 📚 Documentation
+
+- *(readme)* Use installed surge in Russian quickstart
+
 ## Unreleased
 
 ### Language

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,108 @@ It currently starts with the `ret` block-values work and does not backfill older
 
 - *(readme)* Use installed surge in Russian quickstart
 
+## [0.1.11] - 2026-06-19
+
+### 🚀 Features
+
+- *(module)* Implement git module synchronization and update functionality
+- *(stdlib)* Add safe random helpers
+- Add Surge Issue Fixer skill and agent configuration
+- *(stdlib)* Add stable hash module
+- *(runtime)* Trace native net poll counters
+- *(runtime)* Expose native heap stats
+- *(runtime)* Trace compensation high-water mark
+- *(runtime)* Add channel wake placement experiment
+- *(runtime)* Support live async trace dumps
+- *(runtime)* Include task kind counts in trace snapshots
+- *(runtime)* Break down trace tasks by status
+- *(runtime)* Trace task-context channel blocking
+- *(runtime)* Hint channel request handoffs
+
+### 🐛 Bug Fixes
+
+- *(result)* Change exit function return type from nothing to T
+- *(attrs)* Standardize spacing in attribute declarations
+- *(sema)* Accept exhaustive compare return blocks
+- *(runtime)* Prune completed async scope children
+- *(llvm)* Load task handles before runtime task calls
+- *(sema)* Surface channel send diagnostics correctly
+- *(compiler)* Restore Erring<Option<T>, E> pipeline
+- *(sema)* Resolve imported JsonValue method params
+- *(frontend)* Handle shorthand casts consistently
+- *(mir)* Discard control-flow results in side-effect contexts
+- *(sema)* Diagnose compare scrutinee reuse
+- *(mir)* Preserve typed default arg lowering (#76)
+- *(vm)* Reborrow shared calls from map mut refs
+- *(llvm)* Lower time monotonic_now
+- *(llvm)* Tighten monotonic_now follow-up
+- *(vm)* Preserve borrowed async frame locals
+- *(vm)* Retain async borrow backing selectively
+- *(vm)* Address review follow-ups
+- *(vm)* Roll back task-state pin collection safely
+- *(mir)* Avoid double deref for field reborrows
+- Lower duration intrinsics (closes #82)
+- *(llvm)* Lower concrete clone methods (closes #85) (#86)
+- *(lsp)* Resolve shadowed call targets (#89)
+- *(driver)* Reject wrong explicit module import paths (#90)
+- *(mir)* Short-circuit logical operators (closes #87)
+- *(llvm)* Lower fields through array element refs (closes #88)
+- *(sema)* Lower imported magic methods (closes #98)
+- *(stdlib)* Address hash review feedback
+- *(runtime)* Wake net poller on new waiters
+- *(stdlib/net)* Buffer tcp reads and writes
+- *(runtime)* Enable TCP_NODELAY on TCP sockets
+- *(runtime)* Preserve poll context for single-thread awaits
+- *(runtime)* Keep channel fanout progressing
+- *(runtime)* Exclude channel waits from running workers
+- *(runtime)* Keep channel fanout progressing under small thread counts
+- *(sema)* Diagnose blocking channel calls in nonblocking functions
+- *(runtime)* Make live trace snapshots reliable
+- *(runtime)* Prioritize net join continuations
+- *(runtime)* Reuse native listener addresses
+- *(runtime)* Address async scheduler review
+
+### 💼 Other
+
+- *(tooling)* Unify version metadata and checks
+- *(runtime)* Add native channel request-reply baseline
+- *(runtime)* Include trace counters in channel benchmark
+- *(runtime)* Add channel scheduler matrix
+
+### 🚜 Refactor
+
+- *(sema)* Split method call checking units
+- *(target-selection)* Consolidate command target resolution logic
+
+### 📚 Documentation
+
+- *(stdlib)* Remove hash planning drafts
+- *(runtime)* Document scheduler invariants
+- *(runtime)* Document async runtime diagnostics
+- *(runtime)* Document native async runtime
+
+### ⚡ Performance
+
+- *(runtime)* Inject channel handoff receivers
+- *(runtime)* Avoid wake signal on yielded tasks
+- *(runtime)* Defer channel recv ack wake signals
+- *(runtime)* Avoid signal on buffered channel refill
+- *(runtime)* Coallocate buffered channel storage
+
+### 🧪 Testing
+
+- *(vm)* Cover async borrow capture rejection
+- Update golden files
+- Allow empty file-size check set
+- *(runtime)* Add native executor trace diagnostics
+- *(runtime)* Cover compensation scheduler counters
+- *(runtime)* Cover non-yielding channel handoffs
+
+### ⚙️ Miscellaneous Tasks
+
+- Update .gitignore to include scribe/
+- Ignore local skvc package
+
 ## Unreleased
 
 ### Language

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ It keeps the latest release notes; older sections may be replaced.
 
 - Add release archive installer
 - Add surge doctor
+- Validate stdlib tree in doctor
 
 ### Documentation
 

--- a/README.md
+++ b/README.md
@@ -63,10 +63,12 @@ Required dependencies:
    ```bash
    curl -fsSL https://surge-lang.org/install.sh | sh
    export PATH="$HOME/.surge/bin:$PATH"
+   surge doctor
    ```
 
    The installer copies `surge`, `core`, and `stdlib` to `~/.surge`.
    Go is not required for release installs.
+   `surge doctor` checks the installed stdlib and native/LLVM backend tools.
    To update, run the same installer command again.
 
    To install a specific release:
@@ -511,6 +513,7 @@ surge parse       → show the full AST
 surge fix         → auto-apply safe fixes
 surge fmt         → format code
 surge init        → create a basic project
+surge doctor      → check stdlib and native/LLVM backend tools
 surge build       → build an LLVM backend binary (clang/llvm required) or a VM wrapper with --backend=vm
 ```
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -59,10 +59,12 @@ Surge официально тестировался **только на Linux x8
    ```bash
    curl -fsSL https://surge-lang.org/install.sh | sh
    export PATH="$HOME/.surge/bin:$PATH"
+   surge doctor
    ```
 
    Установщик копирует `surge`, `core` и `stdlib` в `~/.surge`.
    Go для установки релиза не нужен.
+   `surge doctor` проверяет установленную stdlib и инструменты native/LLVM backend.
    Для обновления запустите ту же команду ещё раз.
 
    Чтобы установить конкретный релиз:
@@ -507,6 +509,7 @@ surge parse       → показать полное AST
 surge fix         → автоматически применить безопасные исправления
 surge fmt         → форматирование кода
 surge init        → создать базовый проект
+surge doctor      → проверить stdlib и инструменты native/LLVM backend
 surge build       → сборка LLVM бинаря (нужны clang/llvm) или VM wrapper с --backend=vm
 ```
 

--- a/STATS.md
+++ b/STATS.md
@@ -4,15 +4,15 @@
 
 ## 📊 Main code (without tests)
 
-- **Files:** 682 (Go: 652, C: 30)
-- **Lines of code:** 156529 (Go: 142297, C: 14232)
+- **Files:** 683 (Go: 653, C: 30)
+- **Lines of code:** 156673 (Go: 142441, C: 14232)
 
 ## 📁 Directory breakdown
 
 | Directory | Files | Lines |
 |------------|--------|-------|
-| `cmd/` | 27 | 4669 |
-| `internal/` | 623 | 137181 |
+| `cmd/` | 28 | 4808 |
+| `internal/` | 623 | 137186 |
 | `runtime/native/` (C code) | 30 | 14232 |
 
 ## 🏆 Top 10 packages by size
@@ -25,20 +25,20 @@
 | 4 | `internal/mir` | 10319 |
 | 5 | `internal/parser` | 8960 |
 | 6 | `internal/hir` | 7162 |
-| 7 | `internal/driver` | 6057 |
+| 7 | `internal/driver` | 6062 |
 | 8 | `internal/lsp` | 5152 |
 | 9 | `internal/mono` | 5120 |
-| 10 | `cmd/surge` | 4669 |
+| 10 | `cmd/surge` | 4808 |
 
 ## 🧪 Test files
 
-- **Files:** 175
-- **Lines of code:** 36310
+- **Files:** 176
+- **Lines of code:** 36379
 
 ## 📈 Total volume (code + tests)
 
-- **Files:** 857
-- **Lines of code:** 192839
+- **Files:** 859
+- **Lines of code:** 193052
 
 ## 📊 Percentage breakdown
 

--- a/STATS.md
+++ b/STATS.md
@@ -5,13 +5,13 @@
 ## 📊 Main code (without tests)
 
 - **Files:** 683 (Go: 653, C: 30)
-- **Lines of code:** 156673 (Go: 142441, C: 14232)
+- **Lines of code:** 156684 (Go: 142452, C: 14232)
 
 ## 📁 Directory breakdown
 
 | Directory | Files | Lines |
 |------------|--------|-------|
-| `cmd/` | 28 | 4808 |
+| `cmd/` | 28 | 4819 |
 | `internal/` | 623 | 137186 |
 | `runtime/native/` (C code) | 30 | 14232 |
 
@@ -28,17 +28,17 @@
 | 7 | `internal/driver` | 6062 |
 | 8 | `internal/lsp` | 5152 |
 | 9 | `internal/mono` | 5120 |
-| 10 | `cmd/surge` | 4808 |
+| 10 | `cmd/surge` | 4819 |
 
 ## 🧪 Test files
 
 - **Files:** 176
-- **Lines of code:** 36379
+- **Lines of code:** 36435
 
 ## 📈 Total volume (code + tests)
 
 - **Files:** 859
-- **Lines of code:** 193052
+- **Lines of code:** 193119
 
 ## 📊 Percentage breakdown
 

--- a/cliff.toml
+++ b/cliff.toml
@@ -61,7 +61,6 @@ protect_breaking_commits = false
 commit_parsers = [
     { message = "^feat", group = "<!-- 0 -->🚀 Features" },
     { message = "^fix", group = "<!-- 1 -->🐛 Bug Fixes" },
-    { message = "^docs\\(changelog\\)", skip = true },
     { message = "^doc", group = "<!-- 3 -->📚 Documentation" },
     { message = "^perf", group = "<!-- 4 -->⚡ Performance" },
     { message = "^refactor", group = "<!-- 2 -->🚜 Refactor" },

--- a/cliff.toml
+++ b/cliff.toml
@@ -61,6 +61,7 @@ protect_breaking_commits = false
 commit_parsers = [
     { message = "^feat", group = "<!-- 0 -->🚀 Features" },
     { message = "^fix", group = "<!-- 1 -->🐛 Bug Fixes" },
+    { message = "^docs\\(changelog\\)", skip = true },
     { message = "^doc", group = "<!-- 3 -->📚 Documentation" },
     { message = "^perf", group = "<!-- 4 -->⚡ Performance" },
     { message = "^refactor", group = "<!-- 2 -->🚜 Refactor" },

--- a/cmd/surge/doctor.go
+++ b/cmd/surge/doctor.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -103,9 +104,19 @@ func stdlibDoctorCheck(root string) doctorCheck {
 			Required: true,
 		}
 	}
+	clean := filepath.Clean(root)
+	stdlibDir := filepath.Join(clean, "stdlib")
+	info, err := os.Stat(stdlibDir)
+	if err != nil || !info.IsDir() {
+		return doctorCheck{
+			Name:     "stdlib",
+			Detail:   clean + " (missing stdlib directory; reinstall Surge)",
+			Required: true,
+		}
+	}
 	return doctorCheck{
 		Name:     "stdlib",
-		Detail:   filepath.Clean(root),
+		Detail:   clean,
 		Required: true,
 		OK:       true,
 	}

--- a/cmd/surge/doctor.go
+++ b/cmd/surge/doctor.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"surge/internal/driver"
+)
+
+type doctorCheck struct {
+	Name     string
+	Detail   string
+	Required bool
+	OK       bool
+}
+
+type doctorEnv struct {
+	LookupPath func(string) (string, error)
+	Version    func() versionInfo
+	Stdlib     func(string) string
+}
+
+var doctorCmd = &cobra.Command{
+	Use:   "doctor",
+	Short: "Check the local Surge installation",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		failed, err := runDoctor(cmd.OutOrStdout(), defaultDoctorEnv())
+		if err != nil {
+			return err
+		}
+		if failed > 0 {
+			return fmt.Errorf("doctor found %d required problem(s)", failed)
+		}
+		return nil
+	},
+}
+
+func defaultDoctorEnv() doctorEnv {
+	return doctorEnv{
+		LookupPath: exec.LookPath,
+		Version:    collectVersionInfo,
+		Stdlib:     driver.DetectStdlibRootFrom,
+	}
+}
+
+func runDoctor(out io.Writer, env doctorEnv) (int, error) {
+	if env.LookupPath == nil {
+		env.LookupPath = exec.LookPath
+	}
+	if env.Version == nil {
+		env.Version = collectVersionInfo
+	}
+	if env.Stdlib == nil {
+		env.Stdlib = driver.DetectStdlibRootFrom
+	}
+
+	info := env.Version()
+	checks := make([]doctorCheck, 0, 6)
+	checks = append(checks,
+		doctorCheck{Name: "surge", Detail: info.Version, Required: true, OK: strings.TrimSpace(info.Version) != ""},
+		stdlibDoctorCheck(env.Stdlib(".")),
+	)
+	checks = append(checks, toolDoctorChecks(env.LookupPath)...)
+
+	if _, err := fmt.Fprintln(out, "Surge doctor"); err != nil {
+		return 0, err
+	}
+	failed := 0
+	for _, check := range checks {
+		status := "ok"
+		if !check.OK {
+			if check.Required {
+				status = "error"
+				failed++
+			} else {
+				status = "warn"
+			}
+		}
+		if _, err := fmt.Fprintf(out, "[%s] %s: %s\n", status, check.Name, check.Detail); err != nil {
+			return failed, err
+		}
+	}
+	if failed == 0 {
+		if _, err := fmt.Fprintln(out, "ready"); err != nil {
+			return 0, err
+		}
+	}
+	return failed, nil
+}
+
+func stdlibDoctorCheck(root string) doctorCheck {
+	root = strings.TrimSpace(root)
+	if root == "" {
+		return doctorCheck{
+			Name:     "stdlib",
+			Detail:   "not found (set SURGE_STDLIB or reinstall Surge)",
+			Required: true,
+		}
+	}
+	return doctorCheck{
+		Name:     "stdlib",
+		Detail:   filepath.Clean(root),
+		Required: true,
+		OK:       true,
+	}
+}
+
+func toolDoctorChecks(lookup func(string) (string, error)) []doctorCheck {
+	return []doctorCheck{
+		toolDoctorCheck(lookup, "clang", true, "required for native/LLVM backend"),
+		toolDoctorCheck(lookup, "ar", true, "required for native runtime archive"),
+		toolDoctorCheck(lookup, "llc", false, "optional fallback for LLVM IR compilation"),
+		toolDoctorCheck(lookup, "ld.lld", false, "recommended linker from LLVM toolchain"),
+	}
+}
+
+func toolDoctorCheck(lookup func(string) (string, error), name string, required bool, missingDetail string) doctorCheck {
+	path, err := lookup(name)
+	if err != nil || strings.TrimSpace(path) == "" {
+		return doctorCheck{
+			Name:     name,
+			Detail:   "not found (" + missingDetail + ")",
+			Required: required,
+		}
+	}
+	return doctorCheck{
+		Name:     name,
+		Detail:   path,
+		Required: required,
+		OK:       true,
+	}
+}

--- a/cmd/surge/doctor_test.go
+++ b/cmd/surge/doctor_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestRunDoctorReportsReadyWhenRequiredChecksPass(t *testing.T) {
+	var out bytes.Buffer
+	failed, err := runDoctor(&out, doctorEnv{
+		LookupPath: fakeLookPath(map[string]string{
+			"clang":  "/usr/bin/clang",
+			"ar":     "/usr/bin/ar",
+			"llc":    "/usr/bin/llc",
+			"ld.lld": "/usr/bin/ld.lld",
+		}),
+		Version: func() versionInfo { return versionInfo{Version: "0.1.12"} },
+		Stdlib:  func(string) string { return "/opt/surge/share/surge" },
+	})
+	if err != nil {
+		t.Fatalf("runDoctor error: %v", err)
+	}
+
+	if failed != 0 {
+		t.Fatalf("failed = %d, want 0\n%s", failed, out.String())
+	}
+	if !strings.Contains(out.String(), "[ok] stdlib: /opt/surge/share/surge") {
+		t.Fatalf("missing stdlib ok line:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "ready") {
+		t.Fatalf("missing ready line:\n%s", out.String())
+	}
+}
+
+func TestRunDoctorFailsOnlyRequiredChecks(t *testing.T) {
+	var out bytes.Buffer
+	failed, err := runDoctor(&out, doctorEnv{
+		LookupPath: fakeLookPath(map[string]string{
+			"clang": "/usr/bin/clang",
+			"ar":    "/usr/bin/ar",
+		}),
+		Version: func() versionInfo { return versionInfo{Version: "0.1.12"} },
+		Stdlib:  func(string) string { return "" },
+	})
+	if err != nil {
+		t.Fatalf("runDoctor error: %v", err)
+	}
+
+	if failed != 1 {
+		t.Fatalf("failed = %d, want 1\n%s", failed, out.String())
+	}
+	if !strings.Contains(out.String(), "[error] stdlib: not found") {
+		t.Fatalf("missing stdlib error:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "[warn] llc: not found") {
+		t.Fatalf("missing optional llc warning:\n%s", out.String())
+	}
+}
+
+func fakeLookPath(paths map[string]string) func(string) (string, error) {
+	return func(name string) (string, error) {
+		if path := paths[name]; path != "" {
+			return path, nil
+		}
+		return "", errors.New("not found")
+	}
+}

--- a/cmd/surge/doctor_test.go
+++ b/cmd/surge/doctor_test.go
@@ -3,11 +3,14 @@ package main
 import (
 	"bytes"
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
 
 func TestRunDoctorReportsReadyWhenRequiredChecksPass(t *testing.T) {
+	stdlibRoot := makeDoctorStdlibRoot(t)
 	var out bytes.Buffer
 	failed, err := runDoctor(&out, doctorEnv{
 		LookupPath: fakeLookPath(map[string]string{
@@ -17,7 +20,7 @@ func TestRunDoctorReportsReadyWhenRequiredChecksPass(t *testing.T) {
 			"ld.lld": "/usr/bin/ld.lld",
 		}),
 		Version: func() versionInfo { return versionInfo{Version: "0.1.12"} },
-		Stdlib:  func(string) string { return "/opt/surge/share/surge" },
+		Stdlib:  func(string) string { return stdlibRoot },
 	})
 	if err != nil {
 		t.Fatalf("runDoctor error: %v", err)
@@ -26,7 +29,7 @@ func TestRunDoctorReportsReadyWhenRequiredChecksPass(t *testing.T) {
 	if failed != 0 {
 		t.Fatalf("failed = %d, want 0\n%s", failed, out.String())
 	}
-	if !strings.Contains(out.String(), "[ok] stdlib: /opt/surge/share/surge") {
+	if !strings.Contains(out.String(), "[ok] stdlib: "+stdlibRoot) {
 		t.Fatalf("missing stdlib ok line:\n%s", out.String())
 	}
 	if !strings.Contains(out.String(), "ready") {
@@ -57,6 +60,59 @@ func TestRunDoctorFailsOnlyRequiredChecks(t *testing.T) {
 	if !strings.Contains(out.String(), "[warn] llc: not found") {
 		t.Fatalf("missing optional llc warning:\n%s", out.String())
 	}
+	if strings.Contains(out.String(), "ready") {
+		t.Fatalf("unexpected ready line on failed checks:\n%s", out.String())
+	}
+}
+
+func TestRunDoctorRejectsIncompleteStdlibRoot(t *testing.T) {
+	root := makeDoctorCoreOnlyRoot(t)
+	var out bytes.Buffer
+	failed, err := runDoctor(&out, doctorEnv{
+		LookupPath: fakeLookPath(map[string]string{
+			"clang":  "/usr/bin/clang",
+			"ar":     "/usr/bin/ar",
+			"llc":    "/usr/bin/llc",
+			"ld.lld": "/usr/bin/ld.lld",
+		}),
+		Version: func() versionInfo { return versionInfo{Version: "0.1.12"} },
+		Stdlib:  func(string) string { return root },
+	})
+	if err != nil {
+		t.Fatalf("runDoctor error: %v", err)
+	}
+
+	if failed != 1 {
+		t.Fatalf("failed = %d, want 1\n%s", failed, out.String())
+	}
+	if !strings.Contains(out.String(), "[error] stdlib: "+root+" (missing stdlib directory; reinstall Surge)") {
+		t.Fatalf("missing incomplete stdlib error:\n%s", out.String())
+	}
+	if strings.Contains(out.String(), "ready") {
+		t.Fatalf("unexpected ready line on incomplete stdlib:\n%s", out.String())
+	}
+}
+
+func makeDoctorStdlibRoot(t *testing.T) string {
+	t.Helper()
+	root := makeDoctorCoreOnlyRoot(t)
+	if err := os.Mkdir(filepath.Join(root, "stdlib"), 0o755); err != nil {
+		t.Fatalf("create stdlib dir: %v", err)
+	}
+	return root
+}
+
+func makeDoctorCoreOnlyRoot(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	coreDir := filepath.Join(root, "core")
+	if err := os.Mkdir(coreDir, 0o755); err != nil {
+		t.Fatalf("create core dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(coreDir, "intrinsics.sg"), []byte("// test\n"), 0o644); err != nil {
+		t.Fatalf("create intrinsics: %v", err)
+	}
+	return root
 }
 
 func fakeLookPath(paths map[string]string) func(string) (string, error) {

--- a/cmd/surge/init.go
+++ b/cmd/surge/init.go
@@ -141,7 +141,7 @@ func runInit(_ *cobra.Command, args []string) error {
 // The manifest contains [package] metadata and a [run] section pointing at main.sg.
 func buildDefaultManifest(name string) string {
 	// Minimal TOML manifest used as a project marker.
-	versionInfo := collectVersionInfo()
+	info := collectVersionInfo()
 	return fmt.Sprintf(`# Surge project manifest
 [package]
 name = "%s"
@@ -156,7 +156,7 @@ version = %q
 commit = %q
 message = %q
 built = %q
-`, name, versionInfo.Version, versionInfo.GitCommit, versionInfo.GitMessage, versionInfo.BuildDate)
+`, name, info.Version, info.GitCommit, info.GitMessage, info.BuildDate)
 }
 
 // defaultMainSG returns the default placeholder Surge program used when initializing a new project.

--- a/cmd/surge/main.go
+++ b/cmd/surge/main.go
@@ -47,6 +47,7 @@ func main() {
 	rootCmd.AddCommand(lspCmd)
 	rootCmd.AddCommand(philosophyCmd)
 	rootCmd.AddCommand(moduleCmd)
+	rootCmd.AddCommand(doctorCmd)
 
 	// Глобальные флаги
 	rootCmd.PersistentFlags().String("color", "auto", "colorize output (auto|on|off)")

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -29,9 +29,11 @@ On Linux x86_64:
 ```bash
 curl -fsSL https://surge-lang.org/install.sh | sh
 export PATH="$HOME/.surge/bin:$PATH"
+surge doctor
 ```
 
 The release installer includes the compiler, `core`, and `stdlib`.
+`surge doctor` checks the installed stdlib and native/LLVM backend tools.
 To update Surge, run the same installer command again.
 The native/LLVM backend still needs system `clang`, `llvm`, and `lld`.
 

--- a/docs/QUICKSTART.ru.md
+++ b/docs/QUICKSTART.ru.md
@@ -28,9 +28,11 @@ code --install-extension VladimirKirdan.surge-syntax-highlighting
 ```bash
 curl -fsSL https://surge-lang.org/install.sh | sh
 export PATH="$HOME/.surge/bin:$PATH"
+surge doctor
 ```
 
 Установщик релиза включает компилятор, `core` и `stdlib`.
+`surge doctor` проверяет установленную stdlib и инструменты native/LLVM backend.
 Чтобы обновить Surge, запустите ту же команду ещё раз.
 Для native/LLVM backend по-прежнему нужны системные `clang`, `llvm` и `lld`.
 

--- a/internal/driver/stdlib.go
+++ b/internal/driver/stdlib.go
@@ -11,6 +11,11 @@ const (
 	stdModuleCore = "core"
 )
 
+// DetectStdlibRootFrom locates the root that contains Surge core and stdlib modules.
+func DetectStdlibRootFrom(start string) string {
+	return detectStdlibRootFrom(start)
+}
+
 func detectStdlibRootFrom(start string) string {
 	if root := resolveStdlibRoot(os.Getenv("SURGE_STDLIB")); root != "" {
 		return root

--- a/scripts/update_changelog.sh
+++ b/scripts/update_changelog.sh
@@ -1,19 +1,38 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ $# -ne 1 ]]; then
-	echo "usage: $0 <version>" >&2
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+	echo "usage: $0 <version> [git-range]" >&2
 	exit 2
 fi
 
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 version="${1#v}"
 tag="v${version}"
+range="${2:-}"
 tmp="$(mktemp)"
+clean="$(mktemp)"
 out="$(mktemp)"
-trap 'rm -f "$tmp" "$out"' EXIT
+trap 'rm -f "$tmp" "$clean" "$out"' EXIT
 
-git-cliff --config "$root/cliff.toml" --unreleased --tag "$tag" --strip header --output "$tmp"
+if [[ -n "$range" ]]; then
+	git-cliff --config "$root/cliff.toml" --tag "$tag" --strip header --output "$tmp" "$range"
+else
+	git-cliff --config "$root/cliff.toml" --unreleased --tag "$tag" --strip header --output "$tmp"
+fi
+
+awk -v version="$version" '
+	$0 ~ "^## \\[" version "\\]" {
+		skip = 1
+		next
+	}
+	skip && /^## / {
+		skip = 0
+	}
+	!skip {
+		print
+	}
+' "$root/CHANGELOG.md" > "$clean"
 
 awk -v generated="$tmp" '
 	!inserted && /^## / {
@@ -26,11 +45,12 @@ awk -v generated="$tmp" '
 	{ print }
 	END {
 		if (!inserted) {
+			print ""
 			while ((getline line < generated) > 0) {
 				print line
 			}
 		}
 	}
-' "$root/CHANGELOG.md" > "$out"
+' "$clean" > "$out"
 
 mv "$out" "$root/CHANGELOG.md"

--- a/scripts/update_changelog.sh
+++ b/scripts/update_changelog.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+	echo "usage: $0 <version>" >&2
+	exit 2
+fi
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+version="${1#v}"
+tag="v${version}"
+tmp="$(mktemp)"
+out="$(mktemp)"
+trap 'rm -f "$tmp" "$out"' EXIT
+
+git-cliff --config "$root/cliff.toml" --unreleased --tag "$tag" --strip header --output "$tmp"
+
+awk -v generated="$tmp" '
+	!inserted && /^## / {
+		while ((getline line < generated) > 0) {
+			print line
+		}
+		print ""
+		inserted = 1
+	}
+	{ print }
+	END {
+		if (!inserted) {
+			while ((getline line < generated) > 0) {
+				print line
+			}
+		}
+	}
+' "$root/CHANGELOG.md" > "$out"
+
+mv "$out" "$root/CHANGELOG.md"

--- a/scripts/update_changelog.sh
+++ b/scripts/update_changelog.sh
@@ -1,56 +1,188 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ $# -lt 1 || $# -gt 2 ]]; then
-	echo "usage: $0 <version> [git-range]" >&2
+usage() {
+	echo "usage: $0 <version> <git-range> [<version> <git-range> ...]" >&2
 	exit 2
+}
+
+if [[ $# -lt 2 || $(( $# % 2 )) -ne 0 ]]; then
+	usage
 fi
 
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-version="${1#v}"
-tag="v${version}"
-range="${2:-}"
-tmp="$(mktemp)"
-clean="$(mktemp)"
 out="$(mktemp)"
-trap 'rm -f "$tmp" "$clean" "$out"' EXIT
+trimmed="$(mktemp)"
+trap 'rm -f "$out" "$trimmed"' EXIT
 
-if [[ -n "$range" ]]; then
-	git-cliff --config "$root/cliff.toml" --tag "$tag" --strip header --output "$tmp" "$range"
-else
-	git-cliff --config "$root/cliff.toml" --unreleased --tag "$tag" --strip header --output "$tmp"
-fi
+section_order=(
+	"Language"
+	"Diagnostics"
+	"Compiler"
+	"Runtime"
+	"Standard Library"
+	"CLI / Tooling"
+	"Documentation"
+	"Tests"
+	"Other"
+)
 
-awk -v version="$version" '
-	$0 ~ "^## \\[" version "\\]" {
-		skip = 1
-		next
-	}
-	skip && /^## / {
-		skip = 0
-	}
-	!skip {
-		print
-	}
-' "$root/CHANGELOG.md" > "$clean"
+strip_subject() {
+	local subject="$1"
+	local lower="${subject,,}"
+	case "$lower" in
+		"vm async exit poll")
+			printf '%s\n' "VM async exit poll"
+			return
+			;;
+		"feat/entropy random uuid")
+			printf '%s\n' "Entropy random UUID"
+			return
+			;;
+	esac
+	if [[ "$subject" == *": "* && -n "$(commit_type "$subject")" ]]; then
+		local message="${subject#*: }"
+		printf '%s\n' "${message^}"
+	else
+		printf '%s\n' "${subject^}"
+	fi
+}
 
-awk -v generated="$tmp" '
-	!inserted && /^## / {
-		while ((getline line < generated) > 0) {
-			print line
-		}
-		print ""
-		inserted = 1
-	}
+commit_prefix() {
+	local subject="$1"
+	[[ "$subject" == *": "* ]] || return 0
+	printf '%s\n' "${subject%%: *}"
+}
+
+commit_type() {
+	local prefix type
+	prefix="$(commit_prefix "$1")"
+	type="${prefix%%!*}"
+	type="${type%%(*}"
+	if [[ "$type" =~ ^[[:alpha:]]+$ ]]; then
+		printf '%s\n' "$type"
+	fi
+}
+
+commit_scope() {
+	local prefix scope
+	prefix="$(commit_prefix "$1")"
+	if [[ "$prefix" == *"("*")"* ]]; then
+		scope="${prefix#*(}"
+		scope="${scope%)*}"
+		printf '%s\n' "$scope"
+	fi
+}
+
+skip_subject() {
+	local type="$1"
+	local scope="$2"
+	local lower="$3"
+	[[ "$type" == "docs" && "$scope" == "changelog" ]] && return 0
+	[[ "$type" == "chore" && "$lower" =~ ^chore\((release|deps|pr|pull) ]] && return 0
+	return 1
+}
+
+domain_for_subject() {
+	local subject="$1"
+	local type scope lower
+	type="$(commit_type "$subject")"
+	scope="$(commit_scope "$subject")"
+	lower="${subject,,}"
+
+	if skip_subject "$type" "$scope" "$lower"; then
+		printf 'Skip\n'
+		return
+	fi
+
+	if [[ "$type" == "test" || "$lower" == *"golden"* ]]; then
+		printf 'Tests\n'
+		return
+	fi
+	if [[ "$type" == "docs" ]]; then
+		printf 'Documentation\n'
+		return
+	fi
+	if [[ "$scope" == runtime || "$scope" == vm || "$type" == "perf" || "$type" == "bench" || "$lower" == vm\ * || "$lower" == *"async exit poll"* ]]; then
+		printf 'Runtime\n'
+		return
+	fi
+	if [[ "$scope" == stdlib* || "$scope" == hash || "$scope" == random || "$scope" == entropy || "$lower" == *"stdlib"* || "$lower" == *"random"* || "$lower" == *"uuid"* || "$lower" == *"entropy"* || "$lower" == *"duration intrinsics"* ]]; then
+		printf 'Standard Library\n'
+		return
+	fi
+	if [[ "$scope" == cli || "$scope" == install || "$scope" == tooling || "$scope" == lsp || "$scope" == module || "$type" == "build" || "$type" == "ci" || "$type" == "chore" || "$lower" == *"issue fixer skill"* ]]; then
+		printf 'CLI / Tooling\n'
+		return
+	fi
+	if [[ "$scope" == result || "$scope" == attrs || "$lower" == *"compare"* || "$lower" == *"cast"* || "$lower" == *"ret "* || "$lower" == *"block expression"* ]]; then
+		printf 'Language\n'
+		return
+	fi
+	if [[ "$lower" == *"diagnos"* || "$lower" == *"warning"* || "$lower" == *"fix-it"* ]]; then
+		printf 'Diagnostics\n'
+		return
+	fi
+	if [[ "$scope" == compiler || "$scope" == frontend || "$scope" == sema || "$scope" == mir || "$scope" == llvm || "$scope" == driver || "$scope" == mono || "$scope" == target-selection ]]; then
+		printf 'Compiler\n'
+		return
+	fi
+
+	printf 'Other\n'
+}
+
+version_date() {
+	local version="$1"
+	local tag="v${version#v}"
+	if git -C "$root" rev-parse --verify -q "${tag}^{commit}" >/dev/null; then
+		git -C "$root" log -1 --format=%cs "$tag"
+	else
+		date +%F
+	fi
+}
+
+print_release() {
+	local version="${1#v}"
+	local range="$2"
+	declare -A items=()
+
+	while IFS= read -r subject; do
+		[[ -z "$subject" ]] && continue
+		local domain
+		domain="$(domain_for_subject "$subject")"
+		[[ "$domain" == "Skip" ]] && continue
+		items["$domain"]+="- $(strip_subject "$subject")"$'\n'
+	done < <(git -C "$root" log --no-merges --reverse --format=%s "$range")
+
+	printf '## [%s] - %s\n\n' "$version" "$(version_date "$version")"
+	local domain
+	for domain in "${section_order[@]}"; do
+		[[ -z "${items[$domain]:-}" ]] && continue
+		printf '### %s\n\n' "$domain"
+		printf '%s\n' "${items[$domain]}"
+	done
+}
+
+awk '
+	/^## / { exit }
 	{ print }
+' "$root/CHANGELOG.md" > "$out"
+
+while [[ $# -gt 0 ]]; do
+	version="$1"
+	range="$2"
+	shift 2
+	print_release "$version" "$range" >> "$out"
+done
+
+awk '
+	NF { last = NR }
+	{ lines[NR] = $0 }
 	END {
-		if (!inserted) {
-			print ""
-			while ((getline line < generated) > 0) {
-				print line
-			}
+		for (i = 1; i <= last; i++) {
+			print lines[i]
 		}
 	}
-' "$clean" > "$out"
+' "$out" > "$trimmed"
 
-mv "$out" "$root/CHANGELOG.md"
+mv "$trimmed" "$root/CHANGELOG.md"

--- a/scripts/update_changelog.sh
+++ b/scripts/update_changelog.sh
@@ -11,8 +11,8 @@ if [[ $# -lt 2 || $(( $# % 2 )) -ne 0 ]]; then
 fi
 
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-out="$(mktemp)"
-trimmed="$(mktemp)"
+out="$(mktemp "$root/.CHANGELOG.md.out.XXXXXX")"
+trimmed="$(mktemp "$root/.CHANGELOG.md.trimmed.XXXXXX")"
 trap 'rm -f "$out" "$trimmed"' EXIT
 
 section_order=(
@@ -79,7 +79,7 @@ skip_subject() {
 	local scope="$2"
 	local lower="$3"
 	[[ "$type" == "docs" && "$scope" == "changelog" ]] && return 0
-	[[ "$type" == "chore" && "$lower" =~ ^chore\((release|deps|pr|pull) ]] && return 0
+	[[ "$type" == "chore" && "$lower" =~ ^chore\((release|deps|pr|pull)\) ]] && return 0
 	return 1
 }
 
@@ -107,11 +107,15 @@ domain_for_subject() {
 		printf 'Runtime\n'
 		return
 	fi
+	if [[ "$scope" == cli || "$scope" == install || "$scope" == tooling || "$scope" == lsp || "$scope" == module || "$lower" == *"issue fixer skill"* ]]; then
+		printf 'CLI / Tooling\n'
+		return
+	fi
 	if [[ "$scope" == stdlib* || "$scope" == hash || "$scope" == random || "$scope" == entropy || "$lower" == *"stdlib"* || "$lower" == *"random"* || "$lower" == *"uuid"* || "$lower" == *"entropy"* || "$lower" == *"duration intrinsics"* ]]; then
 		printf 'Standard Library\n'
 		return
 	fi
-	if [[ "$scope" == cli || "$scope" == install || "$scope" == tooling || "$scope" == lsp || "$scope" == module || "$type" == "build" || "$type" == "ci" || "$type" == "chore" || "$lower" == *"issue fixer skill"* ]]; then
+	if [[ "$type" == "build" || "$type" == "ci" || "$type" == "chore" ]]; then
 		printf 'CLI / Tooling\n'
 		return
 	fi


### PR DESCRIPTION
## Summary

- Add `surge doctor` to check version metadata, stdlib discovery, and native/LLVM backend tools.
- Document `surge doctor` in the installer quickstart and README toolchain sections.
- Add `scripts/update_changelog.sh` and generate the `0.1.12` changelog entry from git-cliff.

## Validation

- `go test ./cmd/surge ./internal/driver -run 'TestRunDoctor|TestResolveStdlibRoot'`
- `make build && ./surge doctor`
- `make check` via pre-commit hooks
- sentrux MCP scan: quality signal `6220`; existing `max_cc`/`no_god_files` violations unchanged

## Rollout

After merge, run the release workflow for `0.1.12`, then serve `scripts/install.sh` from `surge-lang.org/install.sh`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `surge doctor` to check local installation health, reporting `ok`/`warn`/`error` per required and recommended items and showing `ready` when all required checks pass.
* **Documentation**
  * Updated Quickstart (English and Russian) to run `surge doctor` after installing/copying `core` and `stdlib`.
* **Tests**
  * Added tests covering `surge doctor` success, missing stdlib, and incomplete stdlib scenarios.
* **Chores**
  * Refreshed changelog generation format and updated compiler code-size statistics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->