### PR TITLE
feat(json): add validate-only API

### DIFF
--- a/docs/STDLIB.md
+++ b/docs/STDLIB.md
@@ -491,6 +491,7 @@ Main functions:
 
 - `parse(input: &string) -> Erring<JsonValue, JsonError>`
 - `parse_bytes(input: byte[]) -> Erring<JsonValue, JsonError>`
+- `validate(input: &string) -> Erring<nothing, JsonError>`
 - `stringify(value: &JsonValue) -> string`
 
 There are also `to_json()` implementations for `string`, `bool`, `int`, `uint`, and `JsonValue`.

--- a/docs/STDLIB.ru.md
+++ b/docs/STDLIB.ru.md
@@ -491,6 +491,7 @@ import stdlib/json as json;
 
 - `parse(input: &string) -> Erring<JsonValue, JsonError>`
 - `parse_bytes(input: byte[]) -> Erring<JsonValue, JsonError>`
+- `validate(input: &string) -> Erring<nothing, JsonError>`
 - `stringify(value: &JsonValue) -> string`
 
 Также есть `to_json()`-реализации для `string`, `bool`, `int`, `uint` и `JsonValue`.

--- a/internal/backend/llvm/emit_func.go
+++ b/internal/backend/llvm/emit_func.go
@@ -45,6 +45,15 @@ func (e *Emitter) emitFunction(f *mir.Func) error {
 	}
 	fe.addrOfTargets = fe.collectAddrOfTargets()
 
+	fmt.Fprint(&e.buf, "entry:\n")
+	if err := fe.emitAllocas(); err != nil {
+		return fmt.Errorf("llvm emit %s allocas: %w", f.Name, err)
+	}
+	if err := fe.emitParamStores(); err != nil {
+		return fmt.Errorf("llvm emit %s param stores: %w", f.Name, err)
+	}
+	fmt.Fprintf(&e.buf, "  br label %%bb%d\n", f.Entry)
+
 	order := fe.blockOrder()
 	for _, bb := range order {
 		if bb == nil {
@@ -52,14 +61,6 @@ func (e *Emitter) emitFunction(f *mir.Func) error {
 		}
 		fmt.Fprintf(&e.buf, "bb%d:\n", bb.ID)
 		fe.blockTerminated = false
-		if bb.ID == f.Entry {
-			if err := fe.emitAllocas(); err != nil {
-				return fmt.Errorf("llvm emit %s allocas: %w", f.Name, err)
-			}
-			if err := fe.emitParamStores(); err != nil {
-				return fmt.Errorf("llvm emit %s param stores: %w", f.Name, err)
-			}
-		}
 		for i := range bb.Instrs {
 			if err := fe.emitInstr(&bb.Instrs[i]); err != nil {
 				return fmt.Errorf("llvm emit %s bb%d instr[%d] (%s): %w", f.Name, bb.ID, i, bb.Instrs[i].Kind, err)

--- a/internal/backend/llvm/emit_helpers_tags.go
+++ b/internal/backend/llvm/emit_helpers_tags.go
@@ -202,11 +202,14 @@ func (fe *funcEmitter) emitTagValue(typeID types.TypeID, tagName string, tagSym 
 	}
 	for i := range args {
 		arg := &args[i]
+		payloadTy := meta.PayloadTypes[i]
+		if isNothingType(fe.emitter.types, payloadTy) {
+			continue
+		}
 		val, valTy, err := fe.emitValueOperand(arg)
 		if err != nil {
 			return "", err
 		}
-		payloadTy := meta.PayloadTypes[i]
 		payloadLLVM, err := llvmValueType(fe.emitter.types, payloadTy)
 		if err != nil {
 			return "", err

--- a/internal/backend/llvm/emit_union_cast.go
+++ b/internal/backend/llvm/emit_union_cast.go
@@ -194,6 +194,9 @@ func (fe *funcEmitter) emitTagValueFromValues(typeID types.TypeID, tagIndex int,
 		return "", err
 	}
 	for i := range payloadTypes {
+		if isNothingType(fe.emitter.types, payloadTypes[i]) {
+			continue
+		}
 		off := layoutInfo.PayloadOffset + offsets[i]
 		bytePtr := fe.nextTemp()
 		fmt.Fprintf(&fe.emitter.buf, "  %s = getelementptr inbounds i8, ptr %s, i64 %d\n", bytePtr, mem, off)

--- a/internal/vm/llvm_smoke_test.go
+++ b/internal/vm/llvm_smoke_test.go
@@ -32,6 +32,7 @@ func TestLLVMSmoke(t *testing.T) {
 		{name: "time_monotonic_now", file: "time_monotonic_now.sg"},
 		{name: "unicode_print", file: "unicode_print.sg"},
 		{name: "exit_code", file: "exit_code.sg"},
+		{name: "json_validate", file: "json_validate.sg"},
 	}
 
 	for _, tc := range cases {

--- a/stdlib/json/parser.sg
+++ b/stdlib/json/parser.sg
@@ -405,6 +405,318 @@ fn parse_number_value(p: &mut Parser) -> JsonResult<string> {
     return out_res;
 }
 
+fn validate_string_value(p: &mut Parser) -> Erring<nothing, JsonError> {
+    let start_offset: uint = parser_offset(p);
+    p.cursor = p.cursor + 1;
+    while true {
+        if p.cursor >= p.length {
+            return json_error(JSON_ERR_EOF, "unterminated string", start_offset);
+        }
+        let b: uint = byte_at(&p.data, p.cursor);
+        if b == 34:uint {
+            p.cursor = p.cursor + 1;
+            break;
+        }
+        if b == 92:uint {
+            p.cursor = p.cursor + 1;
+            if p.cursor >= p.length {
+                return json_error(JSON_ERR_EOF, "unterminated escape", parser_offset(p));
+            }
+            let esc: uint = byte_at(&p.data, p.cursor);
+            p.cursor = p.cursor + 1;
+            if esc == 34:uint || esc == 92:uint || esc == 47:uint || esc == 98:uint || esc == 102:uint || esc == 110:uint || esc == 114:uint || esc == 116:uint {
+                continue;
+            }
+            if esc == 117:uint {
+                let first = parse_unicode_escape(p);
+                let mut cp: uint = 0:uint;
+                let mut first_ok: bool = false;
+                let mut first_err: JsonError = json_error(JSON_ERR_PARSE, "invalid unicode escape", parser_offset(p));
+                compare first {
+                    Success(v) => {
+                        cp = v;
+                        first_ok = true;
+                    }
+                    err => {
+                        first_err = err;
+                        first_ok = false;
+                    }
+                };
+                if !first_ok {
+                    return first_err;
+                }
+                if cp >= 0xD800:uint && cp <= 0xDBFF:uint {
+                    if p.cursor + 2 > p.length {
+                        return json_error(JSON_ERR_EOF, "missing low surrogate", parser_offset(p));
+                    }
+                    let esc1: uint = byte_at(&p.data, p.cursor);
+                    let esc2: uint = byte_at(&p.data, p.cursor + 1);
+                    if esc1 != 92:uint || esc2 != 117:uint {
+                        return json_error(JSON_ERR_PARSE, "missing low surrogate", parser_offset(p));
+                    }
+                    p.cursor = p.cursor + 2;
+                    let second = parse_unicode_escape(p);
+                    let mut low_sur: uint = 0:uint;
+                    let mut second_ok: bool = false;
+                    let mut second_err: JsonError = json_error(JSON_ERR_PARSE, "invalid unicode escape", parser_offset(p));
+                    compare second {
+                        Success(v) => {
+                            low_sur = v;
+                            second_ok = true;
+                        }
+                        err => {
+                            second_err = err;
+                            second_ok = false;
+                        }
+                    };
+                    if !second_ok {
+                        return second_err;
+                    }
+                    if low_sur < 0xDC00:uint || low_sur > 0xDFFF:uint {
+                        return json_error(JSON_ERR_PARSE, "invalid low surrogate", parser_offset(p));
+                    }
+                } else if cp >= 0xDC00:uint && cp <= 0xDFFF:uint {
+                    return json_error(JSON_ERR_PARSE, "unexpected low surrogate", parser_offset(p));
+                }
+                continue;
+            }
+            return json_error(JSON_ERR_PARSE, "invalid escape sequence", parser_offset(p));
+        }
+        if b < 32:uint {
+            return json_error(JSON_ERR_PARSE, "control character in string", parser_offset(p));
+        }
+        p.cursor = p.cursor + 1;
+    }
+    return Success(nothing);
+}
+
+fn validate_number_value(p: &mut Parser) -> Erring<nothing, JsonError> {
+    if at_end(p) {
+        return json_error(JSON_ERR_EOF, "expected number", parser_offset(p));
+    }
+    let mut b: uint = byte_at(&p.data, p.cursor);
+    if b == 45:uint {
+        p.cursor = p.cursor + 1;
+        if at_end(p) {
+            return json_error(JSON_ERR_EOF, "expected digit", parser_offset(p));
+        }
+        b = byte_at(&p.data, p.cursor);
+    }
+    if b == 48:uint {
+        p.cursor = p.cursor + 1;
+        if p.cursor < p.length {
+            let next: uint = byte_at(&p.data, p.cursor);
+            if is_digit(next) {
+                return json_error(JSON_ERR_PARSE, "leading zero in number", parser_offset(p));
+            }
+        }
+    } else if is_digit(b) {
+        while p.cursor < p.length {
+            let d: uint = byte_at(&p.data, p.cursor);
+            if !is_digit(d) {
+                break;
+            }
+            p.cursor = p.cursor + 1;
+        }
+    } else {
+        return json_error(JSON_ERR_PARSE, "expected digit", parser_offset(p));
+    }
+
+    if p.cursor < p.length {
+        let dot: uint = byte_at(&p.data, p.cursor);
+        if dot == 46:uint {
+            p.cursor = p.cursor + 1;
+            if p.cursor >= p.length {
+                return json_error(JSON_ERR_EOF, "expected fraction digit", parser_offset(p));
+            }
+            let mut saw_digit: bool = false;
+            while p.cursor < p.length {
+                let d: uint = byte_at(&p.data, p.cursor);
+                if !is_digit(d) {
+                    break;
+                }
+                saw_digit = true;
+                p.cursor = p.cursor + 1;
+            }
+            if !saw_digit {
+                return json_error(JSON_ERR_PARSE, "expected fraction digit", parser_offset(p));
+            }
+        }
+    }
+
+    if p.cursor < p.length {
+        let expc: uint = byte_at(&p.data, p.cursor);
+        if expc == 69:uint || expc == 101:uint {
+            p.cursor = p.cursor + 1;
+            if p.cursor >= p.length {
+                return json_error(JSON_ERR_EOF, "expected exponent digit", parser_offset(p));
+            }
+            let sign: uint = byte_at(&p.data, p.cursor);
+            if sign == 43:uint || sign == 45:uint {
+                p.cursor = p.cursor + 1;
+                if p.cursor >= p.length {
+                    return json_error(JSON_ERR_EOF, "expected exponent digit", parser_offset(p));
+                }
+            }
+            let mut saw_digit: bool = false;
+            while p.cursor < p.length {
+                let d: uint = byte_at(&p.data, p.cursor);
+                if !is_digit(d) {
+                    break;
+                }
+                saw_digit = true;
+                p.cursor = p.cursor + 1;
+            }
+            if !saw_digit {
+                return json_error(JSON_ERR_PARSE, "expected exponent digit", parser_offset(p));
+            }
+        }
+    }
+    return Success(nothing);
+}
+
+fn validate_array_value(p: &mut Parser) -> Erring<nothing, JsonError> {
+    p.cursor = p.cursor + 1;
+    skip_ws(p);
+    if p.cursor < p.length {
+        let b: uint = byte_at(&p.data, p.cursor);
+        if b == 93:uint {
+            p.cursor = p.cursor + 1;
+            return Success(nothing);
+        }
+    }
+    while true {
+        let val_res = validate_value(p);
+        let mut err_out: JsonError = json_error(JSON_ERR_PARSE, "invalid array value", parser_offset(p));
+        let mut ok: bool = true;
+        compare val_res {
+            Success(_) => {
+                ok = true;
+            }
+            err => {
+                err_out = err;
+                ok = false;
+            }
+        };
+        if !ok {
+            return err_out;
+        }
+        skip_ws(p);
+        if at_end(p) {
+            return json_error(JSON_ERR_EOF, "unterminated array", parser_offset(p));
+        }
+        let b: uint = byte_at(&p.data, p.cursor);
+        if b == 44:uint {
+            p.cursor = p.cursor + 1;
+            skip_ws(p);
+            continue;
+        }
+        if b == 93:uint {
+            p.cursor = p.cursor + 1;
+            break;
+        }
+        return json_error(JSON_ERR_PARSE, "expected ',' or ']'", parser_offset(p));
+    }
+    return Success(nothing);
+}
+
+fn validate_object_value(p: &mut Parser) -> Erring<nothing, JsonError> {
+    p.cursor = p.cursor + 1;
+    skip_ws(p);
+    if p.cursor < p.length {
+        let b: uint = byte_at(&p.data, p.cursor);
+        if b == 125:uint {
+            p.cursor = p.cursor + 1;
+            return Success(nothing);
+        }
+    }
+    while true {
+        if at_end(p) {
+            return json_error(JSON_ERR_EOF, "unterminated object", parser_offset(p));
+        }
+        let b: uint = byte_at(&p.data, p.cursor);
+        if b != 34:uint {
+            return json_error(JSON_ERR_PARSE, "expected string key", parser_offset(p));
+        }
+        compare validate_string_value(p) {
+            Success(_) => {}
+            err => {
+                return err;
+            }
+        };
+        skip_ws(p);
+        if at_end(p) {
+            return json_error(JSON_ERR_EOF, "unterminated object", parser_offset(p));
+        }
+        let colon: uint = byte_at(&p.data, p.cursor);
+        if colon != 58:uint {
+            return json_error(JSON_ERR_PARSE, "expected ':'", parser_offset(p));
+        }
+        p.cursor = p.cursor + 1;
+        skip_ws(p);
+        compare validate_value(p) {
+            Success(_) => {}
+            err => {
+                return err;
+            }
+        };
+        skip_ws(p);
+        if at_end(p) {
+            return json_error(JSON_ERR_EOF, "unterminated object", parser_offset(p));
+        }
+        let next: uint = byte_at(&p.data, p.cursor);
+        if next == 44:uint {
+            p.cursor = p.cursor + 1;
+            skip_ws(p);
+            continue;
+        }
+        if next == 125:uint {
+            p.cursor = p.cursor + 1;
+            break;
+        }
+        return json_error(JSON_ERR_PARSE, "expected ',' or '}'", parser_offset(p));
+    }
+    return Success(nothing);
+}
+
+fn validate_value(p: &mut Parser) -> Erring<nothing, JsonError> {
+    if at_end(p) {
+        return json_error(JSON_ERR_EOF, "unexpected end of input", parser_offset(p));
+    }
+    let b: uint = byte_at(&p.data, p.cursor);
+    if b == 110:uint {
+        if consume_literal(p, "null") {
+            return Success(nothing);
+        }
+        return json_error(JSON_ERR_PARSE, "invalid literal", parser_offset(p));
+    }
+    if b == 116:uint {
+        if consume_literal(p, "true") {
+            return Success(nothing);
+        }
+        return json_error(JSON_ERR_PARSE, "invalid literal", parser_offset(p));
+    }
+    if b == 102:uint {
+        if consume_literal(p, "false") {
+            return Success(nothing);
+        }
+        return json_error(JSON_ERR_PARSE, "invalid literal", parser_offset(p));
+    }
+    if b == 34:uint {
+        return validate_string_value(p);
+    }
+    if b == 91:uint {
+        return validate_array_value(p);
+    }
+    if b == 123:uint {
+        return validate_object_value(p);
+    }
+    if b == 45:uint || is_digit(b) {
+        return validate_number_value(p);
+    }
+    return json_error(JSON_ERR_PARSE, "unexpected character", parser_offset(p));
+}
+
 fn parse_array_value(p: &mut Parser) -> JsonResult<JsonValue[]> {
     p.cursor = p.cursor + 1;
     skip_ws(p);
@@ -653,4 +965,26 @@ pub fn parse_bytes(input: byte[]) -> Erring<JsonValue, JsonError> {
 pub fn parse(input: &string) -> Erring<JsonValue, JsonError> {
     let bytes: byte[] = input.__clone() to byte[];
     return parse_bytes(bytes);
+}
+
+pub fn validate(input: &string) -> Erring<nothing, JsonError> {
+    let bytes: byte[] = input.__clone() to byte[];
+    let mut parser: Parser = parser_init(&bytes);
+    skip_ws(&mut parser);
+    let res = validate_value(&mut parser);
+    let mut out: Erring<nothing, JsonError> = json_error(JSON_ERR_PARSE, "invalid json", parser_offset(&mut parser));
+    compare res {
+        Success(_) => {
+            skip_ws(&mut parser);
+            if !at_end(&mut parser) {
+                out = json_error(JSON_ERR_PARSE, "trailing data", parser_offset(&mut parser));
+            } else {
+                out = Success(nothing);
+            }
+        }
+        err => {
+            out = err;
+        }
+    };
+    return out;
 }

--- a/testdata/llvm_smoke/json_validate.sg
+++ b/testdata/llvm_smoke/json_validate.sg
@@ -1,0 +1,45 @@
+import stdlib/json as json;
+
+fn expect_ok(input: &string, code: int) -> int {
+    compare json.validate(input) {
+        Success(_) => {
+            return 0;
+        }
+        err => {
+            let _ = err;
+            return code;
+        }
+    };
+}
+
+fn expect_err_offset(input: &string, offset: uint, code: int) -> int {
+    compare json.validate(input) {
+        Success(_) => {
+            return code;
+        }
+        err => {
+            if err.offset != offset {
+                return code + 1;
+            }
+            return 0;
+        }
+    };
+}
+
+@entrypoint
+fn main() -> int {
+    let valid: string = "{\"a\":[true,false,null],\"b\":\"x\"}";
+    let ok_code: int = expect_ok(&valid, 1);
+    if ok_code != 0 {
+        return ok_code;
+    }
+
+    let invalid_array: string = "[1,]";
+    let array_code: int = expect_err_offset(&invalid_array, 3:uint, 2);
+    if array_code != 0 {
+        return array_code;
+    }
+
+    let invalid_trailing: string = "true false";
+    return expect_err_offset(&invalid_trailing, 5:uint, 4);
+}

--- a/testdata/vm_json/json_suite.sg
+++ b/testdata/vm_json/json_suite.sg
@@ -34,6 +34,33 @@ fn parse_err_offset(input: &string, offset: uint) -> nothing {
     return nothing;
 }
 
+fn validate_ok(input: &string) -> nothing {
+    let res = json.validate(input);
+    compare res {
+        Success(_) => {}
+        err => {
+            let _ = err;
+            panic("validate failed");
+        }
+    };
+    return nothing;
+}
+
+fn validate_err_offset(input: &string, offset: uint) -> nothing {
+    let res = json.validate(input);
+    compare res {
+        Success(_) => {
+            panic("expected validate error");
+        }
+        err => {
+            if err.offset != offset {
+                panic("validate offset mismatch");
+            }
+        }
+    };
+    return nothing;
+}
+
 fn array_eq(a: JsonValue[], b: JsonValue[]) -> bool {
     if a.__len() != b.__len() {
         return false;
@@ -350,6 +377,33 @@ fn test_errors() -> nothing {
     return nothing;
 }
 
+fn test_validate() -> nothing {
+    let input1: string = "{\"a\":[true,false,null],\"b\":{\"c\":\"d\"}}";
+    validate_ok(&input1);
+
+    let input2: string = " \n\t -12.34e+5 ";
+    validate_ok(&input2);
+
+    let input3: string = "\"\\uD834\\uDD1E\"";
+    validate_ok(&input3);
+
+    let bad_trailing: string = "true false";
+    validate_err_offset(&bad_trailing, 5:uint);
+
+    let bad_array: string = "[1,]";
+    validate_err_offset(&bad_array, 3:uint);
+
+    let bad_string: string = "\"abc";
+    validate_err_offset(&bad_string, 0:uint);
+
+    let bad_number: string = "01";
+    validate_err_offset(&bad_number, 1:uint);
+
+    let bad_surrogate: string = "\"\\uD834x\"";
+    validate_err_offset(&bad_surrogate, 7:uint);
+    return nothing;
+}
+
 @entrypoint
 fn main() -> int {
     test_literals();
@@ -361,6 +415,7 @@ fn main() -> int {
     test_stringify();
     test_roundtrip();
     test_errors();
+    test_validate();
     print("ok");
     return 0;
 }


### PR DESCRIPTION
## Summary

- add `json.validate(input: &string) -> Erring<nothing, JsonError>` for allocation-light JSON validation
- cover valid and invalid JSON cases in the VM JSON suite and LLVM smoke
- fix LLVM codegen bugs exposed by the new smoke: entry-block backedges no longer re-run allocas, and `nothing` tag payloads are not stored

Fixes #146.

## Checks

- `SURGE_STDLIB=$PWD go run ./cmd/surge fmt --check stdlib/json/parser.sg testdata/vm_json/json_suite.sg testdata/llvm_smoke/json_validate.sg`
- `go test ./internal/vm -run TestVMJsonSuite -count=1`
- `go test ./internal/backend/llvm -count=1`
- `go test ./internal/vm -run TestLLVMSmoke -count=1`
- `go test ./internal/vm -run "TestLLVMNativeHeapStats|TestLLVMNativeBufferedChannelAllocatesSingleBlock|TestLLVMParityNothingCallArg|TestLLVMBuildPortable|TestLLVMSmoke" -count=1`
- pre-commit `make check` passed before amend; final amend only removed generated `STATS.md` from the commit

## Notes

- `go test ./internal/vm -run LLVM -count=1` still has baseline failures unrelated to this branch; `TestLLVMParity/select_channel` reproduces on clean `origin/main` with `vm=1 llvm=0`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `validate()` function to JSON module for efficient JSON syntax validation without building complete data structures.

* **Documentation**
  * Updated JSON API documentation in English and Russian to reflect new validation function.

* **Tests**
  * Added comprehensive test coverage for JSON validation functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->