### PR TITLE
perf(runtime): bulk append string bytes to byte arrays

### DIFF
--- a/STATS.md
+++ b/STATS.md
@@ -4,24 +4,24 @@
 
 ## 📊 Main code (without tests)
 
-- **Files:** 684 (Go: 654, C: 30)
-- **Lines of code:** 156927 (Go: 142695, C: 14232)
+- **Files:** 685 (Go: 654, C: 31)
+- **Lines of code:** 157190 (Go: 142874, C: 14316)
 
 ## 📁 Directory breakdown
 
 | Directory | Files | Lines |
 |------------|--------|-------|
 | `cmd/` | 28 | 4819 |
-| `internal/` | 624 | 137429 |
-| `runtime/native/` (C code) | 30 | 14232 |
+| `internal/` | 624 | 137496 |
+| `runtime/native/` (C code) | 31 | 14316 |
 
 ## 🏆 Top 10 packages by size
 
 | # | Package | Lines |
 |---|-------|-------|
 | 1 | `internal/sema` | 28571 |
-| 2 | `internal/vm` | 23197 |
-| 3 | `internal/backend/llvm` | 12161 |
+| 2 | `internal/vm` | 23263 |
+| 3 | `internal/backend/llvm` | 12162 |
 | 4 | `internal/mir` | 10330 |
 | 5 | `internal/parser` | 8960 |
 | 6 | `internal/hir` | 7156 |
@@ -33,12 +33,12 @@
 ## 🧪 Test files
 
 - **Files:** 177
-- **Lines of code:** 36568
+- **Lines of code:** 36569
 
 ## 📈 Total volume (code + tests)
 
-- **Files:** 861
-- **Lines of code:** 193495
+- **Files:** 862
+- **Lines of code:** 193759
 
 ## 📊 Percentage breakdown
 

--- a/STATS.md
+++ b/STATS.md
@@ -5,21 +5,21 @@
 ## 📊 Main code (without tests)
 
 - **Files:** 685 (Go: 654, C: 31)
-- **Lines of code:** 157190 (Go: 142874, C: 14316)
+- **Lines of code:** 157199 (Go: 142876, C: 14323)
 
 ## 📁 Directory breakdown
 
 | Directory | Files | Lines |
 |------------|--------|-------|
 | `cmd/` | 28 | 4819 |
-| `internal/` | 624 | 137496 |
-| `runtime/native/` (C code) | 31 | 14316 |
+| `internal/` | 624 | 137498 |
+| `runtime/native/` (C code) | 31 | 14323 |
 
 ## 🏆 Top 10 packages by size
 
 | # | Package | Lines |
 |---|-------|-------|
-| 1 | `internal/sema` | 28571 |
+| 1 | `internal/sema` | 28573 |
 | 2 | `internal/vm` | 23263 |
 | 3 | `internal/backend/llvm` | 12162 |
 | 4 | `internal/mir` | 10330 |
@@ -38,7 +38,7 @@
 ## 📈 Total volume (code + tests)
 
 - **Files:** 862
-- **Lines of code:** 193759
+- **Lines of code:** 193768
 
 ## 📊 Percentage breakdown
 

--- a/core/array.sg
+++ b/core/array.sg
@@ -136,6 +136,18 @@ extern<Array<T>> {
     }
 }
 
+extern<Array<byte>> {
+    pub fn append_string(self: &mut Array<byte>, text: &string) -> nothing {
+        rt_array_append_raw_bytes(self, rt_string_ptr(text), rt_string_len_bytes(text) to uint64);
+        return nothing;
+    }
+
+    pub fn append_bytes_view(self: &mut Array<byte>, view: &BytesView) -> nothing {
+        rt_array_append_raw_bytes(self, view.ptr, view.__len() to uint64);
+        return nothing;
+    }
+}
+
 // contains/find are currently specialized for primitive element types.
 extern<Array<int>> {
     pub fn contains(self: &Array<int>, value: &int) -> bool {

--- a/core/intrinsics.sg
+++ b/core/intrinsics.sg
@@ -129,6 +129,7 @@ extern<TcpConn> {
 @intrinsic fn rt_array_pop<T>(a: &mut Array<T>) -> Option<T>;
 @intrinsic fn rt_array_get_mut<T>(a: &mut Array<T>, index: int) -> &mut T;
 @intrinsic @overload fn rt_array_get_mut<T, const N:int>(a: &mut ArrayFixed<T, N>, index: int) -> &mut T;
+@intrinsic fn rt_array_append_raw_bytes(a: &mut byte[], ptr: *byte, length: uint64) -> nothing;
 
 // Map access intrinsics
 @intrinsic fn rt_map_new<K, V>() -> Map<K, V>;
@@ -685,17 +686,8 @@ extern<string> {
     }
     @overload
     pub fn __to(self: &string, _: byte[]) -> byte[] {
-        let view = self.bytes();
-        let length: uint = view.__len();
         let mut out: byte[] = [];
-        out.reserve(length);
-        let len_i: int = length to int;
-        let mut i: int = 0;
-        while i < len_i {
-            let b: byte = view[i];
-            out.push(b);
-            i = i + 1;
-        }
+        rt_array_append_raw_bytes(&mut out, rt_string_ptr(self), rt_string_len_bytes(self) to uint64);
         return out;
     }
     @intrinsic fn __len(self: &string) -> uint;

--- a/internal/backend/llvm/builtins.go
+++ b/internal/backend/llvm/builtins.go
@@ -14,6 +14,7 @@ func runtimeDecls() []builtinDecl {
 		{name: "rt_realloc", ret: "ptr", params: []string{"ptr", "i64", "i64", "i64"}},
 		{name: "rt_memcpy", ret: "void", params: []string{"ptr", "ptr", "i64"}},
 		{name: "rt_memmove", ret: "void", params: []string{"ptr", "ptr", "i64"}},
+		{name: "rt_array_append_raw_bytes", ret: "void", params: []string{"ptr", "ptr", "i64"}},
 		{name: "rt_write_stdout", ret: "i64", params: []string{"ptr", "i64"}},
 		{name: "rt_write_stderr", ret: "i64", params: []string{"ptr", "i64"}},
 		{name: "rt_entropy_bytes", ret: "ptr", params: []string{"i64"}},

--- a/internal/sema/type_array_view.go
+++ b/internal/sema/type_array_view.go
@@ -124,7 +124,8 @@ func (tc *typeChecker) updateArrayViewBindingFromAssign(left, right ast.ExprID) 
 }
 
 func (tc *typeChecker) checkArrayViewResizeMethod(receiverExpr ast.ExprID, name string, receiverType types.TypeID, span source.Span) {
-	if name != "push" && name != "pop" && name != "reserve" {
+	if name != "push" && name != "pop" && name != "reserve" &&
+		name != "append_string" && name != "append_bytes_view" {
 		return
 	}
 	if !tc.isArrayType(tc.valueType(receiverType)) {
@@ -164,6 +165,7 @@ func (tc *typeChecker) markArrayViewMethodCall(callID ast.ExprID, name string, r
 func (tc *typeChecker) checkArrayViewResizeCall(name string, args []callArg, span source.Span) {
 	switch name {
 	case "rt_array_reserve", "rt_array_push", "rt_array_pop",
+		"rt_array_append_raw_bytes",
 		"array_reserve", "array_push", "array_pop":
 	default:
 		return

--- a/internal/vm/intrinsic.go
+++ b/internal/vm/intrinsic.go
@@ -114,6 +114,8 @@ func (vm *VM) callIntrinsic(frame *Frame, call *mir.CallInstr, writes *[]LocalWr
 		return vm.handleArrayPop(frame, call, writes)
 	case "rt_array_get_mut":
 		return vm.handleArrayGetMut(frame, call, writes)
+	case "rt_array_append_raw_bytes":
+		return vm.handleArrayAppendRawBytes(frame, call, writes)
 
 	case "rt_map_new":
 		return vm.handleMapNew(frame, call, writes)

--- a/internal/vm/intrinsic_array.go
+++ b/internal/vm/intrinsic_array.go
@@ -217,6 +217,70 @@ func (vm *VM) handleArrayGetMut(frame *Frame, call *mir.CallInstr, writes *[]Loc
 	return nil
 }
 
+func (vm *VM) handleArrayAppendRawBytes(frame *Frame, call *mir.CallInstr, writes *[]LocalWrite) *VMError {
+	_ = writes
+	if len(call.Args) != 3 {
+		return vm.eb.makeError(PanicTypeMismatch, "rt_array_append_raw_bytes requires 3 arguments")
+	}
+	arrVal, vmErr := vm.evalOperand(frame, &call.Args[0])
+	if vmErr != nil {
+		return vmErr
+	}
+	defer vm.dropValue(arrVal)
+	ptrVal, vmErr := vm.evalOperand(frame, &call.Args[1])
+	if vmErr != nil {
+		return vmErr
+	}
+	defer vm.dropValue(ptrVal)
+	lenVal, vmErr := vm.evalOperand(frame, &call.Args[2])
+	if vmErr != nil {
+		return vmErr
+	}
+	defer vm.dropValue(lenVal)
+
+	if ptrVal.Kind != VKPtr {
+		return vm.eb.typeMismatch("*byte", ptrVal.Kind.String())
+	}
+	n, vmErr := vm.uintValueToInt(lenVal, "array append length out of range")
+	if vmErr != nil {
+		return vmErr
+	}
+	if n == 0 {
+		return nil
+	}
+	data, vmErr := vm.readBytesFromPointer(ptrVal, n)
+	if vmErr != nil {
+		return vmErr
+	}
+	arrObj, vmErr := vm.arrayOwnedFromValue(arrVal)
+	if vmErr != nil {
+		return vmErr
+	}
+
+	oldLen := len(arrObj.Arr)
+	newLen := oldLen + len(data)
+	if newLen < oldLen {
+		return vm.eb.invalidNumericConversion("array length out of range")
+	}
+	if newLen > cap(arrObj.Arr) {
+		grown := growArrayCapacity(cap(arrObj.Arr), newLen)
+		next := make([]Value, newLen, grown)
+		copy(next, arrObj.Arr)
+		arrObj.Arr = next
+	} else {
+		arrObj.Arr = arrObj.Arr[:newLen]
+	}
+
+	elemType := types.NoTypeID
+	if vm.Types != nil {
+		elemType = vm.Types.Builtins().Uint8
+	}
+	for i, b := range data {
+		arrObj.Arr[oldLen+i] = MakeInt(int64(b), elemType)
+	}
+	return nil
+}
+
 func (vm *VM) makeOptionSome(typeID types.TypeID, elem Value) (Value, *VMError) {
 	if typeID == types.NoTypeID {
 		return Value{}, vm.eb.makeError(PanicTypeMismatch, "invalid Option<T> type")

--- a/internal/vm/llvm_parity_test.go
+++ b/internal/vm/llvm_parity_test.go
@@ -41,6 +41,7 @@ func TestLLVMParity(t *testing.T) {
 		{name: "exit_code", file: "exit_code.sg"},
 		{name: "panic", file: "panic.sg"},
 		{name: "string_concat", file: "string_concat.sg"},
+		{name: "byte_array_append_string", file: "byte_array_append_string.sg"},
 		{name: "tagged_switch", file: "tagged_switch.sg"},
 		{name: "nested_ref_field", file: "nested_ref_field.sg"},
 		{name: "option_tag_cast", file: "option_tag_cast.sg"},

--- a/runtime/native/rt.h
+++ b/runtime/native/rt.h
@@ -14,6 +14,7 @@ void rt_free(uint8_t* ptr, uint64_t size, uint64_t align);
 void* rt_realloc(uint8_t* ptr, uint64_t old_size, uint64_t new_size, uint64_t align);
 void rt_memcpy(uint8_t* dst, const uint8_t* src, uint64_t n);
 void rt_memmove(uint8_t* dst, const uint8_t* src, uint64_t n);
+void rt_array_append_raw_bytes(void* array_slot, const uint8_t* src, uint64_t len);
 size_t rt_tag_payload_offset(size_t payload_align);
 void* rt_tag_alloc(uint32_t tag, size_t payload_align, size_t payload_size);
 

--- a/runtime/native/rt_array.c
+++ b/runtime/native/rt_array.c
@@ -1,0 +1,83 @@
+#include "rt.h"
+
+#include <stdalign.h>
+#include <stdint.h>
+#include <string.h>
+
+typedef struct SurgeArrayHeader {
+    uint64_t len;
+    uint64_t cap;
+    void* data;
+} SurgeArrayHeader;
+
+static void array_panic(const char* msg) {
+    rt_panic_numeric((const uint8_t*)msg, (uint64_t)strlen(msg));
+}
+
+static uint64_t array_grow_cap(uint64_t current, uint64_t min_cap) {
+    if (current < 1) {
+        current = 1;
+    }
+    while (current < min_cap) {
+        if (current > UINT64_MAX / 2) {
+            array_panic("array capacity out of range");
+        }
+        current *= 2;
+    }
+    return current;
+}
+
+void rt_array_append_raw_bytes(void* array_slot, const uint8_t* src, uint64_t len) {
+    if (len == 0) {
+        return;
+    }
+    if (array_slot == NULL || src == NULL) {
+        array_panic("array append bytes received null pointer");
+    }
+
+    SurgeArrayHeader* header = *(SurgeArrayHeader**)array_slot;
+    if (header == NULL) {
+        array_panic("array append bytes received null array");
+    }
+    if (len > UINT64_MAX - header->len) {
+        array_panic("array length out of range");
+    }
+
+    uint64_t old_len = header->len;
+    uint64_t new_len = old_len + len;
+    uintptr_t src_offset = UINTPTR_MAX;
+    if (header->data != NULL && old_len > 0) {
+        uintptr_t data_addr = (uintptr_t)header->data;
+        uintptr_t src_addr = (uintptr_t)src;
+        if (src_addr >= data_addr) {
+            uintptr_t candidate = src_addr - data_addr;
+            if (candidate < old_len) {
+                if (len > old_len - candidate) {
+                    array_panic("array append bytes source range out of range");
+                }
+                src_offset = candidate;
+            }
+        }
+    }
+
+    if (new_len > header->cap) {
+        uint64_t new_cap = array_grow_cap(header->cap, new_len);
+        void* data =
+            rt_realloc((uint8_t*)header->data, header->cap, new_cap, (uint64_t)alignof(uint8_t));
+        if (data == NULL) {
+            array_panic("array allocation failed");
+        }
+        header->data = data;
+        header->cap = new_cap;
+    }
+    if (header->data == NULL) {
+        array_panic("array append bytes received null data");
+    }
+
+    const uint8_t* copy_src = src;
+    if (src_offset != UINTPTR_MAX) {
+        copy_src = (const uint8_t*)header->data + src_offset;
+    }
+    rt_memmove((uint8_t*)header->data + old_len, copy_src, len);
+    header->len = new_len;
+}

--- a/runtime/native/rt_array.c
+++ b/runtime/native/rt_array.c
@@ -21,6 +21,7 @@ static uint64_t array_grow_cap(uint64_t current, uint64_t min_cap) {
     while (current < min_cap) {
         if (current > UINT64_MAX / 2) {
             array_panic("array capacity out of range");
+            return min_cap;
         }
         current *= 2;
     }
@@ -33,14 +34,17 @@ void rt_array_append_raw_bytes(void* array_slot, const uint8_t* src, uint64_t le
     }
     if (array_slot == NULL || src == NULL) {
         array_panic("array append bytes received null pointer");
+        return;
     }
 
     SurgeArrayHeader* header = *(SurgeArrayHeader**)array_slot;
     if (header == NULL) {
         array_panic("array append bytes received null array");
+        return;
     }
     if (len > UINT64_MAX - header->len) {
         array_panic("array length out of range");
+        return;
     }
 
     uint64_t old_len = header->len;
@@ -54,6 +58,7 @@ void rt_array_append_raw_bytes(void* array_slot, const uint8_t* src, uint64_t le
             if (candidate < old_len) {
                 if (len > old_len - candidate) {
                     array_panic("array append bytes source range out of range");
+                    return;
                 }
                 src_offset = candidate;
             }
@@ -66,12 +71,14 @@ void rt_array_append_raw_bytes(void* array_slot, const uint8_t* src, uint64_t le
             rt_realloc((uint8_t*)header->data, header->cap, new_cap, (uint64_t)alignof(uint8_t));
         if (data == NULL) {
             array_panic("array allocation failed");
+            return;
         }
         header->data = data;
         header->cap = new_cap;
     }
     if (header->data == NULL) {
         array_panic("array append bytes received null data");
+        return;
     }
 
     const uint8_t* copy_src = src;

--- a/testdata/golden/core_stdlib/array.ast
+++ b/testdata/golden/core_stdlib/array.ast
@@ -1,4 +1,4 @@
-array.sg (span: 1:1-285:1)
+array.sg (span: 1:1-297:1)
 ├─ Item[0]: Fn (span: 5:1-7:2)
 │  ├─ Name: array_reserve
 │  ├─ Generics: <T>
@@ -305,359 +305,380 @@ Block (span: 122:21-128:10)
 │  │        │  └─ Value: expr#213: self.__len() to string
 │  │        └─ Stmt[2]: Return (span: 135:9-135:46)
 │  │           └─ Expr: expr#218: ((("Array(len=" + length_s)) + ")")
-├─ Item[5]: Extern (span: 140:1-157:2)
+├─ Item[5]: Extern (span: 139:1-149:2)
+│  ├─ Target: Array<byte>
+│  ├─ Members:
+│  │  ├─ Fn[0]: append_string
+│  │  │  ├─ Params: (self: &mut Array<byte>, text: &string)
+│  │  │  ├─ Return: nothing
+│  │  │  └─ Body:
+│  │  │     Stmt[0]: Block (span: 140:76-143:6)
+│  │  │     ├─ Stmt[0]: Expr (span: 141:9-141:99)
+│  │  │     │  └─ Expr: expr#228: rt_array_append_raw_bytes(self, rt_string_ptr(text), rt_string_len_bytes(text) to uint64)
+│  │  │     └─ Stmt[1]: Return (span: 142:9-142:24)
+│  │  │        └─ Expr: expr#229: nothing
+│  │  └─ Fn[1]: append_bytes_view
+│  │     ├─ Params: (self: &mut Array<byte>, view: &BytesView)
+│  │     ├─ Return: nothing
+│  │     └─ Body:
+│  │        Stmt[0]: Block (span: 145:83-148:6)
+│  │        ├─ Stmt[0]: Expr (span: 146:9-146:75)
+│  │        │  └─ Expr: expr#238: rt_array_append_raw_bytes(self, view.ptr, view.__len() to uint64)
+│  │        └─ Stmt[1]: Return (span: 147:9-147:24)
+│  │           └─ Expr: expr#239: nothing
+├─ Item[6]: Extern (span: 152:1-169:2)
 │  ├─ Target: Array<int>
 │  ├─ Members:
 │  │  ├─ Fn[0]: contains
 │  │  │  ├─ Params: (self: &Array<int>, value: &int)
 │  │  │  ├─ Return: bool
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 141:61-144:6)
-│  │  │     ├─ Stmt[0]: Let (span: 142:9-142:50)
+│  │  │     Stmt[0]: Block (span: 153:61-156:6)
+│  │  │     ├─ Stmt[0]: Let (span: 154:9-154:50)
 │  │  │     │  ├─ Name: res
 │  │  │     │  ├─ Mutable: false
 │  │  │     │  ├─ Type: Option<uint>
-│  │  │     │  └─ Value: expr#222: self.find(value)
-│  │  │     └─ Stmt[1]: Return (span: 143:9-143:30)
-│  │  │        └─ Expr: expr#225: res.is_some()
+│  │  │     │  └─ Value: expr#243: self.find(value)
+│  │  │     └─ Stmt[1]: Return (span: 155:9-155:30)
+│  │  │        └─ Expr: expr#246: res.is_some()
 │  │  └─ Fn[1]: find
 │  │     ├─ Params: (self: &Array<int>, value: &int)
 │  │     ├─ Return: Option<uint>
 │  │     └─ Body:
-│  │        Stmt[0]: Block (span: 146:65-156:6)
-│  │        ├─ Stmt[0]: Let (span: 147:9-147:47)
+│  │        Stmt[0]: Block (span: 158:65-168:6)
+│  │        ├─ Stmt[0]: Let (span: 159:9-159:47)
 │  │        │  ├─ Name: length
 │  │        │  ├─ Mutable: false
 │  │        │  ├─ Type: int
-│  │        │  └─ Value: expr#229: self.__len() to int
-│  │        ├─ Stmt[1]: Let (span: 148:9-148:28)
+│  │        │  └─ Value: expr#250: self.__len() to int
+│  │        ├─ Stmt[1]: Let (span: 160:9-160:28)
 │  │        │  ├─ Name: i
 │  │        │  ├─ Mutable: true
 │  │        │  ├─ Type: int
-│  │        │  └─ Value: expr#230: 0
-│  │        ├─ Stmt[2]: While (span: 149:9-154:10)
-│  │        │  ├─ Cond: expr#233: (i < length)
+│  │        │  └─ Value: expr#251: 0
+│  │        ├─ Stmt[2]: While (span: 161:9-166:10)
+│  │        │  ├─ Cond: expr#254: (i < length)
 │  │        │  └─ Body:
-Block (span: 149:26-154:10)
-│  │        │     ├─ Stmt[0]: If (span: 150:13-152:14)
-│  │        │     │  ├─ Cond: expr#239: (self[i] == *value)
+Block (span: 161:26-166:10)
+│  │        │     ├─ Stmt[0]: If (span: 162:13-164:14)
+│  │        │     │  ├─ Cond: expr#260: (self[i] == *value)
 │  │        │     │  ├─ Then:
-Block (span: 150:34-152:14)
-│  │        │     │  │  └─ Stmt[0]: Return (span: 151:17-151:40)
-│  │        │     │  │     └─ Expr: expr#243: Some(i to uint)
+Block (span: 162:34-164:14)
+│  │        │     │  │  └─ Stmt[0]: Return (span: 163:17-163:40)
+│  │        │     │  │     └─ Expr: expr#264: Some(i to uint)
 │  │        │     │  └─ Else: <none>
-│  │        │     └─ Stmt[1]: Expr (span: 153:13-153:23)
-│  │        │        └─ Expr: expr#248: (i = ((i + 1)))
-│  │        └─ Stmt[3]: Return (span: 155:9-155:24)
-│  │           └─ Expr: expr#249: nothing
-├─ Item[6]: Extern (span: 159:1-176:2)
+│  │        │     └─ Stmt[1]: Expr (span: 165:13-165:23)
+│  │        │        └─ Expr: expr#269: (i = ((i + 1)))
+│  │        └─ Stmt[3]: Return (span: 167:9-167:24)
+│  │           └─ Expr: expr#270: nothing
+├─ Item[7]: Extern (span: 171:1-188:2)
 │  ├─ Target: Array<uint>
 │  ├─ Members:
 │  │  ├─ Fn[0]: contains
 │  │  │  ├─ Params: (self: &Array<uint>, value: &uint)
 │  │  │  ├─ Return: bool
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 160:63-163:6)
-│  │  │     ├─ Stmt[0]: Let (span: 161:9-161:50)
+│  │  │     Stmt[0]: Block (span: 172:63-175:6)
+│  │  │     ├─ Stmt[0]: Let (span: 173:9-173:50)
 │  │  │     │  ├─ Name: res
 │  │  │     │  ├─ Mutable: false
 │  │  │     │  ├─ Type: Option<uint>
-│  │  │     │  └─ Value: expr#253: self.find(value)
-│  │  │     └─ Stmt[1]: Return (span: 162:9-162:30)
-│  │  │        └─ Expr: expr#256: res.is_some()
+│  │  │     │  └─ Value: expr#274: self.find(value)
+│  │  │     └─ Stmt[1]: Return (span: 174:9-174:30)
+│  │  │        └─ Expr: expr#277: res.is_some()
 │  │  └─ Fn[1]: find
 │  │     ├─ Params: (self: &Array<uint>, value: &uint)
 │  │     ├─ Return: Option<uint>
 │  │     └─ Body:
-│  │        Stmt[0]: Block (span: 165:67-175:6)
-│  │        ├─ Stmt[0]: Let (span: 166:9-166:47)
+│  │        Stmt[0]: Block (span: 177:67-187:6)
+│  │        ├─ Stmt[0]: Let (span: 178:9-178:47)
 │  │        │  ├─ Name: length
 │  │        │  ├─ Mutable: false
 │  │        │  ├─ Type: int
-│  │        │  └─ Value: expr#260: self.__len() to int
-│  │        ├─ Stmt[1]: Let (span: 167:9-167:28)
+│  │        │  └─ Value: expr#281: self.__len() to int
+│  │        ├─ Stmt[1]: Let (span: 179:9-179:28)
 │  │        │  ├─ Name: i
 │  │        │  ├─ Mutable: true
 │  │        │  ├─ Type: int
-│  │        │  └─ Value: expr#261: 0
-│  │        ├─ Stmt[2]: While (span: 168:9-173:10)
-│  │        │  ├─ Cond: expr#264: (i < length)
+│  │        │  └─ Value: expr#282: 0
+│  │        ├─ Stmt[2]: While (span: 180:9-185:10)
+│  │        │  ├─ Cond: expr#285: (i < length)
 │  │        │  └─ Body:
-Block (span: 168:26-173:10)
-│  │        │     ├─ Stmt[0]: If (span: 169:13-171:14)
-│  │        │     │  ├─ Cond: expr#270: (self[i] == *value)
+Block (span: 180:26-185:10)
+│  │        │     ├─ Stmt[0]: If (span: 181:13-183:14)
+│  │        │     │  ├─ Cond: expr#291: (self[i] == *value)
 │  │        │     │  ├─ Then:
-Block (span: 169:34-171:14)
-│  │        │     │  │  └─ Stmt[0]: Return (span: 170:17-170:40)
-│  │        │     │  │     └─ Expr: expr#274: Some(i to uint)
+Block (span: 181:34-183:14)
+│  │        │     │  │  └─ Stmt[0]: Return (span: 182:17-182:40)
+│  │        │     │  │     └─ Expr: expr#295: Some(i to uint)
 │  │        │     │  └─ Else: <none>
-│  │        │     └─ Stmt[1]: Expr (span: 172:13-172:23)
-│  │        │        └─ Expr: expr#279: (i = ((i + 1)))
-│  │        └─ Stmt[3]: Return (span: 174:9-174:24)
-│  │           └─ Expr: expr#280: nothing
-├─ Item[7]: Extern (span: 178:1-195:2)
+│  │        │     └─ Stmt[1]: Expr (span: 184:13-184:23)
+│  │        │        └─ Expr: expr#300: (i = ((i + 1)))
+│  │        └─ Stmt[3]: Return (span: 186:9-186:24)
+│  │           └─ Expr: expr#301: nothing
+├─ Item[8]: Extern (span: 190:1-207:2)
 │  ├─ Target: Array<float>
 │  ├─ Members:
 │  │  ├─ Fn[0]: contains
 │  │  │  ├─ Params: (self: &Array<float>, value: &float)
 │  │  │  ├─ Return: bool
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 179:65-182:6)
-│  │  │     ├─ Stmt[0]: Let (span: 180:9-180:50)
+│  │  │     Stmt[0]: Block (span: 191:65-194:6)
+│  │  │     ├─ Stmt[0]: Let (span: 192:9-192:50)
 │  │  │     │  ├─ Name: res
 │  │  │     │  ├─ Mutable: false
 │  │  │     │  ├─ Type: Option<uint>
-│  │  │     │  └─ Value: expr#284: self.find(value)
-│  │  │     └─ Stmt[1]: Return (span: 181:9-181:30)
-│  │  │        └─ Expr: expr#287: res.is_some()
+│  │  │     │  └─ Value: expr#305: self.find(value)
+│  │  │     └─ Stmt[1]: Return (span: 193:9-193:30)
+│  │  │        └─ Expr: expr#308: res.is_some()
 │  │  └─ Fn[1]: find
 │  │     ├─ Params: (self: &Array<float>, value: &float)
 │  │     ├─ Return: Option<uint>
 │  │     └─ Body:
-│  │        Stmt[0]: Block (span: 184:69-194:6)
-│  │        ├─ Stmt[0]: Let (span: 185:9-185:47)
+│  │        Stmt[0]: Block (span: 196:69-206:6)
+│  │        ├─ Stmt[0]: Let (span: 197:9-197:47)
 │  │        │  ├─ Name: length
 │  │        │  ├─ Mutable: false
 │  │        │  ├─ Type: int
-│  │        │  └─ Value: expr#291: self.__len() to int
-│  │        ├─ Stmt[1]: Let (span: 186:9-186:28)
+│  │        │  └─ Value: expr#312: self.__len() to int
+│  │        ├─ Stmt[1]: Let (span: 198:9-198:28)
 │  │        │  ├─ Name: i
 │  │        │  ├─ Mutable: true
 │  │        │  ├─ Type: int
-│  │        │  └─ Value: expr#292: 0
-│  │        ├─ Stmt[2]: While (span: 187:9-192:10)
-│  │        │  ├─ Cond: expr#295: (i < length)
+│  │        │  └─ Value: expr#313: 0
+│  │        ├─ Stmt[2]: While (span: 199:9-204:10)
+│  │        │  ├─ Cond: expr#316: (i < length)
 │  │        │  └─ Body:
-Block (span: 187:26-192:10)
-│  │        │     ├─ Stmt[0]: If (span: 188:13-190:14)
-│  │        │     │  ├─ Cond: expr#301: (self[i] == *value)
+Block (span: 199:26-204:10)
+│  │        │     ├─ Stmt[0]: If (span: 200:13-202:14)
+│  │        │     │  ├─ Cond: expr#322: (self[i] == *value)
 │  │        │     │  ├─ Then:
-Block (span: 188:34-190:14)
-│  │        │     │  │  └─ Stmt[0]: Return (span: 189:17-189:40)
-│  │        │     │  │     └─ Expr: expr#305: Some(i to uint)
+Block (span: 200:34-202:14)
+│  │        │     │  │  └─ Stmt[0]: Return (span: 201:17-201:40)
+│  │        │     │  │     └─ Expr: expr#326: Some(i to uint)
 │  │        │     │  └─ Else: <none>
-│  │        │     └─ Stmt[1]: Expr (span: 191:13-191:23)
-│  │        │        └─ Expr: expr#310: (i = ((i + 1)))
-│  │        └─ Stmt[3]: Return (span: 193:9-193:24)
-│  │           └─ Expr: expr#311: nothing
-├─ Item[8]: Extern (span: 197:1-214:2)
+│  │        │     └─ Stmt[1]: Expr (span: 203:13-203:23)
+│  │        │        └─ Expr: expr#331: (i = ((i + 1)))
+│  │        └─ Stmt[3]: Return (span: 205:9-205:24)
+│  │           └─ Expr: expr#332: nothing
+├─ Item[9]: Extern (span: 209:1-226:2)
 │  ├─ Target: Array<bool>
 │  ├─ Members:
 │  │  ├─ Fn[0]: contains
 │  │  │  ├─ Params: (self: &Array<bool>, value: &bool)
 │  │  │  ├─ Return: bool
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 198:63-201:6)
-│  │  │     ├─ Stmt[0]: Let (span: 199:9-199:50)
+│  │  │     Stmt[0]: Block (span: 210:63-213:6)
+│  │  │     ├─ Stmt[0]: Let (span: 211:9-211:50)
 │  │  │     │  ├─ Name: res
 │  │  │     │  ├─ Mutable: false
 │  │  │     │  ├─ Type: Option<uint>
-│  │  │     │  └─ Value: expr#315: self.find(value)
-│  │  │     └─ Stmt[1]: Return (span: 200:9-200:30)
-│  │  │        └─ Expr: expr#318: res.is_some()
+│  │  │     │  └─ Value: expr#336: self.find(value)
+│  │  │     └─ Stmt[1]: Return (span: 212:9-212:30)
+│  │  │        └─ Expr: expr#339: res.is_some()
 │  │  └─ Fn[1]: find
 │  │     ├─ Params: (self: &Array<bool>, value: &bool)
 │  │     ├─ Return: Option<uint>
 │  │     └─ Body:
-│  │        Stmt[0]: Block (span: 203:67-213:6)
-│  │        ├─ Stmt[0]: Let (span: 204:9-204:47)
+│  │        Stmt[0]: Block (span: 215:67-225:6)
+│  │        ├─ Stmt[0]: Let (span: 216:9-216:47)
 │  │        │  ├─ Name: length
 │  │        │  ├─ Mutable: false
 │  │        │  ├─ Type: int
-│  │        │  └─ Value: expr#322: self.__len() to int
-│  │        ├─ Stmt[1]: Let (span: 205:9-205:28)
+│  │        │  └─ Value: expr#343: self.__len() to int
+│  │        ├─ Stmt[1]: Let (span: 217:9-217:28)
 │  │        │  ├─ Name: i
 │  │        │  ├─ Mutable: true
 │  │        │  ├─ Type: int
-│  │        │  └─ Value: expr#323: 0
-│  │        ├─ Stmt[2]: While (span: 206:9-211:10)
-│  │        │  ├─ Cond: expr#326: (i < length)
+│  │        │  └─ Value: expr#344: 0
+│  │        ├─ Stmt[2]: While (span: 218:9-223:10)
+│  │        │  ├─ Cond: expr#347: (i < length)
 │  │        │  └─ Body:
-Block (span: 206:26-211:10)
-│  │        │     ├─ Stmt[0]: If (span: 207:13-209:14)
-│  │        │     │  ├─ Cond: expr#332: (self[i] == *value)
+Block (span: 218:26-223:10)
+│  │        │     ├─ Stmt[0]: If (span: 219:13-221:14)
+│  │        │     │  ├─ Cond: expr#353: (self[i] == *value)
 │  │        │     │  ├─ Then:
-Block (span: 207:34-209:14)
-│  │        │     │  │  └─ Stmt[0]: Return (span: 208:17-208:40)
-│  │        │     │  │     └─ Expr: expr#336: Some(i to uint)
+Block (span: 219:34-221:14)
+│  │        │     │  │  └─ Stmt[0]: Return (span: 220:17-220:40)
+│  │        │     │  │     └─ Expr: expr#357: Some(i to uint)
 │  │        │     │  └─ Else: <none>
-│  │        │     └─ Stmt[1]: Expr (span: 210:13-210:23)
-│  │        │        └─ Expr: expr#341: (i = ((i + 1)))
-│  │        └─ Stmt[3]: Return (span: 212:9-212:24)
-│  │           └─ Expr: expr#342: nothing
-├─ Item[9]: Extern (span: 216:1-233:2)
+│  │        │     └─ Stmt[1]: Expr (span: 222:13-222:23)
+│  │        │        └─ Expr: expr#362: (i = ((i + 1)))
+│  │        └─ Stmt[3]: Return (span: 224:9-224:24)
+│  │           └─ Expr: expr#363: nothing
+├─ Item[10]: Extern (span: 228:1-245:2)
 │  ├─ Target: Array<string>
 │  ├─ Members:
 │  │  ├─ Fn[0]: contains
 │  │  │  ├─ Params: (self: &Array<string>, value: &string)
 │  │  │  ├─ Return: bool
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 217:67-220:6)
-│  │  │     ├─ Stmt[0]: Let (span: 218:9-218:50)
+│  │  │     Stmt[0]: Block (span: 229:67-232:6)
+│  │  │     ├─ Stmt[0]: Let (span: 230:9-230:50)
 │  │  │     │  ├─ Name: res
 │  │  │     │  ├─ Mutable: false
 │  │  │     │  ├─ Type: Option<uint>
-│  │  │     │  └─ Value: expr#346: self.find(value)
-│  │  │     └─ Stmt[1]: Return (span: 219:9-219:30)
-│  │  │        └─ Expr: expr#349: res.is_some()
+│  │  │     │  └─ Value: expr#367: self.find(value)
+│  │  │     └─ Stmt[1]: Return (span: 231:9-231:30)
+│  │  │        └─ Expr: expr#370: res.is_some()
 │  │  └─ Fn[1]: find
 │  │     ├─ Params: (self: &Array<string>, value: &string)
 │  │     ├─ Return: Option<uint>
 │  │     └─ Body:
-│  │        Stmt[0]: Block (span: 222:71-232:6)
-│  │        ├─ Stmt[0]: Let (span: 223:9-223:47)
+│  │        Stmt[0]: Block (span: 234:71-244:6)
+│  │        ├─ Stmt[0]: Let (span: 235:9-235:47)
 │  │        │  ├─ Name: length
 │  │        │  ├─ Mutable: false
 │  │        │  ├─ Type: int
-│  │        │  └─ Value: expr#353: self.__len() to int
-│  │        ├─ Stmt[1]: Let (span: 224:9-224:28)
+│  │        │  └─ Value: expr#374: self.__len() to int
+│  │        ├─ Stmt[1]: Let (span: 236:9-236:28)
 │  │        │  ├─ Name: i
 │  │        │  ├─ Mutable: true
 │  │        │  ├─ Type: int
-│  │        │  └─ Value: expr#354: 0
-│  │        ├─ Stmt[2]: While (span: 225:9-230:10)
-│  │        │  ├─ Cond: expr#357: (i < length)
+│  │        │  └─ Value: expr#375: 0
+│  │        ├─ Stmt[2]: While (span: 237:9-242:10)
+│  │        │  ├─ Cond: expr#378: (i < length)
 │  │        │  └─ Body:
-Block (span: 225:26-230:10)
-│  │        │     ├─ Stmt[0]: If (span: 226:13-228:14)
-│  │        │     │  ├─ Cond: expr#363: (self[i] == *value)
+Block (span: 237:26-242:10)
+│  │        │     ├─ Stmt[0]: If (span: 238:13-240:14)
+│  │        │     │  ├─ Cond: expr#384: (self[i] == *value)
 │  │        │     │  ├─ Then:
-Block (span: 226:34-228:14)
-│  │        │     │  │  └─ Stmt[0]: Return (span: 227:17-227:40)
-│  │        │     │  │     └─ Expr: expr#367: Some(i to uint)
+Block (span: 238:34-240:14)
+│  │        │     │  │  └─ Stmt[0]: Return (span: 239:17-239:40)
+│  │        │     │  │     └─ Expr: expr#388: Some(i to uint)
 │  │        │     │  └─ Else: <none>
-│  │        │     └─ Stmt[1]: Expr (span: 229:13-229:23)
-│  │        │        └─ Expr: expr#372: (i = ((i + 1)))
-│  │        └─ Stmt[3]: Return (span: 231:9-231:24)
-│  │           └─ Expr: expr#373: nothing
-└─ Item[10]: Extern (span: 235:1-284:2)
+│  │        │     └─ Stmt[1]: Expr (span: 241:13-241:23)
+│  │        │        └─ Expr: expr#393: (i = ((i + 1)))
+│  │        └─ Stmt[3]: Return (span: 243:9-243:24)
+│  │           └─ Expr: expr#394: nothing
+└─ Item[11]: Extern (span: 247:1-296:2)
    ├─ Target: ArrayFixed<T, N>
    ├─ Members:
    │  ├─ Fn[0]: with_len
    │  │  ├─ Params: (length: uint)
    │  │  ├─ Return: ArrayFixed<T, N>
    │  │  └─ Body:
-   │  │     Stmt[0]: Block (span: 236:55-243:6)
-   │  │     ├─ Stmt[0]: Let (span: 237:9-237:67)
+   │  │     Stmt[0]: Block (span: 248:55-255:6)
+   │  │     ├─ Stmt[0]: Let (span: 249:9-249:67)
    │  │     │  ├─ Name: out
    │  │     │  ├─ Mutable: false
    │  │     │  ├─ Type: ArrayFixed<T, N>
-   │  │     │  └─ Value: expr#375: default()
-   │  │     ├─ Stmt[1]: Let (span: 238:9-238:42)
+   │  │     │  └─ Value: expr#396: default()
+   │  │     ├─ Stmt[1]: Let (span: 250:9-250:42)
    │  │     │  ├─ Name: expected
    │  │     │  ├─ Mutable: false
    │  │     │  ├─ Type: uint
-   │  │     │  └─ Value: expr#378: out.__len()
-   │  │     ├─ Stmt[2]: If (span: 239:9-241:10)
-   │  │     │  ├─ Cond: expr#381: (length != expected)
+   │  │     │  └─ Value: expr#399: out.__len()
+   │  │     ├─ Stmt[2]: If (span: 251:9-253:10)
+   │  │     │  ├─ Cond: expr#402: (length != expected)
    │  │     │  ├─ Then:
-Block (span: 239:31-241:10)
-   │  │     │  │  └─ Stmt[0]: Expr (span: 240:13-240:49)
-   │  │     │  │     └─ Expr: expr#384: panic("ArrayFixed length mismatch")
+Block (span: 251:31-253:10)
+   │  │     │  │  └─ Stmt[0]: Expr (span: 252:13-252:49)
+   │  │     │  │     └─ Expr: expr#405: panic("ArrayFixed length mismatch")
    │  │     │  └─ Else: <none>
-   │  │     └─ Stmt[3]: Return (span: 242:9-242:20)
-   │  │        └─ Expr: expr#385: out
+   │  │     └─ Stmt[3]: Return (span: 254:9-254:20)
+   │  │        └─ Expr: expr#406: out
    │  ├─ Fn[1]: get_mut
    │  │  ├─ Params: (self: &mut ArrayFixed<T, N>, index: int)
    │  │  ├─ Return: &mut T
    │  │  └─ Body:
-   │  │     Stmt[0]: Block (span: 245:71-247:6)
-   │  │     └─ Stmt[0]: Return (span: 246:9-246:54)
-   │  │        └─ Expr: expr#389: rt_array_get_mut(self, index)
+   │  │     Stmt[0]: Block (span: 257:71-259:6)
+   │  │     └─ Stmt[0]: Return (span: 258:9-258:54)
+   │  │        └─ Expr: expr#410: rt_array_get_mut(self, index)
    │  ├─ Fn[2]: with_len_value
    │  │  ├─ Params: (length: uint, value: T)
    │  │  ├─ Return: ArrayFixed<T, N>
    │  │  └─ Body:
-   │  │     Stmt[0]: Block (span: 249:71-262:6)
-   │  │     ├─ Stmt[0]: Let (span: 250:9-250:71)
+   │  │     Stmt[0]: Block (span: 261:71-274:6)
+   │  │     ├─ Stmt[0]: Let (span: 262:9-262:71)
    │  │     │  ├─ Name: out
    │  │     │  ├─ Mutable: true
    │  │     │  ├─ Type: ArrayFixed<T, N>
-   │  │     │  └─ Value: expr#391: default()
-   │  │     ├─ Stmt[1]: Let (span: 251:9-251:42)
+   │  │     │  └─ Value: expr#412: default()
+   │  │     ├─ Stmt[1]: Let (span: 263:9-263:42)
    │  │     │  ├─ Name: expected
    │  │     │  ├─ Mutable: false
    │  │     │  ├─ Type: uint
-   │  │     │  └─ Value: expr#394: out.__len()
-   │  │     ├─ Stmt[2]: If (span: 252:9-254:10)
-   │  │     │  ├─ Cond: expr#397: (length != expected)
+   │  │     │  └─ Value: expr#415: out.__len()
+   │  │     ├─ Stmt[2]: If (span: 264:9-266:10)
+   │  │     │  ├─ Cond: expr#418: (length != expected)
    │  │     │  ├─ Then:
-Block (span: 252:31-254:10)
-   │  │     │  │  └─ Stmt[0]: Expr (span: 253:13-253:49)
-   │  │     │  │     └─ Expr: expr#400: panic("ArrayFixed length mismatch")
+Block (span: 264:31-266:10)
+   │  │     │  │  └─ Stmt[0]: Expr (span: 265:13-265:49)
+   │  │     │  │     └─ Expr: expr#421: panic("ArrayFixed length mismatch")
    │  │     │  └─ Else: <none>
-   │  │     ├─ Stmt[3]: Let (span: 255:9-255:42)
+   │  │     ├─ Stmt[3]: Let (span: 267:9-267:42)
    │  │     │  ├─ Name: count
    │  │     │  ├─ Mutable: false
    │  │     │  ├─ Type: int
-   │  │     │  └─ Value: expr#402: expected to int
-   │  │     ├─ Stmt[4]: Let (span: 256:9-256:28)
+   │  │     │  └─ Value: expr#423: expected to int
+   │  │     ├─ Stmt[4]: Let (span: 268:9-268:28)
    │  │     │  ├─ Name: i
    │  │     │  ├─ Mutable: true
    │  │     │  ├─ Type: int
-   │  │     │  └─ Value: expr#403: 0
-   │  │     ├─ Stmt[5]: While (span: 257:9-260:10)
-   │  │     │  ├─ Cond: expr#406: (i < count)
+   │  │     │  └─ Value: expr#424: 0
+   │  │     ├─ Stmt[5]: While (span: 269:9-272:10)
+   │  │     │  ├─ Cond: expr#427: (i < count)
    │  │     │  └─ Body:
-Block (span: 257:25-260:10)
-   │  │     │     ├─ Stmt[0]: Expr (span: 258:13-258:36)
-   │  │     │     │  └─ Expr: expr#414: (out[i] = clone(&value))
-   │  │     │     └─ Stmt[1]: Expr (span: 259:13-259:23)
-   │  │     │        └─ Expr: expr#419: (i = ((i + 1)))
-   │  │     └─ Stmt[6]: Return (span: 261:9-261:20)
-   │  │        └─ Expr: expr#420: out
+Block (span: 269:25-272:10)
+   │  │     │     ├─ Stmt[0]: Expr (span: 270:13-270:36)
+   │  │     │     │  └─ Expr: expr#435: (out[i] = clone(&value))
+   │  │     │     └─ Stmt[1]: Expr (span: 271:13-271:23)
+   │  │     │        └─ Expr: expr#440: (i = ((i + 1)))
+   │  │     └─ Stmt[6]: Return (span: 273:9-273:20)
+   │  │        └─ Expr: expr#441: out
    │  ├─ Fn[3]: __to
    │  │  ├─ Params: (self: &ArrayFixed<T, N>, target: string)
    │  │  ├─ Return: string
    │  │  └─ Body:
-   │  │     Stmt[0]: Block (span: 264:68-268:6)
-   │  │     ├─ Stmt[0]: Let (span: 265:9-265:24)
+   │  │     Stmt[0]: Block (span: 276:68-280:6)
+   │  │     ├─ Stmt[0]: Let (span: 277:9-277:24)
    │  │     │  ├─ Name: _
    │  │     │  ├─ Mutable: false
    │  │     │  ├─ Type: <inferred>
-   │  │     │  └─ Value: expr#421: target
-   │  │     ├─ Stmt[1]: Let (span: 266:9-266:55)
+   │  │     │  └─ Value: expr#442: target
+   │  │     ├─ Stmt[1]: Let (span: 278:9-278:55)
    │  │     │  ├─ Name: length_s
    │  │     │  ├─ Mutable: false
    │  │     │  ├─ Type: string
-   │  │     │  └─ Value: expr#425: self.__len() to string
-   │  │     └─ Stmt[2]: Return (span: 267:9-267:51)
-   │  │        └─ Expr: expr#430: ((("ArrayFixed(len=" + length_s)) + ")")
+   │  │     │  └─ Value: expr#446: self.__len() to string
+   │  │     └─ Stmt[2]: Return (span: 279:9-279:51)
+   │  │        └─ Expr: expr#451: ((("ArrayFixed(len=" + length_s)) + ")")
    │  └─ Fn[4]: to_array
    │     ├─ Params: (self: &ArrayFixed<T, N>)
    │     ├─ Return: Array<T>
    │     └─ Body:
-   │        Stmt[0]: Block (span: 270:58-283:6)
-   │        ├─ Stmt[0]: Let (span: 271:9-271:47)
+   │        Stmt[0]: Block (span: 282:58-295:6)
+   │        ├─ Stmt[0]: Let (span: 283:9-283:47)
    │        │  ├─ Name: length
    │        │  ├─ Mutable: false
    │        │  ├─ Type: int
-   │        │  └─ Value: expr#434: self.__len() to int
-   │        ├─ Stmt[1]: Let (span: 272:9-272:36)
+   │        │  └─ Value: expr#455: self.__len() to int
+   │        ├─ Stmt[1]: Let (span: 284:9-284:36)
    │        │  ├─ Name: out
    │        │  ├─ Mutable: true
    │        │  ├─ Type: Array<T>
-   │        │  └─ Value: expr#435: <ExprKind(8)>
-   │        ├─ Stmt[2]: Block (span: 273:9-281:10)
-   │        │  ├─ Stmt[0]: Let (span: 274:13-274:51)
+   │        │  └─ Value: expr#456: <ExprKind(8)>
+   │        ├─ Stmt[2]: Block (span: 285:9-293:10)
+   │        │  ├─ Stmt[0]: Let (span: 286:13-286:51)
    │        │  │  ├─ Name: out_ref
    │        │  │  ├─ Mutable: false
    │        │  │  ├─ Type: &mut Array<T>
-   │        │  │  └─ Value: expr#437: &mut out
-   │        │  ├─ Stmt[1]: Expr (span: 275:13-275:43)
-   │        │  │  └─ Expr: expr#443: out_ref.reserve(self.__len())
-   │        │  ├─ Stmt[2]: Let (span: 276:13-276:32)
+   │        │  │  └─ Value: expr#458: &mut out
+   │        │  ├─ Stmt[1]: Expr (span: 287:13-287:43)
+   │        │  │  └─ Expr: expr#464: out_ref.reserve(self.__len())
+   │        │  ├─ Stmt[2]: Let (span: 288:13-288:32)
    │        │  │  ├─ Name: i
    │        │  │  ├─ Mutable: true
    │        │  │  ├─ Type: int
-   │        │  │  └─ Value: expr#444: 0
-   │        │  └─ Stmt[3]: While (span: 277:13-280:14)
-   │        │     ├─ Cond: expr#447: (i < length)
+   │        │  │  └─ Value: expr#465: 0
+   │        │  └─ Stmt[3]: While (span: 289:13-292:14)
+   │        │     ├─ Cond: expr#468: (i < length)
    │        │     └─ Body:
-Block (span: 277:30-280:14)
-   │        │        ├─ Stmt[0]: Expr (span: 278:17-278:46)
-   │        │        │  └─ Expr: expr#455: out_ref.push(clone(self[i]))
-   │        │        └─ Stmt[1]: Expr (span: 279:17-279:27)
-   │        │           └─ Expr: expr#460: (i = ((i + 1)))
-   │        └─ Stmt[3]: Return (span: 282:9-282:20)
-   │           └─ Expr: expr#461: out
+Block (span: 289:30-292:14)
+   │        │        ├─ Stmt[0]: Expr (span: 290:17-290:46)
+   │        │        │  └─ Expr: expr#476: out_ref.push(clone(self[i]))
+   │        │        └─ Stmt[1]: Expr (span: 291:17-291:27)
+   │        │           └─ Expr: expr#481: (i = ((i + 1)))
+   │        └─ Stmt[3]: Return (span: 294:9-294:20)
+   │           └─ Expr: expr#482: out

--- a/testdata/golden/core_stdlib/array.fmt
+++ b/testdata/golden/core_stdlib/array.fmt
@@ -136,6 +136,18 @@ extern<Array<T>> {
     }
 }
 
+extern<Array<byte>> {
+    pub fn append_string(self: &mut Array<byte>, text: &string) -> nothing {
+        rt_array_append_raw_bytes(self, rt_string_ptr(text), rt_string_len_bytes(text) to uint64);
+        return nothing;
+    }
+
+    pub fn append_bytes_view(self: &mut Array<byte>, view: &BytesView) -> nothing {
+        rt_array_append_raw_bytes(self, view.ptr, view.__len() to uint64);
+        return nothing;
+    }
+}
+
 // contains/find are currently specialized for primitive element types.
 extern<Array<int>> {
     pub fn contains(self: &Array<int>, value: &int) -> bool {

--- a/testdata/golden/core_stdlib/array.sg
+++ b/testdata/golden/core_stdlib/array.sg
@@ -136,6 +136,18 @@ extern<Array<T>> {
     }
 }
 
+extern<Array<byte>> {
+    pub fn append_string(self: &mut Array<byte>, text: &string) -> nothing {
+        rt_array_append_raw_bytes(self, rt_string_ptr(text), rt_string_len_bytes(text) to uint64);
+        return nothing;
+    }
+
+    pub fn append_bytes_view(self: &mut Array<byte>, view: &BytesView) -> nothing {
+        rt_array_append_raw_bytes(self, view.ptr, view.__len() to uint64);
+        return nothing;
+    }
+}
+
 // contains/find are currently specialized for primitive element types.
 extern<Array<int>> {
     pub fn contains(self: &Array<int>, value: &int) -> bool {

--- a/testdata/golden/core_stdlib/array.tokens
+++ b/testdata/golden/core_stdlib/array.tokens
@@ -881,1027 +881,1119 @@
 881: Semicolon       ";" at 135:45-135:46
 882: RBrace          "}" at 136:5-136:6 (leading: Newline, Space)
 883: RBrace          "}" at 137:1-137:2 (leading: Newline)
-884: KwExtern        "extern" at 140:1-140:7 (leading: Newline, LineComment, Newline)
-885: Lt              "<" at 140:7-140:8
-886: Ident           "Array" at 140:8-140:13
-887: Lt              "<" at 140:13-140:14
-888: Ident           "int" at 140:14-140:17
-889: Shr             ">>" at 140:17-140:19
-890: LBrace          "{" at 140:20-140:21 (leading: Space)
-891: KwPub           "pub" at 141:5-141:8 (leading: Newline, Space)
-892: KwFn            "fn" at 141:9-141:11 (leading: Space)
-893: Ident           "contains" at 141:12-141:20 (leading: Space)
-894: LParen          "(" at 141:20-141:21
-895: Ident           "self" at 141:21-141:25
-896: Colon           ":" at 141:25-141:26
-897: Amp             "&" at 141:27-141:28 (leading: Space)
-898: Ident           "Array" at 141:28-141:33
-899: Lt              "<" at 141:33-141:34
-900: Ident           "int" at 141:34-141:37
-901: Gt              ">" at 141:37-141:38
-902: Comma           "," at 141:38-141:39
-903: Ident           "value" at 141:40-141:45 (leading: Space)
-904: Colon           ":" at 141:45-141:46
-905: Amp             "&" at 141:47-141:48 (leading: Space)
-906: Ident           "int" at 141:48-141:51
-907: RParen          ")" at 141:51-141:52
-908: Arrow           "->" at 141:53-141:55 (leading: Space)
-909: Ident           "bool" at 141:56-141:60 (leading: Space)
-910: LBrace          "{" at 141:61-141:62 (leading: Space)
-911: KwLet           "let" at 142:9-142:12 (leading: Newline, Space)
-912: Ident           "res" at 142:13-142:16 (leading: Space)
-913: Colon           ":" at 142:16-142:17
-914: Ident           "Option" at 142:18-142:24 (leading: Space)
-915: Lt              "<" at 142:24-142:25
-916: Ident           "uint" at 142:25-142:29
-917: Gt              ">" at 142:29-142:30
-918: Assign          "=" at 142:31-142:32 (leading: Space)
-919: Ident           "self" at 142:33-142:37 (leading: Space)
-920: Dot             "." at 142:37-142:38
-921: Ident           "find" at 142:38-142:42
-922: LParen          "(" at 142:42-142:43
-923: Ident           "value" at 142:43-142:48
-924: RParen          ")" at 142:48-142:49
-925: Semicolon       ";" at 142:49-142:50
-926: KwReturn        "return" at 143:9-143:15 (leading: Newline, Space)
-927: Ident           "res" at 143:16-143:19 (leading: Space)
-928: Dot             "." at 143:19-143:20
-929: Ident           "is_some" at 143:20-143:27
-930: LParen          "(" at 143:27-143:28
-931: RParen          ")" at 143:28-143:29
-932: Semicolon       ";" at 143:29-143:30
-933: RBrace          "}" at 144:5-144:6 (leading: Newline, Space)
-934: KwPub           "pub" at 146:5-146:8 (leading: Newline, Space)
-935: KwFn            "fn" at 146:9-146:11 (leading: Space)
-936: Ident           "find" at 146:12-146:16 (leading: Space)
-937: LParen          "(" at 146:16-146:17
-938: Ident           "self" at 146:17-146:21
-939: Colon           ":" at 146:21-146:22
-940: Amp             "&" at 146:23-146:24 (leading: Space)
-941: Ident           "Array" at 146:24-146:29
-942: Lt              "<" at 146:29-146:30
-943: Ident           "int" at 146:30-146:33
-944: Gt              ">" at 146:33-146:34
-945: Comma           "," at 146:34-146:35
-946: Ident           "value" at 146:36-146:41 (leading: Space)
-947: Colon           ":" at 146:41-146:42
-948: Amp             "&" at 146:43-146:44 (leading: Space)
-949: Ident           "int" at 146:44-146:47
-950: RParen          ")" at 146:47-146:48
-951: Arrow           "->" at 146:49-146:51 (leading: Space)
-952: Ident           "Option" at 146:52-146:58 (leading: Space)
-953: Lt              "<" at 146:58-146:59
-954: Ident           "uint" at 146:59-146:63
-955: Gt              ">" at 146:63-146:64
-956: LBrace          "{" at 146:65-146:66 (leading: Space)
-957: KwLet           "let" at 147:9-147:12 (leading: Newline, Space)
-958: Ident           "length" at 147:13-147:19 (leading: Space)
-959: Colon           ":" at 147:19-147:20
-960: Ident           "int" at 147:21-147:24 (leading: Space)
-961: Assign          "=" at 147:25-147:26 (leading: Space)
-962: Ident           "self" at 147:27-147:31 (leading: Space)
-963: Dot             "." at 147:31-147:32
-964: Ident           "__len" at 147:32-147:37
-965: LParen          "(" at 147:37-147:38
-966: RParen          ")" at 147:38-147:39
-967: KwTo            "to" at 147:40-147:42 (leading: Space)
-968: Ident           "int" at 147:43-147:46 (leading: Space)
-969: Semicolon       ";" at 147:46-147:47
-970: KwLet           "let" at 148:9-148:12 (leading: Newline, Space)
-971: KwMut           "mut" at 148:13-148:16 (leading: Space)
-972: Ident           "i" at 148:17-148:18 (leading: Space)
-973: Colon           ":" at 148:18-148:19
-974: Ident           "int" at 148:20-148:23 (leading: Space)
-975: Assign          "=" at 148:24-148:25 (leading: Space)
-976: IntLit          "0" at 148:26-148:27 (leading: Space)
-977: Semicolon       ";" at 148:27-148:28
-978: KwWhile         "while" at 149:9-149:14 (leading: Newline, Space)
-979: Ident           "i" at 149:15-149:16 (leading: Space)
-980: Lt              "<" at 149:17-149:18 (leading: Space)
-981: Ident           "length" at 149:19-149:25 (leading: Space)
-982: LBrace          "{" at 149:26-149:27 (leading: Space)
-983: KwIf            "if" at 150:13-150:15 (leading: Newline, Space)
-984: Ident           "self" at 150:16-150:20 (leading: Space)
-985: LBracket        "[" at 150:20-150:21
-986: Ident           "i" at 150:21-150:22
-987: RBracket        "]" at 150:22-150:23
-988: EqEq            "==" at 150:24-150:26 (leading: Space)
-989: Star            "*" at 150:27-150:28 (leading: Space)
-990: Ident           "value" at 150:28-150:33
-991: LBrace          "{" at 150:34-150:35 (leading: Space)
-992: KwReturn        "return" at 151:17-151:23 (leading: Newline, Space)
-993: Ident           "Some" at 151:24-151:28 (leading: Space)
-994: LParen          "(" at 151:28-151:29
-995: Ident           "i" at 151:29-151:30
-996: KwTo            "to" at 151:31-151:33 (leading: Space)
-997: Ident           "uint" at 151:34-151:38 (leading: Space)
-998: RParen          ")" at 151:38-151:39
-999: Semicolon       ";" at 151:39-151:40
-1000: RBrace          "}" at 152:13-152:14 (leading: Newline, Space)
-1001: Ident           "i" at 153:13-153:14 (leading: Newline, Space)
-1002: Assign          "=" at 153:15-153:16 (leading: Space)
-1003: Ident           "i" at 153:17-153:18 (leading: Space)
-1004: Plus            "+" at 153:19-153:20 (leading: Space)
-1005: IntLit          "1" at 153:21-153:22 (leading: Space)
-1006: Semicolon       ";" at 153:22-153:23
-1007: RBrace          "}" at 154:9-154:10 (leading: Newline, Space)
-1008: KwReturn        "return" at 155:9-155:15 (leading: Newline, Space)
-1009: NothingLit      "nothing" at 155:16-155:23 (leading: Space)
-1010: Semicolon       ";" at 155:23-155:24
-1011: RBrace          "}" at 156:5-156:6 (leading: Newline, Space)
-1012: RBrace          "}" at 157:1-157:2 (leading: Newline)
-1013: KwExtern        "extern" at 159:1-159:7 (leading: Newline)
-1014: Lt              "<" at 159:7-159:8
-1015: Ident           "Array" at 159:8-159:13
-1016: Lt              "<" at 159:13-159:14
-1017: Ident           "uint" at 159:14-159:18
-1018: Shr             ">>" at 159:18-159:20
-1019: LBrace          "{" at 159:21-159:22 (leading: Space)
-1020: KwPub           "pub" at 160:5-160:8 (leading: Newline, Space)
-1021: KwFn            "fn" at 160:9-160:11 (leading: Space)
-1022: Ident           "contains" at 160:12-160:20 (leading: Space)
-1023: LParen          "(" at 160:20-160:21
-1024: Ident           "self" at 160:21-160:25
-1025: Colon           ":" at 160:25-160:26
-1026: Amp             "&" at 160:27-160:28 (leading: Space)
-1027: Ident           "Array" at 160:28-160:33
-1028: Lt              "<" at 160:33-160:34
-1029: Ident           "uint" at 160:34-160:38
-1030: Gt              ">" at 160:38-160:39
-1031: Comma           "," at 160:39-160:40
-1032: Ident           "value" at 160:41-160:46 (leading: Space)
-1033: Colon           ":" at 160:46-160:47
-1034: Amp             "&" at 160:48-160:49 (leading: Space)
-1035: Ident           "uint" at 160:49-160:53
-1036: RParen          ")" at 160:53-160:54
-1037: Arrow           "->" at 160:55-160:57 (leading: Space)
-1038: Ident           "bool" at 160:58-160:62 (leading: Space)
-1039: LBrace          "{" at 160:63-160:64 (leading: Space)
-1040: KwLet           "let" at 161:9-161:12 (leading: Newline, Space)
-1041: Ident           "res" at 161:13-161:16 (leading: Space)
-1042: Colon           ":" at 161:16-161:17
-1043: Ident           "Option" at 161:18-161:24 (leading: Space)
-1044: Lt              "<" at 161:24-161:25
-1045: Ident           "uint" at 161:25-161:29
-1046: Gt              ">" at 161:29-161:30
-1047: Assign          "=" at 161:31-161:32 (leading: Space)
-1048: Ident           "self" at 161:33-161:37 (leading: Space)
-1049: Dot             "." at 161:37-161:38
-1050: Ident           "find" at 161:38-161:42
-1051: LParen          "(" at 161:42-161:43
-1052: Ident           "value" at 161:43-161:48
-1053: RParen          ")" at 161:48-161:49
-1054: Semicolon       ";" at 161:49-161:50
-1055: KwReturn        "return" at 162:9-162:15 (leading: Newline, Space)
-1056: Ident           "res" at 162:16-162:19 (leading: Space)
-1057: Dot             "." at 162:19-162:20
-1058: Ident           "is_some" at 162:20-162:27
-1059: LParen          "(" at 162:27-162:28
-1060: RParen          ")" at 162:28-162:29
-1061: Semicolon       ";" at 162:29-162:30
-1062: RBrace          "}" at 163:5-163:6 (leading: Newline, Space)
-1063: KwPub           "pub" at 165:5-165:8 (leading: Newline, Space)
-1064: KwFn            "fn" at 165:9-165:11 (leading: Space)
-1065: Ident           "find" at 165:12-165:16 (leading: Space)
-1066: LParen          "(" at 165:16-165:17
-1067: Ident           "self" at 165:17-165:21
-1068: Colon           ":" at 165:21-165:22
-1069: Amp             "&" at 165:23-165:24 (leading: Space)
-1070: Ident           "Array" at 165:24-165:29
-1071: Lt              "<" at 165:29-165:30
-1072: Ident           "uint" at 165:30-165:34
-1073: Gt              ">" at 165:34-165:35
-1074: Comma           "," at 165:35-165:36
-1075: Ident           "value" at 165:37-165:42 (leading: Space)
-1076: Colon           ":" at 165:42-165:43
-1077: Amp             "&" at 165:44-165:45 (leading: Space)
-1078: Ident           "uint" at 165:45-165:49
-1079: RParen          ")" at 165:49-165:50
-1080: Arrow           "->" at 165:51-165:53 (leading: Space)
-1081: Ident           "Option" at 165:54-165:60 (leading: Space)
-1082: Lt              "<" at 165:60-165:61
-1083: Ident           "uint" at 165:61-165:65
-1084: Gt              ">" at 165:65-165:66
-1085: LBrace          "{" at 165:67-165:68 (leading: Space)
-1086: KwLet           "let" at 166:9-166:12 (leading: Newline, Space)
-1087: Ident           "length" at 166:13-166:19 (leading: Space)
-1088: Colon           ":" at 166:19-166:20
-1089: Ident           "int" at 166:21-166:24 (leading: Space)
-1090: Assign          "=" at 166:25-166:26 (leading: Space)
-1091: Ident           "self" at 166:27-166:31 (leading: Space)
-1092: Dot             "." at 166:31-166:32
-1093: Ident           "__len" at 166:32-166:37
-1094: LParen          "(" at 166:37-166:38
-1095: RParen          ")" at 166:38-166:39
-1096: KwTo            "to" at 166:40-166:42 (leading: Space)
-1097: Ident           "int" at 166:43-166:46 (leading: Space)
-1098: Semicolon       ";" at 166:46-166:47
-1099: KwLet           "let" at 167:9-167:12 (leading: Newline, Space)
-1100: KwMut           "mut" at 167:13-167:16 (leading: Space)
-1101: Ident           "i" at 167:17-167:18 (leading: Space)
-1102: Colon           ":" at 167:18-167:19
-1103: Ident           "int" at 167:20-167:23 (leading: Space)
-1104: Assign          "=" at 167:24-167:25 (leading: Space)
-1105: IntLit          "0" at 167:26-167:27 (leading: Space)
-1106: Semicolon       ";" at 167:27-167:28
-1107: KwWhile         "while" at 168:9-168:14 (leading: Newline, Space)
-1108: Ident           "i" at 168:15-168:16 (leading: Space)
-1109: Lt              "<" at 168:17-168:18 (leading: Space)
-1110: Ident           "length" at 168:19-168:25 (leading: Space)
-1111: LBrace          "{" at 168:26-168:27 (leading: Space)
-1112: KwIf            "if" at 169:13-169:15 (leading: Newline, Space)
-1113: Ident           "self" at 169:16-169:20 (leading: Space)
-1114: LBracket        "[" at 169:20-169:21
-1115: Ident           "i" at 169:21-169:22
-1116: RBracket        "]" at 169:22-169:23
-1117: EqEq            "==" at 169:24-169:26 (leading: Space)
-1118: Star            "*" at 169:27-169:28 (leading: Space)
-1119: Ident           "value" at 169:28-169:33
-1120: LBrace          "{" at 169:34-169:35 (leading: Space)
-1121: KwReturn        "return" at 170:17-170:23 (leading: Newline, Space)
-1122: Ident           "Some" at 170:24-170:28 (leading: Space)
-1123: LParen          "(" at 170:28-170:29
-1124: Ident           "i" at 170:29-170:30
-1125: KwTo            "to" at 170:31-170:33 (leading: Space)
-1126: Ident           "uint" at 170:34-170:38 (leading: Space)
-1127: RParen          ")" at 170:38-170:39
-1128: Semicolon       ";" at 170:39-170:40
-1129: RBrace          "}" at 171:13-171:14 (leading: Newline, Space)
-1130: Ident           "i" at 172:13-172:14 (leading: Newline, Space)
-1131: Assign          "=" at 172:15-172:16 (leading: Space)
-1132: Ident           "i" at 172:17-172:18 (leading: Space)
-1133: Plus            "+" at 172:19-172:20 (leading: Space)
-1134: IntLit          "1" at 172:21-172:22 (leading: Space)
-1135: Semicolon       ";" at 172:22-172:23
-1136: RBrace          "}" at 173:9-173:10 (leading: Newline, Space)
-1137: KwReturn        "return" at 174:9-174:15 (leading: Newline, Space)
-1138: NothingLit      "nothing" at 174:16-174:23 (leading: Space)
-1139: Semicolon       ";" at 174:23-174:24
-1140: RBrace          "}" at 175:5-175:6 (leading: Newline, Space)
-1141: RBrace          "}" at 176:1-176:2 (leading: Newline)
-1142: KwExtern        "extern" at 178:1-178:7 (leading: Newline)
-1143: Lt              "<" at 178:7-178:8
-1144: Ident           "Array" at 178:8-178:13
-1145: Lt              "<" at 178:13-178:14
-1146: Ident           "float" at 178:14-178:19
-1147: Shr             ">>" at 178:19-178:21
-1148: LBrace          "{" at 178:22-178:23 (leading: Space)
-1149: KwPub           "pub" at 179:5-179:8 (leading: Newline, Space)
-1150: KwFn            "fn" at 179:9-179:11 (leading: Space)
-1151: Ident           "contains" at 179:12-179:20 (leading: Space)
-1152: LParen          "(" at 179:20-179:21
-1153: Ident           "self" at 179:21-179:25
-1154: Colon           ":" at 179:25-179:26
-1155: Amp             "&" at 179:27-179:28 (leading: Space)
-1156: Ident           "Array" at 179:28-179:33
-1157: Lt              "<" at 179:33-179:34
-1158: Ident           "float" at 179:34-179:39
-1159: Gt              ">" at 179:39-179:40
-1160: Comma           "," at 179:40-179:41
-1161: Ident           "value" at 179:42-179:47 (leading: Space)
-1162: Colon           ":" at 179:47-179:48
-1163: Amp             "&" at 179:49-179:50 (leading: Space)
-1164: Ident           "float" at 179:50-179:55
-1165: RParen          ")" at 179:55-179:56
-1166: Arrow           "->" at 179:57-179:59 (leading: Space)
-1167: Ident           "bool" at 179:60-179:64 (leading: Space)
-1168: LBrace          "{" at 179:65-179:66 (leading: Space)
-1169: KwLet           "let" at 180:9-180:12 (leading: Newline, Space)
-1170: Ident           "res" at 180:13-180:16 (leading: Space)
-1171: Colon           ":" at 180:16-180:17
-1172: Ident           "Option" at 180:18-180:24 (leading: Space)
-1173: Lt              "<" at 180:24-180:25
-1174: Ident           "uint" at 180:25-180:29
-1175: Gt              ">" at 180:29-180:30
-1176: Assign          "=" at 180:31-180:32 (leading: Space)
-1177: Ident           "self" at 180:33-180:37 (leading: Space)
-1178: Dot             "." at 180:37-180:38
-1179: Ident           "find" at 180:38-180:42
-1180: LParen          "(" at 180:42-180:43
-1181: Ident           "value" at 180:43-180:48
-1182: RParen          ")" at 180:48-180:49
-1183: Semicolon       ";" at 180:49-180:50
-1184: KwReturn        "return" at 181:9-181:15 (leading: Newline, Space)
-1185: Ident           "res" at 181:16-181:19 (leading: Space)
-1186: Dot             "." at 181:19-181:20
-1187: Ident           "is_some" at 181:20-181:27
-1188: LParen          "(" at 181:27-181:28
-1189: RParen          ")" at 181:28-181:29
-1190: Semicolon       ";" at 181:29-181:30
-1191: RBrace          "}" at 182:5-182:6 (leading: Newline, Space)
-1192: KwPub           "pub" at 184:5-184:8 (leading: Newline, Space)
-1193: KwFn            "fn" at 184:9-184:11 (leading: Space)
-1194: Ident           "find" at 184:12-184:16 (leading: Space)
-1195: LParen          "(" at 184:16-184:17
-1196: Ident           "self" at 184:17-184:21
-1197: Colon           ":" at 184:21-184:22
-1198: Amp             "&" at 184:23-184:24 (leading: Space)
-1199: Ident           "Array" at 184:24-184:29
-1200: Lt              "<" at 184:29-184:30
-1201: Ident           "float" at 184:30-184:35
-1202: Gt              ">" at 184:35-184:36
-1203: Comma           "," at 184:36-184:37
-1204: Ident           "value" at 184:38-184:43 (leading: Space)
-1205: Colon           ":" at 184:43-184:44
-1206: Amp             "&" at 184:45-184:46 (leading: Space)
-1207: Ident           "float" at 184:46-184:51
-1208: RParen          ")" at 184:51-184:52
-1209: Arrow           "->" at 184:53-184:55 (leading: Space)
-1210: Ident           "Option" at 184:56-184:62 (leading: Space)
-1211: Lt              "<" at 184:62-184:63
-1212: Ident           "uint" at 184:63-184:67
-1213: Gt              ">" at 184:67-184:68
-1214: LBrace          "{" at 184:69-184:70 (leading: Space)
-1215: KwLet           "let" at 185:9-185:12 (leading: Newline, Space)
-1216: Ident           "length" at 185:13-185:19 (leading: Space)
-1217: Colon           ":" at 185:19-185:20
-1218: Ident           "int" at 185:21-185:24 (leading: Space)
-1219: Assign          "=" at 185:25-185:26 (leading: Space)
-1220: Ident           "self" at 185:27-185:31 (leading: Space)
-1221: Dot             "." at 185:31-185:32
-1222: Ident           "__len" at 185:32-185:37
-1223: LParen          "(" at 185:37-185:38
-1224: RParen          ")" at 185:38-185:39
-1225: KwTo            "to" at 185:40-185:42 (leading: Space)
-1226: Ident           "int" at 185:43-185:46 (leading: Space)
-1227: Semicolon       ";" at 185:46-185:47
-1228: KwLet           "let" at 186:9-186:12 (leading: Newline, Space)
-1229: KwMut           "mut" at 186:13-186:16 (leading: Space)
-1230: Ident           "i" at 186:17-186:18 (leading: Space)
-1231: Colon           ":" at 186:18-186:19
-1232: Ident           "int" at 186:20-186:23 (leading: Space)
-1233: Assign          "=" at 186:24-186:25 (leading: Space)
-1234: IntLit          "0" at 186:26-186:27 (leading: Space)
-1235: Semicolon       ";" at 186:27-186:28
-1236: KwWhile         "while" at 187:9-187:14 (leading: Newline, Space)
-1237: Ident           "i" at 187:15-187:16 (leading: Space)
-1238: Lt              "<" at 187:17-187:18 (leading: Space)
-1239: Ident           "length" at 187:19-187:25 (leading: Space)
-1240: LBrace          "{" at 187:26-187:27 (leading: Space)
-1241: KwIf            "if" at 188:13-188:15 (leading: Newline, Space)
-1242: Ident           "self" at 188:16-188:20 (leading: Space)
-1243: LBracket        "[" at 188:20-188:21
-1244: Ident           "i" at 188:21-188:22
-1245: RBracket        "]" at 188:22-188:23
-1246: EqEq            "==" at 188:24-188:26 (leading: Space)
-1247: Star            "*" at 188:27-188:28 (leading: Space)
-1248: Ident           "value" at 188:28-188:33
-1249: LBrace          "{" at 188:34-188:35 (leading: Space)
-1250: KwReturn        "return" at 189:17-189:23 (leading: Newline, Space)
-1251: Ident           "Some" at 189:24-189:28 (leading: Space)
-1252: LParen          "(" at 189:28-189:29
-1253: Ident           "i" at 189:29-189:30
-1254: KwTo            "to" at 189:31-189:33 (leading: Space)
-1255: Ident           "uint" at 189:34-189:38 (leading: Space)
-1256: RParen          ")" at 189:38-189:39
-1257: Semicolon       ";" at 189:39-189:40
-1258: RBrace          "}" at 190:13-190:14 (leading: Newline, Space)
-1259: Ident           "i" at 191:13-191:14 (leading: Newline, Space)
-1260: Assign          "=" at 191:15-191:16 (leading: Space)
-1261: Ident           "i" at 191:17-191:18 (leading: Space)
-1262: Plus            "+" at 191:19-191:20 (leading: Space)
-1263: IntLit          "1" at 191:21-191:22 (leading: Space)
-1264: Semicolon       ";" at 191:22-191:23
-1265: RBrace          "}" at 192:9-192:10 (leading: Newline, Space)
-1266: KwReturn        "return" at 193:9-193:15 (leading: Newline, Space)
-1267: NothingLit      "nothing" at 193:16-193:23 (leading: Space)
-1268: Semicolon       ";" at 193:23-193:24
-1269: RBrace          "}" at 194:5-194:6 (leading: Newline, Space)
-1270: RBrace          "}" at 195:1-195:2 (leading: Newline)
-1271: KwExtern        "extern" at 197:1-197:7 (leading: Newline)
-1272: Lt              "<" at 197:7-197:8
-1273: Ident           "Array" at 197:8-197:13
-1274: Lt              "<" at 197:13-197:14
-1275: Ident           "bool" at 197:14-197:18
-1276: Shr             ">>" at 197:18-197:20
-1277: LBrace          "{" at 197:21-197:22 (leading: Space)
-1278: KwPub           "pub" at 198:5-198:8 (leading: Newline, Space)
-1279: KwFn            "fn" at 198:9-198:11 (leading: Space)
-1280: Ident           "contains" at 198:12-198:20 (leading: Space)
-1281: LParen          "(" at 198:20-198:21
-1282: Ident           "self" at 198:21-198:25
-1283: Colon           ":" at 198:25-198:26
-1284: Amp             "&" at 198:27-198:28 (leading: Space)
-1285: Ident           "Array" at 198:28-198:33
-1286: Lt              "<" at 198:33-198:34
-1287: Ident           "bool" at 198:34-198:38
-1288: Gt              ">" at 198:38-198:39
-1289: Comma           "," at 198:39-198:40
-1290: Ident           "value" at 198:41-198:46 (leading: Space)
-1291: Colon           ":" at 198:46-198:47
-1292: Amp             "&" at 198:48-198:49 (leading: Space)
-1293: Ident           "bool" at 198:49-198:53
-1294: RParen          ")" at 198:53-198:54
-1295: Arrow           "->" at 198:55-198:57 (leading: Space)
-1296: Ident           "bool" at 198:58-198:62 (leading: Space)
-1297: LBrace          "{" at 198:63-198:64 (leading: Space)
-1298: KwLet           "let" at 199:9-199:12 (leading: Newline, Space)
-1299: Ident           "res" at 199:13-199:16 (leading: Space)
-1300: Colon           ":" at 199:16-199:17
-1301: Ident           "Option" at 199:18-199:24 (leading: Space)
-1302: Lt              "<" at 199:24-199:25
-1303: Ident           "uint" at 199:25-199:29
-1304: Gt              ">" at 199:29-199:30
-1305: Assign          "=" at 199:31-199:32 (leading: Space)
-1306: Ident           "self" at 199:33-199:37 (leading: Space)
-1307: Dot             "." at 199:37-199:38
-1308: Ident           "find" at 199:38-199:42
-1309: LParen          "(" at 199:42-199:43
-1310: Ident           "value" at 199:43-199:48
-1311: RParen          ")" at 199:48-199:49
-1312: Semicolon       ";" at 199:49-199:50
-1313: KwReturn        "return" at 200:9-200:15 (leading: Newline, Space)
-1314: Ident           "res" at 200:16-200:19 (leading: Space)
-1315: Dot             "." at 200:19-200:20
-1316: Ident           "is_some" at 200:20-200:27
-1317: LParen          "(" at 200:27-200:28
-1318: RParen          ")" at 200:28-200:29
-1319: Semicolon       ";" at 200:29-200:30
-1320: RBrace          "}" at 201:5-201:6 (leading: Newline, Space)
-1321: KwPub           "pub" at 203:5-203:8 (leading: Newline, Space)
-1322: KwFn            "fn" at 203:9-203:11 (leading: Space)
-1323: Ident           "find" at 203:12-203:16 (leading: Space)
-1324: LParen          "(" at 203:16-203:17
-1325: Ident           "self" at 203:17-203:21
-1326: Colon           ":" at 203:21-203:22
-1327: Amp             "&" at 203:23-203:24 (leading: Space)
-1328: Ident           "Array" at 203:24-203:29
-1329: Lt              "<" at 203:29-203:30
-1330: Ident           "bool" at 203:30-203:34
-1331: Gt              ">" at 203:34-203:35
-1332: Comma           "," at 203:35-203:36
-1333: Ident           "value" at 203:37-203:42 (leading: Space)
-1334: Colon           ":" at 203:42-203:43
-1335: Amp             "&" at 203:44-203:45 (leading: Space)
-1336: Ident           "bool" at 203:45-203:49
-1337: RParen          ")" at 203:49-203:50
-1338: Arrow           "->" at 203:51-203:53 (leading: Space)
-1339: Ident           "Option" at 203:54-203:60 (leading: Space)
-1340: Lt              "<" at 203:60-203:61
-1341: Ident           "uint" at 203:61-203:65
-1342: Gt              ">" at 203:65-203:66
-1343: LBrace          "{" at 203:67-203:68 (leading: Space)
-1344: KwLet           "let" at 204:9-204:12 (leading: Newline, Space)
-1345: Ident           "length" at 204:13-204:19 (leading: Space)
-1346: Colon           ":" at 204:19-204:20
-1347: Ident           "int" at 204:21-204:24 (leading: Space)
-1348: Assign          "=" at 204:25-204:26 (leading: Space)
-1349: Ident           "self" at 204:27-204:31 (leading: Space)
-1350: Dot             "." at 204:31-204:32
-1351: Ident           "__len" at 204:32-204:37
-1352: LParen          "(" at 204:37-204:38
-1353: RParen          ")" at 204:38-204:39
-1354: KwTo            "to" at 204:40-204:42 (leading: Space)
-1355: Ident           "int" at 204:43-204:46 (leading: Space)
-1356: Semicolon       ";" at 204:46-204:47
-1357: KwLet           "let" at 205:9-205:12 (leading: Newline, Space)
-1358: KwMut           "mut" at 205:13-205:16 (leading: Space)
-1359: Ident           "i" at 205:17-205:18 (leading: Space)
-1360: Colon           ":" at 205:18-205:19
-1361: Ident           "int" at 205:20-205:23 (leading: Space)
-1362: Assign          "=" at 205:24-205:25 (leading: Space)
-1363: IntLit          "0" at 205:26-205:27 (leading: Space)
-1364: Semicolon       ";" at 205:27-205:28
-1365: KwWhile         "while" at 206:9-206:14 (leading: Newline, Space)
-1366: Ident           "i" at 206:15-206:16 (leading: Space)
-1367: Lt              "<" at 206:17-206:18 (leading: Space)
-1368: Ident           "length" at 206:19-206:25 (leading: Space)
-1369: LBrace          "{" at 206:26-206:27 (leading: Space)
-1370: KwIf            "if" at 207:13-207:15 (leading: Newline, Space)
-1371: Ident           "self" at 207:16-207:20 (leading: Space)
-1372: LBracket        "[" at 207:20-207:21
-1373: Ident           "i" at 207:21-207:22
-1374: RBracket        "]" at 207:22-207:23
-1375: EqEq            "==" at 207:24-207:26 (leading: Space)
-1376: Star            "*" at 207:27-207:28 (leading: Space)
-1377: Ident           "value" at 207:28-207:33
-1378: LBrace          "{" at 207:34-207:35 (leading: Space)
-1379: KwReturn        "return" at 208:17-208:23 (leading: Newline, Space)
-1380: Ident           "Some" at 208:24-208:28 (leading: Space)
-1381: LParen          "(" at 208:28-208:29
-1382: Ident           "i" at 208:29-208:30
-1383: KwTo            "to" at 208:31-208:33 (leading: Space)
-1384: Ident           "uint" at 208:34-208:38 (leading: Space)
-1385: RParen          ")" at 208:38-208:39
-1386: Semicolon       ";" at 208:39-208:40
-1387: RBrace          "}" at 209:13-209:14 (leading: Newline, Space)
-1388: Ident           "i" at 210:13-210:14 (leading: Newline, Space)
-1389: Assign          "=" at 210:15-210:16 (leading: Space)
-1390: Ident           "i" at 210:17-210:18 (leading: Space)
-1391: Plus            "+" at 210:19-210:20 (leading: Space)
-1392: IntLit          "1" at 210:21-210:22 (leading: Space)
-1393: Semicolon       ";" at 210:22-210:23
-1394: RBrace          "}" at 211:9-211:10 (leading: Newline, Space)
-1395: KwReturn        "return" at 212:9-212:15 (leading: Newline, Space)
-1396: NothingLit      "nothing" at 212:16-212:23 (leading: Space)
-1397: Semicolon       ";" at 212:23-212:24
-1398: RBrace          "}" at 213:5-213:6 (leading: Newline, Space)
-1399: RBrace          "}" at 214:1-214:2 (leading: Newline)
-1400: KwExtern        "extern" at 216:1-216:7 (leading: Newline)
-1401: Lt              "<" at 216:7-216:8
-1402: Ident           "Array" at 216:8-216:13
-1403: Lt              "<" at 216:13-216:14
-1404: Ident           "string" at 216:14-216:20
-1405: Shr             ">>" at 216:20-216:22
-1406: LBrace          "{" at 216:23-216:24 (leading: Space)
-1407: KwPub           "pub" at 217:5-217:8 (leading: Newline, Space)
-1408: KwFn            "fn" at 217:9-217:11 (leading: Space)
-1409: Ident           "contains" at 217:12-217:20 (leading: Space)
-1410: LParen          "(" at 217:20-217:21
-1411: Ident           "self" at 217:21-217:25
-1412: Colon           ":" at 217:25-217:26
-1413: Amp             "&" at 217:27-217:28 (leading: Space)
-1414: Ident           "Array" at 217:28-217:33
-1415: Lt              "<" at 217:33-217:34
-1416: Ident           "string" at 217:34-217:40
-1417: Gt              ">" at 217:40-217:41
-1418: Comma           "," at 217:41-217:42
-1419: Ident           "value" at 217:43-217:48 (leading: Space)
-1420: Colon           ":" at 217:48-217:49
-1421: Amp             "&" at 217:50-217:51 (leading: Space)
-1422: Ident           "string" at 217:51-217:57
-1423: RParen          ")" at 217:57-217:58
-1424: Arrow           "->" at 217:59-217:61 (leading: Space)
-1425: Ident           "bool" at 217:62-217:66 (leading: Space)
-1426: LBrace          "{" at 217:67-217:68 (leading: Space)
-1427: KwLet           "let" at 218:9-218:12 (leading: Newline, Space)
-1428: Ident           "res" at 218:13-218:16 (leading: Space)
-1429: Colon           ":" at 218:16-218:17
-1430: Ident           "Option" at 218:18-218:24 (leading: Space)
-1431: Lt              "<" at 218:24-218:25
-1432: Ident           "uint" at 218:25-218:29
-1433: Gt              ">" at 218:29-218:30
-1434: Assign          "=" at 218:31-218:32 (leading: Space)
-1435: Ident           "self" at 218:33-218:37 (leading: Space)
-1436: Dot             "." at 218:37-218:38
-1437: Ident           "find" at 218:38-218:42
-1438: LParen          "(" at 218:42-218:43
-1439: Ident           "value" at 218:43-218:48
-1440: RParen          ")" at 218:48-218:49
-1441: Semicolon       ";" at 218:49-218:50
-1442: KwReturn        "return" at 219:9-219:15 (leading: Newline, Space)
-1443: Ident           "res" at 219:16-219:19 (leading: Space)
-1444: Dot             "." at 219:19-219:20
-1445: Ident           "is_some" at 219:20-219:27
-1446: LParen          "(" at 219:27-219:28
-1447: RParen          ")" at 219:28-219:29
-1448: Semicolon       ";" at 219:29-219:30
-1449: RBrace          "}" at 220:5-220:6 (leading: Newline, Space)
-1450: KwPub           "pub" at 222:5-222:8 (leading: Newline, Space)
-1451: KwFn            "fn" at 222:9-222:11 (leading: Space)
-1452: Ident           "find" at 222:12-222:16 (leading: Space)
-1453: LParen          "(" at 222:16-222:17
-1454: Ident           "self" at 222:17-222:21
-1455: Colon           ":" at 222:21-222:22
-1456: Amp             "&" at 222:23-222:24 (leading: Space)
-1457: Ident           "Array" at 222:24-222:29
-1458: Lt              "<" at 222:29-222:30
-1459: Ident           "string" at 222:30-222:36
-1460: Gt              ">" at 222:36-222:37
-1461: Comma           "," at 222:37-222:38
-1462: Ident           "value" at 222:39-222:44 (leading: Space)
-1463: Colon           ":" at 222:44-222:45
-1464: Amp             "&" at 222:46-222:47 (leading: Space)
-1465: Ident           "string" at 222:47-222:53
-1466: RParen          ")" at 222:53-222:54
-1467: Arrow           "->" at 222:55-222:57 (leading: Space)
-1468: Ident           "Option" at 222:58-222:64 (leading: Space)
-1469: Lt              "<" at 222:64-222:65
-1470: Ident           "uint" at 222:65-222:69
-1471: Gt              ">" at 222:69-222:70
-1472: LBrace          "{" at 222:71-222:72 (leading: Space)
-1473: KwLet           "let" at 223:9-223:12 (leading: Newline, Space)
-1474: Ident           "length" at 223:13-223:19 (leading: Space)
-1475: Colon           ":" at 223:19-223:20
-1476: Ident           "int" at 223:21-223:24 (leading: Space)
-1477: Assign          "=" at 223:25-223:26 (leading: Space)
-1478: Ident           "self" at 223:27-223:31 (leading: Space)
-1479: Dot             "." at 223:31-223:32
-1480: Ident           "__len" at 223:32-223:37
-1481: LParen          "(" at 223:37-223:38
-1482: RParen          ")" at 223:38-223:39
-1483: KwTo            "to" at 223:40-223:42 (leading: Space)
-1484: Ident           "int" at 223:43-223:46 (leading: Space)
-1485: Semicolon       ";" at 223:46-223:47
-1486: KwLet           "let" at 224:9-224:12 (leading: Newline, Space)
-1487: KwMut           "mut" at 224:13-224:16 (leading: Space)
-1488: Ident           "i" at 224:17-224:18 (leading: Space)
-1489: Colon           ":" at 224:18-224:19
-1490: Ident           "int" at 224:20-224:23 (leading: Space)
-1491: Assign          "=" at 224:24-224:25 (leading: Space)
-1492: IntLit          "0" at 224:26-224:27 (leading: Space)
-1493: Semicolon       ";" at 224:27-224:28
-1494: KwWhile         "while" at 225:9-225:14 (leading: Newline, Space)
-1495: Ident           "i" at 225:15-225:16 (leading: Space)
-1496: Lt              "<" at 225:17-225:18 (leading: Space)
-1497: Ident           "length" at 225:19-225:25 (leading: Space)
-1498: LBrace          "{" at 225:26-225:27 (leading: Space)
-1499: KwIf            "if" at 226:13-226:15 (leading: Newline, Space)
-1500: Ident           "self" at 226:16-226:20 (leading: Space)
-1501: LBracket        "[" at 226:20-226:21
-1502: Ident           "i" at 226:21-226:22
-1503: RBracket        "]" at 226:22-226:23
-1504: EqEq            "==" at 226:24-226:26 (leading: Space)
-1505: Star            "*" at 226:27-226:28 (leading: Space)
-1506: Ident           "value" at 226:28-226:33
-1507: LBrace          "{" at 226:34-226:35 (leading: Space)
-1508: KwReturn        "return" at 227:17-227:23 (leading: Newline, Space)
-1509: Ident           "Some" at 227:24-227:28 (leading: Space)
-1510: LParen          "(" at 227:28-227:29
-1511: Ident           "i" at 227:29-227:30
-1512: KwTo            "to" at 227:31-227:33 (leading: Space)
-1513: Ident           "uint" at 227:34-227:38 (leading: Space)
-1514: RParen          ")" at 227:38-227:39
-1515: Semicolon       ";" at 227:39-227:40
-1516: RBrace          "}" at 228:13-228:14 (leading: Newline, Space)
-1517: Ident           "i" at 229:13-229:14 (leading: Newline, Space)
-1518: Assign          "=" at 229:15-229:16 (leading: Space)
-1519: Ident           "i" at 229:17-229:18 (leading: Space)
-1520: Plus            "+" at 229:19-229:20 (leading: Space)
-1521: IntLit          "1" at 229:21-229:22 (leading: Space)
-1522: Semicolon       ";" at 229:22-229:23
-1523: RBrace          "}" at 230:9-230:10 (leading: Newline, Space)
-1524: KwReturn        "return" at 231:9-231:15 (leading: Newline, Space)
-1525: NothingLit      "nothing" at 231:16-231:23 (leading: Space)
-1526: Semicolon       ";" at 231:23-231:24
-1527: RBrace          "}" at 232:5-232:6 (leading: Newline, Space)
-1528: RBrace          "}" at 233:1-233:2 (leading: Newline)
-1529: KwExtern        "extern" at 235:1-235:7 (leading: Newline)
-1530: Lt              "<" at 235:7-235:8
-1531: Ident           "ArrayFixed" at 235:8-235:18
-1532: Lt              "<" at 235:18-235:19
-1533: Ident           "T" at 235:19-235:20
-1534: Comma           "," at 235:20-235:21
-1535: Ident           "N" at 235:22-235:23 (leading: Space)
-1536: Shr             ">>" at 235:23-235:25
-1537: LBrace          "{" at 235:26-235:27 (leading: Space)
-1538: KwPub           "pub" at 236:5-236:8 (leading: Newline, Space)
-1539: KwFn            "fn" at 236:9-236:11 (leading: Space)
-1540: Ident           "with_len" at 236:12-236:20 (leading: Space)
-1541: LParen          "(" at 236:20-236:21
-1542: Ident           "length" at 236:21-236:27
-1543: Colon           ":" at 236:27-236:28
-1544: Ident           "uint" at 236:29-236:33 (leading: Space)
-1545: RParen          ")" at 236:33-236:34
-1546: Arrow           "->" at 236:35-236:37 (leading: Space)
-1547: Ident           "ArrayFixed" at 236:38-236:48 (leading: Space)
-1548: Lt              "<" at 236:48-236:49
-1549: Ident           "T" at 236:49-236:50
-1550: Comma           "," at 236:50-236:51
-1551: Ident           "N" at 236:52-236:53 (leading: Space)
-1552: Gt              ">" at 236:53-236:54
-1553: LBrace          "{" at 236:55-236:56 (leading: Space)
-1554: KwLet           "let" at 237:9-237:12 (leading: Newline, Space)
-1555: Ident           "out" at 237:13-237:16 (leading: Space)
-1556: Colon           ":" at 237:16-237:17
-1557: Ident           "ArrayFixed" at 237:18-237:28 (leading: Space)
-1558: Lt              "<" at 237:28-237:29
-1559: Ident           "T" at 237:29-237:30
-1560: Comma           "," at 237:30-237:31
-1561: Ident           "N" at 237:32-237:33 (leading: Space)
-1562: Gt              ">" at 237:33-237:34
-1563: Assign          "=" at 237:35-237:36 (leading: Space)
-1564: Ident           "default" at 237:37-237:44 (leading: Space)
-1565: ColonColon      "::" at 237:44-237:46
-1566: Lt              "<" at 237:46-237:47
-1567: Ident           "ArrayFixed" at 237:47-237:57
-1568: Lt              "<" at 237:57-237:58
-1569: Ident           "T" at 237:58-237:59
-1570: Comma           "," at 237:59-237:60
-1571: Ident           "N" at 237:61-237:62 (leading: Space)
-1572: Shr             ">>" at 237:62-237:64
-1573: LParen          "(" at 237:64-237:65
-1574: RParen          ")" at 237:65-237:66
-1575: Semicolon       ";" at 237:66-237:67
-1576: KwLet           "let" at 238:9-238:12 (leading: Newline, Space)
-1577: Ident           "expected" at 238:13-238:21 (leading: Space)
-1578: Colon           ":" at 238:21-238:22
-1579: Ident           "uint" at 238:23-238:27 (leading: Space)
-1580: Assign          "=" at 238:28-238:29 (leading: Space)
-1581: Ident           "out" at 238:30-238:33 (leading: Space)
-1582: Dot             "." at 238:33-238:34
-1583: Ident           "__len" at 238:34-238:39
-1584: LParen          "(" at 238:39-238:40
-1585: RParen          ")" at 238:40-238:41
-1586: Semicolon       ";" at 238:41-238:42
-1587: KwIf            "if" at 239:9-239:11 (leading: Newline, Space)
-1588: Ident           "length" at 239:12-239:18 (leading: Space)
-1589: BangEq          "!=" at 239:19-239:21 (leading: Space)
-1590: Ident           "expected" at 239:22-239:30 (leading: Space)
-1591: LBrace          "{" at 239:31-239:32 (leading: Space)
-1592: Ident           "panic" at 240:13-240:18 (leading: Newline, Space)
-1593: LParen          "(" at 240:18-240:19
-1594: StringLit       "\"ArrayFixed length mismatch\"" at 240:19-240:47
-1595: RParen          ")" at 240:47-240:48
-1596: Semicolon       ";" at 240:48-240:49
-1597: RBrace          "}" at 241:9-241:10 (leading: Newline, Space)
-1598: KwReturn        "return" at 242:9-242:15 (leading: Newline, Space)
-1599: Ident           "out" at 242:16-242:19 (leading: Space)
-1600: Semicolon       ";" at 242:19-242:20
-1601: RBrace          "}" at 243:5-243:6 (leading: Newline, Space)
-1602: KwPub           "pub" at 245:5-245:8 (leading: Newline, Space)
-1603: KwFn            "fn" at 245:9-245:11 (leading: Space)
-1604: Ident           "get_mut" at 245:12-245:19 (leading: Space)
-1605: LParen          "(" at 245:19-245:20
-1606: Ident           "self" at 245:20-245:24
-1607: Colon           ":" at 245:24-245:25
-1608: Amp             "&" at 245:26-245:27 (leading: Space)
-1609: KwMut           "mut" at 245:27-245:30
-1610: Ident           "ArrayFixed" at 245:31-245:41 (leading: Space)
-1611: Lt              "<" at 245:41-245:42
-1612: Ident           "T" at 245:42-245:43
-1613: Comma           "," at 245:43-245:44
-1614: Ident           "N" at 245:45-245:46 (leading: Space)
-1615: Gt              ">" at 245:46-245:47
-1616: Comma           "," at 245:47-245:48
-1617: Ident           "index" at 245:49-245:54 (leading: Space)
-1618: Colon           ":" at 245:54-245:55
-1619: Ident           "int" at 245:56-245:59 (leading: Space)
-1620: RParen          ")" at 245:59-245:60
-1621: Arrow           "->" at 245:61-245:63 (leading: Space)
-1622: Amp             "&" at 245:64-245:65 (leading: Space)
-1623: KwMut           "mut" at 245:65-245:68
-1624: Ident           "T" at 245:69-245:70 (leading: Space)
-1625: LBrace          "{" at 245:71-245:72 (leading: Space)
-1626: KwReturn        "return" at 246:9-246:15 (leading: Newline, Space)
-1627: Ident           "rt_array_get_mut" at 246:16-246:32 (leading: Space)
-1628: ColonColon      "::" at 246:32-246:34
-1629: Lt              "<" at 246:34-246:35
-1630: Ident           "T" at 246:35-246:36
-1631: Comma           "," at 246:36-246:37
-1632: Ident           "N" at 246:38-246:39 (leading: Space)
-1633: Gt              ">" at 246:39-246:40
-1634: LParen          "(" at 246:40-246:41
-1635: Ident           "self" at 246:41-246:45
-1636: Comma           "," at 246:45-246:46
-1637: Ident           "index" at 246:47-246:52 (leading: Space)
-1638: RParen          ")" at 246:52-246:53
-1639: Semicolon       ";" at 246:53-246:54
-1640: RBrace          "}" at 247:5-247:6 (leading: Newline, Space)
-1641: KwPub           "pub" at 249:5-249:8 (leading: Newline, Space)
-1642: KwFn            "fn" at 249:9-249:11 (leading: Space)
-1643: Ident           "with_len_value" at 249:12-249:26 (leading: Space)
-1644: LParen          "(" at 249:26-249:27
-1645: Ident           "length" at 249:27-249:33
-1646: Colon           ":" at 249:33-249:34
-1647: Ident           "uint" at 249:35-249:39 (leading: Space)
-1648: Comma           "," at 249:39-249:40
-1649: Ident           "value" at 249:41-249:46 (leading: Space)
-1650: Colon           ":" at 249:46-249:47
-1651: Ident           "T" at 249:48-249:49 (leading: Space)
-1652: RParen          ")" at 249:49-249:50
-1653: Arrow           "->" at 249:51-249:53 (leading: Space)
-1654: Ident           "ArrayFixed" at 249:54-249:64 (leading: Space)
-1655: Lt              "<" at 249:64-249:65
-1656: Ident           "T" at 249:65-249:66
-1657: Comma           "," at 249:66-249:67
-1658: Ident           "N" at 249:68-249:69 (leading: Space)
-1659: Gt              ">" at 249:69-249:70
-1660: LBrace          "{" at 249:71-249:72 (leading: Space)
-1661: KwLet           "let" at 250:9-250:12 (leading: Newline, Space)
-1662: KwMut           "mut" at 250:13-250:16 (leading: Space)
-1663: Ident           "out" at 250:17-250:20 (leading: Space)
-1664: Colon           ":" at 250:20-250:21
-1665: Ident           "ArrayFixed" at 250:22-250:32 (leading: Space)
-1666: Lt              "<" at 250:32-250:33
-1667: Ident           "T" at 250:33-250:34
-1668: Comma           "," at 250:34-250:35
-1669: Ident           "N" at 250:36-250:37 (leading: Space)
-1670: Gt              ">" at 250:37-250:38
-1671: Assign          "=" at 250:39-250:40 (leading: Space)
-1672: Ident           "default" at 250:41-250:48 (leading: Space)
-1673: ColonColon      "::" at 250:48-250:50
-1674: Lt              "<" at 250:50-250:51
-1675: Ident           "ArrayFixed" at 250:51-250:61
-1676: Lt              "<" at 250:61-250:62
-1677: Ident           "T" at 250:62-250:63
-1678: Comma           "," at 250:63-250:64
-1679: Ident           "N" at 250:65-250:66 (leading: Space)
-1680: Shr             ">>" at 250:66-250:68
-1681: LParen          "(" at 250:68-250:69
-1682: RParen          ")" at 250:69-250:70
-1683: Semicolon       ";" at 250:70-250:71
-1684: KwLet           "let" at 251:9-251:12 (leading: Newline, Space)
-1685: Ident           "expected" at 251:13-251:21 (leading: Space)
-1686: Colon           ":" at 251:21-251:22
-1687: Ident           "uint" at 251:23-251:27 (leading: Space)
-1688: Assign          "=" at 251:28-251:29 (leading: Space)
-1689: Ident           "out" at 251:30-251:33 (leading: Space)
-1690: Dot             "." at 251:33-251:34
-1691: Ident           "__len" at 251:34-251:39
-1692: LParen          "(" at 251:39-251:40
-1693: RParen          ")" at 251:40-251:41
-1694: Semicolon       ";" at 251:41-251:42
-1695: KwIf            "if" at 252:9-252:11 (leading: Newline, Space)
-1696: Ident           "length" at 252:12-252:18 (leading: Space)
-1697: BangEq          "!=" at 252:19-252:21 (leading: Space)
-1698: Ident           "expected" at 252:22-252:30 (leading: Space)
-1699: LBrace          "{" at 252:31-252:32 (leading: Space)
-1700: Ident           "panic" at 253:13-253:18 (leading: Newline, Space)
-1701: LParen          "(" at 253:18-253:19
-1702: StringLit       "\"ArrayFixed length mismatch\"" at 253:19-253:47
-1703: RParen          ")" at 253:47-253:48
-1704: Semicolon       ";" at 253:48-253:49
-1705: RBrace          "}" at 254:9-254:10 (leading: Newline, Space)
-1706: KwLet           "let" at 255:9-255:12 (leading: Newline, Space)
-1707: Ident           "count" at 255:13-255:18 (leading: Space)
-1708: Colon           ":" at 255:18-255:19
-1709: Ident           "int" at 255:20-255:23 (leading: Space)
-1710: Assign          "=" at 255:24-255:25 (leading: Space)
-1711: Ident           "expected" at 255:26-255:34 (leading: Space)
-1712: KwTo            "to" at 255:35-255:37 (leading: Space)
-1713: Ident           "int" at 255:38-255:41 (leading: Space)
-1714: Semicolon       ";" at 255:41-255:42
-1715: KwLet           "let" at 256:9-256:12 (leading: Newline, Space)
-1716: KwMut           "mut" at 256:13-256:16 (leading: Space)
-1717: Ident           "i" at 256:17-256:18 (leading: Space)
-1718: Colon           ":" at 256:18-256:19
-1719: Ident           "int" at 256:20-256:23 (leading: Space)
-1720: Assign          "=" at 256:24-256:25 (leading: Space)
-1721: IntLit          "0" at 256:26-256:27 (leading: Space)
-1722: Semicolon       ";" at 256:27-256:28
-1723: KwWhile         "while" at 257:9-257:14 (leading: Newline, Space)
-1724: Ident           "i" at 257:15-257:16 (leading: Space)
-1725: Lt              "<" at 257:17-257:18 (leading: Space)
-1726: Ident           "count" at 257:19-257:24 (leading: Space)
-1727: LBrace          "{" at 257:25-257:26 (leading: Space)
-1728: Ident           "out" at 258:13-258:16 (leading: Newline, Space)
-1729: LBracket        "[" at 258:16-258:17
-1730: Ident           "i" at 258:17-258:18
-1731: RBracket        "]" at 258:18-258:19
-1732: Assign          "=" at 258:20-258:21 (leading: Space)
-1733: Ident           "clone" at 258:22-258:27 (leading: Space)
-1734: LParen          "(" at 258:27-258:28
-1735: Amp             "&" at 258:28-258:29
-1736: Ident           "value" at 258:29-258:34
-1737: RParen          ")" at 258:34-258:35
-1738: Semicolon       ";" at 258:35-258:36
-1739: Ident           "i" at 259:13-259:14 (leading: Newline, Space)
-1740: Assign          "=" at 259:15-259:16 (leading: Space)
-1741: Ident           "i" at 259:17-259:18 (leading: Space)
-1742: Plus            "+" at 259:19-259:20 (leading: Space)
-1743: IntLit          "1" at 259:21-259:22 (leading: Space)
-1744: Semicolon       ";" at 259:22-259:23
-1745: RBrace          "}" at 260:9-260:10 (leading: Newline, Space)
-1746: KwReturn        "return" at 261:9-261:15 (leading: Newline, Space)
-1747: Ident           "out" at 261:16-261:19 (leading: Space)
-1748: Semicolon       ";" at 261:19-261:20
-1749: RBrace          "}" at 262:5-262:6 (leading: Newline, Space)
-1750: KwPub           "pub" at 264:5-264:8 (leading: Newline, Space)
-1751: KwFn            "fn" at 264:9-264:11 (leading: Space)
-1752: Ident           "__to" at 264:12-264:16 (leading: Space)
-1753: LParen          "(" at 264:16-264:17
-1754: Ident           "self" at 264:17-264:21
-1755: Colon           ":" at 264:21-264:22
-1756: Amp             "&" at 264:23-264:24 (leading: Space)
-1757: Ident           "ArrayFixed" at 264:24-264:34
-1758: Lt              "<" at 264:34-264:35
-1759: Ident           "T" at 264:35-264:36
-1760: Comma           "," at 264:36-264:37
-1761: Ident           "N" at 264:38-264:39 (leading: Space)
-1762: Gt              ">" at 264:39-264:40
-1763: Comma           "," at 264:40-264:41
-1764: Ident           "target" at 264:42-264:48 (leading: Space)
-1765: Colon           ":" at 264:48-264:49
-1766: Ident           "string" at 264:50-264:56 (leading: Space)
-1767: RParen          ")" at 264:56-264:57
-1768: Arrow           "->" at 264:58-264:60 (leading: Space)
-1769: Ident           "string" at 264:61-264:67 (leading: Space)
-1770: LBrace          "{" at 264:68-264:69 (leading: Space)
-1771: KwLet           "let" at 265:9-265:12 (leading: Newline, Space)
-1772: Underscore      "_" at 265:13-265:14 (leading: Space)
-1773: Assign          "=" at 265:15-265:16 (leading: Space)
-1774: Ident           "target" at 265:17-265:23 (leading: Space)
-1775: Semicolon       ";" at 265:23-265:24
-1776: KwLet           "let" at 266:9-266:12 (leading: Newline, Space)
-1777: Ident           "length_s" at 266:13-266:21 (leading: Space)
-1778: Colon           ":" at 266:21-266:22
-1779: Ident           "string" at 266:23-266:29 (leading: Space)
-1780: Assign          "=" at 266:30-266:31 (leading: Space)
-1781: Ident           "self" at 266:32-266:36 (leading: Space)
-1782: Dot             "." at 266:36-266:37
-1783: Ident           "__len" at 266:37-266:42
-1784: LParen          "(" at 266:42-266:43
-1785: RParen          ")" at 266:43-266:44
-1786: KwTo            "to" at 266:45-266:47 (leading: Space)
-1787: Ident           "string" at 266:48-266:54 (leading: Space)
-1788: Semicolon       ";" at 266:54-266:55
-1789: KwReturn        "return" at 267:9-267:15 (leading: Newline, Space)
-1790: StringLit       "\"ArrayFixed(len=\"" at 267:16-267:33 (leading: Space)
-1791: Plus            "+" at 267:34-267:35 (leading: Space)
-1792: Ident           "length_s" at 267:36-267:44 (leading: Space)
-1793: Plus            "+" at 267:45-267:46 (leading: Space)
-1794: StringLit       "\")\"" at 267:47-267:50 (leading: Space)
-1795: Semicolon       ";" at 267:50-267:51
-1796: RBrace          "}" at 268:5-268:6 (leading: Newline, Space)
-1797: KwPub           "pub" at 270:5-270:8 (leading: Newline, Space)
-1798: KwFn            "fn" at 270:9-270:11 (leading: Space)
-1799: Ident           "to_array" at 270:12-270:20 (leading: Space)
-1800: LParen          "(" at 270:20-270:21
-1801: Ident           "self" at 270:21-270:25
-1802: Colon           ":" at 270:25-270:26
-1803: Amp             "&" at 270:27-270:28 (leading: Space)
-1804: Ident           "ArrayFixed" at 270:28-270:38
-1805: Lt              "<" at 270:38-270:39
-1806: Ident           "T" at 270:39-270:40
-1807: Comma           "," at 270:40-270:41
-1808: Ident           "N" at 270:42-270:43 (leading: Space)
-1809: Gt              ">" at 270:43-270:44
-1810: RParen          ")" at 270:44-270:45
-1811: Arrow           "->" at 270:46-270:48 (leading: Space)
-1812: Ident           "Array" at 270:49-270:54 (leading: Space)
-1813: Lt              "<" at 270:54-270:55
-1814: Ident           "T" at 270:55-270:56
-1815: Gt              ">" at 270:56-270:57
-1816: LBrace          "{" at 270:58-270:59 (leading: Space)
-1817: KwLet           "let" at 271:9-271:12 (leading: Newline, Space)
-1818: Ident           "length" at 271:13-271:19 (leading: Space)
-1819: Colon           ":" at 271:19-271:20
-1820: Ident           "int" at 271:21-271:24 (leading: Space)
-1821: Assign          "=" at 271:25-271:26 (leading: Space)
-1822: Ident           "self" at 271:27-271:31 (leading: Space)
-1823: Dot             "." at 271:31-271:32
-1824: Ident           "__len" at 271:32-271:37
-1825: LParen          "(" at 271:37-271:38
-1826: RParen          ")" at 271:38-271:39
-1827: KwTo            "to" at 271:40-271:42 (leading: Space)
-1828: Ident           "int" at 271:43-271:46 (leading: Space)
-1829: Semicolon       ";" at 271:46-271:47
-1830: KwLet           "let" at 272:9-272:12 (leading: Newline, Space)
-1831: KwMut           "mut" at 272:13-272:16 (leading: Space)
-1832: Ident           "out" at 272:17-272:20 (leading: Space)
-1833: Colon           ":" at 272:20-272:21
-1834: Ident           "Array" at 272:22-272:27 (leading: Space)
-1835: Lt              "<" at 272:27-272:28
-1836: Ident           "T" at 272:28-272:29
-1837: Gt              ">" at 272:29-272:30
-1838: Assign          "=" at 272:31-272:32 (leading: Space)
-1839: LBracket        "[" at 272:33-272:34 (leading: Space)
-1840: RBracket        "]" at 272:34-272:35
-1841: Semicolon       ";" at 272:35-272:36
-1842: LBrace          "{" at 273:9-273:10 (leading: Newline, Space)
-1843: KwLet           "let" at 274:13-274:16 (leading: Newline, Space)
-1844: Ident           "out_ref" at 274:17-274:24 (leading: Space)
-1845: Colon           ":" at 274:24-274:25
-1846: Amp             "&" at 274:26-274:27 (leading: Space)
-1847: KwMut           "mut" at 274:27-274:30
-1848: Ident           "Array" at 274:31-274:36 (leading: Space)
-1849: Lt              "<" at 274:36-274:37
-1850: Ident           "T" at 274:37-274:38
-1851: Gt              ">" at 274:38-274:39
-1852: Assign          "=" at 274:40-274:41 (leading: Space)
-1853: Amp             "&" at 274:42-274:43 (leading: Space)
-1854: KwMut           "mut" at 274:43-274:46
-1855: Ident           "out" at 274:47-274:50 (leading: Space)
-1856: Semicolon       ";" at 274:50-274:51
-1857: Ident           "out_ref" at 275:13-275:20 (leading: Newline, Space)
-1858: Dot             "." at 275:20-275:21
-1859: Ident           "reserve" at 275:21-275:28
-1860: LParen          "(" at 275:28-275:29
-1861: Ident           "self" at 275:29-275:33
-1862: Dot             "." at 275:33-275:34
-1863: Ident           "__len" at 275:34-275:39
-1864: LParen          "(" at 275:39-275:40
-1865: RParen          ")" at 275:40-275:41
-1866: RParen          ")" at 275:41-275:42
-1867: Semicolon       ";" at 275:42-275:43
-1868: KwLet           "let" at 276:13-276:16 (leading: Newline, Space)
-1869: KwMut           "mut" at 276:17-276:20 (leading: Space)
-1870: Ident           "i" at 276:21-276:22 (leading: Space)
-1871: Colon           ":" at 276:22-276:23
-1872: Ident           "int" at 276:24-276:27 (leading: Space)
-1873: Assign          "=" at 276:28-276:29 (leading: Space)
-1874: IntLit          "0" at 276:30-276:31 (leading: Space)
-1875: Semicolon       ";" at 276:31-276:32
-1876: KwWhile         "while" at 277:13-277:18 (leading: Newline, Space)
-1877: Ident           "i" at 277:19-277:20 (leading: Space)
-1878: Lt              "<" at 277:21-277:22 (leading: Space)
-1879: Ident           "length" at 277:23-277:29 (leading: Space)
-1880: LBrace          "{" at 277:30-277:31 (leading: Space)
-1881: Ident           "out_ref" at 278:17-278:24 (leading: Newline, Space)
-1882: Dot             "." at 278:24-278:25
-1883: Ident           "push" at 278:25-278:29
-1884: LParen          "(" at 278:29-278:30
-1885: Ident           "clone" at 278:30-278:35
-1886: LParen          "(" at 278:35-278:36
-1887: Ident           "self" at 278:36-278:40
-1888: LBracket        "[" at 278:40-278:41
-1889: Ident           "i" at 278:41-278:42
-1890: RBracket        "]" at 278:42-278:43
-1891: RParen          ")" at 278:43-278:44
-1892: RParen          ")" at 278:44-278:45
-1893: Semicolon       ";" at 278:45-278:46
-1894: Ident           "i" at 279:17-279:18 (leading: Newline, Space)
-1895: Assign          "=" at 279:19-279:20 (leading: Space)
-1896: Ident           "i" at 279:21-279:22 (leading: Space)
-1897: Plus            "+" at 279:23-279:24 (leading: Space)
-1898: IntLit          "1" at 279:25-279:26 (leading: Space)
-1899: Semicolon       ";" at 279:26-279:27
-1900: RBrace          "}" at 280:13-280:14 (leading: Newline, Space)
-1901: RBrace          "}" at 281:9-281:10 (leading: Newline, Space)
-1902: KwReturn        "return" at 282:9-282:15 (leading: Newline, Space)
-1903: Ident           "out" at 282:16-282:19 (leading: Space)
-1904: Semicolon       ";" at 282:19-282:20
-1905: RBrace          "}" at 283:5-283:6 (leading: Newline, Space)
-1906: RBrace          "}" at 284:1-284:2 (leading: Newline)
-1907: EOF             at 285:1-285:1
+884: KwExtern        "extern" at 139:1-139:7 (leading: Newline)
+885: Lt              "<" at 139:7-139:8
+886: Ident           "Array" at 139:8-139:13
+887: Lt              "<" at 139:13-139:14
+888: Ident           "byte" at 139:14-139:18
+889: Shr             ">>" at 139:18-139:20
+890: LBrace          "{" at 139:21-139:22 (leading: Space)
+891: KwPub           "pub" at 140:5-140:8 (leading: Newline, Space)
+892: KwFn            "fn" at 140:9-140:11 (leading: Space)
+893: Ident           "append_string" at 140:12-140:25 (leading: Space)
+894: LParen          "(" at 140:25-140:26
+895: Ident           "self" at 140:26-140:30
+896: Colon           ":" at 140:30-140:31
+897: Amp             "&" at 140:32-140:33 (leading: Space)
+898: KwMut           "mut" at 140:33-140:36
+899: Ident           "Array" at 140:37-140:42 (leading: Space)
+900: Lt              "<" at 140:42-140:43
+901: Ident           "byte" at 140:43-140:47
+902: Gt              ">" at 140:47-140:48
+903: Comma           "," at 140:48-140:49
+904: Ident           "text" at 140:50-140:54 (leading: Space)
+905: Colon           ":" at 140:54-140:55
+906: Amp             "&" at 140:56-140:57 (leading: Space)
+907: Ident           "string" at 140:57-140:63
+908: RParen          ")" at 140:63-140:64
+909: Arrow           "->" at 140:65-140:67 (leading: Space)
+910: NothingLit      "nothing" at 140:68-140:75 (leading: Space)
+911: LBrace          "{" at 140:76-140:77 (leading: Space)
+912: Ident           "rt_array_append_raw_bytes" at 141:9-141:34 (leading: Newline, Space)
+913: LParen          "(" at 141:34-141:35
+914: Ident           "self" at 141:35-141:39
+915: Comma           "," at 141:39-141:40
+916: Ident           "rt_string_ptr" at 141:41-141:54 (leading: Space)
+917: LParen          "(" at 141:54-141:55
+918: Ident           "text" at 141:55-141:59
+919: RParen          ")" at 141:59-141:60
+920: Comma           "," at 141:60-141:61
+921: Ident           "rt_string_len_bytes" at 141:62-141:81 (leading: Space)
+922: LParen          "(" at 141:81-141:82
+923: Ident           "text" at 141:82-141:86
+924: RParen          ")" at 141:86-141:87
+925: KwTo            "to" at 141:88-141:90 (leading: Space)
+926: Ident           "uint64" at 141:91-141:97 (leading: Space)
+927: RParen          ")" at 141:97-141:98
+928: Semicolon       ";" at 141:98-141:99
+929: KwReturn        "return" at 142:9-142:15 (leading: Newline, Space)
+930: NothingLit      "nothing" at 142:16-142:23 (leading: Space)
+931: Semicolon       ";" at 142:23-142:24
+932: RBrace          "}" at 143:5-143:6 (leading: Newline, Space)
+933: KwPub           "pub" at 145:5-145:8 (leading: Newline, Space)
+934: KwFn            "fn" at 145:9-145:11 (leading: Space)
+935: Ident           "append_bytes_view" at 145:12-145:29 (leading: Space)
+936: LParen          "(" at 145:29-145:30
+937: Ident           "self" at 145:30-145:34
+938: Colon           ":" at 145:34-145:35
+939: Amp             "&" at 145:36-145:37 (leading: Space)
+940: KwMut           "mut" at 145:37-145:40
+941: Ident           "Array" at 145:41-145:46 (leading: Space)
+942: Lt              "<" at 145:46-145:47
+943: Ident           "byte" at 145:47-145:51
+944: Gt              ">" at 145:51-145:52
+945: Comma           "," at 145:52-145:53
+946: Ident           "view" at 145:54-145:58 (leading: Space)
+947: Colon           ":" at 145:58-145:59
+948: Amp             "&" at 145:60-145:61 (leading: Space)
+949: Ident           "BytesView" at 145:61-145:70
+950: RParen          ")" at 145:70-145:71
+951: Arrow           "->" at 145:72-145:74 (leading: Space)
+952: NothingLit      "nothing" at 145:75-145:82 (leading: Space)
+953: LBrace          "{" at 145:83-145:84 (leading: Space)
+954: Ident           "rt_array_append_raw_bytes" at 146:9-146:34 (leading: Newline, Space)
+955: LParen          "(" at 146:34-146:35
+956: Ident           "self" at 146:35-146:39
+957: Comma           "," at 146:39-146:40
+958: Ident           "view" at 146:41-146:45 (leading: Space)
+959: Dot             "." at 146:45-146:46
+960: Ident           "ptr" at 146:46-146:49
+961: Comma           "," at 146:49-146:50
+962: Ident           "view" at 146:51-146:55 (leading: Space)
+963: Dot             "." at 146:55-146:56
+964: Ident           "__len" at 146:56-146:61
+965: LParen          "(" at 146:61-146:62
+966: RParen          ")" at 146:62-146:63
+967: KwTo            "to" at 146:64-146:66 (leading: Space)
+968: Ident           "uint64" at 146:67-146:73 (leading: Space)
+969: RParen          ")" at 146:73-146:74
+970: Semicolon       ";" at 146:74-146:75
+971: KwReturn        "return" at 147:9-147:15 (leading: Newline, Space)
+972: NothingLit      "nothing" at 147:16-147:23 (leading: Space)
+973: Semicolon       ";" at 147:23-147:24
+974: RBrace          "}" at 148:5-148:6 (leading: Newline, Space)
+975: RBrace          "}" at 149:1-149:2 (leading: Newline)
+976: KwExtern        "extern" at 152:1-152:7 (leading: Newline, LineComment, Newline)
+977: Lt              "<" at 152:7-152:8
+978: Ident           "Array" at 152:8-152:13
+979: Lt              "<" at 152:13-152:14
+980: Ident           "int" at 152:14-152:17
+981: Shr             ">>" at 152:17-152:19
+982: LBrace          "{" at 152:20-152:21 (leading: Space)
+983: KwPub           "pub" at 153:5-153:8 (leading: Newline, Space)
+984: KwFn            "fn" at 153:9-153:11 (leading: Space)
+985: Ident           "contains" at 153:12-153:20 (leading: Space)
+986: LParen          "(" at 153:20-153:21
+987: Ident           "self" at 153:21-153:25
+988: Colon           ":" at 153:25-153:26
+989: Amp             "&" at 153:27-153:28 (leading: Space)
+990: Ident           "Array" at 153:28-153:33
+991: Lt              "<" at 153:33-153:34
+992: Ident           "int" at 153:34-153:37
+993: Gt              ">" at 153:37-153:38
+994: Comma           "," at 153:38-153:39
+995: Ident           "value" at 153:40-153:45 (leading: Space)
+996: Colon           ":" at 153:45-153:46
+997: Amp             "&" at 153:47-153:48 (leading: Space)
+998: Ident           "int" at 153:48-153:51
+999: RParen          ")" at 153:51-153:52
+1000: Arrow           "->" at 153:53-153:55 (leading: Space)
+1001: Ident           "bool" at 153:56-153:60 (leading: Space)
+1002: LBrace          "{" at 153:61-153:62 (leading: Space)
+1003: KwLet           "let" at 154:9-154:12 (leading: Newline, Space)
+1004: Ident           "res" at 154:13-154:16 (leading: Space)
+1005: Colon           ":" at 154:16-154:17
+1006: Ident           "Option" at 154:18-154:24 (leading: Space)
+1007: Lt              "<" at 154:24-154:25
+1008: Ident           "uint" at 154:25-154:29
+1009: Gt              ">" at 154:29-154:30
+1010: Assign          "=" at 154:31-154:32 (leading: Space)
+1011: Ident           "self" at 154:33-154:37 (leading: Space)
+1012: Dot             "." at 154:37-154:38
+1013: Ident           "find" at 154:38-154:42
+1014: LParen          "(" at 154:42-154:43
+1015: Ident           "value" at 154:43-154:48
+1016: RParen          ")" at 154:48-154:49
+1017: Semicolon       ";" at 154:49-154:50
+1018: KwReturn        "return" at 155:9-155:15 (leading: Newline, Space)
+1019: Ident           "res" at 155:16-155:19 (leading: Space)
+1020: Dot             "." at 155:19-155:20
+1021: Ident           "is_some" at 155:20-155:27
+1022: LParen          "(" at 155:27-155:28
+1023: RParen          ")" at 155:28-155:29
+1024: Semicolon       ";" at 155:29-155:30
+1025: RBrace          "}" at 156:5-156:6 (leading: Newline, Space)
+1026: KwPub           "pub" at 158:5-158:8 (leading: Newline, Space)
+1027: KwFn            "fn" at 158:9-158:11 (leading: Space)
+1028: Ident           "find" at 158:12-158:16 (leading: Space)
+1029: LParen          "(" at 158:16-158:17
+1030: Ident           "self" at 158:17-158:21
+1031: Colon           ":" at 158:21-158:22
+1032: Amp             "&" at 158:23-158:24 (leading: Space)
+1033: Ident           "Array" at 158:24-158:29
+1034: Lt              "<" at 158:29-158:30
+1035: Ident           "int" at 158:30-158:33
+1036: Gt              ">" at 158:33-158:34
+1037: Comma           "," at 158:34-158:35
+1038: Ident           "value" at 158:36-158:41 (leading: Space)
+1039: Colon           ":" at 158:41-158:42
+1040: Amp             "&" at 158:43-158:44 (leading: Space)
+1041: Ident           "int" at 158:44-158:47
+1042: RParen          ")" at 158:47-158:48
+1043: Arrow           "->" at 158:49-158:51 (leading: Space)
+1044: Ident           "Option" at 158:52-158:58 (leading: Space)
+1045: Lt              "<" at 158:58-158:59
+1046: Ident           "uint" at 158:59-158:63
+1047: Gt              ">" at 158:63-158:64
+1048: LBrace          "{" at 158:65-158:66 (leading: Space)
+1049: KwLet           "let" at 159:9-159:12 (leading: Newline, Space)
+1050: Ident           "length" at 159:13-159:19 (leading: Space)
+1051: Colon           ":" at 159:19-159:20
+1052: Ident           "int" at 159:21-159:24 (leading: Space)
+1053: Assign          "=" at 159:25-159:26 (leading: Space)
+1054: Ident           "self" at 159:27-159:31 (leading: Space)
+1055: Dot             "." at 159:31-159:32
+1056: Ident           "__len" at 159:32-159:37
+1057: LParen          "(" at 159:37-159:38
+1058: RParen          ")" at 159:38-159:39
+1059: KwTo            "to" at 159:40-159:42 (leading: Space)
+1060: Ident           "int" at 159:43-159:46 (leading: Space)
+1061: Semicolon       ";" at 159:46-159:47
+1062: KwLet           "let" at 160:9-160:12 (leading: Newline, Space)
+1063: KwMut           "mut" at 160:13-160:16 (leading: Space)
+1064: Ident           "i" at 160:17-160:18 (leading: Space)
+1065: Colon           ":" at 160:18-160:19
+1066: Ident           "int" at 160:20-160:23 (leading: Space)
+1067: Assign          "=" at 160:24-160:25 (leading: Space)
+1068: IntLit          "0" at 160:26-160:27 (leading: Space)
+1069: Semicolon       ";" at 160:27-160:28
+1070: KwWhile         "while" at 161:9-161:14 (leading: Newline, Space)
+1071: Ident           "i" at 161:15-161:16 (leading: Space)
+1072: Lt              "<" at 161:17-161:18 (leading: Space)
+1073: Ident           "length" at 161:19-161:25 (leading: Space)
+1074: LBrace          "{" at 161:26-161:27 (leading: Space)
+1075: KwIf            "if" at 162:13-162:15 (leading: Newline, Space)
+1076: Ident           "self" at 162:16-162:20 (leading: Space)
+1077: LBracket        "[" at 162:20-162:21
+1078: Ident           "i" at 162:21-162:22
+1079: RBracket        "]" at 162:22-162:23
+1080: EqEq            "==" at 162:24-162:26 (leading: Space)
+1081: Star            "*" at 162:27-162:28 (leading: Space)
+1082: Ident           "value" at 162:28-162:33
+1083: LBrace          "{" at 162:34-162:35 (leading: Space)
+1084: KwReturn        "return" at 163:17-163:23 (leading: Newline, Space)
+1085: Ident           "Some" at 163:24-163:28 (leading: Space)
+1086: LParen          "(" at 163:28-163:29
+1087: Ident           "i" at 163:29-163:30
+1088: KwTo            "to" at 163:31-163:33 (leading: Space)
+1089: Ident           "uint" at 163:34-163:38 (leading: Space)
+1090: RParen          ")" at 163:38-163:39
+1091: Semicolon       ";" at 163:39-163:40
+1092: RBrace          "}" at 164:13-164:14 (leading: Newline, Space)
+1093: Ident           "i" at 165:13-165:14 (leading: Newline, Space)
+1094: Assign          "=" at 165:15-165:16 (leading: Space)
+1095: Ident           "i" at 165:17-165:18 (leading: Space)
+1096: Plus            "+" at 165:19-165:20 (leading: Space)
+1097: IntLit          "1" at 165:21-165:22 (leading: Space)
+1098: Semicolon       ";" at 165:22-165:23
+1099: RBrace          "}" at 166:9-166:10 (leading: Newline, Space)
+1100: KwReturn        "return" at 167:9-167:15 (leading: Newline, Space)
+1101: NothingLit      "nothing" at 167:16-167:23 (leading: Space)
+1102: Semicolon       ";" at 167:23-167:24
+1103: RBrace          "}" at 168:5-168:6 (leading: Newline, Space)
+1104: RBrace          "}" at 169:1-169:2 (leading: Newline)
+1105: KwExtern        "extern" at 171:1-171:7 (leading: Newline)
+1106: Lt              "<" at 171:7-171:8
+1107: Ident           "Array" at 171:8-171:13
+1108: Lt              "<" at 171:13-171:14
+1109: Ident           "uint" at 171:14-171:18
+1110: Shr             ">>" at 171:18-171:20
+1111: LBrace          "{" at 171:21-171:22 (leading: Space)
+1112: KwPub           "pub" at 172:5-172:8 (leading: Newline, Space)
+1113: KwFn            "fn" at 172:9-172:11 (leading: Space)
+1114: Ident           "contains" at 172:12-172:20 (leading: Space)
+1115: LParen          "(" at 172:20-172:21
+1116: Ident           "self" at 172:21-172:25
+1117: Colon           ":" at 172:25-172:26
+1118: Amp             "&" at 172:27-172:28 (leading: Space)
+1119: Ident           "Array" at 172:28-172:33
+1120: Lt              "<" at 172:33-172:34
+1121: Ident           "uint" at 172:34-172:38
+1122: Gt              ">" at 172:38-172:39
+1123: Comma           "," at 172:39-172:40
+1124: Ident           "value" at 172:41-172:46 (leading: Space)
+1125: Colon           ":" at 172:46-172:47
+1126: Amp             "&" at 172:48-172:49 (leading: Space)
+1127: Ident           "uint" at 172:49-172:53
+1128: RParen          ")" at 172:53-172:54
+1129: Arrow           "->" at 172:55-172:57 (leading: Space)
+1130: Ident           "bool" at 172:58-172:62 (leading: Space)
+1131: LBrace          "{" at 172:63-172:64 (leading: Space)
+1132: KwLet           "let" at 173:9-173:12 (leading: Newline, Space)
+1133: Ident           "res" at 173:13-173:16 (leading: Space)
+1134: Colon           ":" at 173:16-173:17
+1135: Ident           "Option" at 173:18-173:24 (leading: Space)
+1136: Lt              "<" at 173:24-173:25
+1137: Ident           "uint" at 173:25-173:29
+1138: Gt              ">" at 173:29-173:30
+1139: Assign          "=" at 173:31-173:32 (leading: Space)
+1140: Ident           "self" at 173:33-173:37 (leading: Space)
+1141: Dot             "." at 173:37-173:38
+1142: Ident           "find" at 173:38-173:42
+1143: LParen          "(" at 173:42-173:43
+1144: Ident           "value" at 173:43-173:48
+1145: RParen          ")" at 173:48-173:49
+1146: Semicolon       ";" at 173:49-173:50
+1147: KwReturn        "return" at 174:9-174:15 (leading: Newline, Space)
+1148: Ident           "res" at 174:16-174:19 (leading: Space)
+1149: Dot             "." at 174:19-174:20
+1150: Ident           "is_some" at 174:20-174:27
+1151: LParen          "(" at 174:27-174:28
+1152: RParen          ")" at 174:28-174:29
+1153: Semicolon       ";" at 174:29-174:30
+1154: RBrace          "}" at 175:5-175:6 (leading: Newline, Space)
+1155: KwPub           "pub" at 177:5-177:8 (leading: Newline, Space)
+1156: KwFn            "fn" at 177:9-177:11 (leading: Space)
+1157: Ident           "find" at 177:12-177:16 (leading: Space)
+1158: LParen          "(" at 177:16-177:17
+1159: Ident           "self" at 177:17-177:21
+1160: Colon           ":" at 177:21-177:22
+1161: Amp             "&" at 177:23-177:24 (leading: Space)
+1162: Ident           "Array" at 177:24-177:29
+1163: Lt              "<" at 177:29-177:30
+1164: Ident           "uint" at 177:30-177:34
+1165: Gt              ">" at 177:34-177:35
+1166: Comma           "," at 177:35-177:36
+1167: Ident           "value" at 177:37-177:42 (leading: Space)
+1168: Colon           ":" at 177:42-177:43
+1169: Amp             "&" at 177:44-177:45 (leading: Space)
+1170: Ident           "uint" at 177:45-177:49
+1171: RParen          ")" at 177:49-177:50
+1172: Arrow           "->" at 177:51-177:53 (leading: Space)
+1173: Ident           "Option" at 177:54-177:60 (leading: Space)
+1174: Lt              "<" at 177:60-177:61
+1175: Ident           "uint" at 177:61-177:65
+1176: Gt              ">" at 177:65-177:66
+1177: LBrace          "{" at 177:67-177:68 (leading: Space)
+1178: KwLet           "let" at 178:9-178:12 (leading: Newline, Space)
+1179: Ident           "length" at 178:13-178:19 (leading: Space)
+1180: Colon           ":" at 178:19-178:20
+1181: Ident           "int" at 178:21-178:24 (leading: Space)
+1182: Assign          "=" at 178:25-178:26 (leading: Space)
+1183: Ident           "self" at 178:27-178:31 (leading: Space)
+1184: Dot             "." at 178:31-178:32
+1185: Ident           "__len" at 178:32-178:37
+1186: LParen          "(" at 178:37-178:38
+1187: RParen          ")" at 178:38-178:39
+1188: KwTo            "to" at 178:40-178:42 (leading: Space)
+1189: Ident           "int" at 178:43-178:46 (leading: Space)
+1190: Semicolon       ";" at 178:46-178:47
+1191: KwLet           "let" at 179:9-179:12 (leading: Newline, Space)
+1192: KwMut           "mut" at 179:13-179:16 (leading: Space)
+1193: Ident           "i" at 179:17-179:18 (leading: Space)
+1194: Colon           ":" at 179:18-179:19
+1195: Ident           "int" at 179:20-179:23 (leading: Space)
+1196: Assign          "=" at 179:24-179:25 (leading: Space)
+1197: IntLit          "0" at 179:26-179:27 (leading: Space)
+1198: Semicolon       ";" at 179:27-179:28
+1199: KwWhile         "while" at 180:9-180:14 (leading: Newline, Space)
+1200: Ident           "i" at 180:15-180:16 (leading: Space)
+1201: Lt              "<" at 180:17-180:18 (leading: Space)
+1202: Ident           "length" at 180:19-180:25 (leading: Space)
+1203: LBrace          "{" at 180:26-180:27 (leading: Space)
+1204: KwIf            "if" at 181:13-181:15 (leading: Newline, Space)
+1205: Ident           "self" at 181:16-181:20 (leading: Space)
+1206: LBracket        "[" at 181:20-181:21
+1207: Ident           "i" at 181:21-181:22
+1208: RBracket        "]" at 181:22-181:23
+1209: EqEq            "==" at 181:24-181:26 (leading: Space)
+1210: Star            "*" at 181:27-181:28 (leading: Space)
+1211: Ident           "value" at 181:28-181:33
+1212: LBrace          "{" at 181:34-181:35 (leading: Space)
+1213: KwReturn        "return" at 182:17-182:23 (leading: Newline, Space)
+1214: Ident           "Some" at 182:24-182:28 (leading: Space)
+1215: LParen          "(" at 182:28-182:29
+1216: Ident           "i" at 182:29-182:30
+1217: KwTo            "to" at 182:31-182:33 (leading: Space)
+1218: Ident           "uint" at 182:34-182:38 (leading: Space)
+1219: RParen          ")" at 182:38-182:39
+1220: Semicolon       ";" at 182:39-182:40
+1221: RBrace          "}" at 183:13-183:14 (leading: Newline, Space)
+1222: Ident           "i" at 184:13-184:14 (leading: Newline, Space)
+1223: Assign          "=" at 184:15-184:16 (leading: Space)
+1224: Ident           "i" at 184:17-184:18 (leading: Space)
+1225: Plus            "+" at 184:19-184:20 (leading: Space)
+1226: IntLit          "1" at 184:21-184:22 (leading: Space)
+1227: Semicolon       ";" at 184:22-184:23
+1228: RBrace          "}" at 185:9-185:10 (leading: Newline, Space)
+1229: KwReturn        "return" at 186:9-186:15 (leading: Newline, Space)
+1230: NothingLit      "nothing" at 186:16-186:23 (leading: Space)
+1231: Semicolon       ";" at 186:23-186:24
+1232: RBrace          "}" at 187:5-187:6 (leading: Newline, Space)
+1233: RBrace          "}" at 188:1-188:2 (leading: Newline)
+1234: KwExtern        "extern" at 190:1-190:7 (leading: Newline)
+1235: Lt              "<" at 190:7-190:8
+1236: Ident           "Array" at 190:8-190:13
+1237: Lt              "<" at 190:13-190:14
+1238: Ident           "float" at 190:14-190:19
+1239: Shr             ">>" at 190:19-190:21
+1240: LBrace          "{" at 190:22-190:23 (leading: Space)
+1241: KwPub           "pub" at 191:5-191:8 (leading: Newline, Space)
+1242: KwFn            "fn" at 191:9-191:11 (leading: Space)
+1243: Ident           "contains" at 191:12-191:20 (leading: Space)
+1244: LParen          "(" at 191:20-191:21
+1245: Ident           "self" at 191:21-191:25
+1246: Colon           ":" at 191:25-191:26
+1247: Amp             "&" at 191:27-191:28 (leading: Space)
+1248: Ident           "Array" at 191:28-191:33
+1249: Lt              "<" at 191:33-191:34
+1250: Ident           "float" at 191:34-191:39
+1251: Gt              ">" at 191:39-191:40
+1252: Comma           "," at 191:40-191:41
+1253: Ident           "value" at 191:42-191:47 (leading: Space)
+1254: Colon           ":" at 191:47-191:48
+1255: Amp             "&" at 191:49-191:50 (leading: Space)
+1256: Ident           "float" at 191:50-191:55
+1257: RParen          ")" at 191:55-191:56
+1258: Arrow           "->" at 191:57-191:59 (leading: Space)
+1259: Ident           "bool" at 191:60-191:64 (leading: Space)
+1260: LBrace          "{" at 191:65-191:66 (leading: Space)
+1261: KwLet           "let" at 192:9-192:12 (leading: Newline, Space)
+1262: Ident           "res" at 192:13-192:16 (leading: Space)
+1263: Colon           ":" at 192:16-192:17
+1264: Ident           "Option" at 192:18-192:24 (leading: Space)
+1265: Lt              "<" at 192:24-192:25
+1266: Ident           "uint" at 192:25-192:29
+1267: Gt              ">" at 192:29-192:30
+1268: Assign          "=" at 192:31-192:32 (leading: Space)
+1269: Ident           "self" at 192:33-192:37 (leading: Space)
+1270: Dot             "." at 192:37-192:38
+1271: Ident           "find" at 192:38-192:42
+1272: LParen          "(" at 192:42-192:43
+1273: Ident           "value" at 192:43-192:48
+1274: RParen          ")" at 192:48-192:49
+1275: Semicolon       ";" at 192:49-192:50
+1276: KwReturn        "return" at 193:9-193:15 (leading: Newline, Space)
+1277: Ident           "res" at 193:16-193:19 (leading: Space)
+1278: Dot             "." at 193:19-193:20
+1279: Ident           "is_some" at 193:20-193:27
+1280: LParen          "(" at 193:27-193:28
+1281: RParen          ")" at 193:28-193:29
+1282: Semicolon       ";" at 193:29-193:30
+1283: RBrace          "}" at 194:5-194:6 (leading: Newline, Space)
+1284: KwPub           "pub" at 196:5-196:8 (leading: Newline, Space)
+1285: KwFn            "fn" at 196:9-196:11 (leading: Space)
+1286: Ident           "find" at 196:12-196:16 (leading: Space)
+1287: LParen          "(" at 196:16-196:17
+1288: Ident           "self" at 196:17-196:21
+1289: Colon           ":" at 196:21-196:22
+1290: Amp             "&" at 196:23-196:24 (leading: Space)
+1291: Ident           "Array" at 196:24-196:29
+1292: Lt              "<" at 196:29-196:30
+1293: Ident           "float" at 196:30-196:35
+1294: Gt              ">" at 196:35-196:36
+1295: Comma           "," at 196:36-196:37
+1296: Ident           "value" at 196:38-196:43 (leading: Space)
+1297: Colon           ":" at 196:43-196:44
+1298: Amp             "&" at 196:45-196:46 (leading: Space)
+1299: Ident           "float" at 196:46-196:51
+1300: RParen          ")" at 196:51-196:52
+1301: Arrow           "->" at 196:53-196:55 (leading: Space)
+1302: Ident           "Option" at 196:56-196:62 (leading: Space)
+1303: Lt              "<" at 196:62-196:63
+1304: Ident           "uint" at 196:63-196:67
+1305: Gt              ">" at 196:67-196:68
+1306: LBrace          "{" at 196:69-196:70 (leading: Space)
+1307: KwLet           "let" at 197:9-197:12 (leading: Newline, Space)
+1308: Ident           "length" at 197:13-197:19 (leading: Space)
+1309: Colon           ":" at 197:19-197:20
+1310: Ident           "int" at 197:21-197:24 (leading: Space)
+1311: Assign          "=" at 197:25-197:26 (leading: Space)
+1312: Ident           "self" at 197:27-197:31 (leading: Space)
+1313: Dot             "." at 197:31-197:32
+1314: Ident           "__len" at 197:32-197:37
+1315: LParen          "(" at 197:37-197:38
+1316: RParen          ")" at 197:38-197:39
+1317: KwTo            "to" at 197:40-197:42 (leading: Space)
+1318: Ident           "int" at 197:43-197:46 (leading: Space)
+1319: Semicolon       ";" at 197:46-197:47
+1320: KwLet           "let" at 198:9-198:12 (leading: Newline, Space)
+1321: KwMut           "mut" at 198:13-198:16 (leading: Space)
+1322: Ident           "i" at 198:17-198:18 (leading: Space)
+1323: Colon           ":" at 198:18-198:19
+1324: Ident           "int" at 198:20-198:23 (leading: Space)
+1325: Assign          "=" at 198:24-198:25 (leading: Space)
+1326: IntLit          "0" at 198:26-198:27 (leading: Space)
+1327: Semicolon       ";" at 198:27-198:28
+1328: KwWhile         "while" at 199:9-199:14 (leading: Newline, Space)
+1329: Ident           "i" at 199:15-199:16 (leading: Space)
+1330: Lt              "<" at 199:17-199:18 (leading: Space)
+1331: Ident           "length" at 199:19-199:25 (leading: Space)
+1332: LBrace          "{" at 199:26-199:27 (leading: Space)
+1333: KwIf            "if" at 200:13-200:15 (leading: Newline, Space)
+1334: Ident           "self" at 200:16-200:20 (leading: Space)
+1335: LBracket        "[" at 200:20-200:21
+1336: Ident           "i" at 200:21-200:22
+1337: RBracket        "]" at 200:22-200:23
+1338: EqEq            "==" at 200:24-200:26 (leading: Space)
+1339: Star            "*" at 200:27-200:28 (leading: Space)
+1340: Ident           "value" at 200:28-200:33
+1341: LBrace          "{" at 200:34-200:35 (leading: Space)
+1342: KwReturn        "return" at 201:17-201:23 (leading: Newline, Space)
+1343: Ident           "Some" at 201:24-201:28 (leading: Space)
+1344: LParen          "(" at 201:28-201:29
+1345: Ident           "i" at 201:29-201:30
+1346: KwTo            "to" at 201:31-201:33 (leading: Space)
+1347: Ident           "uint" at 201:34-201:38 (leading: Space)
+1348: RParen          ")" at 201:38-201:39
+1349: Semicolon       ";" at 201:39-201:40
+1350: RBrace          "}" at 202:13-202:14 (leading: Newline, Space)
+1351: Ident           "i" at 203:13-203:14 (leading: Newline, Space)
+1352: Assign          "=" at 203:15-203:16 (leading: Space)
+1353: Ident           "i" at 203:17-203:18 (leading: Space)
+1354: Plus            "+" at 203:19-203:20 (leading: Space)
+1355: IntLit          "1" at 203:21-203:22 (leading: Space)
+1356: Semicolon       ";" at 203:22-203:23
+1357: RBrace          "}" at 204:9-204:10 (leading: Newline, Space)
+1358: KwReturn        "return" at 205:9-205:15 (leading: Newline, Space)
+1359: NothingLit      "nothing" at 205:16-205:23 (leading: Space)
+1360: Semicolon       ";" at 205:23-205:24
+1361: RBrace          "}" at 206:5-206:6 (leading: Newline, Space)
+1362: RBrace          "}" at 207:1-207:2 (leading: Newline)
+1363: KwExtern        "extern" at 209:1-209:7 (leading: Newline)
+1364: Lt              "<" at 209:7-209:8
+1365: Ident           "Array" at 209:8-209:13
+1366: Lt              "<" at 209:13-209:14
+1367: Ident           "bool" at 209:14-209:18
+1368: Shr             ">>" at 209:18-209:20
+1369: LBrace          "{" at 209:21-209:22 (leading: Space)
+1370: KwPub           "pub" at 210:5-210:8 (leading: Newline, Space)
+1371: KwFn            "fn" at 210:9-210:11 (leading: Space)
+1372: Ident           "contains" at 210:12-210:20 (leading: Space)
+1373: LParen          "(" at 210:20-210:21
+1374: Ident           "self" at 210:21-210:25
+1375: Colon           ":" at 210:25-210:26
+1376: Amp             "&" at 210:27-210:28 (leading: Space)
+1377: Ident           "Array" at 210:28-210:33
+1378: Lt              "<" at 210:33-210:34
+1379: Ident           "bool" at 210:34-210:38
+1380: Gt              ">" at 210:38-210:39
+1381: Comma           "," at 210:39-210:40
+1382: Ident           "value" at 210:41-210:46 (leading: Space)
+1383: Colon           ":" at 210:46-210:47
+1384: Amp             "&" at 210:48-210:49 (leading: Space)
+1385: Ident           "bool" at 210:49-210:53
+1386: RParen          ")" at 210:53-210:54
+1387: Arrow           "->" at 210:55-210:57 (leading: Space)
+1388: Ident           "bool" at 210:58-210:62 (leading: Space)
+1389: LBrace          "{" at 210:63-210:64 (leading: Space)
+1390: KwLet           "let" at 211:9-211:12 (leading: Newline, Space)
+1391: Ident           "res" at 211:13-211:16 (leading: Space)
+1392: Colon           ":" at 211:16-211:17
+1393: Ident           "Option" at 211:18-211:24 (leading: Space)
+1394: Lt              "<" at 211:24-211:25
+1395: Ident           "uint" at 211:25-211:29
+1396: Gt              ">" at 211:29-211:30
+1397: Assign          "=" at 211:31-211:32 (leading: Space)
+1398: Ident           "self" at 211:33-211:37 (leading: Space)
+1399: Dot             "." at 211:37-211:38
+1400: Ident           "find" at 211:38-211:42
+1401: LParen          "(" at 211:42-211:43
+1402: Ident           "value" at 211:43-211:48
+1403: RParen          ")" at 211:48-211:49
+1404: Semicolon       ";" at 211:49-211:50
+1405: KwReturn        "return" at 212:9-212:15 (leading: Newline, Space)
+1406: Ident           "res" at 212:16-212:19 (leading: Space)
+1407: Dot             "." at 212:19-212:20
+1408: Ident           "is_some" at 212:20-212:27
+1409: LParen          "(" at 212:27-212:28
+1410: RParen          ")" at 212:28-212:29
+1411: Semicolon       ";" at 212:29-212:30
+1412: RBrace          "}" at 213:5-213:6 (leading: Newline, Space)
+1413: KwPub           "pub" at 215:5-215:8 (leading: Newline, Space)
+1414: KwFn            "fn" at 215:9-215:11 (leading: Space)
+1415: Ident           "find" at 215:12-215:16 (leading: Space)
+1416: LParen          "(" at 215:16-215:17
+1417: Ident           "self" at 215:17-215:21
+1418: Colon           ":" at 215:21-215:22
+1419: Amp             "&" at 215:23-215:24 (leading: Space)
+1420: Ident           "Array" at 215:24-215:29
+1421: Lt              "<" at 215:29-215:30
+1422: Ident           "bool" at 215:30-215:34
+1423: Gt              ">" at 215:34-215:35
+1424: Comma           "," at 215:35-215:36
+1425: Ident           "value" at 215:37-215:42 (leading: Space)
+1426: Colon           ":" at 215:42-215:43
+1427: Amp             "&" at 215:44-215:45 (leading: Space)
+1428: Ident           "bool" at 215:45-215:49
+1429: RParen          ")" at 215:49-215:50
+1430: Arrow           "->" at 215:51-215:53 (leading: Space)
+1431: Ident           "Option" at 215:54-215:60 (leading: Space)
+1432: Lt              "<" at 215:60-215:61
+1433: Ident           "uint" at 215:61-215:65
+1434: Gt              ">" at 215:65-215:66
+1435: LBrace          "{" at 215:67-215:68 (leading: Space)
+1436: KwLet           "let" at 216:9-216:12 (leading: Newline, Space)
+1437: Ident           "length" at 216:13-216:19 (leading: Space)
+1438: Colon           ":" at 216:19-216:20
+1439: Ident           "int" at 216:21-216:24 (leading: Space)
+1440: Assign          "=" at 216:25-216:26 (leading: Space)
+1441: Ident           "self" at 216:27-216:31 (leading: Space)
+1442: Dot             "." at 216:31-216:32
+1443: Ident           "__len" at 216:32-216:37
+1444: LParen          "(" at 216:37-216:38
+1445: RParen          ")" at 216:38-216:39
+1446: KwTo            "to" at 216:40-216:42 (leading: Space)
+1447: Ident           "int" at 216:43-216:46 (leading: Space)
+1448: Semicolon       ";" at 216:46-216:47
+1449: KwLet           "let" at 217:9-217:12 (leading: Newline, Space)
+1450: KwMut           "mut" at 217:13-217:16 (leading: Space)
+1451: Ident           "i" at 217:17-217:18 (leading: Space)
+1452: Colon           ":" at 217:18-217:19
+1453: Ident           "int" at 217:20-217:23 (leading: Space)
+1454: Assign          "=" at 217:24-217:25 (leading: Space)
+1455: IntLit          "0" at 217:26-217:27 (leading: Space)
+1456: Semicolon       ";" at 217:27-217:28
+1457: KwWhile         "while" at 218:9-218:14 (leading: Newline, Space)
+1458: Ident           "i" at 218:15-218:16 (leading: Space)
+1459: Lt              "<" at 218:17-218:18 (leading: Space)
+1460: Ident           "length" at 218:19-218:25 (leading: Space)
+1461: LBrace          "{" at 218:26-218:27 (leading: Space)
+1462: KwIf            "if" at 219:13-219:15 (leading: Newline, Space)
+1463: Ident           "self" at 219:16-219:20 (leading: Space)
+1464: LBracket        "[" at 219:20-219:21
+1465: Ident           "i" at 219:21-219:22
+1466: RBracket        "]" at 219:22-219:23
+1467: EqEq            "==" at 219:24-219:26 (leading: Space)
+1468: Star            "*" at 219:27-219:28 (leading: Space)
+1469: Ident           "value" at 219:28-219:33
+1470: LBrace          "{" at 219:34-219:35 (leading: Space)
+1471: KwReturn        "return" at 220:17-220:23 (leading: Newline, Space)
+1472: Ident           "Some" at 220:24-220:28 (leading: Space)
+1473: LParen          "(" at 220:28-220:29
+1474: Ident           "i" at 220:29-220:30
+1475: KwTo            "to" at 220:31-220:33 (leading: Space)
+1476: Ident           "uint" at 220:34-220:38 (leading: Space)
+1477: RParen          ")" at 220:38-220:39
+1478: Semicolon       ";" at 220:39-220:40
+1479: RBrace          "}" at 221:13-221:14 (leading: Newline, Space)
+1480: Ident           "i" at 222:13-222:14 (leading: Newline, Space)
+1481: Assign          "=" at 222:15-222:16 (leading: Space)
+1482: Ident           "i" at 222:17-222:18 (leading: Space)
+1483: Plus            "+" at 222:19-222:20 (leading: Space)
+1484: IntLit          "1" at 222:21-222:22 (leading: Space)
+1485: Semicolon       ";" at 222:22-222:23
+1486: RBrace          "}" at 223:9-223:10 (leading: Newline, Space)
+1487: KwReturn        "return" at 224:9-224:15 (leading: Newline, Space)
+1488: NothingLit      "nothing" at 224:16-224:23 (leading: Space)
+1489: Semicolon       ";" at 224:23-224:24
+1490: RBrace          "}" at 225:5-225:6 (leading: Newline, Space)
+1491: RBrace          "}" at 226:1-226:2 (leading: Newline)
+1492: KwExtern        "extern" at 228:1-228:7 (leading: Newline)
+1493: Lt              "<" at 228:7-228:8
+1494: Ident           "Array" at 228:8-228:13
+1495: Lt              "<" at 228:13-228:14
+1496: Ident           "string" at 228:14-228:20
+1497: Shr             ">>" at 228:20-228:22
+1498: LBrace          "{" at 228:23-228:24 (leading: Space)
+1499: KwPub           "pub" at 229:5-229:8 (leading: Newline, Space)
+1500: KwFn            "fn" at 229:9-229:11 (leading: Space)
+1501: Ident           "contains" at 229:12-229:20 (leading: Space)
+1502: LParen          "(" at 229:20-229:21
+1503: Ident           "self" at 229:21-229:25
+1504: Colon           ":" at 229:25-229:26
+1505: Amp             "&" at 229:27-229:28 (leading: Space)
+1506: Ident           "Array" at 229:28-229:33
+1507: Lt              "<" at 229:33-229:34
+1508: Ident           "string" at 229:34-229:40
+1509: Gt              ">" at 229:40-229:41
+1510: Comma           "," at 229:41-229:42
+1511: Ident           "value" at 229:43-229:48 (leading: Space)
+1512: Colon           ":" at 229:48-229:49
+1513: Amp             "&" at 229:50-229:51 (leading: Space)
+1514: Ident           "string" at 229:51-229:57
+1515: RParen          ")" at 229:57-229:58
+1516: Arrow           "->" at 229:59-229:61 (leading: Space)
+1517: Ident           "bool" at 229:62-229:66 (leading: Space)
+1518: LBrace          "{" at 229:67-229:68 (leading: Space)
+1519: KwLet           "let" at 230:9-230:12 (leading: Newline, Space)
+1520: Ident           "res" at 230:13-230:16 (leading: Space)
+1521: Colon           ":" at 230:16-230:17
+1522: Ident           "Option" at 230:18-230:24 (leading: Space)
+1523: Lt              "<" at 230:24-230:25
+1524: Ident           "uint" at 230:25-230:29
+1525: Gt              ">" at 230:29-230:30
+1526: Assign          "=" at 230:31-230:32 (leading: Space)
+1527: Ident           "self" at 230:33-230:37 (leading: Space)
+1528: Dot             "." at 230:37-230:38
+1529: Ident           "find" at 230:38-230:42
+1530: LParen          "(" at 230:42-230:43
+1531: Ident           "value" at 230:43-230:48
+1532: RParen          ")" at 230:48-230:49
+1533: Semicolon       ";" at 230:49-230:50
+1534: KwReturn        "return" at 231:9-231:15 (leading: Newline, Space)
+1535: Ident           "res" at 231:16-231:19 (leading: Space)
+1536: Dot             "." at 231:19-231:20
+1537: Ident           "is_some" at 231:20-231:27
+1538: LParen          "(" at 231:27-231:28
+1539: RParen          ")" at 231:28-231:29
+1540: Semicolon       ";" at 231:29-231:30
+1541: RBrace          "}" at 232:5-232:6 (leading: Newline, Space)
+1542: KwPub           "pub" at 234:5-234:8 (leading: Newline, Space)
+1543: KwFn            "fn" at 234:9-234:11 (leading: Space)
+1544: Ident           "find" at 234:12-234:16 (leading: Space)
+1545: LParen          "(" at 234:16-234:17
+1546: Ident           "self" at 234:17-234:21
+1547: Colon           ":" at 234:21-234:22
+1548: Amp             "&" at 234:23-234:24 (leading: Space)
+1549: Ident           "Array" at 234:24-234:29
+1550: Lt              "<" at 234:29-234:30
+1551: Ident           "string" at 234:30-234:36
+1552: Gt              ">" at 234:36-234:37
+1553: Comma           "," at 234:37-234:38
+1554: Ident           "value" at 234:39-234:44 (leading: Space)
+1555: Colon           ":" at 234:44-234:45
+1556: Amp             "&" at 234:46-234:47 (leading: Space)
+1557: Ident           "string" at 234:47-234:53
+1558: RParen          ")" at 234:53-234:54
+1559: Arrow           "->" at 234:55-234:57 (leading: Space)
+1560: Ident           "Option" at 234:58-234:64 (leading: Space)
+1561: Lt              "<" at 234:64-234:65
+1562: Ident           "uint" at 234:65-234:69
+1563: Gt              ">" at 234:69-234:70
+1564: LBrace          "{" at 234:71-234:72 (leading: Space)
+1565: KwLet           "let" at 235:9-235:12 (leading: Newline, Space)
+1566: Ident           "length" at 235:13-235:19 (leading: Space)
+1567: Colon           ":" at 235:19-235:20
+1568: Ident           "int" at 235:21-235:24 (leading: Space)
+1569: Assign          "=" at 235:25-235:26 (leading: Space)
+1570: Ident           "self" at 235:27-235:31 (leading: Space)
+1571: Dot             "." at 235:31-235:32
+1572: Ident           "__len" at 235:32-235:37
+1573: LParen          "(" at 235:37-235:38
+1574: RParen          ")" at 235:38-235:39
+1575: KwTo            "to" at 235:40-235:42 (leading: Space)
+1576: Ident           "int" at 235:43-235:46 (leading: Space)
+1577: Semicolon       ";" at 235:46-235:47
+1578: KwLet           "let" at 236:9-236:12 (leading: Newline, Space)
+1579: KwMut           "mut" at 236:13-236:16 (leading: Space)
+1580: Ident           "i" at 236:17-236:18 (leading: Space)
+1581: Colon           ":" at 236:18-236:19
+1582: Ident           "int" at 236:20-236:23 (leading: Space)
+1583: Assign          "=" at 236:24-236:25 (leading: Space)
+1584: IntLit          "0" at 236:26-236:27 (leading: Space)
+1585: Semicolon       ";" at 236:27-236:28
+1586: KwWhile         "while" at 237:9-237:14 (leading: Newline, Space)
+1587: Ident           "i" at 237:15-237:16 (leading: Space)
+1588: Lt              "<" at 237:17-237:18 (leading: Space)
+1589: Ident           "length" at 237:19-237:25 (leading: Space)
+1590: LBrace          "{" at 237:26-237:27 (leading: Space)
+1591: KwIf            "if" at 238:13-238:15 (leading: Newline, Space)
+1592: Ident           "self" at 238:16-238:20 (leading: Space)
+1593: LBracket        "[" at 238:20-238:21
+1594: Ident           "i" at 238:21-238:22
+1595: RBracket        "]" at 238:22-238:23
+1596: EqEq            "==" at 238:24-238:26 (leading: Space)
+1597: Star            "*" at 238:27-238:28 (leading: Space)
+1598: Ident           "value" at 238:28-238:33
+1599: LBrace          "{" at 238:34-238:35 (leading: Space)
+1600: KwReturn        "return" at 239:17-239:23 (leading: Newline, Space)
+1601: Ident           "Some" at 239:24-239:28 (leading: Space)
+1602: LParen          "(" at 239:28-239:29
+1603: Ident           "i" at 239:29-239:30
+1604: KwTo            "to" at 239:31-239:33 (leading: Space)
+1605: Ident           "uint" at 239:34-239:38 (leading: Space)
+1606: RParen          ")" at 239:38-239:39
+1607: Semicolon       ";" at 239:39-239:40
+1608: RBrace          "}" at 240:13-240:14 (leading: Newline, Space)
+1609: Ident           "i" at 241:13-241:14 (leading: Newline, Space)
+1610: Assign          "=" at 241:15-241:16 (leading: Space)
+1611: Ident           "i" at 241:17-241:18 (leading: Space)
+1612: Plus            "+" at 241:19-241:20 (leading: Space)
+1613: IntLit          "1" at 241:21-241:22 (leading: Space)
+1614: Semicolon       ";" at 241:22-241:23
+1615: RBrace          "}" at 242:9-242:10 (leading: Newline, Space)
+1616: KwReturn        "return" at 243:9-243:15 (leading: Newline, Space)
+1617: NothingLit      "nothing" at 243:16-243:23 (leading: Space)
+1618: Semicolon       ";" at 243:23-243:24
+1619: RBrace          "}" at 244:5-244:6 (leading: Newline, Space)
+1620: RBrace          "}" at 245:1-245:2 (leading: Newline)
+1621: KwExtern        "extern" at 247:1-247:7 (leading: Newline)
+1622: Lt              "<" at 247:7-247:8
+1623: Ident           "ArrayFixed" at 247:8-247:18
+1624: Lt              "<" at 247:18-247:19
+1625: Ident           "T" at 247:19-247:20
+1626: Comma           "," at 247:20-247:21
+1627: Ident           "N" at 247:22-247:23 (leading: Space)
+1628: Shr             ">>" at 247:23-247:25
+1629: LBrace          "{" at 247:26-247:27 (leading: Space)
+1630: KwPub           "pub" at 248:5-248:8 (leading: Newline, Space)
+1631: KwFn            "fn" at 248:9-248:11 (leading: Space)
+1632: Ident           "with_len" at 248:12-248:20 (leading: Space)
+1633: LParen          "(" at 248:20-248:21
+1634: Ident           "length" at 248:21-248:27
+1635: Colon           ":" at 248:27-248:28
+1636: Ident           "uint" at 248:29-248:33 (leading: Space)
+1637: RParen          ")" at 248:33-248:34
+1638: Arrow           "->" at 248:35-248:37 (leading: Space)
+1639: Ident           "ArrayFixed" at 248:38-248:48 (leading: Space)
+1640: Lt              "<" at 248:48-248:49
+1641: Ident           "T" at 248:49-248:50
+1642: Comma           "," at 248:50-248:51
+1643: Ident           "N" at 248:52-248:53 (leading: Space)
+1644: Gt              ">" at 248:53-248:54
+1645: LBrace          "{" at 248:55-248:56 (leading: Space)
+1646: KwLet           "let" at 249:9-249:12 (leading: Newline, Space)
+1647: Ident           "out" at 249:13-249:16 (leading: Space)
+1648: Colon           ":" at 249:16-249:17
+1649: Ident           "ArrayFixed" at 249:18-249:28 (leading: Space)
+1650: Lt              "<" at 249:28-249:29
+1651: Ident           "T" at 249:29-249:30
+1652: Comma           "," at 249:30-249:31
+1653: Ident           "N" at 249:32-249:33 (leading: Space)
+1654: Gt              ">" at 249:33-249:34
+1655: Assign          "=" at 249:35-249:36 (leading: Space)
+1656: Ident           "default" at 249:37-249:44 (leading: Space)
+1657: ColonColon      "::" at 249:44-249:46
+1658: Lt              "<" at 249:46-249:47
+1659: Ident           "ArrayFixed" at 249:47-249:57
+1660: Lt              "<" at 249:57-249:58
+1661: Ident           "T" at 249:58-249:59
+1662: Comma           "," at 249:59-249:60
+1663: Ident           "N" at 249:61-249:62 (leading: Space)
+1664: Shr             ">>" at 249:62-249:64
+1665: LParen          "(" at 249:64-249:65
+1666: RParen          ")" at 249:65-249:66
+1667: Semicolon       ";" at 249:66-249:67
+1668: KwLet           "let" at 250:9-250:12 (leading: Newline, Space)
+1669: Ident           "expected" at 250:13-250:21 (leading: Space)
+1670: Colon           ":" at 250:21-250:22
+1671: Ident           "uint" at 250:23-250:27 (leading: Space)
+1672: Assign          "=" at 250:28-250:29 (leading: Space)
+1673: Ident           "out" at 250:30-250:33 (leading: Space)
+1674: Dot             "." at 250:33-250:34
+1675: Ident           "__len" at 250:34-250:39
+1676: LParen          "(" at 250:39-250:40
+1677: RParen          ")" at 250:40-250:41
+1678: Semicolon       ";" at 250:41-250:42
+1679: KwIf            "if" at 251:9-251:11 (leading: Newline, Space)
+1680: Ident           "length" at 251:12-251:18 (leading: Space)
+1681: BangEq          "!=" at 251:19-251:21 (leading: Space)
+1682: Ident           "expected" at 251:22-251:30 (leading: Space)
+1683: LBrace          "{" at 251:31-251:32 (leading: Space)
+1684: Ident           "panic" at 252:13-252:18 (leading: Newline, Space)
+1685: LParen          "(" at 252:18-252:19
+1686: StringLit       "\"ArrayFixed length mismatch\"" at 252:19-252:47
+1687: RParen          ")" at 252:47-252:48
+1688: Semicolon       ";" at 252:48-252:49
+1689: RBrace          "}" at 253:9-253:10 (leading: Newline, Space)
+1690: KwReturn        "return" at 254:9-254:15 (leading: Newline, Space)
+1691: Ident           "out" at 254:16-254:19 (leading: Space)
+1692: Semicolon       ";" at 254:19-254:20
+1693: RBrace          "}" at 255:5-255:6 (leading: Newline, Space)
+1694: KwPub           "pub" at 257:5-257:8 (leading: Newline, Space)
+1695: KwFn            "fn" at 257:9-257:11 (leading: Space)
+1696: Ident           "get_mut" at 257:12-257:19 (leading: Space)
+1697: LParen          "(" at 257:19-257:20
+1698: Ident           "self" at 257:20-257:24
+1699: Colon           ":" at 257:24-257:25
+1700: Amp             "&" at 257:26-257:27 (leading: Space)
+1701: KwMut           "mut" at 257:27-257:30
+1702: Ident           "ArrayFixed" at 257:31-257:41 (leading: Space)
+1703: Lt              "<" at 257:41-257:42
+1704: Ident           "T" at 257:42-257:43
+1705: Comma           "," at 257:43-257:44
+1706: Ident           "N" at 257:45-257:46 (leading: Space)
+1707: Gt              ">" at 257:46-257:47
+1708: Comma           "," at 257:47-257:48
+1709: Ident           "index" at 257:49-257:54 (leading: Space)
+1710: Colon           ":" at 257:54-257:55
+1711: Ident           "int" at 257:56-257:59 (leading: Space)
+1712: RParen          ")" at 257:59-257:60
+1713: Arrow           "->" at 257:61-257:63 (leading: Space)
+1714: Amp             "&" at 257:64-257:65 (leading: Space)
+1715: KwMut           "mut" at 257:65-257:68
+1716: Ident           "T" at 257:69-257:70 (leading: Space)
+1717: LBrace          "{" at 257:71-257:72 (leading: Space)
+1718: KwReturn        "return" at 258:9-258:15 (leading: Newline, Space)
+1719: Ident           "rt_array_get_mut" at 258:16-258:32 (leading: Space)
+1720: ColonColon      "::" at 258:32-258:34
+1721: Lt              "<" at 258:34-258:35
+1722: Ident           "T" at 258:35-258:36
+1723: Comma           "," at 258:36-258:37
+1724: Ident           "N" at 258:38-258:39 (leading: Space)
+1725: Gt              ">" at 258:39-258:40
+1726: LParen          "(" at 258:40-258:41
+1727: Ident           "self" at 258:41-258:45
+1728: Comma           "," at 258:45-258:46
+1729: Ident           "index" at 258:47-258:52 (leading: Space)
+1730: RParen          ")" at 258:52-258:53
+1731: Semicolon       ";" at 258:53-258:54
+1732: RBrace          "}" at 259:5-259:6 (leading: Newline, Space)
+1733: KwPub           "pub" at 261:5-261:8 (leading: Newline, Space)
+1734: KwFn            "fn" at 261:9-261:11 (leading: Space)
+1735: Ident           "with_len_value" at 261:12-261:26 (leading: Space)
+1736: LParen          "(" at 261:26-261:27
+1737: Ident           "length" at 261:27-261:33
+1738: Colon           ":" at 261:33-261:34
+1739: Ident           "uint" at 261:35-261:39 (leading: Space)
+1740: Comma           "," at 261:39-261:40
+1741: Ident           "value" at 261:41-261:46 (leading: Space)
+1742: Colon           ":" at 261:46-261:47
+1743: Ident           "T" at 261:48-261:49 (leading: Space)
+1744: RParen          ")" at 261:49-261:50
+1745: Arrow           "->" at 261:51-261:53 (leading: Space)
+1746: Ident           "ArrayFixed" at 261:54-261:64 (leading: Space)
+1747: Lt              "<" at 261:64-261:65
+1748: Ident           "T" at 261:65-261:66
+1749: Comma           "," at 261:66-261:67
+1750: Ident           "N" at 261:68-261:69 (leading: Space)
+1751: Gt              ">" at 261:69-261:70
+1752: LBrace          "{" at 261:71-261:72 (leading: Space)
+1753: KwLet           "let" at 262:9-262:12 (leading: Newline, Space)
+1754: KwMut           "mut" at 262:13-262:16 (leading: Space)
+1755: Ident           "out" at 262:17-262:20 (leading: Space)
+1756: Colon           ":" at 262:20-262:21
+1757: Ident           "ArrayFixed" at 262:22-262:32 (leading: Space)
+1758: Lt              "<" at 262:32-262:33
+1759: Ident           "T" at 262:33-262:34
+1760: Comma           "," at 262:34-262:35
+1761: Ident           "N" at 262:36-262:37 (leading: Space)
+1762: Gt              ">" at 262:37-262:38
+1763: Assign          "=" at 262:39-262:40 (leading: Space)
+1764: Ident           "default" at 262:41-262:48 (leading: Space)
+1765: ColonColon      "::" at 262:48-262:50
+1766: Lt              "<" at 262:50-262:51
+1767: Ident           "ArrayFixed" at 262:51-262:61
+1768: Lt              "<" at 262:61-262:62
+1769: Ident           "T" at 262:62-262:63
+1770: Comma           "," at 262:63-262:64
+1771: Ident           "N" at 262:65-262:66 (leading: Space)
+1772: Shr             ">>" at 262:66-262:68
+1773: LParen          "(" at 262:68-262:69
+1774: RParen          ")" at 262:69-262:70
+1775: Semicolon       ";" at 262:70-262:71
+1776: KwLet           "let" at 263:9-263:12 (leading: Newline, Space)
+1777: Ident           "expected" at 263:13-263:21 (leading: Space)
+1778: Colon           ":" at 263:21-263:22
+1779: Ident           "uint" at 263:23-263:27 (leading: Space)
+1780: Assign          "=" at 263:28-263:29 (leading: Space)
+1781: Ident           "out" at 263:30-263:33 (leading: Space)
+1782: Dot             "." at 263:33-263:34
+1783: Ident           "__len" at 263:34-263:39
+1784: LParen          "(" at 263:39-263:40
+1785: RParen          ")" at 263:40-263:41
+1786: Semicolon       ";" at 263:41-263:42
+1787: KwIf            "if" at 264:9-264:11 (leading: Newline, Space)
+1788: Ident           "length" at 264:12-264:18 (leading: Space)
+1789: BangEq          "!=" at 264:19-264:21 (leading: Space)
+1790: Ident           "expected" at 264:22-264:30 (leading: Space)
+1791: LBrace          "{" at 264:31-264:32 (leading: Space)
+1792: Ident           "panic" at 265:13-265:18 (leading: Newline, Space)
+1793: LParen          "(" at 265:18-265:19
+1794: StringLit       "\"ArrayFixed length mismatch\"" at 265:19-265:47
+1795: RParen          ")" at 265:47-265:48
+1796: Semicolon       ";" at 265:48-265:49
+1797: RBrace          "}" at 266:9-266:10 (leading: Newline, Space)
+1798: KwLet           "let" at 267:9-267:12 (leading: Newline, Space)
+1799: Ident           "count" at 267:13-267:18 (leading: Space)
+1800: Colon           ":" at 267:18-267:19
+1801: Ident           "int" at 267:20-267:23 (leading: Space)
+1802: Assign          "=" at 267:24-267:25 (leading: Space)
+1803: Ident           "expected" at 267:26-267:34 (leading: Space)
+1804: KwTo            "to" at 267:35-267:37 (leading: Space)
+1805: Ident           "int" at 267:38-267:41 (leading: Space)
+1806: Semicolon       ";" at 267:41-267:42
+1807: KwLet           "let" at 268:9-268:12 (leading: Newline, Space)
+1808: KwMut           "mut" at 268:13-268:16 (leading: Space)
+1809: Ident           "i" at 268:17-268:18 (leading: Space)
+1810: Colon           ":" at 268:18-268:19
+1811: Ident           "int" at 268:20-268:23 (leading: Space)
+1812: Assign          "=" at 268:24-268:25 (leading: Space)
+1813: IntLit          "0" at 268:26-268:27 (leading: Space)
+1814: Semicolon       ";" at 268:27-268:28
+1815: KwWhile         "while" at 269:9-269:14 (leading: Newline, Space)
+1816: Ident           "i" at 269:15-269:16 (leading: Space)
+1817: Lt              "<" at 269:17-269:18 (leading: Space)
+1818: Ident           "count" at 269:19-269:24 (leading: Space)
+1819: LBrace          "{" at 269:25-269:26 (leading: Space)
+1820: Ident           "out" at 270:13-270:16 (leading: Newline, Space)
+1821: LBracket        "[" at 270:16-270:17
+1822: Ident           "i" at 270:17-270:18
+1823: RBracket        "]" at 270:18-270:19
+1824: Assign          "=" at 270:20-270:21 (leading: Space)
+1825: Ident           "clone" at 270:22-270:27 (leading: Space)
+1826: LParen          "(" at 270:27-270:28
+1827: Amp             "&" at 270:28-270:29
+1828: Ident           "value" at 270:29-270:34
+1829: RParen          ")" at 270:34-270:35
+1830: Semicolon       ";" at 270:35-270:36
+1831: Ident           "i" at 271:13-271:14 (leading: Newline, Space)
+1832: Assign          "=" at 271:15-271:16 (leading: Space)
+1833: Ident           "i" at 271:17-271:18 (leading: Space)
+1834: Plus            "+" at 271:19-271:20 (leading: Space)
+1835: IntLit          "1" at 271:21-271:22 (leading: Space)
+1836: Semicolon       ";" at 271:22-271:23
+1837: RBrace          "}" at 272:9-272:10 (leading: Newline, Space)
+1838: KwReturn        "return" at 273:9-273:15 (leading: Newline, Space)
+1839: Ident           "out" at 273:16-273:19 (leading: Space)
+1840: Semicolon       ";" at 273:19-273:20
+1841: RBrace          "}" at 274:5-274:6 (leading: Newline, Space)
+1842: KwPub           "pub" at 276:5-276:8 (leading: Newline, Space)
+1843: KwFn            "fn" at 276:9-276:11 (leading: Space)
+1844: Ident           "__to" at 276:12-276:16 (leading: Space)
+1845: LParen          "(" at 276:16-276:17
+1846: Ident           "self" at 276:17-276:21
+1847: Colon           ":" at 276:21-276:22
+1848: Amp             "&" at 276:23-276:24 (leading: Space)
+1849: Ident           "ArrayFixed" at 276:24-276:34
+1850: Lt              "<" at 276:34-276:35
+1851: Ident           "T" at 276:35-276:36
+1852: Comma           "," at 276:36-276:37
+1853: Ident           "N" at 276:38-276:39 (leading: Space)
+1854: Gt              ">" at 276:39-276:40
+1855: Comma           "," at 276:40-276:41
+1856: Ident           "target" at 276:42-276:48 (leading: Space)
+1857: Colon           ":" at 276:48-276:49
+1858: Ident           "string" at 276:50-276:56 (leading: Space)
+1859: RParen          ")" at 276:56-276:57
+1860: Arrow           "->" at 276:58-276:60 (leading: Space)
+1861: Ident           "string" at 276:61-276:67 (leading: Space)
+1862: LBrace          "{" at 276:68-276:69 (leading: Space)
+1863: KwLet           "let" at 277:9-277:12 (leading: Newline, Space)
+1864: Underscore      "_" at 277:13-277:14 (leading: Space)
+1865: Assign          "=" at 277:15-277:16 (leading: Space)
+1866: Ident           "target" at 277:17-277:23 (leading: Space)
+1867: Semicolon       ";" at 277:23-277:24
+1868: KwLet           "let" at 278:9-278:12 (leading: Newline, Space)
+1869: Ident           "length_s" at 278:13-278:21 (leading: Space)
+1870: Colon           ":" at 278:21-278:22
+1871: Ident           "string" at 278:23-278:29 (leading: Space)
+1872: Assign          "=" at 278:30-278:31 (leading: Space)
+1873: Ident           "self" at 278:32-278:36 (leading: Space)
+1874: Dot             "." at 278:36-278:37
+1875: Ident           "__len" at 278:37-278:42
+1876: LParen          "(" at 278:42-278:43
+1877: RParen          ")" at 278:43-278:44
+1878: KwTo            "to" at 278:45-278:47 (leading: Space)
+1879: Ident           "string" at 278:48-278:54 (leading: Space)
+1880: Semicolon       ";" at 278:54-278:55
+1881: KwReturn        "return" at 279:9-279:15 (leading: Newline, Space)
+1882: StringLit       "\"ArrayFixed(len=\"" at 279:16-279:33 (leading: Space)
+1883: Plus            "+" at 279:34-279:35 (leading: Space)
+1884: Ident           "length_s" at 279:36-279:44 (leading: Space)
+1885: Plus            "+" at 279:45-279:46 (leading: Space)
+1886: StringLit       "\")\"" at 279:47-279:50 (leading: Space)
+1887: Semicolon       ";" at 279:50-279:51
+1888: RBrace          "}" at 280:5-280:6 (leading: Newline, Space)
+1889: KwPub           "pub" at 282:5-282:8 (leading: Newline, Space)
+1890: KwFn            "fn" at 282:9-282:11 (leading: Space)
+1891: Ident           "to_array" at 282:12-282:20 (leading: Space)
+1892: LParen          "(" at 282:20-282:21
+1893: Ident           "self" at 282:21-282:25
+1894: Colon           ":" at 282:25-282:26
+1895: Amp             "&" at 282:27-282:28 (leading: Space)
+1896: Ident           "ArrayFixed" at 282:28-282:38
+1897: Lt              "<" at 282:38-282:39
+1898: Ident           "T" at 282:39-282:40
+1899: Comma           "," at 282:40-282:41
+1900: Ident           "N" at 282:42-282:43 (leading: Space)
+1901: Gt              ">" at 282:43-282:44
+1902: RParen          ")" at 282:44-282:45
+1903: Arrow           "->" at 282:46-282:48 (leading: Space)
+1904: Ident           "Array" at 282:49-282:54 (leading: Space)
+1905: Lt              "<" at 282:54-282:55
+1906: Ident           "T" at 282:55-282:56
+1907: Gt              ">" at 282:56-282:57
+1908: LBrace          "{" at 282:58-282:59 (leading: Space)
+1909: KwLet           "let" at 283:9-283:12 (leading: Newline, Space)
+1910: Ident           "length" at 283:13-283:19 (leading: Space)
+1911: Colon           ":" at 283:19-283:20
+1912: Ident           "int" at 283:21-283:24 (leading: Space)
+1913: Assign          "=" at 283:25-283:26 (leading: Space)
+1914: Ident           "self" at 283:27-283:31 (leading: Space)
+1915: Dot             "." at 283:31-283:32
+1916: Ident           "__len" at 283:32-283:37
+1917: LParen          "(" at 283:37-283:38
+1918: RParen          ")" at 283:38-283:39
+1919: KwTo            "to" at 283:40-283:42 (leading: Space)
+1920: Ident           "int" at 283:43-283:46 (leading: Space)
+1921: Semicolon       ";" at 283:46-283:47
+1922: KwLet           "let" at 284:9-284:12 (leading: Newline, Space)
+1923: KwMut           "mut" at 284:13-284:16 (leading: Space)
+1924: Ident           "out" at 284:17-284:20 (leading: Space)
+1925: Colon           ":" at 284:20-284:21
+1926: Ident           "Array" at 284:22-284:27 (leading: Space)
+1927: Lt              "<" at 284:27-284:28
+1928: Ident           "T" at 284:28-284:29
+1929: Gt              ">" at 284:29-284:30
+1930: Assign          "=" at 284:31-284:32 (leading: Space)
+1931: LBracket        "[" at 284:33-284:34 (leading: Space)
+1932: RBracket        "]" at 284:34-284:35
+1933: Semicolon       ";" at 284:35-284:36
+1934: LBrace          "{" at 285:9-285:10 (leading: Newline, Space)
+1935: KwLet           "let" at 286:13-286:16 (leading: Newline, Space)
+1936: Ident           "out_ref" at 286:17-286:24 (leading: Space)
+1937: Colon           ":" at 286:24-286:25
+1938: Amp             "&" at 286:26-286:27 (leading: Space)
+1939: KwMut           "mut" at 286:27-286:30
+1940: Ident           "Array" at 286:31-286:36 (leading: Space)
+1941: Lt              "<" at 286:36-286:37
+1942: Ident           "T" at 286:37-286:38
+1943: Gt              ">" at 286:38-286:39
+1944: Assign          "=" at 286:40-286:41 (leading: Space)
+1945: Amp             "&" at 286:42-286:43 (leading: Space)
+1946: KwMut           "mut" at 286:43-286:46
+1947: Ident           "out" at 286:47-286:50 (leading: Space)
+1948: Semicolon       ";" at 286:50-286:51
+1949: Ident           "out_ref" at 287:13-287:20 (leading: Newline, Space)
+1950: Dot             "." at 287:20-287:21
+1951: Ident           "reserve" at 287:21-287:28
+1952: LParen          "(" at 287:28-287:29
+1953: Ident           "self" at 287:29-287:33
+1954: Dot             "." at 287:33-287:34
+1955: Ident           "__len" at 287:34-287:39
+1956: LParen          "(" at 287:39-287:40
+1957: RParen          ")" at 287:40-287:41
+1958: RParen          ")" at 287:41-287:42
+1959: Semicolon       ";" at 287:42-287:43
+1960: KwLet           "let" at 288:13-288:16 (leading: Newline, Space)
+1961: KwMut           "mut" at 288:17-288:20 (leading: Space)
+1962: Ident           "i" at 288:21-288:22 (leading: Space)
+1963: Colon           ":" at 288:22-288:23
+1964: Ident           "int" at 288:24-288:27 (leading: Space)
+1965: Assign          "=" at 288:28-288:29 (leading: Space)
+1966: IntLit          "0" at 288:30-288:31 (leading: Space)
+1967: Semicolon       ";" at 288:31-288:32
+1968: KwWhile         "while" at 289:13-289:18 (leading: Newline, Space)
+1969: Ident           "i" at 289:19-289:20 (leading: Space)
+1970: Lt              "<" at 289:21-289:22 (leading: Space)
+1971: Ident           "length" at 289:23-289:29 (leading: Space)
+1972: LBrace          "{" at 289:30-289:31 (leading: Space)
+1973: Ident           "out_ref" at 290:17-290:24 (leading: Newline, Space)
+1974: Dot             "." at 290:24-290:25
+1975: Ident           "push" at 290:25-290:29
+1976: LParen          "(" at 290:29-290:30
+1977: Ident           "clone" at 290:30-290:35
+1978: LParen          "(" at 290:35-290:36
+1979: Ident           "self" at 290:36-290:40
+1980: LBracket        "[" at 290:40-290:41
+1981: Ident           "i" at 290:41-290:42
+1982: RBracket        "]" at 290:42-290:43
+1983: RParen          ")" at 290:43-290:44
+1984: RParen          ")" at 290:44-290:45
+1985: Semicolon       ";" at 290:45-290:46
+1986: Ident           "i" at 291:17-291:18 (leading: Newline, Space)
+1987: Assign          "=" at 291:19-291:20 (leading: Space)
+1988: Ident           "i" at 291:21-291:22 (leading: Space)
+1989: Plus            "+" at 291:23-291:24 (leading: Space)
+1990: IntLit          "1" at 291:25-291:26 (leading: Space)
+1991: Semicolon       ";" at 291:26-291:27
+1992: RBrace          "}" at 292:13-292:14 (leading: Newline, Space)
+1993: RBrace          "}" at 293:9-293:10 (leading: Newline, Space)
+1994: KwReturn        "return" at 294:9-294:15 (leading: Newline, Space)
+1995: Ident           "out" at 294:16-294:19 (leading: Space)
+1996: Semicolon       ";" at 294:19-294:20
+1997: RBrace          "}" at 295:5-295:6 (leading: Newline, Space)
+1998: RBrace          "}" at 296:1-296:2 (leading: Newline)
+1999: EOF             at 297:1-297:1

--- a/testdata/golden/core_stdlib/intrinsics.ast
+++ b/testdata/golden/core_stdlib/intrinsics.ast
@@ -1,4 +1,4 @@
-intrinsics.sg (span: 1:1-875:1)
+intrinsics.sg (span: 1:1-867:1)
 ├─ Item[0]: Type (span: 3:1-3:23)
 │  ├─ Name: byte
 │  ├─ Kind: Alias
@@ -373,60 +373,65 @@ intrinsics.sg (span: 1:1-875:1)
 │  ├─ Params: (a: &mut ArrayFixed<T, N>, index: int)
 │  ├─ Return: &mut T
 │  └─ Body: <none>
-├─ Item[70]: Fn (span: 134:1-134:47)
+├─ Item[70]: Fn (span: 132:1-132:96)
+│  ├─ Name: rt_array_append_raw_bytes
+│  ├─ Params: (a: &mut byte[], ptr: *byte, length: uint64)
+│  ├─ Return: nothing
+│  └─ Body: <none>
+├─ Item[71]: Fn (span: 135:1-135:47)
 │  ├─ Name: rt_map_new
 │  ├─ Generics: <K, V>
 │  ├─ Params: ()
 │  ├─ Return: Map<K, V>
 │  └─ Body: <none>
-├─ Item[71]: Fn (span: 135:1-135:55)
+├─ Item[72]: Fn (span: 136:1-136:55)
 │  ├─ Name: rt_map_len
 │  ├─ Generics: <K, V>
 │  ├─ Params: (m: &Map<K, V>)
 │  ├─ Return: uint
 │  └─ Body: <none>
-├─ Item[72]: Fn (span: 136:1-136:69)
+├─ Item[73]: Fn (span: 137:1-137:69)
 │  ├─ Name: rt_map_contains
 │  ├─ Generics: <K, V>
 │  ├─ Params: (m: &Map<K, V>, key: &K)
 │  ├─ Return: bool
 │  └─ Body: <none>
-├─ Item[73]: Fn (span: 137:1-137:74)
+├─ Item[74]: Fn (span: 138:1-138:74)
 │  ├─ Name: rt_map_get_ref
 │  ├─ Generics: <K, V>
 │  ├─ Params: (m: &Map<K, V>, key: &K)
 │  ├─ Return: Option<&V>
 │  └─ Body: <none>
-├─ Item[74]: Fn (span: 138:1-138:82)
+├─ Item[75]: Fn (span: 139:1-139:82)
 │  ├─ Name: rt_map_get_mut
 │  ├─ Generics: <K, V>
 │  ├─ Params: (m: &mut Map<K, V>, key: &K)
 │  ├─ Return: Option<&mut V>
 │  └─ Body: <none>
-├─ Item[75]: Fn (span: 139:1-139:85)
+├─ Item[76]: Fn (span: 140:1-140:85)
 │  ├─ Name: rt_map_insert
 │  ├─ Generics: <K, V>
 │  ├─ Params: (m: &mut Map<K, V>, key: K, value: V)
 │  ├─ Return: Option<V>
 │  └─ Body: <none>
-├─ Item[76]: Fn (span: 140:1-140:76)
+├─ Item[77]: Fn (span: 141:1-141:76)
 │  ├─ Name: rt_map_remove
 │  ├─ Generics: <K, V>
 │  ├─ Params: (m: &mut Map<K, V>, key: &K)
 │  ├─ Return: Option<V>
 │  └─ Body: <none>
-├─ Item[77]: Fn (span: 141:1-141:55)
+├─ Item[78]: Fn (span: 142:1-142:55)
 │  ├─ Name: rt_map_keys
 │  ├─ Generics: <K, V>
 │  ├─ Params: (m: &Map<K, V>)
 │  ├─ Return: K[]
 │  └─ Body: <none>
-├─ Item[78]: Fn (span: 144:1-145:29)
+├─ Item[79]: Fn (span: 145:1-146:29)
 │  ├─ Name: readline
 │  ├─ Params: ()
 │  ├─ Return: string
 │  └─ Body: <none>
-├─ Item[79]: Type (span: 147:1-150:3)
+├─ Item[80]: Type (span: 148:1-151:3)
 │  ├─ Name: Range
 │  ├─ Kind: Struct
 │  ├─ Visibility: public
@@ -434,34 +439,34 @@ intrinsics.sg (span: 1:1-875:1)
 │  ├─ Attributes: @intrinsic
 │  └─ Struct:
 │     └─ Field[0]: __state: *byte
-├─ Item[80]: Fn (span: 153:1-153:89)
+├─ Item[81]: Fn (span: 154:1-154:89)
 │  ├─ Name: rt_range_int_new
 │  ├─ Params: (start: int, end: int, inclusive: bool)
 │  ├─ Return: Range<int>
 │  └─ Body: <none>
-├─ Item[81]: Fn (span: 154:1-154:86)
+├─ Item[82]: Fn (span: 155:1-155:86)
 │  ├─ Name: rt_range_int_from_start
 │  ├─ Params: (start: int, inclusive: bool)
 │  ├─ Return: Range<int>
 │  └─ Body: <none>
-├─ Item[82]: Fn (span: 155:1-155:80)
+├─ Item[83]: Fn (span: 156:1-156:80)
 │  ├─ Name: rt_range_int_to_end
 │  ├─ Params: (end: int, inclusive: bool)
 │  ├─ Return: Range<int>
 │  └─ Body: <none>
-├─ Item[83]: Fn (span: 156:1-156:68)
+├─ Item[84]: Fn (span: 157:1-157:68)
 │  ├─ Name: rt_range_int_full
 │  ├─ Params: (inclusive: bool)
 │  ├─ Return: Range<int>
 │  └─ Body: <none>
-├─ Item[84]: Extern (span: 158:1-160:2)
+├─ Item[85]: Extern (span: 159:1-161:2)
 │  ├─ Target: Range<T>
 │  ├─ Members:
 │  │  └─ Fn[0]: next
 │  │     ├─ Params: (self: &mut Range<T>)
 │  │     ├─ Return: Option<T>
 │  │     └─ Attributes: @intrinsic
-├─ Item[85]: Type (span: 162:1-169:3)
+├─ Item[86]: Type (span: 163:1-170:3)
 │  ├─ Name: HeapStats
 │  ├─ Kind: Struct
 │  ├─ Visibility: public
@@ -472,32 +477,32 @@ intrinsics.sg (span: 1:1-875:1)
 │     ├─ Field[3]: live_bytes: uint
 │     ├─ Field[4]: rc_increments: uint
 │     └─ Field[5]: rc_decrements: uint
-├─ Item[86]: Fn (span: 175:1-175:48)
+├─ Item[87]: Fn (span: 176:1-176:48)
 │  ├─ Name: rt_heap_stats
 │  ├─ Params: ()
 │  ├─ Return: HeapStats
 │  └─ Body: <none>
-├─ Item[87]: Fn (span: 177:1-177:44)
+├─ Item[88]: Fn (span: 178:1-178:44)
 │  ├─ Name: rt_heap_dump
 │  ├─ Params: ()
 │  ├─ Return: string
 │  └─ Body: <none>
-├─ Item[88]: Fn (span: 179:1-179:45)
+├─ Item[89]: Fn (span: 180:1-180:45)
 │  ├─ Name: rt_worker_count
 │  ├─ Params: ()
 │  ├─ Return: uint
 │  └─ Body: <none>
-├─ Item[89]: Type (span: 181:1-183:3)
+├─ Item[90]: Type (span: 182:1-184:3)
 │  ├─ Name: Task
 │  ├─ Kind: Struct
 │  ├─ Visibility: public
 │  ├─ Generics: <T>
 │  └─ Struct:
 │     └─ Field[0]: __opaque: int
-├─ Item[90]: Tag (span: 185:1-185:21)
+├─ Item[91]: Tag (span: 186:1-186:21)
 │  ├─ Name: Cancelled
 │  └─ Visibility: public
-├─ Item[91]: Type (span: 186:1-186:49)
+├─ Item[92]: Type (span: 187:1-187:49)
 │  ├─ Name: TaskResult
 │  ├─ Kind: Union
 │  ├─ Visibility: public
@@ -505,33 +510,33 @@ intrinsics.sg (span: 1:1-875:1)
 │  └─ Union:
 │     ├─ Member[0]: Success(T)
 │     └─ Member[1]: Cancelled
-├─ Item[92]: Fn (span: 188:1-188:54)
+├─ Item[93]: Fn (span: 189:1-189:54)
 │  ├─ Name: rt_scope_enter
 │  ├─ Params: (failfast: bool)
 │  ├─ Return: uint
 │  └─ Body: <none>
-├─ Item[93]: Fn (span: 189:1-189:82)
+├─ Item[94]: Fn (span: 190:1-190:82)
 │  ├─ Name: rt_scope_register_child
 │  ├─ Generics: <T>
 │  ├─ Params: (scope: uint, child: Task<T>)
 │  ├─ Return: nothing
 │  └─ Body: <none>
-├─ Item[94]: Fn (span: 190:1-190:59)
+├─ Item[95]: Fn (span: 191:1-191:59)
 │  ├─ Name: rt_scope_cancel_all
 │  ├─ Params: (scope: uint)
 │  ├─ Return: nothing
 │  └─ Body: <none>
-├─ Item[95]: Fn (span: 191:1-191:54)
+├─ Item[96]: Fn (span: 192:1-192:54)
 │  ├─ Name: rt_scope_join_all
 │  ├─ Params: (scope: uint)
 │  ├─ Return: bool
 │  └─ Body: <none>
-├─ Item[96]: Fn (span: 192:1-192:53)
+├─ Item[97]: Fn (span: 193:1-193:53)
 │  ├─ Name: rt_scope_exit
 │  ├─ Params: (scope: uint)
 │  ├─ Return: nothing
 │  └─ Body: <none>
-├─ Item[97]: Extern (span: 194:1-198:2)
+├─ Item[98]: Extern (span: 195:1-199:2)
 │  ├─ Target: Task<T>
 │  ├─ Members:
 │  │  ├─ Fn[0]: clone
@@ -546,23 +551,23 @@ intrinsics.sg (span: 1:1-875:1)
 │  │     ├─ Params: (self: own Task<T>)
 │  │     ├─ Return: TaskResult<T>
 │  │     └─ Attributes: @intrinsic
-├─ Item[98]: Fn (span: 202:1-203:38)
+├─ Item[99]: Fn (span: 203:1-204:38)
 │  ├─ Name: checkpoint
 │  ├─ Params: ()
 │  ├─ Return: Task<nothing>
 │  └─ Body: <none>
-├─ Item[99]: Fn (span: 206:1-206:52)
+├─ Item[100]: Fn (span: 207:1-207:52)
 │  ├─ Name: sleep
 │  ├─ Params: (ms: uint)
 │  ├─ Return: Task<nothing>
 │  └─ Body: <none>
-├─ Item[100]: Fn (span: 210:1-210:69)
+├─ Item[101]: Fn (span: 211:1-211:69)
 │  ├─ Name: timeout
 │  ├─ Generics: <T>
 │  ├─ Params: (t: Task<T>, ms: uint)
 │  ├─ Return: TaskResult<T>
 │  └─ Body: <none>
-├─ Item[101]: Type (span: 213:1-217:3)
+├─ Item[102]: Type (span: 214:1-218:3)
 │  ├─ Name: Channel
 │  ├─ Kind: Struct
 │  ├─ Visibility: public
@@ -570,7 +575,7 @@ intrinsics.sg (span: 1:1-875:1)
 │  ├─ Attributes: @copy, @intrinsic
 │  └─ Struct:
 │     └─ Field[0]: __opaque: *byte
-├─ Item[102]: Extern (span: 219:1-232:2)
+├─ Item[103]: Extern (span: 220:1-233:2)
 │  ├─ Target: Channel<T>
 │  ├─ Members:
 │  │  ├─ Fn[0]: new
@@ -597,34 +602,34 @@ intrinsics.sg (span: 1:1-875:1)
 │  │     ├─ Params: (self: &Channel<T>)
 │  │     ├─ Return: nothing
 │  │     └─ Attributes: @intrinsic
-├─ Item[103]: Fn (span: 234:1-235:54)
+├─ Item[104]: Fn (span: 235:1-236:54)
 │  ├─ Name: make_channel
 │  ├─ Generics: <T>
 │  ├─ Params: (capacity: uint)
 │  ├─ Return: own Channel<T>
 │  └─ Body: <none>
-├─ Item[104]: Contract (span: 237:1-240:2)
-├─ Item[105]: Contract (span: 242:1-244:2)
-├─ Item[106]: Contract (span: 246:1-248:2)
-├─ Item[107]: Fn (span: 250:1-252:2)
+├─ Item[105]: Contract (span: 238:1-241:2)
+├─ Item[106]: Contract (span: 243:1-245:2)
+├─ Item[107]: Contract (span: 247:1-249:2)
+├─ Item[108]: Fn (span: 251:1-253:2)
 │  ├─ Name: max_value
 │  ├─ Generics: <T>
 │  ├─ Params: ()
 │  ├─ Return: T
 │  └─ Body:
-│     └─ Stmt[0]: Block (span: 250:40-252:2)
-│        └─ Stmt[0]: Return (span: 251:5-251:28)
+│     └─ Stmt[0]: Block (span: 251:40-253:2)
+│        └─ Stmt[0]: Return (span: 252:5-252:28)
 │           └─ Expr: expr#11: T.__max_value()
-├─ Item[108]: Fn (span: 254:1-256:2)
+├─ Item[109]: Fn (span: 255:1-257:2)
 │  ├─ Name: min_value
 │  ├─ Generics: <T>
 │  ├─ Params: ()
 │  ├─ Return: T
 │  └─ Body:
-│     └─ Stmt[0]: Block (span: 254:40-256:2)
-│        └─ Stmt[0]: Return (span: 255:5-255:28)
+│     └─ Stmt[0]: Block (span: 255:40-257:2)
+│        └─ Stmt[0]: Return (span: 256:5-256:28)
 │           └─ Expr: expr#14: T.__min_value()
-├─ Item[109]: Extern (span: 258:1-297:2)
+├─ Item[110]: Extern (span: 259:1-298:2)
 │  ├─ Target: int
 │  ├─ Members:
 │  │  ├─ Fn[0]: __add
@@ -712,8 +717,8 @@ intrinsics.sg (span: 1:1-875:1)
 │  │  │  ├─ Return: string
 │  │  │  ├─ Attributes: @overload
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 279:60-281:6)
-│  │  │     └─ Stmt[0]: Return (span: 280:9-280:34)
+│  │  │     Stmt[0]: Block (span: 280:60-282:6)
+│  │  │     └─ Stmt[0]: Return (span: 281:9-281:34)
 │  │  │        └─ Expr: expr#18: (*self) to string
 │  │  ├─ Fn[21]: __to
 │  │  │  ├─ Params: (self: int, target: float)
@@ -771,7 +776,7 @@ intrinsics.sg (span: 1:1-875:1)
 │  │     ├─ Params: (s: &string)
 │  │     ├─ Return: Erring<int, Error>
 │  │     └─ Attributes: @intrinsic
-├─ Item[110]: Extern (span: 299:1-337:2)
+├─ Item[111]: Extern (span: 300:1-338:2)
 │  ├─ Target: uint
 │  ├─ Members:
 │  │  ├─ Fn[0]: __add
@@ -855,8 +860,8 @@ intrinsics.sg (span: 1:1-875:1)
 │  │  │  ├─ Return: string
 │  │  │  ├─ Attributes: @overload
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 319:61-321:6)
-│  │  │     └─ Stmt[0]: Return (span: 320:9-320:34)
+│  │  │     Stmt[0]: Block (span: 320:61-322:6)
+│  │  │     └─ Stmt[0]: Return (span: 321:9-321:34)
 │  │  │        └─ Expr: expr#22: (*self) to string
 │  │  ├─ Fn[20]: __to
 │  │  │  ├─ Params: (self: uint, target: int)
@@ -914,22 +919,22 @@ intrinsics.sg (span: 1:1-875:1)
 │  │     ├─ Params: (s: &string)
 │  │     ├─ Return: Erring<uint, Error>
 │  │     └─ Attributes: @intrinsic
-├─ Item[111]: Extern (span: 339:1-366:2)
+├─ Item[112]: Extern (span: 340:1-367:2)
 │  ├─ Target: int8
 │  ├─ Members:
 │  │  ├─ Fn[0]: __min_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: int8
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 340:34-340:57)
-│  │  │     └─ Stmt[0]: Return (span: 340:36-340:55)
+│  │  │     Stmt[0]: Block (span: 341:34-341:57)
+│  │  │     └─ Stmt[0]: Return (span: 341:36-341:55)
 │  │  │        └─ Expr: expr#26: (-128) to int8
 │  │  ├─ Fn[1]: __max_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: int8
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 341:34-341:56)
-│  │  │     └─ Stmt[0]: Return (span: 341:36-341:54)
+│  │  │     Stmt[0]: Block (span: 342:34-342:56)
+│  │  │     └─ Stmt[0]: Return (span: 342:36-342:54)
 │  │  │        └─ Expr: expr#29: (127) to int8
 │  │  ├─ Fn[2]: __add
 │  │  │  ├─ Params: (self: int8, other: int8)
@@ -1027,22 +1032,22 @@ intrinsics.sg (span: 1:1-875:1)
 │  │     ├─ Params: (s: &string)
 │  │     ├─ Return: Erring<int8, Error>
 │  │     └─ Attributes: @intrinsic
-├─ Item[112]: Extern (span: 368:1-395:2)
+├─ Item[113]: Extern (span: 369:1-396:2)
 │  ├─ Target: int16
 │  ├─ Members:
 │  │  ├─ Fn[0]: __min_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: int16
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 369:35-369:62)
-│  │  │     └─ Stmt[0]: Return (span: 369:37-369:60)
+│  │  │     Stmt[0]: Block (span: 370:35-370:62)
+│  │  │     └─ Stmt[0]: Return (span: 370:37-370:60)
 │  │  │        └─ Expr: expr#33: (-32_768) to int16
 │  │  ├─ Fn[1]: __max_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: int16
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 370:35-370:61)
-│  │  │     └─ Stmt[0]: Return (span: 370:37-370:59)
+│  │  │     Stmt[0]: Block (span: 371:35-371:61)
+│  │  │     └─ Stmt[0]: Return (span: 371:37-371:59)
 │  │  │        └─ Expr: expr#36: (32_767) to int16
 │  │  ├─ Fn[2]: __add
 │  │  │  ├─ Params: (self: int16, other: int16)
@@ -1140,22 +1145,22 @@ intrinsics.sg (span: 1:1-875:1)
 │  │     ├─ Params: (s: &string)
 │  │     ├─ Return: Erring<int16, Error>
 │  │     └─ Attributes: @intrinsic
-├─ Item[113]: Extern (span: 397:1-424:2)
+├─ Item[114]: Extern (span: 398:1-425:2)
 │  ├─ Target: int32
 │  ├─ Members:
 │  │  ├─ Fn[0]: __min_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: int32
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 398:35-398:69)
-│  │  │     └─ Stmt[0]: Return (span: 398:37-398:67)
+│  │  │     Stmt[0]: Block (span: 399:35-399:69)
+│  │  │     └─ Stmt[0]: Return (span: 399:37-399:67)
 │  │  │        └─ Expr: expr#40: (-2_147_483_648) to int32
 │  │  ├─ Fn[1]: __max_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: int32
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 399:35-399:68)
-│  │  │     └─ Stmt[0]: Return (span: 399:37-399:66)
+│  │  │     Stmt[0]: Block (span: 400:35-400:68)
+│  │  │     └─ Stmt[0]: Return (span: 400:37-400:66)
 │  │  │        └─ Expr: expr#43: (2_147_483_647) to int32
 │  │  ├─ Fn[2]: __add
 │  │  │  ├─ Params: (self: int32, other: int32)
@@ -1253,22 +1258,22 @@ intrinsics.sg (span: 1:1-875:1)
 │  │     ├─ Params: (s: &string)
 │  │     ├─ Return: Erring<int32, Error>
 │  │     └─ Attributes: @intrinsic
-├─ Item[114]: Extern (span: 426:1-453:2)
+├─ Item[115]: Extern (span: 427:1-454:2)
 │  ├─ Target: int64
 │  ├─ Members:
 │  │  ├─ Fn[0]: __min_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: int64
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 427:35-427:81)
-│  │  │     └─ Stmt[0]: Return (span: 427:37-427:79)
+│  │  │     Stmt[0]: Block (span: 428:35-428:81)
+│  │  │     └─ Stmt[0]: Return (span: 428:37-428:79)
 │  │  │        └─ Expr: expr#47: (-9_223_372_036_854_775_808) to int64
 │  │  ├─ Fn[1]: __max_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: int64
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 428:35-428:80)
-│  │  │     └─ Stmt[0]: Return (span: 428:37-428:78)
+│  │  │     Stmt[0]: Block (span: 429:35-429:80)
+│  │  │     └─ Stmt[0]: Return (span: 429:37-429:78)
 │  │  │        └─ Expr: expr#50: (9_223_372_036_854_775_807) to int64
 │  │  ├─ Fn[2]: __add
 │  │  │  ├─ Params: (self: int64, other: int64)
@@ -1366,22 +1371,22 @@ intrinsics.sg (span: 1:1-875:1)
 │  │     ├─ Params: (s: &string)
 │  │     ├─ Return: Erring<int64, Error>
 │  │     └─ Attributes: @intrinsic
-├─ Item[115]: Extern (span: 455:1-481:2)
+├─ Item[116]: Extern (span: 456:1-482:2)
 │  ├─ Target: uint8
 │  ├─ Members:
 │  │  ├─ Fn[0]: __min_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: uint8
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 456:35-456:56)
-│  │  │     └─ Stmt[0]: Return (span: 456:37-456:54)
+│  │  │     Stmt[0]: Block (span: 457:35-457:56)
+│  │  │     └─ Stmt[0]: Return (span: 457:37-457:54)
 │  │  │        └─ Expr: expr#53: (0) to uint8
 │  │  ├─ Fn[1]: __max_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: uint8
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 457:35-457:58)
-│  │  │     └─ Stmt[0]: Return (span: 457:37-457:56)
+│  │  │     Stmt[0]: Block (span: 458:35-458:58)
+│  │  │     └─ Stmt[0]: Return (span: 458:37-458:56)
 │  │  │        └─ Expr: expr#56: (255) to uint8
 │  │  ├─ Fn[2]: __add
 │  │  │  ├─ Params: (self: uint8, other: uint8)
@@ -1475,22 +1480,22 @@ intrinsics.sg (span: 1:1-875:1)
 │  │     ├─ Params: (s: &string)
 │  │     ├─ Return: Erring<uint8, Error>
 │  │     └─ Attributes: @intrinsic
-├─ Item[116]: Extern (span: 483:1-509:2)
+├─ Item[117]: Extern (span: 484:1-510:2)
 │  ├─ Target: uint16
 │  ├─ Members:
 │  │  ├─ Fn[0]: __min_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: uint16
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 484:36-484:58)
-│  │  │     └─ Stmt[0]: Return (span: 484:38-484:56)
+│  │  │     Stmt[0]: Block (span: 485:36-485:58)
+│  │  │     └─ Stmt[0]: Return (span: 485:38-485:56)
 │  │  │        └─ Expr: expr#59: (0) to uint16
 │  │  ├─ Fn[1]: __max_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: uint16
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 485:36-485:63)
-│  │  │     └─ Stmt[0]: Return (span: 485:38-485:61)
+│  │  │     Stmt[0]: Block (span: 486:36-486:63)
+│  │  │     └─ Stmt[0]: Return (span: 486:38-486:61)
 │  │  │        └─ Expr: expr#62: (65_535) to uint16
 │  │  ├─ Fn[2]: __add
 │  │  │  ├─ Params: (self: uint16, other: uint16)
@@ -1584,22 +1589,22 @@ intrinsics.sg (span: 1:1-875:1)
 │  │     ├─ Params: (s: &string)
 │  │     ├─ Return: Erring<uint16, Error>
 │  │     └─ Attributes: @intrinsic
-├─ Item[117]: Extern (span: 511:1-537:2)
+├─ Item[118]: Extern (span: 512:1-538:2)
 │  ├─ Target: uint32
 │  ├─ Members:
 │  │  ├─ Fn[0]: __min_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: uint32
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 512:36-512:58)
-│  │  │     └─ Stmt[0]: Return (span: 512:38-512:56)
+│  │  │     Stmt[0]: Block (span: 513:36-513:58)
+│  │  │     └─ Stmt[0]: Return (span: 513:38-513:56)
 │  │  │        └─ Expr: expr#65: (0) to uint32
 │  │  ├─ Fn[1]: __max_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: uint32
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 513:36-513:70)
-│  │  │     └─ Stmt[0]: Return (span: 513:38-513:68)
+│  │  │     Stmt[0]: Block (span: 514:36-514:70)
+│  │  │     └─ Stmt[0]: Return (span: 514:38-514:68)
 │  │  │        └─ Expr: expr#68: (4_294_967_295) to uint32
 │  │  ├─ Fn[2]: __add
 │  │  │  ├─ Params: (self: uint32, other: uint32)
@@ -1693,22 +1698,22 @@ intrinsics.sg (span: 1:1-875:1)
 │  │     ├─ Params: (s: &string)
 │  │     ├─ Return: Erring<uint32, Error>
 │  │     └─ Attributes: @intrinsic
-├─ Item[118]: Extern (span: 539:1-565:2)
+├─ Item[119]: Extern (span: 540:1-566:2)
 │  ├─ Target: uint64
 │  ├─ Members:
 │  │  ├─ Fn[0]: __min_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: uint64
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 540:36-540:58)
-│  │  │     └─ Stmt[0]: Return (span: 540:38-540:56)
+│  │  │     Stmt[0]: Block (span: 541:36-541:58)
+│  │  │     └─ Stmt[0]: Return (span: 541:38-541:56)
 │  │  │        └─ Expr: expr#71: (0) to uint64
 │  │  ├─ Fn[1]: __max_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: uint64
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 541:36-541:83)
-│  │  │     └─ Stmt[0]: Return (span: 541:38-541:81)
+│  │  │     Stmt[0]: Block (span: 542:36-542:83)
+│  │  │     └─ Stmt[0]: Return (span: 542:38-542:81)
 │  │  │        └─ Expr: expr#74: (18_446_744_073_709_551_615) to uint64
 │  │  ├─ Fn[2]: __add
 │  │  │  ├─ Params: (self: uint64, other: uint64)
@@ -1802,22 +1807,22 @@ intrinsics.sg (span: 1:1-875:1)
 │  │     ├─ Params: (s: &string)
 │  │     ├─ Return: Erring<uint64, Error>
 │  │     └─ Attributes: @intrinsic
-├─ Item[119]: Extern (span: 567:1-588:2)
+├─ Item[120]: Extern (span: 568:1-589:2)
 │  ├─ Target: float16
 │  ├─ Members:
 │  │  ├─ Fn[0]: __min_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: float16
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 568:37-568:67)
-│  │  │     └─ Stmt[0]: Return (span: 568:39-568:65)
+│  │  │     Stmt[0]: Block (span: 569:37-569:67)
+│  │  │     └─ Stmt[0]: Return (span: 569:39-569:65)
 │  │  │        └─ Expr: expr#78: (-65504.0) to float16
 │  │  ├─ Fn[1]: __max_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: float16
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 569:37-569:66)
-│  │  │     └─ Stmt[0]: Return (span: 569:39-569:64)
+│  │  │     Stmt[0]: Block (span: 570:37-570:66)
+│  │  │     └─ Stmt[0]: Return (span: 570:39-570:64)
 │  │  │        └─ Expr: expr#81: (65504.0) to float16
 │  │  ├─ Fn[2]: __add
 │  │  │  ├─ Params: (self: float16, other: float16)
@@ -1891,22 +1896,22 @@ intrinsics.sg (span: 1:1-875:1)
 │  │     ├─ Params: (s: &string)
 │  │     ├─ Return: Erring<float16, Error>
 │  │     └─ Attributes: @intrinsic
-├─ Item[120]: Extern (span: 590:1-611:2)
+├─ Item[121]: Extern (span: 591:1-612:2)
 │  ├─ Target: float32
 │  ├─ Members:
 │  │  ├─ Fn[0]: __min_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: float32
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 591:37-591:86)
-│  │  │     └─ Stmt[0]: Return (span: 591:39-591:84)
+│  │  │     Stmt[0]: Block (span: 592:37-592:86)
+│  │  │     └─ Stmt[0]: Return (span: 592:39-592:84)
 │  │  │        └─ Expr: expr#85: (-3.402_823_466_385_2886e+38) to float32
 │  │  ├─ Fn[1]: __max_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: float32
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 592:37-592:85)
-│  │  │     └─ Stmt[0]: Return (span: 592:39-592:83)
+│  │  │     Stmt[0]: Block (span: 593:37-593:85)
+│  │  │     └─ Stmt[0]: Return (span: 593:39-593:83)
 │  │  │        └─ Expr: expr#88: (3.402_823_466_385_2886e+38) to float32
 │  │  ├─ Fn[2]: __add
 │  │  │  ├─ Params: (self: float32, other: float32)
@@ -1980,22 +1985,22 @@ intrinsics.sg (span: 1:1-875:1)
 │  │     ├─ Params: (s: &string)
 │  │     ├─ Return: Erring<float32, Error>
 │  │     └─ Attributes: @intrinsic
-├─ Item[121]: Extern (span: 613:1-634:2)
+├─ Item[122]: Extern (span: 614:1-635:2)
 │  ├─ Target: float64
 │  ├─ Members:
 │  │  ├─ Fn[0]: __min_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: float64
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 614:37-614:87)
-│  │  │     └─ Stmt[0]: Return (span: 614:39-614:85)
+│  │  │     Stmt[0]: Block (span: 615:37-615:87)
+│  │  │     └─ Stmt[0]: Return (span: 615:39-615:85)
 │  │  │        └─ Expr: expr#92: (-1.797_693_134_862_3157e+308) to float64
 │  │  ├─ Fn[1]: __max_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: float64
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 615:37-615:86)
-│  │  │     └─ Stmt[0]: Return (span: 615:39-615:84)
+│  │  │     Stmt[0]: Block (span: 616:37-616:86)
+│  │  │     └─ Stmt[0]: Return (span: 616:39-616:84)
 │  │  │        └─ Expr: expr#95: (1.797_693_134_862_3157e+308) to float64
 │  │  ├─ Fn[2]: __add
 │  │  │  ├─ Params: (self: float64, other: float64)
@@ -2069,7 +2074,7 @@ intrinsics.sg (span: 1:1-875:1)
 │  │     ├─ Params: (s: &string)
 │  │     ├─ Return: Erring<float64, Error>
 │  │     └─ Attributes: @intrinsic
-├─ Item[122]: Extern (span: 636:1-670:2)
+├─ Item[123]: Extern (span: 637:1-671:2)
 │  ├─ Target: float
 │  ├─ Members:
 │  │  ├─ Fn[0]: __add
@@ -2137,8 +2142,8 @@ intrinsics.sg (span: 1:1-875:1)
 │  │  │  ├─ Return: string
 │  │  │  ├─ Attributes: @overload
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 652:62-654:6)
-│  │  │     └─ Stmt[0]: Return (span: 653:9-653:34)
+│  │  │     Stmt[0]: Block (span: 653:62-655:6)
+│  │  │     └─ Stmt[0]: Return (span: 654:9-654:34)
 │  │  │        └─ Expr: expr#99: (*self) to string
 │  │  ├─ Fn[16]: __to
 │  │  │  ├─ Params: (self: float, target: int)
@@ -2196,7 +2201,7 @@ intrinsics.sg (span: 1:1-875:1)
 │  │     ├─ Params: (s: &string)
 │  │     ├─ Return: Erring<float, Error>
 │  │     └─ Attributes: @intrinsic
-├─ Item[123]: Extern (span: 672:1-705:2)
+├─ Item[124]: Extern (span: 673:1-697:2)
 │  ├─ Target: string
 │  ├─ Members:
 │  │  ├─ Fn[0]: __add
@@ -2212,8 +2217,8 @@ intrinsics.sg (span: 1:1-875:1)
 │  │  │  ├─ Return: string
 │  │  │  ├─ Attributes: @overload
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 675:66-677:6)
-│  │  │     └─ Stmt[0]: Return (span: 676:9-676:38)
+│  │  │     Stmt[0]: Block (span: 676:66-678:6)
+│  │  │     └─ Stmt[0]: Return (span: 677:9-677:38)
 │  │  │        └─ Expr: expr#104: (self * (other to int))
 │  │  ├─ Fn[3]: __eq
 │  │  │  ├─ Params: (self: &string, other: &string)
@@ -2240,57 +2245,24 @@ intrinsics.sg (span: 1:1-875:1)
 │  │  │  ├─ Return: string
 │  │  │  ├─ Attributes: @overload
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 683:63-685:6)
-│  │  │     └─ Stmt[0]: Return (span: 684:9-684:31)
+│  │  │     Stmt[0]: Block (span: 684:63-686:6)
+│  │  │     └─ Stmt[0]: Return (span: 685:9-685:31)
 │  │  │        └─ Expr: expr#107: self.__clone()
 │  │  ├─ Fn[9]: __to
 │  │  │  ├─ Params: (self: &string, _: byte[])
 │  │  │  ├─ Return: byte[]
 │  │  │  ├─ Attributes: @overload
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 687:53-700:6)
-│  │  │     ├─ Stmt[0]: Let (span: 688:9-688:33)
-│  │  │     │  ├─ Name: view
-│  │  │     │  ├─ Mutable: false
-│  │  │     │  ├─ Type: <inferred>
-│  │  │     │  └─ Value: expr#110: self.bytes()
-│  │  │     ├─ Stmt[1]: Let (span: 689:9-689:41)
-│  │  │     │  ├─ Name: length
-│  │  │     │  ├─ Mutable: false
-│  │  │     │  ├─ Type: uint
-│  │  │     │  └─ Value: expr#113: view.__len()
-│  │  │     ├─ Stmt[2]: Let (span: 690:9-690:34)
+│  │  │     Stmt[0]: Block (span: 688:53-692:6)
+│  │  │     ├─ Stmt[0]: Let (span: 689:9-689:34)
 │  │  │     │  ├─ Name: out
 │  │  │     │  ├─ Mutable: true
 │  │  │     │  ├─ Type: byte[]
-│  │  │     │  └─ Value: expr#114: <ExprKind(8)>
-│  │  │     ├─ Stmt[3]: Expr (span: 691:9-691:29)
-│  │  │     │  └─ Expr: expr#118: out.reserve(length)
-│  │  │     ├─ Stmt[4]: Let (span: 692:9-692:40)
-│  │  │     │  ├─ Name: len_i
-│  │  │     │  ├─ Mutable: false
-│  │  │     │  ├─ Type: int
-│  │  │     │  └─ Value: expr#120: length to int
-│  │  │     ├─ Stmt[5]: Let (span: 693:9-693:28)
-│  │  │     │  ├─ Name: i
-│  │  │     │  ├─ Mutable: true
-│  │  │     │  ├─ Type: int
-│  │  │     │  └─ Value: expr#121: 0
-│  │  │     ├─ Stmt[6]: While (span: 694:9-698:10)
-│  │  │     │  ├─ Cond: expr#124: (i < len_i)
-│  │  │     │  └─ Body:
-Block (span: 694:25-698:10)
-│  │  │     │     ├─ Stmt[0]: Let (span: 695:13-695:35)
-│  │  │     │     │  ├─ Name: b
-│  │  │     │     │  ├─ Mutable: false
-│  │  │     │     │  ├─ Type: byte
-│  │  │     │     │  └─ Value: expr#127: view[i]
-│  │  │     │     ├─ Stmt[1]: Expr (span: 696:13-696:25)
-│  │  │     │     │  └─ Expr: expr#131: out.push(b)
-│  │  │     │     └─ Stmt[2]: Expr (span: 697:13-697:23)
-│  │  │     │        └─ Expr: expr#136: (i = ((i + 1)))
-│  │  │     └─ Stmt[7]: Return (span: 699:9-699:20)
-│  │  │        └─ Expr: expr#137: out
+│  │  │     │  └─ Value: expr#108: <ExprKind(8)>
+│  │  │     ├─ Stmt[1]: Expr (span: 690:9-690:103)
+│  │  │     │  └─ Expr: expr#119: rt_array_append_raw_bytes(&mut out, rt_string_ptr(self), rt_string_len_bytes(self) to uint64)
+│  │  │     └─ Stmt[2]: Return (span: 691:9-691:20)
+│  │  │        └─ Expr: expr#120: out
 │  │  ├─ Fn[10]: __len
 │  │  │  ├─ Params: (self: &string)
 │  │  │  ├─ Return: uint
@@ -2307,7 +2279,7 @@ Block (span: 694:25-698:10)
 │  │     ├─ Params: (self: &string, index: Range<int>)
 │  │     ├─ Return: string
 │  │     └─ Attributes: @intrinsic, @overload
-├─ Item[124]: Type (span: 707:1-712:3)
+├─ Item[125]: Type (span: 699:1-704:3)
 │  ├─ Name: BytesView
 │  ├─ Kind: Struct
 │  ├─ Visibility: public
@@ -2316,7 +2288,7 @@ Block (span: 694:25-698:10)
 │     ├─ Field[0]: owner: string
 │     ├─ Field[1]: ptr: *byte
 │     └─ Field[2]: len: uint
-├─ Item[125]: Extern (span: 714:1-718:2)
+├─ Item[126]: Extern (span: 706:1-710:2)
 │  ├─ Target: BytesView
 │  ├─ Members:
 │  │  ├─ Fn[0]: __len
@@ -2331,7 +2303,7 @@ Block (span: 694:25-698:10)
 │  │     ├─ Params: (self: &BytesView, index: int64)
 │  │     ├─ Return: uint8
 │  │     └─ Attributes: @intrinsic, @overload
-├─ Item[126]: Extern (span: 720:1-731:2)
+├─ Item[127]: Extern (span: 712:1-723:2)
 │  ├─ Target: bool
 │  ├─ Members:
 │  │  ├─ Fn[0]: __eq
@@ -2355,9 +2327,9 @@ Block (span: 694:25-698:10)
 │  │  │  ├─ Return: string
 │  │  │  ├─ Attributes: @overload
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 725:61-727:6)
-│  │  │     └─ Stmt[0]: Return (span: 726:9-726:34)
-│  │  │        └─ Expr: expr#141: (*self) to string
+│  │  │     Stmt[0]: Block (span: 717:61-719:6)
+│  │  │     └─ Stmt[0]: Return (span: 718:9-718:34)
+│  │  │        └─ Expr: expr#124: (*self) to string
 │  │  ├─ Fn[5]: __to
 │  │  │  ├─ Params: (self: bool, target: int)
 │  │  │  ├─ Return: int
@@ -2366,7 +2338,7 @@ Block (span: 694:25-698:10)
 │  │     ├─ Params: (s: &string)
 │  │     ├─ Return: Erring<bool, Error>
 │  │     └─ Attributes: @intrinsic
-├─ Item[127]: Extern (span: 733:1-740:2)
+├─ Item[128]: Extern (span: 725:1-732:2)
 │  ├─ Target: Array<T>
 │  ├─ Members:
 │  │  ├─ Fn[0]: __add
@@ -2393,7 +2365,7 @@ Block (span: 694:25-698:10)
 │  │     ├─ Params: (self: &Array<T>)
 │  │     ├─ Return: uint
 │  │     └─ Attributes: @intrinsic
-├─ Item[128]: Extern (span: 742:1-749:2)
+├─ Item[129]: Extern (span: 734:1-741:2)
 │  ├─ Target: ArrayFixed<T, N>
 │  ├─ Members:
 │  │  ├─ Fn[0]: __add
@@ -2420,62 +2392,62 @@ Block (span: 694:25-698:10)
 │  │     ├─ Params: (self: &ArrayFixed<T, N>)
 │  │     ├─ Return: uint
 │  │     └─ Attributes: @intrinsic
-├─ Item[129]: Fn (span: 751:1-752:26)
+├─ Item[130]: Fn (span: 743:1-744:26)
 │  ├─ Name: default
 │  ├─ Generics: <T>
 │  ├─ Params: ()
 │  ├─ Return: T
 │  └─ Body: <none>
-├─ Item[130]: Fn (span: 754:1-755:29)
+├─ Item[131]: Fn (span: 746:1-747:29)
 │  ├─ Name: size_of
 │  ├─ Generics: <T>
 │  ├─ Params: ()
 │  ├─ Return: uint
 │  └─ Body: <none>
-├─ Item[131]: Fn (span: 757:1-758:30)
+├─ Item[132]: Fn (span: 749:1-750:30)
 │  ├─ Name: align_of
 │  ├─ Generics: <T>
 │  ├─ Params: ()
 │  ├─ Return: uint
 │  └─ Body: <none>
-├─ Item[132]: Contract (span: 760:1-763:2)
-├─ Item[133]: Fn (span: 765:1-766:44)
+├─ Item[133]: Contract (span: 752:1-755:2)
+├─ Item[134]: Fn (span: 757:1-758:44)
 │  ├─ Name: exit
 │  ├─ Generics: <E>
 │  ├─ Params: (e: E)
 │  ├─ Return: nothing
 │  └─ Body: <none>
-├─ Item[134]: Fn (span: 768:1-769:54)
+├─ Item[135]: Fn (span: 760:1-761:54)
 │  ├─ Name: rt_panic
 │  ├─ Params: (ptr: *byte, length: uint)
 │  ├─ Return: nothing
 │  └─ Body: <none>
-├─ Item[135]: Fn (span: 771:1-775:2)
+├─ Item[136]: Fn (span: 763:1-767:2)
 │  ├─ Name: panic
 │  ├─ Params: (msg: string)
 │  ├─ Return: nothing
 │  └─ Body:
-│     └─ Stmt[0]: Block (span: 771:38-775:2)
-│        ├─ Stmt[0]: Let (span: 772:5-772:35)
+│     └─ Stmt[0]: Block (span: 763:38-767:2)
+│        ├─ Stmt[0]: Let (span: 764:5-764:35)
 │        │  ├─ Name: ptr
 │        │  ├─ Mutable: false
 │        │  ├─ Type: <inferred>
-│        │  └─ Value: expr#145: rt_string_ptr(&msg)
-│        ├─ Stmt[1]: Let (span: 773:5-773:44)
+│        │  └─ Value: expr#128: rt_string_ptr(&msg)
+│        ├─ Stmt[1]: Let (span: 765:5-765:44)
 │        │  ├─ Name: length
 │        │  ├─ Mutable: false
 │        │  ├─ Type: <inferred>
-│        │  └─ Value: expr#149: rt_string_len_bytes(&msg)
-│        └─ Stmt[2]: Expr (span: 774:5-774:27)
-│           └─ Expr: expr#153: rt_panic(ptr, length)
-├─ Item[136]: Type (span: 777:1-780:3)
+│        │  └─ Value: expr#132: rt_string_len_bytes(&msg)
+│        └─ Stmt[2]: Expr (span: 766:5-766:27)
+│           └─ Expr: expr#136: rt_panic(ptr, length)
+├─ Item[137]: Type (span: 769:1-772:3)
 │  ├─ Name: RwLock
 │  ├─ Kind: Struct
 │  ├─ Visibility: public
 │  ├─ Attributes: @intrinsic
 │  └─ Struct:
 │     └─ Field[0]: __opaque: *byte
-├─ Item[137]: Extern (span: 782:1-790:2)
+├─ Item[138]: Extern (span: 774:1-782:2)
 │  ├─ Target: RwLock
 │  ├─ Members:
 │  │  ├─ Fn[0]: new
@@ -2506,97 +2478,97 @@ Block (span: 694:25-698:10)
 │  │     ├─ Params: (self: &mut RwLock)
 │  │     ├─ Return: bool
 │  │     └─ Attributes: @intrinsic
-├─ Item[138]: Fn (span: 798:1-799:38)
+├─ Item[139]: Fn (span: 790:1-791:38)
 │  ├─ Name: atomic_load
 │  ├─ Params: (ptr: &int)
 │  ├─ Return: int
 │  └─ Body: <none>
-├─ Item[139]: Fn (span: 801:1-803:40)
+├─ Item[140]: Fn (span: 793:1-795:40)
 │  ├─ Name: atomic_load
 │  ├─ Params: (ptr: &uint)
 │  ├─ Return: uint
 │  └─ Body: <none>
-├─ Item[140]: Fn (span: 805:1-807:40)
+├─ Item[141]: Fn (span: 797:1-799:40)
 │  ├─ Name: atomic_load
 │  ├─ Params: (ptr: &bool)
 │  ├─ Return: bool
 │  └─ Body: <none>
-├─ Item[141]: Fn (span: 810:1-811:59)
+├─ Item[142]: Fn (span: 802:1-803:59)
 │  ├─ Name: atomic_store
 │  ├─ Params: (ptr: &mut int, value: int)
 │  ├─ Return: nothing
 │  └─ Body: <none>
-├─ Item[142]: Fn (span: 813:1-815:61)
+├─ Item[143]: Fn (span: 805:1-807:61)
 │  ├─ Name: atomic_store
 │  ├─ Params: (ptr: &mut uint, value: uint)
 │  ├─ Return: nothing
 │  └─ Body: <none>
-├─ Item[143]: Fn (span: 817:1-819:61)
+├─ Item[144]: Fn (span: 809:1-811:61)
 │  ├─ Name: atomic_store
 │  ├─ Params: (ptr: &mut bool, value: bool)
 │  ├─ Return: nothing
 │  └─ Body: <none>
-├─ Item[144]: Fn (span: 822:1-823:60)
+├─ Item[145]: Fn (span: 814:1-815:60)
 │  ├─ Name: atomic_exchange
 │  ├─ Params: (ptr: &mut int, new_val: int)
 │  ├─ Return: int
 │  └─ Body: <none>
-├─ Item[145]: Fn (span: 825:1-827:63)
+├─ Item[146]: Fn (span: 817:1-819:63)
 │  ├─ Name: atomic_exchange
 │  ├─ Params: (ptr: &mut uint, new_val: uint)
 │  ├─ Return: uint
 │  └─ Body: <none>
-├─ Item[146]: Fn (span: 829:1-831:63)
+├─ Item[147]: Fn (span: 821:1-823:63)
 │  ├─ Name: atomic_exchange
 │  ├─ Params: (ptr: &mut bool, new_val: bool)
 │  ├─ Return: bool
 │  └─ Body: <none>
-├─ Item[147]: Fn (span: 835:1-836:84)
+├─ Item[148]: Fn (span: 827:1-828:84)
 │  ├─ Name: atomic_compare_exchange
 │  ├─ Params: (ptr: &mut int, expected: int, desired: int)
 │  ├─ Return: bool
 │  └─ Body: <none>
-├─ Item[148]: Fn (span: 838:1-840:87)
+├─ Item[149]: Fn (span: 830:1-832:87)
 │  ├─ Name: atomic_compare_exchange
 │  ├─ Params: (ptr: &mut uint, expected: uint, desired: uint)
 │  ├─ Return: bool
 │  └─ Body: <none>
-├─ Item[149]: Fn (span: 842:1-844:87)
+├─ Item[150]: Fn (span: 834:1-836:87)
 │  ├─ Name: atomic_compare_exchange
 │  ├─ Params: (ptr: &mut bool, expected: bool, desired: bool)
 │  ├─ Return: bool
 │  └─ Body: <none>
-├─ Item[150]: Fn (span: 847:1-848:59)
+├─ Item[151]: Fn (span: 839:1-840:59)
 │  ├─ Name: atomic_fetch_add
 │  ├─ Params: (ptr: &mut int, delta: int)
 │  ├─ Return: int
 │  └─ Body: <none>
-├─ Item[151]: Fn (span: 850:1-852:62)
+├─ Item[152]: Fn (span: 842:1-844:62)
 │  ├─ Name: atomic_fetch_add
 │  ├─ Params: (ptr: &mut uint, delta: uint)
 │  ├─ Return: uint
 │  └─ Body: <none>
-├─ Item[152]: Fn (span: 855:1-856:59)
+├─ Item[153]: Fn (span: 847:1-848:59)
 │  ├─ Name: atomic_fetch_sub
 │  ├─ Params: (ptr: &mut int, delta: int)
 │  ├─ Return: int
 │  └─ Body: <none>
-├─ Item[153]: Fn (span: 858:1-860:62)
+├─ Item[154]: Fn (span: 850:1-852:62)
 │  ├─ Name: atomic_fetch_sub
 │  ├─ Params: (ptr: &mut uint, delta: uint)
 │  ├─ Return: uint
 │  └─ Body: <none>
-├─ Item[154]: Fn (span: 865:1-866:30)
+├─ Item[155]: Fn (span: 857:1-858:30)
 │  ├─ Name: rt_argv
 │  ├─ Params: ()
 │  ├─ Return: string[]
 │  └─ Body: <none>
-├─ Item[155]: Fn (span: 869:1-870:38)
+├─ Item[156]: Fn (span: 861:1-862:38)
 │  ├─ Name: rt_stdin_read_all
 │  ├─ Params: ()
 │  ├─ Return: string
 │  └─ Body: <none>
-└─ Item[156]: Fn (span: 873:1-874:38)
+└─ Item[157]: Fn (span: 865:1-866:38)
    ├─ Name: rt_exit
    ├─ Params: (code: int)
    ├─ Return: nothing

--- a/testdata/golden/core_stdlib/intrinsics.fmt
+++ b/testdata/golden/core_stdlib/intrinsics.fmt
@@ -129,6 +129,7 @@ extern<TcpConn> {
 @intrinsic fn rt_array_pop<T>(a: &mut Array<T>) -> Option<T>;
 @intrinsic fn rt_array_get_mut<T>(a: &mut Array<T>, index: int) -> &mut T;
 @intrinsic @overload fn rt_array_get_mut<T, N>(a: &mut ArrayFixed<T, N>, index: int) -> &mut T;
+@intrinsic fn rt_array_append_raw_bytes(a: &mut byte[], ptr: *byte, length: uint64) -> nothing;
 
 // Map access intrinsics
 @intrinsic fn rt_map_new<K, V>() -> Map<K, V>;
@@ -685,17 +686,8 @@ extern<string> {
     }
     @overload
     pub fn __to(self: &string, _: byte[]) -> byte[] {
-        let view = self.bytes();
-        let length: uint = view.__len();
         let mut out: byte[] = [];
-        out.reserve(length);
-        let len_i: int = length to int;
-        let mut i: int = 0;
-        while i < len_i {
-            let b: byte = view[i];
-            out.push(b);
-            i = i + 1;
-        }
+        rt_array_append_raw_bytes(&mut out, rt_string_ptr(self), rt_string_len_bytes(self) to uint64);
         return out;
     }
     @intrinsic fn __len(self: &string) -> uint;

--- a/testdata/golden/core_stdlib/intrinsics.sg
+++ b/testdata/golden/core_stdlib/intrinsics.sg
@@ -129,6 +129,7 @@ extern<TcpConn> {
 @intrinsic fn rt_array_pop<T>(a: &mut Array<T>) -> Option<T>;
 @intrinsic fn rt_array_get_mut<T>(a: &mut Array<T>, index: int) -> &mut T;
 @intrinsic @overload fn rt_array_get_mut<T, const N:int>(a: &mut ArrayFixed<T, N>, index: int) -> &mut T;
+@intrinsic fn rt_array_append_raw_bytes(a: &mut byte[], ptr: *byte, length: uint64) -> nothing;
 
 // Map access intrinsics
 @intrinsic fn rt_map_new<K, V>() -> Map<K, V>;
@@ -685,17 +686,8 @@ extern<string> {
     }
     @overload
     pub fn __to(self: &string, _: byte[]) -> byte[] {
-        let view = self.bytes();
-        let length: uint = view.__len();
         let mut out: byte[] = [];
-        out.reserve(length);
-        let len_i: int = length to int;
-        let mut i: int = 0;
-        while i < len_i {
-            let b: byte = view[i];
-            out.push(b);
-            i = i + 1;
-        }
+        rt_array_append_raw_bytes(&mut out, rt_string_ptr(self), rt_string_len_bytes(self) to uint64);
         return out;
     }
     @intrinsic fn __len(self: &string) -> uint;

--- a/testdata/golden/core_stdlib/intrinsics.tokens
+++ b/testdata/golden/core_stdlib/intrinsics.tokens
@@ -1307,8370 +1307,8341 @@
 1307: KwMut           "mut" at 131:100-131:103
 1308: Ident           "T" at 131:104-131:105 (leading: Space)
 1309: Semicolon       ";" at 131:105-131:106
-1310: At              "@" at 134:1-134:2 (leading: Newline, LineComment, Newline)
-1311: Ident           "intrinsic" at 134:2-134:11
-1312: KwFn            "fn" at 134:12-134:14 (leading: Space)
-1313: Ident           "rt_map_new" at 134:15-134:25 (leading: Space)
-1314: Lt              "<" at 134:25-134:26
-1315: Ident           "K" at 134:26-134:27
-1316: Comma           "," at 134:27-134:28
-1317: Ident           "V" at 134:29-134:30 (leading: Space)
-1318: Gt              ">" at 134:30-134:31
-1319: LParen          "(" at 134:31-134:32
-1320: RParen          ")" at 134:32-134:33
-1321: Arrow           "->" at 134:34-134:36 (leading: Space)
-1322: Ident           "Map" at 134:37-134:40 (leading: Space)
-1323: Lt              "<" at 134:40-134:41
-1324: Ident           "K" at 134:41-134:42
-1325: Comma           "," at 134:42-134:43
-1326: Ident           "V" at 134:44-134:45 (leading: Space)
-1327: Gt              ">" at 134:45-134:46
-1328: Semicolon       ";" at 134:46-134:47
-1329: At              "@" at 135:1-135:2 (leading: Newline)
-1330: Ident           "intrinsic" at 135:2-135:11
-1331: KwFn            "fn" at 135:12-135:14 (leading: Space)
-1332: Ident           "rt_map_len" at 135:15-135:25 (leading: Space)
-1333: Lt              "<" at 135:25-135:26
-1334: Ident           "K" at 135:26-135:27
-1335: Comma           "," at 135:27-135:28
-1336: Ident           "V" at 135:29-135:30 (leading: Space)
-1337: Gt              ">" at 135:30-135:31
-1338: LParen          "(" at 135:31-135:32
-1339: Ident           "m" at 135:32-135:33
-1340: Colon           ":" at 135:33-135:34
-1341: Amp             "&" at 135:35-135:36 (leading: Space)
-1342: Ident           "Map" at 135:36-135:39
-1343: Lt              "<" at 135:39-135:40
-1344: Ident           "K" at 135:40-135:41
-1345: Comma           "," at 135:41-135:42
-1346: Ident           "V" at 135:43-135:44 (leading: Space)
-1347: Gt              ">" at 135:44-135:45
-1348: RParen          ")" at 135:45-135:46
-1349: Arrow           "->" at 135:47-135:49 (leading: Space)
-1350: Ident           "uint" at 135:50-135:54 (leading: Space)
-1351: Semicolon       ";" at 135:54-135:55
-1352: At              "@" at 136:1-136:2 (leading: Newline)
-1353: Ident           "intrinsic" at 136:2-136:11
-1354: KwFn            "fn" at 136:12-136:14 (leading: Space)
-1355: Ident           "rt_map_contains" at 136:15-136:30 (leading: Space)
-1356: Lt              "<" at 136:30-136:31
-1357: Ident           "K" at 136:31-136:32
-1358: Comma           "," at 136:32-136:33
-1359: Ident           "V" at 136:34-136:35 (leading: Space)
-1360: Gt              ">" at 136:35-136:36
-1361: LParen          "(" at 136:36-136:37
-1362: Ident           "m" at 136:37-136:38
-1363: Colon           ":" at 136:38-136:39
-1364: Amp             "&" at 136:40-136:41 (leading: Space)
-1365: Ident           "Map" at 136:41-136:44
-1366: Lt              "<" at 136:44-136:45
-1367: Ident           "K" at 136:45-136:46
-1368: Comma           "," at 136:46-136:47
-1369: Ident           "V" at 136:48-136:49 (leading: Space)
-1370: Gt              ">" at 136:49-136:50
-1371: Comma           "," at 136:50-136:51
-1372: Ident           "key" at 136:52-136:55 (leading: Space)
-1373: Colon           ":" at 136:55-136:56
-1374: Amp             "&" at 136:57-136:58 (leading: Space)
-1375: Ident           "K" at 136:58-136:59
-1376: RParen          ")" at 136:59-136:60
-1377: Arrow           "->" at 136:61-136:63 (leading: Space)
-1378: Ident           "bool" at 136:64-136:68 (leading: Space)
-1379: Semicolon       ";" at 136:68-136:69
-1380: At              "@" at 137:1-137:2 (leading: Newline)
-1381: Ident           "intrinsic" at 137:2-137:11
-1382: KwFn            "fn" at 137:12-137:14 (leading: Space)
-1383: Ident           "rt_map_get_ref" at 137:15-137:29 (leading: Space)
-1384: Lt              "<" at 137:29-137:30
-1385: Ident           "K" at 137:30-137:31
-1386: Comma           "," at 137:31-137:32
-1387: Ident           "V" at 137:33-137:34 (leading: Space)
-1388: Gt              ">" at 137:34-137:35
-1389: LParen          "(" at 137:35-137:36
-1390: Ident           "m" at 137:36-137:37
-1391: Colon           ":" at 137:37-137:38
-1392: Amp             "&" at 137:39-137:40 (leading: Space)
-1393: Ident           "Map" at 137:40-137:43
-1394: Lt              "<" at 137:43-137:44
-1395: Ident           "K" at 137:44-137:45
-1396: Comma           "," at 137:45-137:46
-1397: Ident           "V" at 137:47-137:48 (leading: Space)
-1398: Gt              ">" at 137:48-137:49
-1399: Comma           "," at 137:49-137:50
-1400: Ident           "key" at 137:51-137:54 (leading: Space)
-1401: Colon           ":" at 137:54-137:55
-1402: Amp             "&" at 137:56-137:57 (leading: Space)
-1403: Ident           "K" at 137:57-137:58
-1404: RParen          ")" at 137:58-137:59
-1405: Arrow           "->" at 137:60-137:62 (leading: Space)
-1406: Ident           "Option" at 137:63-137:69 (leading: Space)
-1407: Lt              "<" at 137:69-137:70
-1408: Amp             "&" at 137:70-137:71
-1409: Ident           "V" at 137:71-137:72
-1410: Gt              ">" at 137:72-137:73
-1411: Semicolon       ";" at 137:73-137:74
-1412: At              "@" at 138:1-138:2 (leading: Newline)
-1413: Ident           "intrinsic" at 138:2-138:11
-1414: KwFn            "fn" at 138:12-138:14 (leading: Space)
-1415: Ident           "rt_map_get_mut" at 138:15-138:29 (leading: Space)
-1416: Lt              "<" at 138:29-138:30
-1417: Ident           "K" at 138:30-138:31
-1418: Comma           "," at 138:31-138:32
-1419: Ident           "V" at 138:33-138:34 (leading: Space)
-1420: Gt              ">" at 138:34-138:35
-1421: LParen          "(" at 138:35-138:36
-1422: Ident           "m" at 138:36-138:37
-1423: Colon           ":" at 138:37-138:38
-1424: Amp             "&" at 138:39-138:40 (leading: Space)
-1425: KwMut           "mut" at 138:40-138:43
-1426: Ident           "Map" at 138:44-138:47 (leading: Space)
-1427: Lt              "<" at 138:47-138:48
-1428: Ident           "K" at 138:48-138:49
-1429: Comma           "," at 138:49-138:50
-1430: Ident           "V" at 138:51-138:52 (leading: Space)
-1431: Gt              ">" at 138:52-138:53
-1432: Comma           "," at 138:53-138:54
-1433: Ident           "key" at 138:55-138:58 (leading: Space)
-1434: Colon           ":" at 138:58-138:59
-1435: Amp             "&" at 138:60-138:61 (leading: Space)
-1436: Ident           "K" at 138:61-138:62
-1437: RParen          ")" at 138:62-138:63
-1438: Arrow           "->" at 138:64-138:66 (leading: Space)
-1439: Ident           "Option" at 138:67-138:73 (leading: Space)
-1440: Lt              "<" at 138:73-138:74
-1441: Amp             "&" at 138:74-138:75
-1442: KwMut           "mut" at 138:75-138:78
-1443: Ident           "V" at 138:79-138:80 (leading: Space)
-1444: Gt              ">" at 138:80-138:81
-1445: Semicolon       ";" at 138:81-138:82
-1446: At              "@" at 139:1-139:2 (leading: Newline)
-1447: Ident           "intrinsic" at 139:2-139:11
-1448: KwFn            "fn" at 139:12-139:14 (leading: Space)
-1449: Ident           "rt_map_insert" at 139:15-139:28 (leading: Space)
-1450: Lt              "<" at 139:28-139:29
-1451: Ident           "K" at 139:29-139:30
-1452: Comma           "," at 139:30-139:31
-1453: Ident           "V" at 139:32-139:33 (leading: Space)
-1454: Gt              ">" at 139:33-139:34
-1455: LParen          "(" at 139:34-139:35
-1456: Ident           "m" at 139:35-139:36
-1457: Colon           ":" at 139:36-139:37
-1458: Amp             "&" at 139:38-139:39 (leading: Space)
-1459: KwMut           "mut" at 139:39-139:42
-1460: Ident           "Map" at 139:43-139:46 (leading: Space)
-1461: Lt              "<" at 139:46-139:47
-1462: Ident           "K" at 139:47-139:48
-1463: Comma           "," at 139:48-139:49
-1464: Ident           "V" at 139:50-139:51 (leading: Space)
-1465: Gt              ">" at 139:51-139:52
-1466: Comma           "," at 139:52-139:53
-1467: Ident           "key" at 139:54-139:57 (leading: Space)
-1468: Colon           ":" at 139:57-139:58
-1469: Ident           "K" at 139:59-139:60 (leading: Space)
-1470: Comma           "," at 139:60-139:61
-1471: Ident           "value" at 139:62-139:67 (leading: Space)
-1472: Colon           ":" at 139:67-139:68
-1473: Ident           "V" at 139:69-139:70 (leading: Space)
-1474: RParen          ")" at 139:70-139:71
-1475: Arrow           "->" at 139:72-139:74 (leading: Space)
-1476: Ident           "Option" at 139:75-139:81 (leading: Space)
-1477: Lt              "<" at 139:81-139:82
-1478: Ident           "V" at 139:82-139:83
-1479: Gt              ">" at 139:83-139:84
-1480: Semicolon       ";" at 139:84-139:85
-1481: At              "@" at 140:1-140:2 (leading: Newline)
-1482: Ident           "intrinsic" at 140:2-140:11
-1483: KwFn            "fn" at 140:12-140:14 (leading: Space)
-1484: Ident           "rt_map_remove" at 140:15-140:28 (leading: Space)
-1485: Lt              "<" at 140:28-140:29
-1486: Ident           "K" at 140:29-140:30
-1487: Comma           "," at 140:30-140:31
-1488: Ident           "V" at 140:32-140:33 (leading: Space)
-1489: Gt              ">" at 140:33-140:34
-1490: LParen          "(" at 140:34-140:35
-1491: Ident           "m" at 140:35-140:36
-1492: Colon           ":" at 140:36-140:37
-1493: Amp             "&" at 140:38-140:39 (leading: Space)
-1494: KwMut           "mut" at 140:39-140:42
-1495: Ident           "Map" at 140:43-140:46 (leading: Space)
-1496: Lt              "<" at 140:46-140:47
-1497: Ident           "K" at 140:47-140:48
-1498: Comma           "," at 140:48-140:49
-1499: Ident           "V" at 140:50-140:51 (leading: Space)
-1500: Gt              ">" at 140:51-140:52
-1501: Comma           "," at 140:52-140:53
-1502: Ident           "key" at 140:54-140:57 (leading: Space)
-1503: Colon           ":" at 140:57-140:58
-1504: Amp             "&" at 140:59-140:60 (leading: Space)
-1505: Ident           "K" at 140:60-140:61
-1506: RParen          ")" at 140:61-140:62
-1507: Arrow           "->" at 140:63-140:65 (leading: Space)
-1508: Ident           "Option" at 140:66-140:72 (leading: Space)
-1509: Lt              "<" at 140:72-140:73
-1510: Ident           "V" at 140:73-140:74
-1511: Gt              ">" at 140:74-140:75
-1512: Semicolon       ";" at 140:75-140:76
-1513: At              "@" at 141:1-141:2 (leading: Newline)
-1514: Ident           "intrinsic" at 141:2-141:11
-1515: KwFn            "fn" at 141:12-141:14 (leading: Space)
-1516: Ident           "rt_map_keys" at 141:15-141:26 (leading: Space)
-1517: Lt              "<" at 141:26-141:27
-1518: Ident           "K" at 141:27-141:28
-1519: Comma           "," at 141:28-141:29
-1520: Ident           "V" at 141:30-141:31 (leading: Space)
-1521: Gt              ">" at 141:31-141:32
-1522: LParen          "(" at 141:32-141:33
-1523: Ident           "m" at 141:33-141:34
-1524: Colon           ":" at 141:34-141:35
-1525: Amp             "&" at 141:36-141:37 (leading: Space)
-1526: Ident           "Map" at 141:37-141:40
-1527: Lt              "<" at 141:40-141:41
-1528: Ident           "K" at 141:41-141:42
-1529: Comma           "," at 141:42-141:43
-1530: Ident           "V" at 141:44-141:45 (leading: Space)
-1531: Gt              ">" at 141:45-141:46
-1532: RParen          ")" at 141:46-141:47
-1533: Arrow           "->" at 141:48-141:50 (leading: Space)
-1534: Ident           "K" at 141:51-141:52 (leading: Space)
-1535: LBracket        "[" at 141:52-141:53
-1536: RBracket        "]" at 141:53-141:54
-1537: Semicolon       ";" at 141:54-141:55
-1538: At              "@" at 144:1-144:2 (leading: Newline, LineComment, Newline)
-1539: Ident           "intrinsic" at 144:2-144:11
-1540: KwPub           "pub" at 145:1-145:4 (leading: Newline)
-1541: KwFn            "fn" at 145:5-145:7 (leading: Space)
-1542: Ident           "readline" at 145:8-145:16 (leading: Space)
-1543: LParen          "(" at 145:16-145:17
-1544: RParen          ")" at 145:17-145:18
-1545: Arrow           "->" at 145:19-145:21 (leading: Space)
-1546: Ident           "string" at 145:22-145:28 (leading: Space)
-1547: Semicolon       ";" at 145:28-145:29
-1548: At              "@" at 147:1-147:2 (leading: Newline)
-1549: Ident           "intrinsic" at 147:2-147:11
-1550: KwPub           "pub" at 148:1-148:4 (leading: Newline)
-1551: KwType          "type" at 148:5-148:9 (leading: Space)
-1552: Ident           "Range" at 148:10-148:15 (leading: Space)
-1553: Lt              "<" at 148:15-148:16
-1554: Ident           "T" at 148:16-148:17
-1555: Gt              ">" at 148:17-148:18
-1556: Assign          "=" at 148:19-148:20 (leading: Space)
-1557: LBrace          "{" at 148:21-148:22 (leading: Space)
-1558: Ident           "__state" at 149:5-149:12 (leading: Newline, Space)
-1559: Colon           ":" at 149:12-149:13
-1560: Star            "*" at 149:14-149:15 (leading: Space)
-1561: Ident           "byte" at 149:15-149:19
-1562: Comma           "," at 149:19-149:20
-1563: RBrace          "}" at 150:1-150:2 (leading: Newline)
-1564: Semicolon       ";" at 150:2-150:3
-1565: At              "@" at 153:1-153:2 (leading: Newline, LineComment, Newline)
-1566: Ident           "intrinsic" at 153:2-153:11
-1567: KwPub           "pub" at 153:12-153:15 (leading: Space)
-1568: KwFn            "fn" at 153:16-153:18 (leading: Space)
-1569: Ident           "rt_range_int_new" at 153:19-153:35 (leading: Space)
-1570: LParen          "(" at 153:35-153:36
-1571: Ident           "start" at 153:36-153:41
-1572: Colon           ":" at 153:41-153:42
-1573: Ident           "int" at 153:43-153:46 (leading: Space)
-1574: Comma           "," at 153:46-153:47
-1575: Ident           "end" at 153:48-153:51 (leading: Space)
-1576: Colon           ":" at 153:51-153:52
-1577: Ident           "int" at 153:53-153:56 (leading: Space)
-1578: Comma           "," at 153:56-153:57
-1579: Ident           "inclusive" at 153:58-153:67 (leading: Space)
-1580: Colon           ":" at 153:67-153:68
-1581: Ident           "bool" at 153:69-153:73 (leading: Space)
-1582: RParen          ")" at 153:73-153:74
-1583: Arrow           "->" at 153:75-153:77 (leading: Space)
-1584: Ident           "Range" at 153:78-153:83 (leading: Space)
-1585: Lt              "<" at 153:83-153:84
-1586: Ident           "int" at 153:84-153:87
-1587: Gt              ">" at 153:87-153:88
-1588: Semicolon       ";" at 153:88-153:89
-1589: At              "@" at 154:1-154:2 (leading: Newline)
-1590: Ident           "intrinsic" at 154:2-154:11
-1591: KwPub           "pub" at 154:12-154:15 (leading: Space)
-1592: KwFn            "fn" at 154:16-154:18 (leading: Space)
-1593: Ident           "rt_range_int_from_start" at 154:19-154:42 (leading: Space)
-1594: LParen          "(" at 154:42-154:43
-1595: Ident           "start" at 154:43-154:48
-1596: Colon           ":" at 154:48-154:49
-1597: Ident           "int" at 154:50-154:53 (leading: Space)
-1598: Comma           "," at 154:53-154:54
-1599: Ident           "inclusive" at 154:55-154:64 (leading: Space)
-1600: Colon           ":" at 154:64-154:65
-1601: Ident           "bool" at 154:66-154:70 (leading: Space)
-1602: RParen          ")" at 154:70-154:71
-1603: Arrow           "->" at 154:72-154:74 (leading: Space)
-1604: Ident           "Range" at 154:75-154:80 (leading: Space)
-1605: Lt              "<" at 154:80-154:81
-1606: Ident           "int" at 154:81-154:84
-1607: Gt              ">" at 154:84-154:85
-1608: Semicolon       ";" at 154:85-154:86
-1609: At              "@" at 155:1-155:2 (leading: Newline)
-1610: Ident           "intrinsic" at 155:2-155:11
-1611: KwPub           "pub" at 155:12-155:15 (leading: Space)
-1612: KwFn            "fn" at 155:16-155:18 (leading: Space)
-1613: Ident           "rt_range_int_to_end" at 155:19-155:38 (leading: Space)
-1614: LParen          "(" at 155:38-155:39
-1615: Ident           "end" at 155:39-155:42
-1616: Colon           ":" at 155:42-155:43
-1617: Ident           "int" at 155:44-155:47 (leading: Space)
-1618: Comma           "," at 155:47-155:48
-1619: Ident           "inclusive" at 155:49-155:58 (leading: Space)
-1620: Colon           ":" at 155:58-155:59
-1621: Ident           "bool" at 155:60-155:64 (leading: Space)
-1622: RParen          ")" at 155:64-155:65
-1623: Arrow           "->" at 155:66-155:68 (leading: Space)
-1624: Ident           "Range" at 155:69-155:74 (leading: Space)
-1625: Lt              "<" at 155:74-155:75
-1626: Ident           "int" at 155:75-155:78
-1627: Gt              ">" at 155:78-155:79
-1628: Semicolon       ";" at 155:79-155:80
-1629: At              "@" at 156:1-156:2 (leading: Newline)
-1630: Ident           "intrinsic" at 156:2-156:11
-1631: KwPub           "pub" at 156:12-156:15 (leading: Space)
-1632: KwFn            "fn" at 156:16-156:18 (leading: Space)
-1633: Ident           "rt_range_int_full" at 156:19-156:36 (leading: Space)
-1634: LParen          "(" at 156:36-156:37
-1635: Ident           "inclusive" at 156:37-156:46
-1636: Colon           ":" at 156:46-156:47
-1637: Ident           "bool" at 156:48-156:52 (leading: Space)
-1638: RParen          ")" at 156:52-156:53
-1639: Arrow           "->" at 156:54-156:56 (leading: Space)
-1640: Ident           "Range" at 156:57-156:62 (leading: Space)
-1641: Lt              "<" at 156:62-156:63
-1642: Ident           "int" at 156:63-156:66
-1643: Gt              ">" at 156:66-156:67
-1644: Semicolon       ";" at 156:67-156:68
-1645: KwExtern        "extern" at 158:1-158:7 (leading: Newline)
-1646: Lt              "<" at 158:7-158:8
-1647: Ident           "Range" at 158:8-158:13
-1648: Lt              "<" at 158:13-158:14
-1649: Ident           "T" at 158:14-158:15
-1650: Shr             ">>" at 158:15-158:17
-1651: LBrace          "{" at 158:18-158:19 (leading: Space)
-1652: At              "@" at 159:5-159:6 (leading: Newline, Space)
-1653: Ident           "intrinsic" at 159:6-159:15
-1654: KwPub           "pub" at 159:16-159:19 (leading: Space)
-1655: KwFn            "fn" at 159:20-159:22 (leading: Space)
-1656: Ident           "next" at 159:23-159:27 (leading: Space)
-1657: LParen          "(" at 159:27-159:28
-1658: Ident           "self" at 159:28-159:32
-1659: Colon           ":" at 159:32-159:33
-1660: Amp             "&" at 159:34-159:35 (leading: Space)
-1661: KwMut           "mut" at 159:35-159:38
-1662: Ident           "Range" at 159:39-159:44 (leading: Space)
-1663: Lt              "<" at 159:44-159:45
-1664: Ident           "T" at 159:45-159:46
-1665: Gt              ">" at 159:46-159:47
-1666: RParen          ")" at 159:47-159:48
-1667: Arrow           "->" at 159:49-159:51 (leading: Space)
-1668: Ident           "Option" at 159:52-159:58 (leading: Space)
-1669: Lt              "<" at 159:58-159:59
-1670: Ident           "T" at 159:59-159:60
-1671: Gt              ">" at 159:60-159:61
-1672: Semicolon       ";" at 159:61-159:62
-1673: RBrace          "}" at 160:1-160:2 (leading: Newline)
-1674: KwPub           "pub" at 162:1-162:4 (leading: Newline)
-1675: KwType          "type" at 162:5-162:9 (leading: Space)
-1676: Ident           "HeapStats" at 162:10-162:19 (leading: Space)
-1677: Assign          "=" at 162:20-162:21 (leading: Space)
-1678: LBrace          "{" at 162:22-162:23 (leading: Space)
-1679: Ident           "alloc_count" at 163:5-163:16 (leading: Newline, Space)
-1680: Colon           ":" at 163:16-163:17
-1681: Ident           "uint" at 163:18-163:22 (leading: Space)
-1682: Comma           "," at 163:22-163:23
-1683: Ident           "free_count" at 164:5-164:15 (leading: Newline, Space)
-1684: Colon           ":" at 164:15-164:16
-1685: Ident           "uint" at 164:17-164:21 (leading: Space)
-1686: Comma           "," at 164:21-164:22
-1687: Ident           "live_blocks" at 165:5-165:16 (leading: Newline, Space)
-1688: Colon           ":" at 165:16-165:17
-1689: Ident           "uint" at 165:18-165:22 (leading: Space)
-1690: Comma           "," at 165:22-165:23
-1691: Ident           "live_bytes" at 166:5-166:15 (leading: Newline, Space)
-1692: Colon           ":" at 166:15-166:16
-1693: Ident           "uint" at 166:17-166:21 (leading: Space)
-1694: Comma           "," at 166:21-166:22
-1695: Ident           "rc_increments" at 167:5-167:18 (leading: Newline, Space)
-1696: Colon           ":" at 167:18-167:19
-1697: Ident           "uint" at 167:20-167:24 (leading: Space)
-1698: Comma           "," at 167:24-167:25
-1699: Ident           "rc_decrements" at 168:5-168:18 (leading: Newline, Space)
-1700: Colon           ":" at 168:18-168:19
-1701: Ident           "uint" at 168:20-168:24 (leading: Space)
-1702: Comma           "," at 168:24-168:25
-1703: RBrace          "}" at 169:1-169:2 (leading: Newline)
-1704: Semicolon       ";" at 169:2-169:3
-1705: At              "@" at 175:1-175:2 (leading: Newline, LineComment, Newline, LineComment, Newline, LineComment, Newline, LineComment, Newline)
-1706: Ident           "intrinsic" at 175:2-175:11
-1707: KwPub           "pub" at 175:12-175:15 (leading: Space)
-1708: KwFn            "fn" at 175:16-175:18 (leading: Space)
-1709: Ident           "rt_heap_stats" at 175:19-175:32 (leading: Space)
-1710: LParen          "(" at 175:32-175:33
-1711: RParen          ")" at 175:33-175:34
-1712: Arrow           "->" at 175:35-175:37 (leading: Space)
-1713: Ident           "HeapStats" at 175:38-175:47 (leading: Space)
-1714: Semicolon       ";" at 175:47-175:48
-1715: At              "@" at 177:1-177:2 (leading: Newline, LineComment, Newline)
-1716: Ident           "intrinsic" at 177:2-177:11
-1717: KwPub           "pub" at 177:12-177:15 (leading: Space)
-1718: KwFn            "fn" at 177:16-177:18 (leading: Space)
-1719: Ident           "rt_heap_dump" at 177:19-177:31 (leading: Space)
-1720: LParen          "(" at 177:31-177:32
-1721: RParen          ")" at 177:32-177:33
-1722: Arrow           "->" at 177:34-177:36 (leading: Space)
-1723: Ident           "string" at 177:37-177:43 (leading: Space)
-1724: Semicolon       ";" at 177:43-177:44
-1725: At              "@" at 179:1-179:2 (leading: Newline, LineComment, Newline)
-1726: Ident           "intrinsic" at 179:2-179:11
-1727: KwPub           "pub" at 179:12-179:15 (leading: Space)
-1728: KwFn            "fn" at 179:16-179:18 (leading: Space)
-1729: Ident           "rt_worker_count" at 179:19-179:34 (leading: Space)
-1730: LParen          "(" at 179:34-179:35
-1731: RParen          ")" at 179:35-179:36
-1732: Arrow           "->" at 179:37-179:39 (leading: Space)
-1733: Ident           "uint" at 179:40-179:44 (leading: Space)
-1734: Semicolon       ";" at 179:44-179:45
-1735: KwPub           "pub" at 181:1-181:4 (leading: Newline)
-1736: KwType          "type" at 181:5-181:9 (leading: Space)
-1737: Ident           "Task" at 181:10-181:14 (leading: Space)
-1738: Lt              "<" at 181:14-181:15
-1739: Ident           "T" at 181:15-181:16
-1740: Gt              ">" at 181:16-181:17
-1741: Assign          "=" at 181:18-181:19 (leading: Space)
-1742: LBrace          "{" at 181:20-181:21 (leading: Space)
-1743: Ident           "__opaque" at 182:5-182:13 (leading: Newline, Space)
-1744: Colon           ":" at 182:13-182:14
-1745: Ident           "int" at 182:15-182:18 (leading: Space)
-1746: Comma           "," at 182:18-182:19
-1747: RBrace          "}" at 183:1-183:2 (leading: Newline)
-1748: Semicolon       ";" at 183:2-183:3
-1749: KwPub           "pub" at 185:1-185:4 (leading: Newline)
-1750: KwTag           "tag" at 185:5-185:8 (leading: Space)
-1751: Ident           "Cancelled" at 185:9-185:18 (leading: Space)
-1752: LParen          "(" at 185:18-185:19
-1753: RParen          ")" at 185:19-185:20
-1754: Semicolon       ";" at 185:20-185:21
-1755: KwPub           "pub" at 186:1-186:4 (leading: Newline)
-1756: KwType          "type" at 186:5-186:9 (leading: Space)
-1757: Ident           "TaskResult" at 186:10-186:20 (leading: Space)
-1758: Lt              "<" at 186:20-186:21
-1759: Ident           "T" at 186:21-186:22
-1760: Gt              ">" at 186:22-186:23
-1761: Assign          "=" at 186:24-186:25 (leading: Space)
-1762: Ident           "Success" at 186:26-186:33 (leading: Space)
-1763: LParen          "(" at 186:33-186:34
-1764: Ident           "T" at 186:34-186:35
-1765: RParen          ")" at 186:35-186:36
-1766: Pipe            "|" at 186:37-186:38 (leading: Space)
-1767: Ident           "Cancelled" at 186:39-186:48 (leading: Space)
-1768: Semicolon       ";" at 186:48-186:49
-1769: At              "@" at 188:1-188:2 (leading: Newline)
-1770: Ident           "intrinsic" at 188:2-188:11
-1771: KwFn            "fn" at 188:12-188:14 (leading: Space)
-1772: Ident           "rt_scope_enter" at 188:15-188:29 (leading: Space)
-1773: LParen          "(" at 188:29-188:30
-1774: Ident           "failfast" at 188:30-188:38
-1775: Colon           ":" at 188:38-188:39
-1776: Ident           "bool" at 188:40-188:44 (leading: Space)
-1777: RParen          ")" at 188:44-188:45
-1778: Arrow           "->" at 188:46-188:48 (leading: Space)
-1779: Ident           "uint" at 188:49-188:53 (leading: Space)
-1780: Semicolon       ";" at 188:53-188:54
-1781: At              "@" at 189:1-189:2 (leading: Newline)
-1782: Ident           "intrinsic" at 189:2-189:11
-1783: KwFn            "fn" at 189:12-189:14 (leading: Space)
-1784: Ident           "rt_scope_register_child" at 189:15-189:38 (leading: Space)
-1785: Lt              "<" at 189:38-189:39
-1786: Ident           "T" at 189:39-189:40
-1787: Gt              ">" at 189:40-189:41
-1788: LParen          "(" at 189:41-189:42
-1789: Ident           "scope" at 189:42-189:47
-1790: Colon           ":" at 189:47-189:48
-1791: Ident           "uint" at 189:49-189:53 (leading: Space)
-1792: Comma           "," at 189:53-189:54
-1793: Ident           "child" at 189:55-189:60 (leading: Space)
-1794: Colon           ":" at 189:60-189:61
-1795: Ident           "Task" at 189:62-189:66 (leading: Space)
-1796: Lt              "<" at 189:66-189:67
-1797: Ident           "T" at 189:67-189:68
-1798: Gt              ">" at 189:68-189:69
-1799: RParen          ")" at 189:69-189:70
-1800: Arrow           "->" at 189:71-189:73 (leading: Space)
-1801: NothingLit      "nothing" at 189:74-189:81 (leading: Space)
-1802: Semicolon       ";" at 189:81-189:82
-1803: At              "@" at 190:1-190:2 (leading: Newline)
-1804: Ident           "intrinsic" at 190:2-190:11
-1805: KwFn            "fn" at 190:12-190:14 (leading: Space)
-1806: Ident           "rt_scope_cancel_all" at 190:15-190:34 (leading: Space)
-1807: LParen          "(" at 190:34-190:35
-1808: Ident           "scope" at 190:35-190:40
-1809: Colon           ":" at 190:40-190:41
-1810: Ident           "uint" at 190:42-190:46 (leading: Space)
-1811: RParen          ")" at 190:46-190:47
-1812: Arrow           "->" at 190:48-190:50 (leading: Space)
-1813: NothingLit      "nothing" at 190:51-190:58 (leading: Space)
-1814: Semicolon       ";" at 190:58-190:59
-1815: At              "@" at 191:1-191:2 (leading: Newline)
-1816: Ident           "intrinsic" at 191:2-191:11
-1817: KwFn            "fn" at 191:12-191:14 (leading: Space)
-1818: Ident           "rt_scope_join_all" at 191:15-191:32 (leading: Space)
-1819: LParen          "(" at 191:32-191:33
-1820: Ident           "scope" at 191:33-191:38
-1821: Colon           ":" at 191:38-191:39
-1822: Ident           "uint" at 191:40-191:44 (leading: Space)
-1823: RParen          ")" at 191:44-191:45
-1824: Arrow           "->" at 191:46-191:48 (leading: Space)
-1825: Ident           "bool" at 191:49-191:53 (leading: Space)
-1826: Semicolon       ";" at 191:53-191:54
-1827: At              "@" at 192:1-192:2 (leading: Newline)
-1828: Ident           "intrinsic" at 192:2-192:11
-1829: KwFn            "fn" at 192:12-192:14 (leading: Space)
-1830: Ident           "rt_scope_exit" at 192:15-192:28 (leading: Space)
-1831: LParen          "(" at 192:28-192:29
-1832: Ident           "scope" at 192:29-192:34
-1833: Colon           ":" at 192:34-192:35
-1834: Ident           "uint" at 192:36-192:40 (leading: Space)
-1835: RParen          ")" at 192:40-192:41
-1836: Arrow           "->" at 192:42-192:44 (leading: Space)
-1837: NothingLit      "nothing" at 192:45-192:52 (leading: Space)
-1838: Semicolon       ";" at 192:52-192:53
-1839: KwExtern        "extern" at 194:1-194:7 (leading: Newline)
-1840: Lt              "<" at 194:7-194:8
-1841: Ident           "Task" at 194:8-194:12
-1842: Lt              "<" at 194:12-194:13
-1843: Ident           "T" at 194:13-194:14
-1844: Shr             ">>" at 194:14-194:16
-1845: LBrace          "{" at 194:17-194:18 (leading: Space)
-1846: At              "@" at 195:5-195:6 (leading: Newline, Space)
-1847: Ident           "intrinsic" at 195:6-195:15
-1848: KwPub           "pub" at 195:16-195:19 (leading: Space)
-1849: KwFn            "fn" at 195:20-195:22 (leading: Space)
-1850: Ident           "clone" at 195:23-195:28 (leading: Space)
-1851: LParen          "(" at 195:28-195:29
-1852: Ident           "self" at 195:29-195:33
-1853: Colon           ":" at 195:33-195:34
-1854: Amp             "&" at 195:35-195:36 (leading: Space)
-1855: Ident           "Task" at 195:36-195:40
-1856: Lt              "<" at 195:40-195:41
-1857: Ident           "T" at 195:41-195:42
-1858: Gt              ">" at 195:42-195:43
-1859: RParen          ")" at 195:43-195:44
-1860: Arrow           "->" at 195:45-195:47 (leading: Space)
-1861: Ident           "Task" at 195:48-195:52 (leading: Space)
-1862: Lt              "<" at 195:52-195:53
-1863: Ident           "T" at 195:53-195:54
-1864: Gt              ">" at 195:54-195:55
-1865: Semicolon       ";" at 195:55-195:56
-1866: At              "@" at 196:5-196:6 (leading: Newline, Space)
-1867: Ident           "intrinsic" at 196:6-196:15
-1868: KwPub           "pub" at 196:16-196:19 (leading: Space)
-1869: KwFn            "fn" at 196:20-196:22 (leading: Space)
-1870: Ident           "cancel" at 196:23-196:29 (leading: Space)
-1871: LParen          "(" at 196:29-196:30
-1872: Ident           "self" at 196:30-196:34
-1873: Colon           ":" at 196:34-196:35
-1874: Amp             "&" at 196:36-196:37 (leading: Space)
-1875: Ident           "Task" at 196:37-196:41
-1876: Lt              "<" at 196:41-196:42
-1877: Ident           "T" at 196:42-196:43
-1878: Gt              ">" at 196:43-196:44
-1879: RParen          ")" at 196:44-196:45
-1880: Arrow           "->" at 196:46-196:48 (leading: Space)
-1881: NothingLit      "nothing" at 196:49-196:56 (leading: Space)
-1882: Semicolon       ";" at 196:56-196:57
-1883: At              "@" at 197:5-197:6 (leading: Newline, Space)
-1884: Ident           "intrinsic" at 197:6-197:15
-1885: KwPub           "pub" at 197:16-197:19 (leading: Space)
-1886: KwFn            "fn" at 197:20-197:22 (leading: Space)
-1887: Ident           "await" at 197:23-197:28 (leading: Space)
-1888: LParen          "(" at 197:28-197:29
-1889: Ident           "self" at 197:29-197:33
-1890: Colon           ":" at 197:33-197:34
-1891: KwOwn           "own" at 197:35-197:38 (leading: Space)
-1892: Ident           "Task" at 197:39-197:43 (leading: Space)
-1893: Lt              "<" at 197:43-197:44
-1894: Ident           "T" at 197:44-197:45
-1895: Gt              ">" at 197:45-197:46
-1896: RParen          ")" at 197:46-197:47
-1897: Arrow           "->" at 197:48-197:50 (leading: Space)
-1898: Ident           "TaskResult" at 197:51-197:61 (leading: Space)
-1899: Lt              "<" at 197:61-197:62
-1900: Ident           "T" at 197:62-197:63
-1901: Gt              ">" at 197:63-197:64
-1902: Semicolon       ";" at 197:64-197:65
-1903: RBrace          "}" at 198:1-198:2 (leading: Newline)
-1904: At              "@" at 202:1-202:2 (leading: Newline, LineComment, Newline, LineComment, Newline)
-1905: Ident           "intrinsic" at 202:2-202:11
-1906: KwPub           "pub" at 203:1-203:4 (leading: Newline)
-1907: KwFn            "fn" at 203:5-203:7 (leading: Space)
-1908: Ident           "checkpoint" at 203:8-203:18 (leading: Space)
-1909: LParen          "(" at 203:18-203:19
-1910: RParen          ")" at 203:19-203:20
-1911: Arrow           "->" at 203:21-203:23 (leading: Space)
-1912: Ident           "Task" at 203:24-203:28 (leading: Space)
-1913: Lt              "<" at 203:28-203:29
-1914: NothingLit      "nothing" at 203:29-203:36
-1915: Gt              ">" at 203:36-203:37
-1916: Semicolon       ";" at 203:37-203:38
-1917: At              "@" at 206:1-206:2 (leading: Newline, LineComment, Newline)
-1918: Ident           "intrinsic" at 206:2-206:11
-1919: KwPub           "pub" at 206:12-206:15 (leading: Space)
-1920: KwFn            "fn" at 206:16-206:18 (leading: Space)
-1921: Ident           "sleep" at 206:19-206:24 (leading: Space)
-1922: LParen          "(" at 206:24-206:25
-1923: Ident           "ms" at 206:25-206:27
-1924: Colon           ":" at 206:27-206:28
-1925: Ident           "uint" at 206:29-206:33 (leading: Space)
-1926: RParen          ")" at 206:33-206:34
-1927: Arrow           "->" at 206:35-206:37 (leading: Space)
-1928: Ident           "Task" at 206:38-206:42 (leading: Space)
-1929: Lt              "<" at 206:42-206:43
-1930: NothingLit      "nothing" at 206:43-206:50
-1931: Gt              ">" at 206:50-206:51
-1932: Semicolon       ";" at 206:51-206:52
-1933: At              "@" at 210:1-210:2 (leading: Newline, LineComment, Newline, LineComment, Newline)
-1934: Ident           "intrinsic" at 210:2-210:11
-1935: KwPub           "pub" at 210:12-210:15 (leading: Space)
-1936: KwFn            "fn" at 210:16-210:18 (leading: Space)
-1937: Ident           "timeout" at 210:19-210:26 (leading: Space)
-1938: Lt              "<" at 210:26-210:27
-1939: Ident           "T" at 210:27-210:28
-1940: Gt              ">" at 210:28-210:29
-1941: LParen          "(" at 210:29-210:30
-1942: Ident           "t" at 210:30-210:31
-1943: Colon           ":" at 210:31-210:32
-1944: Ident           "Task" at 210:33-210:37 (leading: Space)
-1945: Lt              "<" at 210:37-210:38
-1946: Ident           "T" at 210:38-210:39
-1947: Gt              ">" at 210:39-210:40
-1948: Comma           "," at 210:40-210:41
-1949: Ident           "ms" at 210:42-210:44 (leading: Space)
-1950: Colon           ":" at 210:44-210:45
-1951: Ident           "uint" at 210:46-210:50 (leading: Space)
-1952: RParen          ")" at 210:50-210:51
-1953: Arrow           "->" at 210:52-210:54 (leading: Space)
-1954: Ident           "TaskResult" at 210:55-210:65 (leading: Space)
-1955: Lt              "<" at 210:65-210:66
-1956: Ident           "T" at 210:66-210:67
-1957: Gt              ">" at 210:67-210:68
-1958: Semicolon       ";" at 210:68-210:69
-1959: At              "@" at 213:1-213:2 (leading: Newline, LineComment, Newline)
-1960: Ident           "copy" at 213:2-213:6
-1961: At              "@" at 214:1-214:2 (leading: Newline)
-1962: Ident           "intrinsic" at 214:2-214:11
-1963: KwPub           "pub" at 215:1-215:4 (leading: Newline)
-1964: KwType          "type" at 215:5-215:9 (leading: Space)
-1965: Ident           "Channel" at 215:10-215:17 (leading: Space)
-1966: Lt              "<" at 215:17-215:18
-1967: Ident           "T" at 215:18-215:19
-1968: Gt              ">" at 215:19-215:20
-1969: Assign          "=" at 215:21-215:22 (leading: Space)
-1970: LBrace          "{" at 215:23-215:24 (leading: Space)
-1971: Ident           "__opaque" at 216:5-216:13 (leading: Newline, Space)
-1972: Colon           ":" at 216:13-216:14
-1973: Star            "*" at 216:15-216:16 (leading: Space)
-1974: Ident           "byte" at 216:16-216:20
-1975: Comma           "," at 216:20-216:21
-1976: RBrace          "}" at 217:1-217:2 (leading: Newline)
-1977: Semicolon       ";" at 217:2-217:3
-1978: KwExtern        "extern" at 219:1-219:7 (leading: Newline)
-1979: Lt              "<" at 219:7-219:8
-1980: Ident           "Channel" at 219:8-219:15
-1981: Lt              "<" at 219:15-219:16
-1982: Ident           "T" at 219:16-219:17
-1983: Shr             ">>" at 219:17-219:19
-1984: LBrace          "{" at 219:20-219:21 (leading: Space)
-1985: At              "@" at 221:5-221:6 (leading: Newline, Space, LineComment, Newline, Space)
-1986: Ident           "intrinsic" at 221:6-221:15
-1987: KwPub           "pub" at 221:16-221:19 (leading: Space)
-1988: KwFn            "fn" at 221:20-221:22 (leading: Space)
-1989: Ident           "new" at 221:23-221:26 (leading: Space)
-1990: LParen          "(" at 221:26-221:27
-1991: Ident           "capacity" at 221:27-221:35
-1992: Colon           ":" at 221:35-221:36
-1993: Ident           "uint" at 221:37-221:41 (leading: Space)
-1994: RParen          ")" at 221:41-221:42
-1995: Arrow           "->" at 221:43-221:45 (leading: Space)
-1996: KwOwn           "own" at 221:46-221:49 (leading: Space)
-1997: Ident           "Channel" at 221:50-221:57 (leading: Space)
-1998: Lt              "<" at 221:57-221:58
-1999: Ident           "T" at 221:58-221:59
-2000: Gt              ">" at 221:59-221:60
-2001: Semicolon       ";" at 221:60-221:61
-2002: At              "@" at 223:5-223:6 (leading: Newline, Space, LineComment, Newline, Space)
-2003: Ident           "intrinsic" at 223:6-223:15
-2004: KwPub           "pub" at 223:16-223:19 (leading: Space)
-2005: KwFn            "fn" at 223:20-223:22 (leading: Space)
-2006: Ident           "send" at 223:23-223:27 (leading: Space)
-2007: LParen          "(" at 223:27-223:28
-2008: Ident           "self" at 223:28-223:32
-2009: Colon           ":" at 223:32-223:33
-2010: Amp             "&" at 223:34-223:35 (leading: Space)
-2011: Ident           "Channel" at 223:35-223:42
-2012: Lt              "<" at 223:42-223:43
-2013: Ident           "T" at 223:43-223:44
-2014: Gt              ">" at 223:44-223:45
-2015: Comma           "," at 223:45-223:46
-2016: Ident           "value" at 223:47-223:52 (leading: Space)
-2017: Colon           ":" at 223:52-223:53
-2018: KwOwn           "own" at 223:54-223:57 (leading: Space)
-2019: Ident           "T" at 223:58-223:59 (leading: Space)
-2020: RParen          ")" at 223:59-223:60
-2021: Arrow           "->" at 223:61-223:63 (leading: Space)
-2022: NothingLit      "nothing" at 223:64-223:71 (leading: Space)
-2023: Semicolon       ";" at 223:71-223:72
-2024: At              "@" at 225:5-225:6 (leading: Newline, Space, LineComment, Newline, Space)
-2025: Ident           "intrinsic" at 225:6-225:15
-2026: KwPub           "pub" at 225:16-225:19 (leading: Space)
-2027: KwFn            "fn" at 225:20-225:22 (leading: Space)
-2028: Ident           "recv" at 225:23-225:27 (leading: Space)
-2029: LParen          "(" at 225:27-225:28
-2030: Ident           "self" at 225:28-225:32
-2031: Colon           ":" at 225:32-225:33
-2032: Amp             "&" at 225:34-225:35 (leading: Space)
-2033: Ident           "Channel" at 225:35-225:42
-2034: Lt              "<" at 225:42-225:43
-2035: Ident           "T" at 225:43-225:44
-2036: Gt              ">" at 225:44-225:45
-2037: RParen          ")" at 225:45-225:46
-2038: Arrow           "->" at 225:47-225:49 (leading: Space)
-2039: Ident           "Option" at 225:50-225:56 (leading: Space)
-2040: Lt              "<" at 225:56-225:57
-2041: Ident           "T" at 225:57-225:58
-2042: Gt              ">" at 225:58-225:59
-2043: Semicolon       ";" at 225:59-225:60
-2044: At              "@" at 227:5-227:6 (leading: Newline, Space, LineComment, Newline, Space)
-2045: Ident           "intrinsic" at 227:6-227:15
-2046: KwPub           "pub" at 227:16-227:19 (leading: Space)
-2047: KwFn            "fn" at 227:20-227:22 (leading: Space)
-2048: Ident           "try_send" at 227:23-227:31 (leading: Space)
-2049: LParen          "(" at 227:31-227:32
-2050: Ident           "self" at 227:32-227:36
-2051: Colon           ":" at 227:36-227:37
-2052: Amp             "&" at 227:38-227:39 (leading: Space)
-2053: Ident           "Channel" at 227:39-227:46
-2054: Lt              "<" at 227:46-227:47
-2055: Ident           "T" at 227:47-227:48
-2056: Gt              ">" at 227:48-227:49
-2057: Comma           "," at 227:49-227:50
-2058: Ident           "value" at 227:51-227:56 (leading: Space)
-2059: Colon           ":" at 227:56-227:57
-2060: KwOwn           "own" at 227:58-227:61 (leading: Space)
-2061: Ident           "T" at 227:62-227:63 (leading: Space)
-2062: RParen          ")" at 227:63-227:64
-2063: Arrow           "->" at 227:65-227:67 (leading: Space)
-2064: Ident           "bool" at 227:68-227:72 (leading: Space)
-2065: Semicolon       ";" at 227:72-227:73
-2066: At              "@" at 229:5-229:6 (leading: Newline, Space, LineComment, Newline, Space)
-2067: Ident           "intrinsic" at 229:6-229:15
-2068: KwPub           "pub" at 229:16-229:19 (leading: Space)
-2069: KwFn            "fn" at 229:20-229:22 (leading: Space)
-2070: Ident           "try_recv" at 229:23-229:31 (leading: Space)
-2071: LParen          "(" at 229:31-229:32
-2072: Ident           "self" at 229:32-229:36
-2073: Colon           ":" at 229:36-229:37
-2074: Amp             "&" at 229:38-229:39 (leading: Space)
-2075: Ident           "Channel" at 229:39-229:46
-2076: Lt              "<" at 229:46-229:47
-2077: Ident           "T" at 229:47-229:48
-2078: Gt              ">" at 229:48-229:49
-2079: RParen          ")" at 229:49-229:50
-2080: Arrow           "->" at 229:51-229:53 (leading: Space)
-2081: Ident           "Option" at 229:54-229:60 (leading: Space)
-2082: Lt              "<" at 229:60-229:61
-2083: Ident           "T" at 229:61-229:62
-2084: Gt              ">" at 229:62-229:63
-2085: Semicolon       ";" at 229:63-229:64
-2086: At              "@" at 231:5-231:6 (leading: Newline, Space, LineComment, Newline, Space)
-2087: Ident           "intrinsic" at 231:6-231:15
-2088: KwPub           "pub" at 231:16-231:19 (leading: Space)
-2089: KwFn            "fn" at 231:20-231:22 (leading: Space)
-2090: Ident           "close" at 231:23-231:28 (leading: Space)
-2091: LParen          "(" at 231:28-231:29
-2092: Ident           "self" at 231:29-231:33
-2093: Colon           ":" at 231:33-231:34
-2094: Amp             "&" at 231:35-231:36 (leading: Space)
-2095: Ident           "Channel" at 231:36-231:43
-2096: Lt              "<" at 231:43-231:44
-2097: Ident           "T" at 231:44-231:45
-2098: Gt              ">" at 231:45-231:46
-2099: RParen          ")" at 231:46-231:47
-2100: Arrow           "->" at 231:48-231:50 (leading: Space)
-2101: NothingLit      "nothing" at 231:51-231:58 (leading: Space)
-2102: Semicolon       ";" at 231:58-231:59
-2103: RBrace          "}" at 232:1-232:2 (leading: Newline)
-2104: At              "@" at 234:1-234:2 (leading: Newline)
-2105: Ident           "intrinsic" at 234:2-234:11
-2106: KwFn            "fn" at 235:1-235:3 (leading: Newline)
-2107: Ident           "make_channel" at 235:4-235:16 (leading: Space)
-2108: Lt              "<" at 235:16-235:17
-2109: Ident           "T" at 235:17-235:18
-2110: Gt              ">" at 235:18-235:19
-2111: LParen          "(" at 235:19-235:20
-2112: Ident           "capacity" at 235:20-235:28
-2113: Colon           ":" at 235:28-235:29
-2114: Ident           "uint" at 235:30-235:34 (leading: Space)
-2115: RParen          ")" at 235:34-235:35
-2116: Arrow           "->" at 235:36-235:38 (leading: Space)
-2117: KwOwn           "own" at 235:39-235:42 (leading: Space)
-2118: Ident           "Channel" at 235:43-235:50 (leading: Space)
-2119: Lt              "<" at 235:50-235:51
-2120: Ident           "T" at 235:51-235:52
-2121: Gt              ">" at 235:52-235:53
-2122: Semicolon       ";" at 235:53-235:54
-2123: KwPub           "pub" at 237:1-237:4 (leading: Newline)
-2124: KwContract      "contract" at 237:5-237:13 (leading: Space)
-2125: Ident           "Bounded" at 237:14-237:21 (leading: Space)
-2126: Lt              "<" at 237:21-237:22
-2127: Ident           "T" at 237:22-237:23
-2128: Gt              ">" at 237:23-237:24
-2129: LBrace          "{" at 237:25-237:26 (leading: Space)
-2130: KwFn            "fn" at 238:5-238:7 (leading: Newline, Space)
-2131: Ident           "__min_value" at 238:8-238:19 (leading: Space)
-2132: LParen          "(" at 238:19-238:20
-2133: RParen          ")" at 238:20-238:21
-2134: Arrow           "->" at 238:22-238:24 (leading: Space)
-2135: Ident           "T" at 238:25-238:26 (leading: Space)
-2136: Semicolon       ";" at 238:26-238:27
-2137: KwFn            "fn" at 239:5-239:7 (leading: Newline, Space)
-2138: Ident           "__max_value" at 239:8-239:19 (leading: Space)
-2139: LParen          "(" at 239:19-239:20
-2140: RParen          ")" at 239:20-239:21
-2141: Arrow           "->" at 239:22-239:24 (leading: Space)
-2142: Ident           "T" at 239:25-239:26 (leading: Space)
-2143: Semicolon       ";" at 239:26-239:27
-2144: RBrace          "}" at 240:1-240:2 (leading: Newline)
-2145: KwPub           "pub" at 242:1-242:4 (leading: Newline)
-2146: KwContract      "contract" at 242:5-242:13 (leading: Space)
-2147: Ident           "HasLength" at 242:14-242:23 (leading: Space)
-2148: Lt              "<" at 242:23-242:24
-2149: Ident           "T" at 242:24-242:25
-2150: Gt              ">" at 242:25-242:26
-2151: LBrace          "{" at 242:27-242:28 (leading: Space)
-2152: KwFn            "fn" at 243:5-243:7 (leading: Newline, Space)
-2153: Ident           "__len" at 243:8-243:13 (leading: Space)
-2154: LParen          "(" at 243:13-243:14
-2155: Ident           "self" at 243:14-243:18
-2156: Colon           ":" at 243:18-243:19
-2157: Amp             "&" at 243:20-243:21 (leading: Space)
-2158: Ident           "T" at 243:21-243:22
-2159: RParen          ")" at 243:22-243:23
-2160: Arrow           "->" at 243:24-243:26 (leading: Space)
-2161: Ident           "uint" at 243:27-243:31 (leading: Space)
-2162: Semicolon       ";" at 243:31-243:32
-2163: RBrace          "}" at 244:1-244:2 (leading: Newline)
-2164: KwPub           "pub" at 246:1-246:4 (leading: Newline)
-2165: KwContract      "contract" at 246:5-246:13 (leading: Space)
-2166: Ident           "Printable" at 246:14-246:23 (leading: Space)
-2167: Lt              "<" at 246:23-246:24
-2168: Ident           "T" at 246:24-246:25
-2169: Gt              ">" at 246:25-246:26
-2170: LBrace          "{" at 246:27-246:28 (leading: Space)
-2171: KwFn            "fn" at 247:5-247:7 (leading: Newline, Space)
-2172: Ident           "__to" at 247:8-247:12 (leading: Space)
-2173: LParen          "(" at 247:12-247:13
-2174: Ident           "self" at 247:13-247:17
-2175: Colon           ":" at 247:17-247:18
-2176: Amp             "&" at 247:19-247:20 (leading: Space)
-2177: Ident           "T" at 247:20-247:21
-2178: Comma           "," at 247:21-247:22
-2179: Ident           "target" at 247:23-247:29 (leading: Space)
-2180: Colon           ":" at 247:29-247:30
-2181: Ident           "string" at 247:31-247:37 (leading: Space)
-2182: RParen          ")" at 247:37-247:38
-2183: Arrow           "->" at 247:39-247:41 (leading: Space)
-2184: Ident           "string" at 247:42-247:48 (leading: Space)
-2185: Semicolon       ";" at 247:48-247:49
-2186: RBrace          "}" at 248:1-248:2 (leading: Newline)
-2187: KwPub           "pub" at 250:1-250:4 (leading: Newline)
-2188: KwFn            "fn" at 250:5-250:7 (leading: Space)
-2189: Ident           "max_value" at 250:8-250:17 (leading: Space)
-2190: Lt              "<" at 250:17-250:18
-2191: Ident           "T" at 250:18-250:19
-2192: Colon           ":" at 250:19-250:20
-2193: Ident           "Bounded" at 250:21-250:28 (leading: Space)
-2194: Lt              "<" at 250:28-250:29
-2195: Ident           "T" at 250:29-250:30
-2196: Shr             ">>" at 250:30-250:32
-2197: LParen          "(" at 250:32-250:33
-2198: RParen          ")" at 250:33-250:34
-2199: Arrow           "->" at 250:35-250:37 (leading: Space)
-2200: Ident           "T" at 250:38-250:39 (leading: Space)
-2201: LBrace          "{" at 250:40-250:41 (leading: Space)
-2202: KwReturn        "return" at 251:5-251:11 (leading: Newline, Space)
-2203: Ident           "T" at 251:12-251:13 (leading: Space)
-2204: Dot             "." at 251:13-251:14
-2205: Ident           "__max_value" at 251:14-251:25
-2206: LParen          "(" at 251:25-251:26
-2207: RParen          ")" at 251:26-251:27
-2208: Semicolon       ";" at 251:27-251:28
-2209: RBrace          "}" at 252:1-252:2 (leading: Newline)
-2210: KwPub           "pub" at 254:1-254:4 (leading: Newline)
-2211: KwFn            "fn" at 254:5-254:7 (leading: Space)
-2212: Ident           "min_value" at 254:8-254:17 (leading: Space)
-2213: Lt              "<" at 254:17-254:18
-2214: Ident           "T" at 254:18-254:19
-2215: Colon           ":" at 254:19-254:20
-2216: Ident           "Bounded" at 254:21-254:28 (leading: Space)
-2217: Lt              "<" at 254:28-254:29
-2218: Ident           "T" at 254:29-254:30
-2219: Shr             ">>" at 254:30-254:32
-2220: LParen          "(" at 254:32-254:33
-2221: RParen          ")" at 254:33-254:34
-2222: Arrow           "->" at 254:35-254:37 (leading: Space)
-2223: Ident           "T" at 254:38-254:39 (leading: Space)
-2224: LBrace          "{" at 254:40-254:41 (leading: Space)
-2225: KwReturn        "return" at 255:5-255:11 (leading: Newline, Space)
-2226: Ident           "T" at 255:12-255:13 (leading: Space)
-2227: Dot             "." at 255:13-255:14
-2228: Ident           "__min_value" at 255:14-255:25
-2229: LParen          "(" at 255:25-255:26
-2230: RParen          ")" at 255:26-255:27
-2231: Semicolon       ";" at 255:27-255:28
-2232: RBrace          "}" at 256:1-256:2 (leading: Newline)
-2233: KwExtern        "extern" at 258:1-258:7 (leading: Newline)
-2234: Lt              "<" at 258:7-258:8
-2235: Ident           "int" at 258:8-258:11
-2236: Gt              ">" at 258:11-258:12
-2237: LBrace          "{" at 258:13-258:14 (leading: Space)
-2238: At              "@" at 259:5-259:6 (leading: Newline, Space)
-2239: Ident           "intrinsic" at 259:6-259:15
-2240: KwFn            "fn" at 259:16-259:18 (leading: Space)
-2241: Ident           "__add" at 259:19-259:24 (leading: Space)
-2242: LParen          "(" at 259:24-259:25
-2243: Ident           "self" at 259:25-259:29
-2244: Colon           ":" at 259:29-259:30
-2245: Ident           "int" at 259:31-259:34 (leading: Space)
-2246: Comma           "," at 259:34-259:35
-2247: Ident           "other" at 259:36-259:41 (leading: Space)
-2248: Colon           ":" at 259:41-259:42
-2249: Ident           "int" at 259:43-259:46 (leading: Space)
-2250: RParen          ")" at 259:46-259:47
-2251: Arrow           "->" at 259:48-259:50 (leading: Space)
-2252: Ident           "int" at 259:51-259:54 (leading: Space)
-2253: Semicolon       ";" at 259:54-259:55
-2254: At              "@" at 260:5-260:6 (leading: Newline, Space)
-2255: Ident           "intrinsic" at 260:6-260:15
-2256: KwFn            "fn" at 260:16-260:18 (leading: Space)
-2257: Ident           "__sub" at 260:19-260:24 (leading: Space)
-2258: LParen          "(" at 260:24-260:25
-2259: Ident           "self" at 260:25-260:29
-2260: Colon           ":" at 260:29-260:30
-2261: Ident           "int" at 260:31-260:34 (leading: Space)
-2262: Comma           "," at 260:34-260:35
-2263: Ident           "other" at 260:36-260:41 (leading: Space)
-2264: Colon           ":" at 260:41-260:42
-2265: Ident           "int" at 260:43-260:46 (leading: Space)
-2266: RParen          ")" at 260:46-260:47
-2267: Arrow           "->" at 260:48-260:50 (leading: Space)
-2268: Ident           "int" at 260:51-260:54 (leading: Space)
-2269: Semicolon       ";" at 260:54-260:55
-2270: At              "@" at 261:5-261:6 (leading: Newline, Space)
-2271: Ident           "intrinsic" at 261:6-261:15
-2272: KwFn            "fn" at 261:16-261:18 (leading: Space)
-2273: Ident           "__mul" at 261:19-261:24 (leading: Space)
-2274: LParen          "(" at 261:24-261:25
-2275: Ident           "self" at 261:25-261:29
-2276: Colon           ":" at 261:29-261:30
-2277: Ident           "int" at 261:31-261:34 (leading: Space)
-2278: Comma           "," at 261:34-261:35
-2279: Ident           "other" at 261:36-261:41 (leading: Space)
-2280: Colon           ":" at 261:41-261:42
-2281: Ident           "int" at 261:43-261:46 (leading: Space)
-2282: RParen          ")" at 261:46-261:47
-2283: Arrow           "->" at 261:48-261:50 (leading: Space)
-2284: Ident           "int" at 261:51-261:54 (leading: Space)
-2285: Semicolon       ";" at 261:54-261:55
-2286: At              "@" at 262:5-262:6 (leading: Newline, Space)
-2287: Ident           "intrinsic" at 262:6-262:15
-2288: KwFn            "fn" at 262:16-262:18 (leading: Space)
-2289: Ident           "__div" at 262:19-262:24 (leading: Space)
-2290: LParen          "(" at 262:24-262:25
-2291: Ident           "self" at 262:25-262:29
-2292: Colon           ":" at 262:29-262:30
-2293: Ident           "int" at 262:31-262:34 (leading: Space)
-2294: Comma           "," at 262:34-262:35
-2295: Ident           "other" at 262:36-262:41 (leading: Space)
-2296: Colon           ":" at 262:41-262:42
-2297: Ident           "int" at 262:43-262:46 (leading: Space)
-2298: RParen          ")" at 262:46-262:47
-2299: Arrow           "->" at 262:48-262:50 (leading: Space)
-2300: Ident           "int" at 262:51-262:54 (leading: Space)
-2301: Semicolon       ";" at 262:54-262:55
-2302: At              "@" at 263:5-263:6 (leading: Newline, Space)
-2303: Ident           "intrinsic" at 263:6-263:15
-2304: KwFn            "fn" at 263:16-263:18 (leading: Space)
-2305: Ident           "__mod" at 263:19-263:24 (leading: Space)
-2306: LParen          "(" at 263:24-263:25
-2307: Ident           "self" at 263:25-263:29
-2308: Colon           ":" at 263:29-263:30
-2309: Ident           "int" at 263:31-263:34 (leading: Space)
-2310: Comma           "," at 263:34-263:35
-2311: Ident           "other" at 263:36-263:41 (leading: Space)
-2312: Colon           ":" at 263:41-263:42
-2313: Ident           "int" at 263:43-263:46 (leading: Space)
-2314: RParen          ")" at 263:46-263:47
-2315: Arrow           "->" at 263:48-263:50 (leading: Space)
-2316: Ident           "int" at 263:51-263:54 (leading: Space)
-2317: Semicolon       ";" at 263:54-263:55
-2318: At              "@" at 264:5-264:6 (leading: Newline, Space)
-2319: Ident           "intrinsic" at 264:6-264:15
-2320: KwFn            "fn" at 264:16-264:18 (leading: Space)
-2321: Ident           "__bit_and" at 264:19-264:28 (leading: Space)
-2322: LParen          "(" at 264:28-264:29
-2323: Ident           "self" at 264:29-264:33
-2324: Colon           ":" at 264:33-264:34
-2325: Ident           "int" at 264:35-264:38 (leading: Space)
-2326: Comma           "," at 264:38-264:39
-2327: Ident           "other" at 264:40-264:45 (leading: Space)
-2328: Colon           ":" at 264:45-264:46
-2329: Ident           "int" at 264:47-264:50 (leading: Space)
-2330: RParen          ")" at 264:50-264:51
-2331: Arrow           "->" at 264:52-264:54 (leading: Space)
-2332: Ident           "int" at 264:55-264:58 (leading: Space)
-2333: Semicolon       ";" at 264:58-264:59
-2334: At              "@" at 265:5-265:6 (leading: Newline, Space)
-2335: Ident           "intrinsic" at 265:6-265:15
-2336: KwFn            "fn" at 265:16-265:18 (leading: Space)
-2337: Ident           "__bit_or" at 265:19-265:27 (leading: Space)
-2338: LParen          "(" at 265:27-265:28
-2339: Ident           "self" at 265:28-265:32
-2340: Colon           ":" at 265:32-265:33
-2341: Ident           "int" at 265:34-265:37 (leading: Space)
-2342: Comma           "," at 265:37-265:38
-2343: Ident           "other" at 265:39-265:44 (leading: Space)
-2344: Colon           ":" at 265:44-265:45
-2345: Ident           "int" at 265:46-265:49 (leading: Space)
-2346: RParen          ")" at 265:49-265:50
-2347: Arrow           "->" at 265:51-265:53 (leading: Space)
-2348: Ident           "int" at 265:54-265:57 (leading: Space)
-2349: Semicolon       ";" at 265:57-265:58
-2350: At              "@" at 266:5-266:6 (leading: Newline, Space)
-2351: Ident           "intrinsic" at 266:6-266:15
-2352: KwFn            "fn" at 266:16-266:18 (leading: Space)
-2353: Ident           "__bit_xor" at 266:19-266:28 (leading: Space)
-2354: LParen          "(" at 266:28-266:29
-2355: Ident           "self" at 266:29-266:33
-2356: Colon           ":" at 266:33-266:34
-2357: Ident           "int" at 266:35-266:38 (leading: Space)
-2358: Comma           "," at 266:38-266:39
-2359: Ident           "other" at 266:40-266:45 (leading: Space)
-2360: Colon           ":" at 266:45-266:46
-2361: Ident           "int" at 266:47-266:50 (leading: Space)
-2362: RParen          ")" at 266:50-266:51
-2363: Arrow           "->" at 266:52-266:54 (leading: Space)
-2364: Ident           "int" at 266:55-266:58 (leading: Space)
-2365: Semicolon       ";" at 266:58-266:59
-2366: At              "@" at 267:5-267:6 (leading: Newline, Space)
-2367: Ident           "intrinsic" at 267:6-267:15
-2368: KwFn            "fn" at 267:16-267:18 (leading: Space)
-2369: Ident           "__shl" at 267:19-267:24 (leading: Space)
-2370: LParen          "(" at 267:24-267:25
-2371: Ident           "self" at 267:25-267:29
-2372: Colon           ":" at 267:29-267:30
-2373: Ident           "int" at 267:31-267:34 (leading: Space)
-2374: Comma           "," at 267:34-267:35
-2375: Ident           "other" at 267:36-267:41 (leading: Space)
-2376: Colon           ":" at 267:41-267:42
-2377: Ident           "int" at 267:43-267:46 (leading: Space)
-2378: RParen          ")" at 267:46-267:47
-2379: Arrow           "->" at 267:48-267:50 (leading: Space)
-2380: Ident           "int" at 267:51-267:54 (leading: Space)
-2381: Semicolon       ";" at 267:54-267:55
-2382: At              "@" at 268:5-268:6 (leading: Newline, Space)
-2383: Ident           "intrinsic" at 268:6-268:15
-2384: KwFn            "fn" at 268:16-268:18 (leading: Space)
-2385: Ident           "__shr" at 268:19-268:24 (leading: Space)
-2386: LParen          "(" at 268:24-268:25
-2387: Ident           "self" at 268:25-268:29
-2388: Colon           ":" at 268:29-268:30
-2389: Ident           "int" at 268:31-268:34 (leading: Space)
-2390: Comma           "," at 268:34-268:35
-2391: Ident           "other" at 268:36-268:41 (leading: Space)
-2392: Colon           ":" at 268:41-268:42
-2393: Ident           "int" at 268:43-268:46 (leading: Space)
-2394: RParen          ")" at 268:46-268:47
-2395: Arrow           "->" at 268:48-268:50 (leading: Space)
-2396: Ident           "int" at 268:51-268:54 (leading: Space)
-2397: Semicolon       ";" at 268:54-268:55
-2398: At              "@" at 269:5-269:6 (leading: Newline, Space)
-2399: Ident           "intrinsic" at 269:6-269:15
-2400: KwFn            "fn" at 269:16-269:18 (leading: Space)
-2401: Ident           "__lt" at 269:19-269:23 (leading: Space)
-2402: LParen          "(" at 269:23-269:24
-2403: Ident           "self" at 269:24-269:28
-2404: Colon           ":" at 269:28-269:29
-2405: Ident           "int" at 269:30-269:33 (leading: Space)
-2406: Comma           "," at 269:33-269:34
-2407: Ident           "other" at 269:35-269:40 (leading: Space)
-2408: Colon           ":" at 269:40-269:41
-2409: Ident           "int" at 269:42-269:45 (leading: Space)
-2410: RParen          ")" at 269:45-269:46
-2411: Arrow           "->" at 269:47-269:49 (leading: Space)
-2412: Ident           "bool" at 269:50-269:54 (leading: Space)
-2413: Semicolon       ";" at 269:54-269:55
-2414: At              "@" at 270:5-270:6 (leading: Newline, Space)
-2415: Ident           "intrinsic" at 270:6-270:15
-2416: KwFn            "fn" at 270:16-270:18 (leading: Space)
-2417: Ident           "__le" at 270:19-270:23 (leading: Space)
-2418: LParen          "(" at 270:23-270:24
-2419: Ident           "self" at 270:24-270:28
-2420: Colon           ":" at 270:28-270:29
-2421: Ident           "int" at 270:30-270:33 (leading: Space)
-2422: Comma           "," at 270:33-270:34
-2423: Ident           "other" at 270:35-270:40 (leading: Space)
-2424: Colon           ":" at 270:40-270:41
-2425: Ident           "int" at 270:42-270:45 (leading: Space)
-2426: RParen          ")" at 270:45-270:46
-2427: Arrow           "->" at 270:47-270:49 (leading: Space)
-2428: Ident           "bool" at 270:50-270:54 (leading: Space)
-2429: Semicolon       ";" at 270:54-270:55
-2430: At              "@" at 271:5-271:6 (leading: Newline, Space)
-2431: Ident           "intrinsic" at 271:6-271:15
-2432: KwFn            "fn" at 271:16-271:18 (leading: Space)
-2433: Ident           "__eq" at 271:19-271:23 (leading: Space)
-2434: LParen          "(" at 271:23-271:24
-2435: Ident           "self" at 271:24-271:28
-2436: Colon           ":" at 271:28-271:29
-2437: Ident           "int" at 271:30-271:33 (leading: Space)
-2438: Comma           "," at 271:33-271:34
-2439: Ident           "other" at 271:35-271:40 (leading: Space)
-2440: Colon           ":" at 271:40-271:41
-2441: Ident           "int" at 271:42-271:45 (leading: Space)
-2442: RParen          ")" at 271:45-271:46
-2443: Arrow           "->" at 271:47-271:49 (leading: Space)
-2444: Ident           "bool" at 271:50-271:54 (leading: Space)
-2445: Semicolon       ";" at 271:54-271:55
-2446: At              "@" at 272:5-272:6 (leading: Newline, Space)
-2447: Ident           "intrinsic" at 272:6-272:15
-2448: KwFn            "fn" at 272:16-272:18 (leading: Space)
-2449: Ident           "__ne" at 272:19-272:23 (leading: Space)
-2450: LParen          "(" at 272:23-272:24
-2451: Ident           "self" at 272:24-272:28
-2452: Colon           ":" at 272:28-272:29
-2453: Ident           "int" at 272:30-272:33 (leading: Space)
-2454: Comma           "," at 272:33-272:34
-2455: Ident           "other" at 272:35-272:40 (leading: Space)
-2456: Colon           ":" at 272:40-272:41
-2457: Ident           "int" at 272:42-272:45 (leading: Space)
-2458: RParen          ")" at 272:45-272:46
-2459: Arrow           "->" at 272:47-272:49 (leading: Space)
-2460: Ident           "bool" at 272:50-272:54 (leading: Space)
-2461: Semicolon       ";" at 272:54-272:55
-2462: At              "@" at 273:5-273:6 (leading: Newline, Space)
-2463: Ident           "intrinsic" at 273:6-273:15
-2464: KwFn            "fn" at 273:16-273:18 (leading: Space)
-2465: Ident           "__ge" at 273:19-273:23 (leading: Space)
-2466: LParen          "(" at 273:23-273:24
-2467: Ident           "self" at 273:24-273:28
-2468: Colon           ":" at 273:28-273:29
-2469: Ident           "int" at 273:30-273:33 (leading: Space)
-2470: Comma           "," at 273:33-273:34
-2471: Ident           "other" at 273:35-273:40 (leading: Space)
-2472: Colon           ":" at 273:40-273:41
-2473: Ident           "int" at 273:42-273:45 (leading: Space)
-2474: RParen          ")" at 273:45-273:46
-2475: Arrow           "->" at 273:47-273:49 (leading: Space)
-2476: Ident           "bool" at 273:50-273:54 (leading: Space)
-2477: Semicolon       ";" at 273:54-273:55
-2478: At              "@" at 274:5-274:6 (leading: Newline, Space)
-2479: Ident           "intrinsic" at 274:6-274:15
-2480: KwFn            "fn" at 274:16-274:18 (leading: Space)
-2481: Ident           "__gt" at 274:19-274:23 (leading: Space)
-2482: LParen          "(" at 274:23-274:24
-2483: Ident           "self" at 274:24-274:28
-2484: Colon           ":" at 274:28-274:29
-2485: Ident           "int" at 274:30-274:33 (leading: Space)
-2486: Comma           "," at 274:33-274:34
-2487: Ident           "other" at 274:35-274:40 (leading: Space)
-2488: Colon           ":" at 274:40-274:41
-2489: Ident           "int" at 274:42-274:45 (leading: Space)
-2490: RParen          ")" at 274:45-274:46
-2491: Arrow           "->" at 274:47-274:49 (leading: Space)
-2492: Ident           "bool" at 274:50-274:54 (leading: Space)
-2493: Semicolon       ";" at 274:54-274:55
-2494: At              "@" at 275:5-275:6 (leading: Newline, Space)
-2495: Ident           "intrinsic" at 275:6-275:15
-2496: KwFn            "fn" at 275:16-275:18 (leading: Space)
-2497: Ident           "__pos" at 275:19-275:24 (leading: Space)
-2498: LParen          "(" at 275:24-275:25
-2499: Ident           "self" at 275:25-275:29
-2500: Colon           ":" at 275:29-275:30
-2501: Ident           "int" at 275:31-275:34 (leading: Space)
-2502: RParen          ")" at 275:34-275:35
-2503: Arrow           "->" at 275:36-275:38 (leading: Space)
-2504: Ident           "int" at 275:39-275:42 (leading: Space)
-2505: Semicolon       ";" at 275:42-275:43
-2506: At              "@" at 276:5-276:6 (leading: Newline, Space)
-2507: Ident           "intrinsic" at 276:6-276:15
-2508: KwFn            "fn" at 276:16-276:18 (leading: Space)
-2509: Ident           "__neg" at 276:19-276:24 (leading: Space)
-2510: LParen          "(" at 276:24-276:25
-2511: Ident           "self" at 276:25-276:29
-2512: Colon           ":" at 276:29-276:30
-2513: Ident           "int" at 276:31-276:34 (leading: Space)
-2514: RParen          ")" at 276:34-276:35
-2515: Arrow           "->" at 276:36-276:38 (leading: Space)
-2516: Ident           "int" at 276:39-276:42 (leading: Space)
-2517: Semicolon       ";" at 276:42-276:43
-2518: At              "@" at 277:5-277:6 (leading: Newline, Space)
-2519: Ident           "intrinsic" at 277:6-277:15
-2520: KwFn            "fn" at 277:16-277:18 (leading: Space)
-2521: Ident           "__abs" at 277:19-277:24 (leading: Space)
-2522: LParen          "(" at 277:24-277:25
-2523: Ident           "self" at 277:25-277:29
-2524: Colon           ":" at 277:29-277:30
-2525: Ident           "int" at 277:31-277:34 (leading: Space)
-2526: RParen          ")" at 277:34-277:35
-2527: Arrow           "->" at 277:36-277:38 (leading: Space)
-2528: Ident           "int" at 277:39-277:42 (leading: Space)
-2529: Semicolon       ";" at 277:42-277:43
-2530: At              "@" at 278:5-278:6 (leading: Newline, Space)
-2531: Ident           "intrinsic" at 278:6-278:15
-2532: KwFn            "fn" at 278:16-278:18 (leading: Space)
-2533: Ident           "__to" at 278:19-278:23 (leading: Space)
-2534: LParen          "(" at 278:23-278:24
-2535: Ident           "self" at 278:24-278:28
-2536: Colon           ":" at 278:28-278:29
-2537: Ident           "int" at 278:30-278:33 (leading: Space)
-2538: Comma           "," at 278:33-278:34
-2539: Ident           "target" at 278:35-278:41 (leading: Space)
-2540: Colon           ":" at 278:41-278:42
-2541: Ident           "string" at 278:43-278:49 (leading: Space)
-2542: RParen          ")" at 278:49-278:50
-2543: Arrow           "->" at 278:51-278:53 (leading: Space)
-2544: Ident           "string" at 278:54-278:60 (leading: Space)
-2545: Semicolon       ";" at 278:60-278:61
-2546: At              "@" at 279:5-279:6 (leading: Newline, Space)
-2547: Ident           "overload" at 279:6-279:14
-2548: KwPub           "pub" at 279:15-279:18 (leading: Space)
-2549: KwFn            "fn" at 279:19-279:21 (leading: Space)
-2550: Ident           "__to" at 279:22-279:26 (leading: Space)
-2551: LParen          "(" at 279:26-279:27
-2552: Ident           "self" at 279:27-279:31
-2553: Colon           ":" at 279:31-279:32
-2554: Amp             "&" at 279:33-279:34 (leading: Space)
-2555: Ident           "int" at 279:34-279:37
-2556: Comma           "," at 279:37-279:38
-2557: Underscore      "_" at 279:39-279:40 (leading: Space)
-2558: Colon           ":" at 279:40-279:41
-2559: Ident           "string" at 279:42-279:48 (leading: Space)
-2560: RParen          ")" at 279:48-279:49
-2561: Arrow           "->" at 279:50-279:52 (leading: Space)
-2562: Ident           "string" at 279:53-279:59 (leading: Space)
-2563: LBrace          "{" at 279:60-279:61 (leading: Space)
-2564: KwReturn        "return" at 280:9-280:15 (leading: Newline, Space)
-2565: LParen          "(" at 280:16-280:17 (leading: Space)
-2566: Star            "*" at 280:17-280:18
-2567: Ident           "self" at 280:18-280:22
-2568: RParen          ")" at 280:22-280:23
-2569: KwTo            "to" at 280:24-280:26 (leading: Space)
-2570: Ident           "string" at 280:27-280:33 (leading: Space)
-2571: Semicolon       ";" at 280:33-280:34
-2572: RBrace          "}" at 281:5-281:6 (leading: Newline, Space)
-2573: At              "@" at 282:5-282:6 (leading: Newline, Space)
-2574: Ident           "intrinsic" at 282:6-282:15
-2575: At              "@" at 282:16-282:17 (leading: Space)
-2576: Ident           "overload" at 282:17-282:25
-2577: KwFn            "fn" at 282:26-282:28 (leading: Space)
-2578: Ident           "__to" at 282:29-282:33 (leading: Space)
-2579: LParen          "(" at 282:33-282:34
-2580: Ident           "self" at 282:34-282:38
-2581: Colon           ":" at 282:38-282:39
-2582: Ident           "int" at 282:40-282:43 (leading: Space)
-2583: Comma           "," at 282:43-282:44
-2584: Ident           "target" at 282:45-282:51 (leading: Space)
-2585: Colon           ":" at 282:51-282:52
-2586: Ident           "float" at 282:53-282:58 (leading: Space)
-2587: RParen          ")" at 282:58-282:59
-2588: Arrow           "->" at 282:60-282:62 (leading: Space)
-2589: Ident           "float" at 282:63-282:68 (leading: Space)
-2590: Semicolon       ";" at 282:68-282:69
-2591: At              "@" at 283:5-283:6 (leading: Newline, Space)
-2592: Ident           "intrinsic" at 283:6-283:15
-2593: At              "@" at 283:16-283:17 (leading: Space)
-2594: Ident           "overload" at 283:17-283:25
-2595: KwFn            "fn" at 283:26-283:28 (leading: Space)
-2596: Ident           "__to" at 283:29-283:33 (leading: Space)
-2597: LParen          "(" at 283:33-283:34
-2598: Ident           "self" at 283:34-283:38
-2599: Colon           ":" at 283:38-283:39
-2600: Ident           "int" at 283:40-283:43 (leading: Space)
-2601: Comma           "," at 283:43-283:44
-2602: Ident           "target" at 283:45-283:51 (leading: Space)
-2603: Colon           ":" at 283:51-283:52
-2604: Ident           "uint" at 283:53-283:57 (leading: Space)
-2605: RParen          ")" at 283:57-283:58
-2606: Arrow           "->" at 283:59-283:61 (leading: Space)
-2607: Ident           "uint" at 283:62-283:66 (leading: Space)
-2608: Semicolon       ";" at 283:66-283:67
-2609: At              "@" at 284:5-284:6 (leading: Newline, Space)
-2610: Ident           "intrinsic" at 284:6-284:15
-2611: At              "@" at 284:16-284:17 (leading: Space)
-2612: Ident           "overload" at 284:17-284:25
-2613: KwFn            "fn" at 284:26-284:28 (leading: Space)
-2614: Ident           "__to" at 284:29-284:33 (leading: Space)
-2615: LParen          "(" at 284:33-284:34
-2616: Ident           "self" at 284:34-284:38
-2617: Colon           ":" at 284:38-284:39
-2618: Ident           "int" at 284:40-284:43 (leading: Space)
-2619: Comma           "," at 284:43-284:44
-2620: Ident           "target" at 284:45-284:51 (leading: Space)
-2621: Colon           ":" at 284:51-284:52
-2622: Ident           "int8" at 284:53-284:57 (leading: Space)
-2623: RParen          ")" at 284:57-284:58
-2624: Arrow           "->" at 284:59-284:61 (leading: Space)
-2625: Ident           "int8" at 284:62-284:66 (leading: Space)
-2626: Semicolon       ";" at 284:66-284:67
-2627: At              "@" at 285:5-285:6 (leading: Newline, Space)
-2628: Ident           "intrinsic" at 285:6-285:15
-2629: At              "@" at 285:16-285:17 (leading: Space)
-2630: Ident           "overload" at 285:17-285:25
-2631: KwFn            "fn" at 285:26-285:28 (leading: Space)
-2632: Ident           "__to" at 285:29-285:33 (leading: Space)
-2633: LParen          "(" at 285:33-285:34
-2634: Ident           "self" at 285:34-285:38
-2635: Colon           ":" at 285:38-285:39
-2636: Ident           "int" at 285:40-285:43 (leading: Space)
-2637: Comma           "," at 285:43-285:44
-2638: Ident           "target" at 285:45-285:51 (leading: Space)
-2639: Colon           ":" at 285:51-285:52
-2640: Ident           "int16" at 285:53-285:58 (leading: Space)
-2641: RParen          ")" at 285:58-285:59
-2642: Arrow           "->" at 285:60-285:62 (leading: Space)
-2643: Ident           "int16" at 285:63-285:68 (leading: Space)
-2644: Semicolon       ";" at 285:68-285:69
-2645: At              "@" at 286:5-286:6 (leading: Newline, Space)
-2646: Ident           "intrinsic" at 286:6-286:15
-2647: At              "@" at 286:16-286:17 (leading: Space)
-2648: Ident           "overload" at 286:17-286:25
-2649: KwFn            "fn" at 286:26-286:28 (leading: Space)
-2650: Ident           "__to" at 286:29-286:33 (leading: Space)
-2651: LParen          "(" at 286:33-286:34
-2652: Ident           "self" at 286:34-286:38
-2653: Colon           ":" at 286:38-286:39
-2654: Ident           "int" at 286:40-286:43 (leading: Space)
-2655: Comma           "," at 286:43-286:44
-2656: Ident           "target" at 286:45-286:51 (leading: Space)
-2657: Colon           ":" at 286:51-286:52
-2658: Ident           "int32" at 286:53-286:58 (leading: Space)
-2659: RParen          ")" at 286:58-286:59
-2660: Arrow           "->" at 286:60-286:62 (leading: Space)
-2661: Ident           "int32" at 286:63-286:68 (leading: Space)
-2662: Semicolon       ";" at 286:68-286:69
-2663: At              "@" at 287:5-287:6 (leading: Newline, Space)
-2664: Ident           "intrinsic" at 287:6-287:15
-2665: At              "@" at 287:16-287:17 (leading: Space)
-2666: Ident           "overload" at 287:17-287:25
-2667: KwFn            "fn" at 287:26-287:28 (leading: Space)
-2668: Ident           "__to" at 287:29-287:33 (leading: Space)
-2669: LParen          "(" at 287:33-287:34
-2670: Ident           "self" at 287:34-287:38
-2671: Colon           ":" at 287:38-287:39
-2672: Ident           "int" at 287:40-287:43 (leading: Space)
-2673: Comma           "," at 287:43-287:44
-2674: Ident           "target" at 287:45-287:51 (leading: Space)
-2675: Colon           ":" at 287:51-287:52
-2676: Ident           "int64" at 287:53-287:58 (leading: Space)
-2677: RParen          ")" at 287:58-287:59
-2678: Arrow           "->" at 287:60-287:62 (leading: Space)
-2679: Ident           "int64" at 287:63-287:68 (leading: Space)
-2680: Semicolon       ";" at 287:68-287:69
-2681: At              "@" at 288:5-288:6 (leading: Newline, Space)
-2682: Ident           "intrinsic" at 288:6-288:15
-2683: At              "@" at 288:16-288:17 (leading: Space)
-2684: Ident           "overload" at 288:17-288:25
-2685: KwFn            "fn" at 288:26-288:28 (leading: Space)
-2686: Ident           "__to" at 288:29-288:33 (leading: Space)
-2687: LParen          "(" at 288:33-288:34
-2688: Ident           "self" at 288:34-288:38
-2689: Colon           ":" at 288:38-288:39
-2690: Ident           "int" at 288:40-288:43 (leading: Space)
-2691: Comma           "," at 288:43-288:44
-2692: Ident           "target" at 288:45-288:51 (leading: Space)
-2693: Colon           ":" at 288:51-288:52
-2694: Ident           "uint8" at 288:53-288:58 (leading: Space)
-2695: RParen          ")" at 288:58-288:59
-2696: Arrow           "->" at 288:60-288:62 (leading: Space)
-2697: Ident           "uint8" at 288:63-288:68 (leading: Space)
-2698: Semicolon       ";" at 288:68-288:69
-2699: At              "@" at 289:5-289:6 (leading: Newline, Space)
-2700: Ident           "intrinsic" at 289:6-289:15
-2701: At              "@" at 289:16-289:17 (leading: Space)
-2702: Ident           "overload" at 289:17-289:25
-2703: KwFn            "fn" at 289:26-289:28 (leading: Space)
-2704: Ident           "__to" at 289:29-289:33 (leading: Space)
-2705: LParen          "(" at 289:33-289:34
-2706: Ident           "self" at 289:34-289:38
-2707: Colon           ":" at 289:38-289:39
-2708: Ident           "int" at 289:40-289:43 (leading: Space)
-2709: Comma           "," at 289:43-289:44
-2710: Ident           "target" at 289:45-289:51 (leading: Space)
-2711: Colon           ":" at 289:51-289:52
-2712: Ident           "uint16" at 289:53-289:59 (leading: Space)
-2713: RParen          ")" at 289:59-289:60
-2714: Arrow           "->" at 289:61-289:63 (leading: Space)
-2715: Ident           "uint16" at 289:64-289:70 (leading: Space)
-2716: Semicolon       ";" at 289:70-289:71
-2717: At              "@" at 290:5-290:6 (leading: Newline, Space)
-2718: Ident           "intrinsic" at 290:6-290:15
-2719: At              "@" at 290:16-290:17 (leading: Space)
-2720: Ident           "overload" at 290:17-290:25
-2721: KwFn            "fn" at 290:26-290:28 (leading: Space)
-2722: Ident           "__to" at 290:29-290:33 (leading: Space)
-2723: LParen          "(" at 290:33-290:34
-2724: Ident           "self" at 290:34-290:38
-2725: Colon           ":" at 290:38-290:39
-2726: Ident           "int" at 290:40-290:43 (leading: Space)
-2727: Comma           "," at 290:43-290:44
-2728: Ident           "target" at 290:45-290:51 (leading: Space)
-2729: Colon           ":" at 290:51-290:52
-2730: Ident           "uint32" at 290:53-290:59 (leading: Space)
-2731: RParen          ")" at 290:59-290:60
-2732: Arrow           "->" at 290:61-290:63 (leading: Space)
-2733: Ident           "uint32" at 290:64-290:70 (leading: Space)
-2734: Semicolon       ";" at 290:70-290:71
-2735: At              "@" at 291:5-291:6 (leading: Newline, Space)
-2736: Ident           "intrinsic" at 291:6-291:15
-2737: At              "@" at 291:16-291:17 (leading: Space)
-2738: Ident           "overload" at 291:17-291:25
-2739: KwFn            "fn" at 291:26-291:28 (leading: Space)
-2740: Ident           "__to" at 291:29-291:33 (leading: Space)
-2741: LParen          "(" at 291:33-291:34
-2742: Ident           "self" at 291:34-291:38
-2743: Colon           ":" at 291:38-291:39
-2744: Ident           "int" at 291:40-291:43 (leading: Space)
-2745: Comma           "," at 291:43-291:44
-2746: Ident           "target" at 291:45-291:51 (leading: Space)
-2747: Colon           ":" at 291:51-291:52
-2748: Ident           "uint64" at 291:53-291:59 (leading: Space)
-2749: RParen          ")" at 291:59-291:60
-2750: Arrow           "->" at 291:61-291:63 (leading: Space)
-2751: Ident           "uint64" at 291:64-291:70 (leading: Space)
-2752: Semicolon       ";" at 291:70-291:71
-2753: At              "@" at 292:5-292:6 (leading: Newline, Space)
-2754: Ident           "intrinsic" at 292:6-292:15
-2755: At              "@" at 292:16-292:17 (leading: Space)
-2756: Ident           "overload" at 292:17-292:25
-2757: KwFn            "fn" at 292:26-292:28 (leading: Space)
-2758: Ident           "__to" at 292:29-292:33 (leading: Space)
-2759: LParen          "(" at 292:33-292:34
-2760: Ident           "self" at 292:34-292:38
-2761: Colon           ":" at 292:38-292:39
-2762: Ident           "int" at 292:40-292:43 (leading: Space)
-2763: Comma           "," at 292:43-292:44
-2764: Ident           "target" at 292:45-292:51 (leading: Space)
-2765: Colon           ":" at 292:51-292:52
-2766: Ident           "float16" at 292:53-292:60 (leading: Space)
-2767: RParen          ")" at 292:60-292:61
-2768: Arrow           "->" at 292:62-292:64 (leading: Space)
-2769: Ident           "float16" at 292:65-292:72 (leading: Space)
-2770: Semicolon       ";" at 292:72-292:73
-2771: At              "@" at 293:5-293:6 (leading: Newline, Space)
-2772: Ident           "intrinsic" at 293:6-293:15
-2773: At              "@" at 293:16-293:17 (leading: Space)
-2774: Ident           "overload" at 293:17-293:25
-2775: KwFn            "fn" at 293:26-293:28 (leading: Space)
-2776: Ident           "__to" at 293:29-293:33 (leading: Space)
-2777: LParen          "(" at 293:33-293:34
-2778: Ident           "self" at 293:34-293:38
-2779: Colon           ":" at 293:38-293:39
-2780: Ident           "int" at 293:40-293:43 (leading: Space)
-2781: Comma           "," at 293:43-293:44
-2782: Ident           "target" at 293:45-293:51 (leading: Space)
-2783: Colon           ":" at 293:51-293:52
-2784: Ident           "float32" at 293:53-293:60 (leading: Space)
-2785: RParen          ")" at 293:60-293:61
-2786: Arrow           "->" at 293:62-293:64 (leading: Space)
-2787: Ident           "float32" at 293:65-293:72 (leading: Space)
-2788: Semicolon       ";" at 293:72-293:73
-2789: At              "@" at 294:5-294:6 (leading: Newline, Space)
-2790: Ident           "intrinsic" at 294:6-294:15
-2791: At              "@" at 294:16-294:17 (leading: Space)
-2792: Ident           "overload" at 294:17-294:25
-2793: KwFn            "fn" at 294:26-294:28 (leading: Space)
-2794: Ident           "__to" at 294:29-294:33 (leading: Space)
-2795: LParen          "(" at 294:33-294:34
-2796: Ident           "self" at 294:34-294:38
-2797: Colon           ":" at 294:38-294:39
-2798: Ident           "int" at 294:40-294:43 (leading: Space)
-2799: Comma           "," at 294:43-294:44
-2800: Ident           "target" at 294:45-294:51 (leading: Space)
-2801: Colon           ":" at 294:51-294:52
-2802: Ident           "float64" at 294:53-294:60 (leading: Space)
-2803: RParen          ")" at 294:60-294:61
-2804: Arrow           "->" at 294:62-294:64 (leading: Space)
-2805: Ident           "float64" at 294:65-294:72 (leading: Space)
-2806: Semicolon       ";" at 294:72-294:73
-2807: At              "@" at 296:5-296:6 (leading: Newline, Space, LineComment, Newline, Space)
-2808: Ident           "intrinsic" at 296:6-296:15
-2809: KwPub           "pub" at 296:16-296:19 (leading: Space)
-2810: KwFn            "fn" at 296:20-296:22 (leading: Space)
-2811: Ident           "from_str" at 296:23-296:31 (leading: Space)
-2812: LParen          "(" at 296:31-296:32
-2813: Ident           "s" at 296:32-296:33
-2814: Colon           ":" at 296:33-296:34
-2815: Amp             "&" at 296:35-296:36 (leading: Space)
-2816: Ident           "string" at 296:36-296:42
-2817: RParen          ")" at 296:42-296:43
-2818: Arrow           "->" at 296:44-296:46 (leading: Space)
-2819: Ident           "Erring" at 296:47-296:53 (leading: Space)
-2820: Lt              "<" at 296:53-296:54
-2821: Ident           "int" at 296:54-296:57
-2822: Comma           "," at 296:57-296:58
-2823: Ident           "Error" at 296:59-296:64 (leading: Space)
-2824: Gt              ">" at 296:64-296:65
-2825: Semicolon       ";" at 296:65-296:66
-2826: RBrace          "}" at 297:1-297:2 (leading: Newline)
-2827: KwExtern        "extern" at 299:1-299:7 (leading: Newline)
-2828: Lt              "<" at 299:7-299:8
-2829: Ident           "uint" at 299:8-299:12
-2830: Gt              ">" at 299:12-299:13
-2831: LBrace          "{" at 299:14-299:15 (leading: Space)
-2832: At              "@" at 300:5-300:6 (leading: Newline, Space)
-2833: Ident           "intrinsic" at 300:6-300:15
-2834: KwFn            "fn" at 300:16-300:18 (leading: Space)
-2835: Ident           "__add" at 300:19-300:24 (leading: Space)
-2836: LParen          "(" at 300:24-300:25
-2837: Ident           "self" at 300:25-300:29
-2838: Colon           ":" at 300:29-300:30
-2839: Ident           "uint" at 300:31-300:35 (leading: Space)
-2840: Comma           "," at 300:35-300:36
-2841: Ident           "other" at 300:37-300:42 (leading: Space)
-2842: Colon           ":" at 300:42-300:43
-2843: Ident           "uint" at 300:44-300:48 (leading: Space)
-2844: RParen          ")" at 300:48-300:49
-2845: Arrow           "->" at 300:50-300:52 (leading: Space)
-2846: Ident           "uint" at 300:53-300:57 (leading: Space)
-2847: Semicolon       ";" at 300:57-300:58
-2848: At              "@" at 301:5-301:6 (leading: Newline, Space)
-2849: Ident           "intrinsic" at 301:6-301:15
-2850: KwFn            "fn" at 301:16-301:18 (leading: Space)
-2851: Ident           "__sub" at 301:19-301:24 (leading: Space)
-2852: LParen          "(" at 301:24-301:25
-2853: Ident           "self" at 301:25-301:29
-2854: Colon           ":" at 301:29-301:30
-2855: Ident           "uint" at 301:31-301:35 (leading: Space)
-2856: Comma           "," at 301:35-301:36
-2857: Ident           "other" at 301:37-301:42 (leading: Space)
-2858: Colon           ":" at 301:42-301:43
-2859: Ident           "uint" at 301:44-301:48 (leading: Space)
-2860: RParen          ")" at 301:48-301:49
-2861: Arrow           "->" at 301:50-301:52 (leading: Space)
-2862: Ident           "uint" at 301:53-301:57 (leading: Space)
-2863: Semicolon       ";" at 301:57-301:58
-2864: At              "@" at 302:5-302:6 (leading: Newline, Space)
-2865: Ident           "intrinsic" at 302:6-302:15
-2866: KwFn            "fn" at 302:16-302:18 (leading: Space)
-2867: Ident           "__mul" at 302:19-302:24 (leading: Space)
-2868: LParen          "(" at 302:24-302:25
-2869: Ident           "self" at 302:25-302:29
-2870: Colon           ":" at 302:29-302:30
-2871: Ident           "uint" at 302:31-302:35 (leading: Space)
-2872: Comma           "," at 302:35-302:36
-2873: Ident           "other" at 302:37-302:42 (leading: Space)
-2874: Colon           ":" at 302:42-302:43
-2875: Ident           "uint" at 302:44-302:48 (leading: Space)
-2876: RParen          ")" at 302:48-302:49
-2877: Arrow           "->" at 302:50-302:52 (leading: Space)
-2878: Ident           "uint" at 302:53-302:57 (leading: Space)
-2879: Semicolon       ";" at 302:57-302:58
-2880: At              "@" at 303:5-303:6 (leading: Newline, Space)
-2881: Ident           "intrinsic" at 303:6-303:15
-2882: KwFn            "fn" at 303:16-303:18 (leading: Space)
-2883: Ident           "__div" at 303:19-303:24 (leading: Space)
-2884: LParen          "(" at 303:24-303:25
-2885: Ident           "self" at 303:25-303:29
-2886: Colon           ":" at 303:29-303:30
-2887: Ident           "uint" at 303:31-303:35 (leading: Space)
-2888: Comma           "," at 303:35-303:36
-2889: Ident           "other" at 303:37-303:42 (leading: Space)
-2890: Colon           ":" at 303:42-303:43
-2891: Ident           "uint" at 303:44-303:48 (leading: Space)
-2892: RParen          ")" at 303:48-303:49
-2893: Arrow           "->" at 303:50-303:52 (leading: Space)
-2894: Ident           "uint" at 303:53-303:57 (leading: Space)
-2895: Semicolon       ";" at 303:57-303:58
-2896: At              "@" at 304:5-304:6 (leading: Newline, Space)
-2897: Ident           "intrinsic" at 304:6-304:15
-2898: KwFn            "fn" at 304:16-304:18 (leading: Space)
-2899: Ident           "__mod" at 304:19-304:24 (leading: Space)
-2900: LParen          "(" at 304:24-304:25
-2901: Ident           "self" at 304:25-304:29
-2902: Colon           ":" at 304:29-304:30
-2903: Ident           "uint" at 304:31-304:35 (leading: Space)
-2904: Comma           "," at 304:35-304:36
-2905: Ident           "other" at 304:37-304:42 (leading: Space)
-2906: Colon           ":" at 304:42-304:43
-2907: Ident           "uint" at 304:44-304:48 (leading: Space)
-2908: RParen          ")" at 304:48-304:49
-2909: Arrow           "->" at 304:50-304:52 (leading: Space)
-2910: Ident           "uint" at 304:53-304:57 (leading: Space)
-2911: Semicolon       ";" at 304:57-304:58
-2912: At              "@" at 305:5-305:6 (leading: Newline, Space)
-2913: Ident           "intrinsic" at 305:6-305:15
-2914: KwFn            "fn" at 305:16-305:18 (leading: Space)
-2915: Ident           "__bit_and" at 305:19-305:28 (leading: Space)
-2916: LParen          "(" at 305:28-305:29
-2917: Ident           "self" at 305:29-305:33
-2918: Colon           ":" at 305:33-305:34
-2919: Ident           "uint" at 305:35-305:39 (leading: Space)
-2920: Comma           "," at 305:39-305:40
-2921: Ident           "other" at 305:41-305:46 (leading: Space)
-2922: Colon           ":" at 305:46-305:47
-2923: Ident           "uint" at 305:48-305:52 (leading: Space)
-2924: RParen          ")" at 305:52-305:53
-2925: Arrow           "->" at 305:54-305:56 (leading: Space)
-2926: Ident           "uint" at 305:57-305:61 (leading: Space)
-2927: Semicolon       ";" at 305:61-305:62
-2928: At              "@" at 306:5-306:6 (leading: Newline, Space)
-2929: Ident           "intrinsic" at 306:6-306:15
-2930: KwFn            "fn" at 306:16-306:18 (leading: Space)
-2931: Ident           "__bit_or" at 306:19-306:27 (leading: Space)
-2932: LParen          "(" at 306:27-306:28
-2933: Ident           "self" at 306:28-306:32
-2934: Colon           ":" at 306:32-306:33
-2935: Ident           "uint" at 306:34-306:38 (leading: Space)
-2936: Comma           "," at 306:38-306:39
-2937: Ident           "other" at 306:40-306:45 (leading: Space)
-2938: Colon           ":" at 306:45-306:46
-2939: Ident           "uint" at 306:47-306:51 (leading: Space)
-2940: RParen          ")" at 306:51-306:52
-2941: Arrow           "->" at 306:53-306:55 (leading: Space)
-2942: Ident           "uint" at 306:56-306:60 (leading: Space)
-2943: Semicolon       ";" at 306:60-306:61
-2944: At              "@" at 307:5-307:6 (leading: Newline, Space)
-2945: Ident           "intrinsic" at 307:6-307:15
-2946: KwFn            "fn" at 307:16-307:18 (leading: Space)
-2947: Ident           "__bit_xor" at 307:19-307:28 (leading: Space)
-2948: LParen          "(" at 307:28-307:29
-2949: Ident           "self" at 307:29-307:33
-2950: Colon           ":" at 307:33-307:34
-2951: Ident           "uint" at 307:35-307:39 (leading: Space)
-2952: Comma           "," at 307:39-307:40
-2953: Ident           "other" at 307:41-307:46 (leading: Space)
-2954: Colon           ":" at 307:46-307:47
-2955: Ident           "uint" at 307:48-307:52 (leading: Space)
-2956: RParen          ")" at 307:52-307:53
-2957: Arrow           "->" at 307:54-307:56 (leading: Space)
-2958: Ident           "uint" at 307:57-307:61 (leading: Space)
-2959: Semicolon       ";" at 307:61-307:62
-2960: At              "@" at 308:5-308:6 (leading: Newline, Space)
-2961: Ident           "intrinsic" at 308:6-308:15
-2962: KwFn            "fn" at 308:16-308:18 (leading: Space)
-2963: Ident           "__shl" at 308:19-308:24 (leading: Space)
-2964: LParen          "(" at 308:24-308:25
-2965: Ident           "self" at 308:25-308:29
-2966: Colon           ":" at 308:29-308:30
-2967: Ident           "uint" at 308:31-308:35 (leading: Space)
-2968: Comma           "," at 308:35-308:36
-2969: Ident           "other" at 308:37-308:42 (leading: Space)
-2970: Colon           ":" at 308:42-308:43
-2971: Ident           "uint" at 308:44-308:48 (leading: Space)
-2972: RParen          ")" at 308:48-308:49
-2973: Arrow           "->" at 308:50-308:52 (leading: Space)
-2974: Ident           "uint" at 308:53-308:57 (leading: Space)
-2975: Semicolon       ";" at 308:57-308:58
-2976: At              "@" at 309:5-309:6 (leading: Newline, Space)
-2977: Ident           "intrinsic" at 309:6-309:15
-2978: KwFn            "fn" at 309:16-309:18 (leading: Space)
-2979: Ident           "__shr" at 309:19-309:24 (leading: Space)
-2980: LParen          "(" at 309:24-309:25
-2981: Ident           "self" at 309:25-309:29
-2982: Colon           ":" at 309:29-309:30
-2983: Ident           "uint" at 309:31-309:35 (leading: Space)
-2984: Comma           "," at 309:35-309:36
-2985: Ident           "other" at 309:37-309:42 (leading: Space)
-2986: Colon           ":" at 309:42-309:43
-2987: Ident           "uint" at 309:44-309:48 (leading: Space)
-2988: RParen          ")" at 309:48-309:49
-2989: Arrow           "->" at 309:50-309:52 (leading: Space)
-2990: Ident           "uint" at 309:53-309:57 (leading: Space)
-2991: Semicolon       ";" at 309:57-309:58
-2992: At              "@" at 310:5-310:6 (leading: Newline, Space)
-2993: Ident           "intrinsic" at 310:6-310:15
-2994: KwFn            "fn" at 310:16-310:18 (leading: Space)
-2995: Ident           "__lt" at 310:19-310:23 (leading: Space)
-2996: LParen          "(" at 310:23-310:24
-2997: Ident           "self" at 310:24-310:28
-2998: Colon           ":" at 310:28-310:29
-2999: Ident           "uint" at 310:30-310:34 (leading: Space)
-3000: Comma           "," at 310:34-310:35
-3001: Ident           "other" at 310:36-310:41 (leading: Space)
-3002: Colon           ":" at 310:41-310:42
-3003: Ident           "uint" at 310:43-310:47 (leading: Space)
-3004: RParen          ")" at 310:47-310:48
-3005: Arrow           "->" at 310:49-310:51 (leading: Space)
-3006: Ident           "bool" at 310:52-310:56 (leading: Space)
-3007: Semicolon       ";" at 310:56-310:57
-3008: At              "@" at 311:5-311:6 (leading: Newline, Space)
-3009: Ident           "intrinsic" at 311:6-311:15
-3010: KwFn            "fn" at 311:16-311:18 (leading: Space)
-3011: Ident           "__le" at 311:19-311:23 (leading: Space)
-3012: LParen          "(" at 311:23-311:24
-3013: Ident           "self" at 311:24-311:28
-3014: Colon           ":" at 311:28-311:29
-3015: Ident           "uint" at 311:30-311:34 (leading: Space)
-3016: Comma           "," at 311:34-311:35
-3017: Ident           "other" at 311:36-311:41 (leading: Space)
-3018: Colon           ":" at 311:41-311:42
-3019: Ident           "uint" at 311:43-311:47 (leading: Space)
-3020: RParen          ")" at 311:47-311:48
-3021: Arrow           "->" at 311:49-311:51 (leading: Space)
-3022: Ident           "bool" at 311:52-311:56 (leading: Space)
-3023: Semicolon       ";" at 311:56-311:57
-3024: At              "@" at 312:5-312:6 (leading: Newline, Space)
-3025: Ident           "intrinsic" at 312:6-312:15
-3026: KwFn            "fn" at 312:16-312:18 (leading: Space)
-3027: Ident           "__eq" at 312:19-312:23 (leading: Space)
-3028: LParen          "(" at 312:23-312:24
-3029: Ident           "self" at 312:24-312:28
-3030: Colon           ":" at 312:28-312:29
-3031: Ident           "uint" at 312:30-312:34 (leading: Space)
-3032: Comma           "," at 312:34-312:35
-3033: Ident           "other" at 312:36-312:41 (leading: Space)
-3034: Colon           ":" at 312:41-312:42
-3035: Ident           "uint" at 312:43-312:47 (leading: Space)
-3036: RParen          ")" at 312:47-312:48
-3037: Arrow           "->" at 312:49-312:51 (leading: Space)
-3038: Ident           "bool" at 312:52-312:56 (leading: Space)
-3039: Semicolon       ";" at 312:56-312:57
-3040: At              "@" at 313:5-313:6 (leading: Newline, Space)
-3041: Ident           "intrinsic" at 313:6-313:15
-3042: KwFn            "fn" at 313:16-313:18 (leading: Space)
-3043: Ident           "__ne" at 313:19-313:23 (leading: Space)
-3044: LParen          "(" at 313:23-313:24
-3045: Ident           "self" at 313:24-313:28
-3046: Colon           ":" at 313:28-313:29
-3047: Ident           "uint" at 313:30-313:34 (leading: Space)
-3048: Comma           "," at 313:34-313:35
-3049: Ident           "other" at 313:36-313:41 (leading: Space)
-3050: Colon           ":" at 313:41-313:42
-3051: Ident           "uint" at 313:43-313:47 (leading: Space)
-3052: RParen          ")" at 313:47-313:48
-3053: Arrow           "->" at 313:49-313:51 (leading: Space)
-3054: Ident           "bool" at 313:52-313:56 (leading: Space)
-3055: Semicolon       ";" at 313:56-313:57
-3056: At              "@" at 314:5-314:6 (leading: Newline, Space)
-3057: Ident           "intrinsic" at 314:6-314:15
-3058: KwFn            "fn" at 314:16-314:18 (leading: Space)
-3059: Ident           "__ge" at 314:19-314:23 (leading: Space)
-3060: LParen          "(" at 314:23-314:24
-3061: Ident           "self" at 314:24-314:28
-3062: Colon           ":" at 314:28-314:29
-3063: Ident           "uint" at 314:30-314:34 (leading: Space)
-3064: Comma           "," at 314:34-314:35
-3065: Ident           "other" at 314:36-314:41 (leading: Space)
-3066: Colon           ":" at 314:41-314:42
-3067: Ident           "uint" at 314:43-314:47 (leading: Space)
-3068: RParen          ")" at 314:47-314:48
-3069: Arrow           "->" at 314:49-314:51 (leading: Space)
-3070: Ident           "bool" at 314:52-314:56 (leading: Space)
-3071: Semicolon       ";" at 314:56-314:57
-3072: At              "@" at 315:5-315:6 (leading: Newline, Space)
-3073: Ident           "intrinsic" at 315:6-315:15
-3074: KwFn            "fn" at 315:16-315:18 (leading: Space)
-3075: Ident           "__gt" at 315:19-315:23 (leading: Space)
-3076: LParen          "(" at 315:23-315:24
-3077: Ident           "self" at 315:24-315:28
-3078: Colon           ":" at 315:28-315:29
-3079: Ident           "uint" at 315:30-315:34 (leading: Space)
-3080: Comma           "," at 315:34-315:35
-3081: Ident           "other" at 315:36-315:41 (leading: Space)
-3082: Colon           ":" at 315:41-315:42
-3083: Ident           "uint" at 315:43-315:47 (leading: Space)
-3084: RParen          ")" at 315:47-315:48
-3085: Arrow           "->" at 315:49-315:51 (leading: Space)
-3086: Ident           "bool" at 315:52-315:56 (leading: Space)
-3087: Semicolon       ";" at 315:56-315:57
-3088: At              "@" at 316:5-316:6 (leading: Newline, Space)
-3089: Ident           "intrinsic" at 316:6-316:15
-3090: KwFn            "fn" at 316:16-316:18 (leading: Space)
-3091: Ident           "__pos" at 316:19-316:24 (leading: Space)
-3092: LParen          "(" at 316:24-316:25
-3093: Ident           "self" at 316:25-316:29
-3094: Colon           ":" at 316:29-316:30
-3095: Ident           "uint" at 316:31-316:35 (leading: Space)
-3096: RParen          ")" at 316:35-316:36
-3097: Arrow           "->" at 316:37-316:39 (leading: Space)
-3098: Ident           "uint" at 316:40-316:44 (leading: Space)
-3099: Semicolon       ";" at 316:44-316:45
-3100: At              "@" at 317:5-317:6 (leading: Newline, Space)
-3101: Ident           "intrinsic" at 317:6-317:15
-3102: KwFn            "fn" at 317:16-317:18 (leading: Space)
-3103: Ident           "__abs" at 317:19-317:24 (leading: Space)
-3104: LParen          "(" at 317:24-317:25
-3105: Ident           "self" at 317:25-317:29
-3106: Colon           ":" at 317:29-317:30
-3107: Ident           "uint" at 317:31-317:35 (leading: Space)
-3108: RParen          ")" at 317:35-317:36
-3109: Arrow           "->" at 317:37-317:39 (leading: Space)
-3110: Ident           "uint" at 317:40-317:44 (leading: Space)
-3111: Semicolon       ";" at 317:44-317:45
-3112: At              "@" at 318:5-318:6 (leading: Newline, Space)
-3113: Ident           "intrinsic" at 318:6-318:15
-3114: KwFn            "fn" at 318:16-318:18 (leading: Space)
-3115: Ident           "__to" at 318:19-318:23 (leading: Space)
-3116: LParen          "(" at 318:23-318:24
-3117: Ident           "self" at 318:24-318:28
-3118: Colon           ":" at 318:28-318:29
-3119: Ident           "uint" at 318:30-318:34 (leading: Space)
-3120: Comma           "," at 318:34-318:35
-3121: Ident           "target" at 318:36-318:42 (leading: Space)
-3122: Colon           ":" at 318:42-318:43
-3123: Ident           "string" at 318:44-318:50 (leading: Space)
-3124: RParen          ")" at 318:50-318:51
-3125: Arrow           "->" at 318:52-318:54 (leading: Space)
-3126: Ident           "string" at 318:55-318:61 (leading: Space)
-3127: Semicolon       ";" at 318:61-318:62
-3128: At              "@" at 319:5-319:6 (leading: Newline, Space)
-3129: Ident           "overload" at 319:6-319:14
-3130: KwPub           "pub" at 319:15-319:18 (leading: Space)
-3131: KwFn            "fn" at 319:19-319:21 (leading: Space)
-3132: Ident           "__to" at 319:22-319:26 (leading: Space)
-3133: LParen          "(" at 319:26-319:27
-3134: Ident           "self" at 319:27-319:31
-3135: Colon           ":" at 319:31-319:32
-3136: Amp             "&" at 319:33-319:34 (leading: Space)
-3137: Ident           "uint" at 319:34-319:38
-3138: Comma           "," at 319:38-319:39
-3139: Underscore      "_" at 319:40-319:41 (leading: Space)
-3140: Colon           ":" at 319:41-319:42
-3141: Ident           "string" at 319:43-319:49 (leading: Space)
-3142: RParen          ")" at 319:49-319:50
-3143: Arrow           "->" at 319:51-319:53 (leading: Space)
-3144: Ident           "string" at 319:54-319:60 (leading: Space)
-3145: LBrace          "{" at 319:61-319:62 (leading: Space)
-3146: KwReturn        "return" at 320:9-320:15 (leading: Newline, Space)
-3147: LParen          "(" at 320:16-320:17 (leading: Space)
-3148: Star            "*" at 320:17-320:18
-3149: Ident           "self" at 320:18-320:22
-3150: RParen          ")" at 320:22-320:23
-3151: KwTo            "to" at 320:24-320:26 (leading: Space)
-3152: Ident           "string" at 320:27-320:33 (leading: Space)
-3153: Semicolon       ";" at 320:33-320:34
-3154: RBrace          "}" at 321:5-321:6 (leading: Newline, Space)
-3155: At              "@" at 322:5-322:6 (leading: Newline, Space)
-3156: Ident           "intrinsic" at 322:6-322:15
-3157: At              "@" at 322:16-322:17 (leading: Space)
-3158: Ident           "overload" at 322:17-322:25
-3159: KwFn            "fn" at 322:26-322:28 (leading: Space)
-3160: Ident           "__to" at 322:29-322:33 (leading: Space)
-3161: LParen          "(" at 322:33-322:34
-3162: Ident           "self" at 322:34-322:38
-3163: Colon           ":" at 322:38-322:39
-3164: Ident           "uint" at 322:40-322:44 (leading: Space)
-3165: Comma           "," at 322:44-322:45
-3166: Ident           "target" at 322:46-322:52 (leading: Space)
-3167: Colon           ":" at 322:52-322:53
-3168: Ident           "int" at 322:54-322:57 (leading: Space)
-3169: RParen          ")" at 322:57-322:58
-3170: Arrow           "->" at 322:59-322:61 (leading: Space)
-3171: Ident           "int" at 322:62-322:65 (leading: Space)
-3172: Semicolon       ";" at 322:65-322:66
-3173: At              "@" at 323:5-323:6 (leading: Newline, Space)
-3174: Ident           "intrinsic" at 323:6-323:15
-3175: At              "@" at 323:16-323:17 (leading: Space)
-3176: Ident           "overload" at 323:17-323:25
-3177: KwFn            "fn" at 323:26-323:28 (leading: Space)
-3178: Ident           "__to" at 323:29-323:33 (leading: Space)
-3179: LParen          "(" at 323:33-323:34
-3180: Ident           "self" at 323:34-323:38
-3181: Colon           ":" at 323:38-323:39
-3182: Ident           "uint" at 323:40-323:44 (leading: Space)
-3183: Comma           "," at 323:44-323:45
-3184: Ident           "target" at 323:46-323:52 (leading: Space)
-3185: Colon           ":" at 323:52-323:53
-3186: Ident           "float" at 323:54-323:59 (leading: Space)
-3187: RParen          ")" at 323:59-323:60
-3188: Arrow           "->" at 323:61-323:63 (leading: Space)
-3189: Ident           "float" at 323:64-323:69 (leading: Space)
-3190: Semicolon       ";" at 323:69-323:70
-3191: At              "@" at 324:5-324:6 (leading: Newline, Space)
-3192: Ident           "intrinsic" at 324:6-324:15
-3193: At              "@" at 324:16-324:17 (leading: Space)
-3194: Ident           "overload" at 324:17-324:25
-3195: KwFn            "fn" at 324:26-324:28 (leading: Space)
-3196: Ident           "__to" at 324:29-324:33 (leading: Space)
-3197: LParen          "(" at 324:33-324:34
-3198: Ident           "self" at 324:34-324:38
-3199: Colon           ":" at 324:38-324:39
-3200: Ident           "uint" at 324:40-324:44 (leading: Space)
-3201: Comma           "," at 324:44-324:45
-3202: Ident           "target" at 324:46-324:52 (leading: Space)
-3203: Colon           ":" at 324:52-324:53
-3204: Ident           "int8" at 324:54-324:58 (leading: Space)
-3205: RParen          ")" at 324:58-324:59
-3206: Arrow           "->" at 324:60-324:62 (leading: Space)
-3207: Ident           "int8" at 324:63-324:67 (leading: Space)
-3208: Semicolon       ";" at 324:67-324:68
-3209: At              "@" at 325:5-325:6 (leading: Newline, Space)
-3210: Ident           "intrinsic" at 325:6-325:15
-3211: At              "@" at 325:16-325:17 (leading: Space)
-3212: Ident           "overload" at 325:17-325:25
-3213: KwFn            "fn" at 325:26-325:28 (leading: Space)
-3214: Ident           "__to" at 325:29-325:33 (leading: Space)
-3215: LParen          "(" at 325:33-325:34
-3216: Ident           "self" at 325:34-325:38
-3217: Colon           ":" at 325:38-325:39
-3218: Ident           "uint" at 325:40-325:44 (leading: Space)
-3219: Comma           "," at 325:44-325:45
-3220: Ident           "target" at 325:46-325:52 (leading: Space)
-3221: Colon           ":" at 325:52-325:53
-3222: Ident           "int16" at 325:54-325:59 (leading: Space)
-3223: RParen          ")" at 325:59-325:60
-3224: Arrow           "->" at 325:61-325:63 (leading: Space)
-3225: Ident           "int16" at 325:64-325:69 (leading: Space)
-3226: Semicolon       ";" at 325:69-325:70
-3227: At              "@" at 326:5-326:6 (leading: Newline, Space)
-3228: Ident           "intrinsic" at 326:6-326:15
-3229: At              "@" at 326:16-326:17 (leading: Space)
-3230: Ident           "overload" at 326:17-326:25
-3231: KwFn            "fn" at 326:26-326:28 (leading: Space)
-3232: Ident           "__to" at 326:29-326:33 (leading: Space)
-3233: LParen          "(" at 326:33-326:34
-3234: Ident           "self" at 326:34-326:38
-3235: Colon           ":" at 326:38-326:39
-3236: Ident           "uint" at 326:40-326:44 (leading: Space)
-3237: Comma           "," at 326:44-326:45
-3238: Ident           "target" at 326:46-326:52 (leading: Space)
-3239: Colon           ":" at 326:52-326:53
-3240: Ident           "int32" at 326:54-326:59 (leading: Space)
-3241: RParen          ")" at 326:59-326:60
-3242: Arrow           "->" at 326:61-326:63 (leading: Space)
-3243: Ident           "int32" at 326:64-326:69 (leading: Space)
-3244: Semicolon       ";" at 326:69-326:70
-3245: At              "@" at 327:5-327:6 (leading: Newline, Space)
-3246: Ident           "intrinsic" at 327:6-327:15
-3247: At              "@" at 327:16-327:17 (leading: Space)
-3248: Ident           "overload" at 327:17-327:25
-3249: KwFn            "fn" at 327:26-327:28 (leading: Space)
-3250: Ident           "__to" at 327:29-327:33 (leading: Space)
-3251: LParen          "(" at 327:33-327:34
-3252: Ident           "self" at 327:34-327:38
-3253: Colon           ":" at 327:38-327:39
-3254: Ident           "uint" at 327:40-327:44 (leading: Space)
-3255: Comma           "," at 327:44-327:45
-3256: Ident           "target" at 327:46-327:52 (leading: Space)
-3257: Colon           ":" at 327:52-327:53
-3258: Ident           "int64" at 327:54-327:59 (leading: Space)
-3259: RParen          ")" at 327:59-327:60
-3260: Arrow           "->" at 327:61-327:63 (leading: Space)
-3261: Ident           "int64" at 327:64-327:69 (leading: Space)
-3262: Semicolon       ";" at 327:69-327:70
-3263: At              "@" at 328:5-328:6 (leading: Newline, Space)
-3264: Ident           "intrinsic" at 328:6-328:15
-3265: At              "@" at 328:16-328:17 (leading: Space)
-3266: Ident           "overload" at 328:17-328:25
-3267: KwFn            "fn" at 328:26-328:28 (leading: Space)
-3268: Ident           "__to" at 328:29-328:33 (leading: Space)
-3269: LParen          "(" at 328:33-328:34
-3270: Ident           "self" at 328:34-328:38
-3271: Colon           ":" at 328:38-328:39
-3272: Ident           "uint" at 328:40-328:44 (leading: Space)
-3273: Comma           "," at 328:44-328:45
-3274: Ident           "target" at 328:46-328:52 (leading: Space)
-3275: Colon           ":" at 328:52-328:53
-3276: Ident           "uint8" at 328:54-328:59 (leading: Space)
-3277: RParen          ")" at 328:59-328:60
-3278: Arrow           "->" at 328:61-328:63 (leading: Space)
-3279: Ident           "uint8" at 328:64-328:69 (leading: Space)
-3280: Semicolon       ";" at 328:69-328:70
-3281: At              "@" at 329:5-329:6 (leading: Newline, Space)
-3282: Ident           "intrinsic" at 329:6-329:15
-3283: At              "@" at 329:16-329:17 (leading: Space)
-3284: Ident           "overload" at 329:17-329:25
-3285: KwFn            "fn" at 329:26-329:28 (leading: Space)
-3286: Ident           "__to" at 329:29-329:33 (leading: Space)
-3287: LParen          "(" at 329:33-329:34
-3288: Ident           "self" at 329:34-329:38
-3289: Colon           ":" at 329:38-329:39
-3290: Ident           "uint" at 329:40-329:44 (leading: Space)
-3291: Comma           "," at 329:44-329:45
-3292: Ident           "target" at 329:46-329:52 (leading: Space)
-3293: Colon           ":" at 329:52-329:53
-3294: Ident           "uint16" at 329:54-329:60 (leading: Space)
-3295: RParen          ")" at 329:60-329:61
-3296: Arrow           "->" at 329:62-329:64 (leading: Space)
-3297: Ident           "uint16" at 329:65-329:71 (leading: Space)
-3298: Semicolon       ";" at 329:71-329:72
-3299: At              "@" at 330:5-330:6 (leading: Newline, Space)
-3300: Ident           "intrinsic" at 330:6-330:15
-3301: At              "@" at 330:16-330:17 (leading: Space)
-3302: Ident           "overload" at 330:17-330:25
-3303: KwFn            "fn" at 330:26-330:28 (leading: Space)
-3304: Ident           "__to" at 330:29-330:33 (leading: Space)
-3305: LParen          "(" at 330:33-330:34
-3306: Ident           "self" at 330:34-330:38
-3307: Colon           ":" at 330:38-330:39
-3308: Ident           "uint" at 330:40-330:44 (leading: Space)
-3309: Comma           "," at 330:44-330:45
-3310: Ident           "target" at 330:46-330:52 (leading: Space)
-3311: Colon           ":" at 330:52-330:53
-3312: Ident           "uint32" at 330:54-330:60 (leading: Space)
-3313: RParen          ")" at 330:60-330:61
-3314: Arrow           "->" at 330:62-330:64 (leading: Space)
-3315: Ident           "uint32" at 330:65-330:71 (leading: Space)
-3316: Semicolon       ";" at 330:71-330:72
-3317: At              "@" at 331:5-331:6 (leading: Newline, Space)
-3318: Ident           "intrinsic" at 331:6-331:15
-3319: At              "@" at 331:16-331:17 (leading: Space)
-3320: Ident           "overload" at 331:17-331:25
-3321: KwFn            "fn" at 331:26-331:28 (leading: Space)
-3322: Ident           "__to" at 331:29-331:33 (leading: Space)
-3323: LParen          "(" at 331:33-331:34
-3324: Ident           "self" at 331:34-331:38
-3325: Colon           ":" at 331:38-331:39
-3326: Ident           "uint" at 331:40-331:44 (leading: Space)
-3327: Comma           "," at 331:44-331:45
-3328: Ident           "target" at 331:46-331:52 (leading: Space)
-3329: Colon           ":" at 331:52-331:53
-3330: Ident           "uint64" at 331:54-331:60 (leading: Space)
-3331: RParen          ")" at 331:60-331:61
-3332: Arrow           "->" at 331:62-331:64 (leading: Space)
-3333: Ident           "uint64" at 331:65-331:71 (leading: Space)
-3334: Semicolon       ";" at 331:71-331:72
-3335: At              "@" at 332:5-332:6 (leading: Newline, Space)
-3336: Ident           "intrinsic" at 332:6-332:15
-3337: At              "@" at 332:16-332:17 (leading: Space)
-3338: Ident           "overload" at 332:17-332:25
-3339: KwFn            "fn" at 332:26-332:28 (leading: Space)
-3340: Ident           "__to" at 332:29-332:33 (leading: Space)
-3341: LParen          "(" at 332:33-332:34
-3342: Ident           "self" at 332:34-332:38
-3343: Colon           ":" at 332:38-332:39
-3344: Ident           "uint" at 332:40-332:44 (leading: Space)
-3345: Comma           "," at 332:44-332:45
-3346: Ident           "target" at 332:46-332:52 (leading: Space)
-3347: Colon           ":" at 332:52-332:53
-3348: Ident           "float16" at 332:54-332:61 (leading: Space)
-3349: RParen          ")" at 332:61-332:62
-3350: Arrow           "->" at 332:63-332:65 (leading: Space)
-3351: Ident           "float16" at 332:66-332:73 (leading: Space)
-3352: Semicolon       ";" at 332:73-332:74
-3353: At              "@" at 333:5-333:6 (leading: Newline, Space)
-3354: Ident           "intrinsic" at 333:6-333:15
-3355: At              "@" at 333:16-333:17 (leading: Space)
-3356: Ident           "overload" at 333:17-333:25
-3357: KwFn            "fn" at 333:26-333:28 (leading: Space)
-3358: Ident           "__to" at 333:29-333:33 (leading: Space)
-3359: LParen          "(" at 333:33-333:34
-3360: Ident           "self" at 333:34-333:38
-3361: Colon           ":" at 333:38-333:39
-3362: Ident           "uint" at 333:40-333:44 (leading: Space)
-3363: Comma           "," at 333:44-333:45
-3364: Ident           "target" at 333:46-333:52 (leading: Space)
-3365: Colon           ":" at 333:52-333:53
-3366: Ident           "float32" at 333:54-333:61 (leading: Space)
-3367: RParen          ")" at 333:61-333:62
-3368: Arrow           "->" at 333:63-333:65 (leading: Space)
-3369: Ident           "float32" at 333:66-333:73 (leading: Space)
-3370: Semicolon       ";" at 333:73-333:74
-3371: At              "@" at 334:5-334:6 (leading: Newline, Space)
-3372: Ident           "intrinsic" at 334:6-334:15
-3373: At              "@" at 334:16-334:17 (leading: Space)
-3374: Ident           "overload" at 334:17-334:25
-3375: KwFn            "fn" at 334:26-334:28 (leading: Space)
-3376: Ident           "__to" at 334:29-334:33 (leading: Space)
-3377: LParen          "(" at 334:33-334:34
-3378: Ident           "self" at 334:34-334:38
-3379: Colon           ":" at 334:38-334:39
-3380: Ident           "uint" at 334:40-334:44 (leading: Space)
-3381: Comma           "," at 334:44-334:45
-3382: Ident           "target" at 334:46-334:52 (leading: Space)
-3383: Colon           ":" at 334:52-334:53
-3384: Ident           "float64" at 334:54-334:61 (leading: Space)
-3385: RParen          ")" at 334:61-334:62
-3386: Arrow           "->" at 334:63-334:65 (leading: Space)
-3387: Ident           "float64" at 334:66-334:73 (leading: Space)
-3388: Semicolon       ";" at 334:73-334:74
-3389: At              "@" at 336:5-336:6 (leading: Newline, Space, LineComment, Newline, Space)
-3390: Ident           "intrinsic" at 336:6-336:15
-3391: KwPub           "pub" at 336:16-336:19 (leading: Space)
-3392: KwFn            "fn" at 336:20-336:22 (leading: Space)
-3393: Ident           "from_str" at 336:23-336:31 (leading: Space)
-3394: LParen          "(" at 336:31-336:32
-3395: Ident           "s" at 336:32-336:33
-3396: Colon           ":" at 336:33-336:34
-3397: Amp             "&" at 336:35-336:36 (leading: Space)
-3398: Ident           "string" at 336:36-336:42
-3399: RParen          ")" at 336:42-336:43
-3400: Arrow           "->" at 336:44-336:46 (leading: Space)
-3401: Ident           "Erring" at 336:47-336:53 (leading: Space)
-3402: Lt              "<" at 336:53-336:54
-3403: Ident           "uint" at 336:54-336:58
-3404: Comma           "," at 336:58-336:59
-3405: Ident           "Error" at 336:60-336:65 (leading: Space)
-3406: Gt              ">" at 336:65-336:66
-3407: Semicolon       ";" at 336:66-336:67
-3408: RBrace          "}" at 337:1-337:2 (leading: Newline)
-3409: KwExtern        "extern" at 339:1-339:7 (leading: Newline)
-3410: Lt              "<" at 339:7-339:8
-3411: Ident           "int8" at 339:8-339:12
-3412: Gt              ">" at 339:12-339:13
-3413: LBrace          "{" at 339:14-339:15 (leading: Space)
-3414: KwPub           "pub" at 340:5-340:8 (leading: Newline, Space)
-3415: KwFn            "fn" at 340:9-340:11 (leading: Space)
-3416: Ident           "__min_value" at 340:12-340:23 (leading: Space)
-3417: LParen          "(" at 340:23-340:24
-3418: RParen          ")" at 340:24-340:25
-3419: Arrow           "->" at 340:26-340:28 (leading: Space)
-3420: Ident           "int8" at 340:29-340:33 (leading: Space)
-3421: LBrace          "{" at 340:34-340:35 (leading: Space)
-3422: KwReturn        "return" at 340:36-340:42 (leading: Space)
-3423: LParen          "(" at 340:43-340:44 (leading: Space)
-3424: Minus           "-" at 340:44-340:45
-3425: IntLit          "128" at 340:45-340:48
-3426: RParen          ")" at 340:48-340:49
-3427: Colon           ":" at 340:49-340:50
-3428: Ident           "int8" at 340:50-340:54
-3429: Semicolon       ";" at 340:54-340:55
-3430: RBrace          "}" at 340:56-340:57 (leading: Space)
-3431: KwPub           "pub" at 341:5-341:8 (leading: Newline, Space)
-3432: KwFn            "fn" at 341:9-341:11 (leading: Space)
-3433: Ident           "__max_value" at 341:12-341:23 (leading: Space)
-3434: LParen          "(" at 341:23-341:24
-3435: RParen          ")" at 341:24-341:25
-3436: Arrow           "->" at 341:26-341:28 (leading: Space)
-3437: Ident           "int8" at 341:29-341:33 (leading: Space)
-3438: LBrace          "{" at 341:34-341:35 (leading: Space)
-3439: KwReturn        "return" at 341:36-341:42 (leading: Space)
-3440: LParen          "(" at 341:43-341:44 (leading: Space)
-3441: IntLit          "127" at 341:44-341:47
-3442: RParen          ")" at 341:47-341:48
-3443: Colon           ":" at 341:48-341:49
-3444: Ident           "int8" at 341:49-341:53
-3445: Semicolon       ";" at 341:53-341:54
-3446: RBrace          "}" at 341:55-341:56 (leading: Space)
-3447: At              "@" at 342:5-342:6 (leading: Newline, Space)
-3448: Ident           "intrinsic" at 342:6-342:15
-3449: KwFn            "fn" at 342:16-342:18 (leading: Space)
-3450: Ident           "__add" at 342:19-342:24 (leading: Space)
-3451: LParen          "(" at 342:24-342:25
-3452: Ident           "self" at 342:25-342:29
-3453: Colon           ":" at 342:29-342:30
-3454: Ident           "int8" at 342:31-342:35 (leading: Space)
-3455: Comma           "," at 342:35-342:36
-3456: Ident           "other" at 342:37-342:42 (leading: Space)
-3457: Colon           ":" at 342:42-342:43
-3458: Ident           "int8" at 342:44-342:48 (leading: Space)
-3459: RParen          ")" at 342:48-342:49
-3460: Arrow           "->" at 342:50-342:52 (leading: Space)
-3461: Ident           "int8" at 342:53-342:57 (leading: Space)
-3462: Semicolon       ";" at 342:57-342:58
-3463: At              "@" at 343:5-343:6 (leading: Newline, Space)
-3464: Ident           "intrinsic" at 343:6-343:15
-3465: KwFn            "fn" at 343:16-343:18 (leading: Space)
-3466: Ident           "__sub" at 343:19-343:24 (leading: Space)
-3467: LParen          "(" at 343:24-343:25
-3468: Ident           "self" at 343:25-343:29
-3469: Colon           ":" at 343:29-343:30
-3470: Ident           "int8" at 343:31-343:35 (leading: Space)
-3471: Comma           "," at 343:35-343:36
-3472: Ident           "other" at 343:37-343:42 (leading: Space)
-3473: Colon           ":" at 343:42-343:43
-3474: Ident           "int8" at 343:44-343:48 (leading: Space)
-3475: RParen          ")" at 343:48-343:49
-3476: Arrow           "->" at 343:50-343:52 (leading: Space)
-3477: Ident           "int8" at 343:53-343:57 (leading: Space)
-3478: Semicolon       ";" at 343:57-343:58
-3479: At              "@" at 344:5-344:6 (leading: Newline, Space)
-3480: Ident           "intrinsic" at 344:6-344:15
-3481: KwFn            "fn" at 344:16-344:18 (leading: Space)
-3482: Ident           "__mul" at 344:19-344:24 (leading: Space)
-3483: LParen          "(" at 344:24-344:25
-3484: Ident           "self" at 344:25-344:29
-3485: Colon           ":" at 344:29-344:30
-3486: Ident           "int8" at 344:31-344:35 (leading: Space)
-3487: Comma           "," at 344:35-344:36
-3488: Ident           "other" at 344:37-344:42 (leading: Space)
-3489: Colon           ":" at 344:42-344:43
-3490: Ident           "int8" at 344:44-344:48 (leading: Space)
-3491: RParen          ")" at 344:48-344:49
-3492: Arrow           "->" at 344:50-344:52 (leading: Space)
-3493: Ident           "int8" at 344:53-344:57 (leading: Space)
-3494: Semicolon       ";" at 344:57-344:58
-3495: At              "@" at 345:5-345:6 (leading: Newline, Space)
-3496: Ident           "intrinsic" at 345:6-345:15
-3497: KwFn            "fn" at 345:16-345:18 (leading: Space)
-3498: Ident           "__div" at 345:19-345:24 (leading: Space)
-3499: LParen          "(" at 345:24-345:25
-3500: Ident           "self" at 345:25-345:29
-3501: Colon           ":" at 345:29-345:30
-3502: Ident           "int8" at 345:31-345:35 (leading: Space)
-3503: Comma           "," at 345:35-345:36
-3504: Ident           "other" at 345:37-345:42 (leading: Space)
-3505: Colon           ":" at 345:42-345:43
-3506: Ident           "int8" at 345:44-345:48 (leading: Space)
-3507: RParen          ")" at 345:48-345:49
-3508: Arrow           "->" at 345:50-345:52 (leading: Space)
-3509: Ident           "int8" at 345:53-345:57 (leading: Space)
-3510: Semicolon       ";" at 345:57-345:58
-3511: At              "@" at 346:5-346:6 (leading: Newline, Space)
-3512: Ident           "intrinsic" at 346:6-346:15
-3513: KwFn            "fn" at 346:16-346:18 (leading: Space)
-3514: Ident           "__mod" at 346:19-346:24 (leading: Space)
-3515: LParen          "(" at 346:24-346:25
-3516: Ident           "self" at 346:25-346:29
-3517: Colon           ":" at 346:29-346:30
-3518: Ident           "int8" at 346:31-346:35 (leading: Space)
-3519: Comma           "," at 346:35-346:36
-3520: Ident           "other" at 346:37-346:42 (leading: Space)
-3521: Colon           ":" at 346:42-346:43
-3522: Ident           "int8" at 346:44-346:48 (leading: Space)
-3523: RParen          ")" at 346:48-346:49
-3524: Arrow           "->" at 346:50-346:52 (leading: Space)
-3525: Ident           "int8" at 346:53-346:57 (leading: Space)
-3526: Semicolon       ";" at 346:57-346:58
-3527: At              "@" at 347:5-347:6 (leading: Newline, Space)
-3528: Ident           "intrinsic" at 347:6-347:15
-3529: KwFn            "fn" at 347:16-347:18 (leading: Space)
-3530: Ident           "__bit_and" at 347:19-347:28 (leading: Space)
-3531: LParen          "(" at 347:28-347:29
-3532: Ident           "self" at 347:29-347:33
-3533: Colon           ":" at 347:33-347:34
-3534: Ident           "int8" at 347:35-347:39 (leading: Space)
-3535: Comma           "," at 347:39-347:40
-3536: Ident           "other" at 347:41-347:46 (leading: Space)
-3537: Colon           ":" at 347:46-347:47
-3538: Ident           "int8" at 347:48-347:52 (leading: Space)
-3539: RParen          ")" at 347:52-347:53
-3540: Arrow           "->" at 347:54-347:56 (leading: Space)
-3541: Ident           "int8" at 347:57-347:61 (leading: Space)
-3542: Semicolon       ";" at 347:61-347:62
-3543: At              "@" at 348:5-348:6 (leading: Newline, Space)
-3544: Ident           "intrinsic" at 348:6-348:15
-3545: KwFn            "fn" at 348:16-348:18 (leading: Space)
-3546: Ident           "__bit_or" at 348:19-348:27 (leading: Space)
-3547: LParen          "(" at 348:27-348:28
-3548: Ident           "self" at 348:28-348:32
-3549: Colon           ":" at 348:32-348:33
-3550: Ident           "int8" at 348:34-348:38 (leading: Space)
-3551: Comma           "," at 348:38-348:39
-3552: Ident           "other" at 348:40-348:45 (leading: Space)
-3553: Colon           ":" at 348:45-348:46
-3554: Ident           "int8" at 348:47-348:51 (leading: Space)
-3555: RParen          ")" at 348:51-348:52
-3556: Arrow           "->" at 348:53-348:55 (leading: Space)
-3557: Ident           "int8" at 348:56-348:60 (leading: Space)
-3558: Semicolon       ";" at 348:60-348:61
-3559: At              "@" at 349:5-349:6 (leading: Newline, Space)
-3560: Ident           "intrinsic" at 349:6-349:15
-3561: KwFn            "fn" at 349:16-349:18 (leading: Space)
-3562: Ident           "__bit_xor" at 349:19-349:28 (leading: Space)
-3563: LParen          "(" at 349:28-349:29
-3564: Ident           "self" at 349:29-349:33
-3565: Colon           ":" at 349:33-349:34
-3566: Ident           "int8" at 349:35-349:39 (leading: Space)
-3567: Comma           "," at 349:39-349:40
-3568: Ident           "other" at 349:41-349:46 (leading: Space)
-3569: Colon           ":" at 349:46-349:47
-3570: Ident           "int8" at 349:48-349:52 (leading: Space)
-3571: RParen          ")" at 349:52-349:53
-3572: Arrow           "->" at 349:54-349:56 (leading: Space)
-3573: Ident           "int8" at 349:57-349:61 (leading: Space)
-3574: Semicolon       ";" at 349:61-349:62
-3575: At              "@" at 350:5-350:6 (leading: Newline, Space)
-3576: Ident           "intrinsic" at 350:6-350:15
-3577: KwFn            "fn" at 350:16-350:18 (leading: Space)
-3578: Ident           "__shl" at 350:19-350:24 (leading: Space)
-3579: LParen          "(" at 350:24-350:25
-3580: Ident           "self" at 350:25-350:29
-3581: Colon           ":" at 350:29-350:30
-3582: Ident           "int8" at 350:31-350:35 (leading: Space)
-3583: Comma           "," at 350:35-350:36
-3584: Ident           "other" at 350:37-350:42 (leading: Space)
-3585: Colon           ":" at 350:42-350:43
-3586: Ident           "int8" at 350:44-350:48 (leading: Space)
-3587: RParen          ")" at 350:48-350:49
-3588: Arrow           "->" at 350:50-350:52 (leading: Space)
-3589: Ident           "int8" at 350:53-350:57 (leading: Space)
-3590: Semicolon       ";" at 350:57-350:58
-3591: At              "@" at 351:5-351:6 (leading: Newline, Space)
-3592: Ident           "intrinsic" at 351:6-351:15
-3593: KwFn            "fn" at 351:16-351:18 (leading: Space)
-3594: Ident           "__shr" at 351:19-351:24 (leading: Space)
-3595: LParen          "(" at 351:24-351:25
-3596: Ident           "self" at 351:25-351:29
-3597: Colon           ":" at 351:29-351:30
-3598: Ident           "int8" at 351:31-351:35 (leading: Space)
-3599: Comma           "," at 351:35-351:36
-3600: Ident           "other" at 351:37-351:42 (leading: Space)
-3601: Colon           ":" at 351:42-351:43
-3602: Ident           "int8" at 351:44-351:48 (leading: Space)
-3603: RParen          ")" at 351:48-351:49
-3604: Arrow           "->" at 351:50-351:52 (leading: Space)
-3605: Ident           "int8" at 351:53-351:57 (leading: Space)
-3606: Semicolon       ";" at 351:57-351:58
-3607: At              "@" at 352:5-352:6 (leading: Newline, Space)
-3608: Ident           "intrinsic" at 352:6-352:15
-3609: KwFn            "fn" at 352:16-352:18 (leading: Space)
-3610: Ident           "__lt" at 352:19-352:23 (leading: Space)
-3611: LParen          "(" at 352:23-352:24
-3612: Ident           "self" at 352:24-352:28
-3613: Colon           ":" at 352:28-352:29
-3614: Ident           "int8" at 352:30-352:34 (leading: Space)
-3615: Comma           "," at 352:34-352:35
-3616: Ident           "other" at 352:36-352:41 (leading: Space)
-3617: Colon           ":" at 352:41-352:42
-3618: Ident           "int8" at 352:43-352:47 (leading: Space)
-3619: RParen          ")" at 352:47-352:48
-3620: Arrow           "->" at 352:49-352:51 (leading: Space)
-3621: Ident           "bool" at 352:52-352:56 (leading: Space)
-3622: Semicolon       ";" at 352:56-352:57
-3623: At              "@" at 353:5-353:6 (leading: Newline, Space)
-3624: Ident           "intrinsic" at 353:6-353:15
-3625: KwFn            "fn" at 353:16-353:18 (leading: Space)
-3626: Ident           "__le" at 353:19-353:23 (leading: Space)
-3627: LParen          "(" at 353:23-353:24
-3628: Ident           "self" at 353:24-353:28
-3629: Colon           ":" at 353:28-353:29
-3630: Ident           "int8" at 353:30-353:34 (leading: Space)
-3631: Comma           "," at 353:34-353:35
-3632: Ident           "other" at 353:36-353:41 (leading: Space)
-3633: Colon           ":" at 353:41-353:42
-3634: Ident           "int8" at 353:43-353:47 (leading: Space)
-3635: RParen          ")" at 353:47-353:48
-3636: Arrow           "->" at 353:49-353:51 (leading: Space)
-3637: Ident           "bool" at 353:52-353:56 (leading: Space)
-3638: Semicolon       ";" at 353:56-353:57
-3639: At              "@" at 354:5-354:6 (leading: Newline, Space)
-3640: Ident           "intrinsic" at 354:6-354:15
-3641: KwFn            "fn" at 354:16-354:18 (leading: Space)
-3642: Ident           "__eq" at 354:19-354:23 (leading: Space)
-3643: LParen          "(" at 354:23-354:24
-3644: Ident           "self" at 354:24-354:28
-3645: Colon           ":" at 354:28-354:29
-3646: Ident           "int8" at 354:30-354:34 (leading: Space)
-3647: Comma           "," at 354:34-354:35
-3648: Ident           "other" at 354:36-354:41 (leading: Space)
-3649: Colon           ":" at 354:41-354:42
-3650: Ident           "int8" at 354:43-354:47 (leading: Space)
-3651: RParen          ")" at 354:47-354:48
-3652: Arrow           "->" at 354:49-354:51 (leading: Space)
-3653: Ident           "bool" at 354:52-354:56 (leading: Space)
-3654: Semicolon       ";" at 354:56-354:57
-3655: At              "@" at 355:5-355:6 (leading: Newline, Space)
-3656: Ident           "intrinsic" at 355:6-355:15
-3657: KwFn            "fn" at 355:16-355:18 (leading: Space)
-3658: Ident           "__ne" at 355:19-355:23 (leading: Space)
-3659: LParen          "(" at 355:23-355:24
-3660: Ident           "self" at 355:24-355:28
-3661: Colon           ":" at 355:28-355:29
-3662: Ident           "int8" at 355:30-355:34 (leading: Space)
-3663: Comma           "," at 355:34-355:35
-3664: Ident           "other" at 355:36-355:41 (leading: Space)
-3665: Colon           ":" at 355:41-355:42
-3666: Ident           "int8" at 355:43-355:47 (leading: Space)
-3667: RParen          ")" at 355:47-355:48
-3668: Arrow           "->" at 355:49-355:51 (leading: Space)
-3669: Ident           "bool" at 355:52-355:56 (leading: Space)
-3670: Semicolon       ";" at 355:56-355:57
-3671: At              "@" at 356:5-356:6 (leading: Newline, Space)
-3672: Ident           "intrinsic" at 356:6-356:15
-3673: KwFn            "fn" at 356:16-356:18 (leading: Space)
-3674: Ident           "__ge" at 356:19-356:23 (leading: Space)
-3675: LParen          "(" at 356:23-356:24
-3676: Ident           "self" at 356:24-356:28
-3677: Colon           ":" at 356:28-356:29
-3678: Ident           "int8" at 356:30-356:34 (leading: Space)
-3679: Comma           "," at 356:34-356:35
-3680: Ident           "other" at 356:36-356:41 (leading: Space)
-3681: Colon           ":" at 356:41-356:42
-3682: Ident           "int8" at 356:43-356:47 (leading: Space)
-3683: RParen          ")" at 356:47-356:48
-3684: Arrow           "->" at 356:49-356:51 (leading: Space)
-3685: Ident           "bool" at 356:52-356:56 (leading: Space)
-3686: Semicolon       ";" at 356:56-356:57
-3687: At              "@" at 357:5-357:6 (leading: Newline, Space)
-3688: Ident           "intrinsic" at 357:6-357:15
-3689: KwFn            "fn" at 357:16-357:18 (leading: Space)
-3690: Ident           "__gt" at 357:19-357:23 (leading: Space)
-3691: LParen          "(" at 357:23-357:24
-3692: Ident           "self" at 357:24-357:28
-3693: Colon           ":" at 357:28-357:29
-3694: Ident           "int8" at 357:30-357:34 (leading: Space)
-3695: Comma           "," at 357:34-357:35
-3696: Ident           "other" at 357:36-357:41 (leading: Space)
-3697: Colon           ":" at 357:41-357:42
-3698: Ident           "int8" at 357:43-357:47 (leading: Space)
-3699: RParen          ")" at 357:47-357:48
-3700: Arrow           "->" at 357:49-357:51 (leading: Space)
-3701: Ident           "bool" at 357:52-357:56 (leading: Space)
-3702: Semicolon       ";" at 357:56-357:57
-3703: At              "@" at 358:5-358:6 (leading: Newline, Space)
-3704: Ident           "intrinsic" at 358:6-358:15
-3705: KwFn            "fn" at 358:16-358:18 (leading: Space)
-3706: Ident           "__pos" at 358:19-358:24 (leading: Space)
-3707: LParen          "(" at 358:24-358:25
-3708: Ident           "self" at 358:25-358:29
-3709: Colon           ":" at 358:29-358:30
-3710: Ident           "int8" at 358:31-358:35 (leading: Space)
-3711: RParen          ")" at 358:35-358:36
-3712: Arrow           "->" at 358:37-358:39 (leading: Space)
-3713: Ident           "int8" at 358:40-358:44 (leading: Space)
-3714: Semicolon       ";" at 358:44-358:45
-3715: At              "@" at 359:5-359:6 (leading: Newline, Space)
-3716: Ident           "intrinsic" at 359:6-359:15
-3717: KwFn            "fn" at 359:16-359:18 (leading: Space)
-3718: Ident           "__neg" at 359:19-359:24 (leading: Space)
-3719: LParen          "(" at 359:24-359:25
-3720: Ident           "self" at 359:25-359:29
-3721: Colon           ":" at 359:29-359:30
-3722: Ident           "int8" at 359:31-359:35 (leading: Space)
-3723: RParen          ")" at 359:35-359:36
-3724: Arrow           "->" at 359:37-359:39 (leading: Space)
-3725: Ident           "int8" at 359:40-359:44 (leading: Space)
-3726: Semicolon       ";" at 359:44-359:45
-3727: At              "@" at 360:5-360:6 (leading: Newline, Space)
-3728: Ident           "intrinsic" at 360:6-360:15
-3729: KwFn            "fn" at 360:16-360:18 (leading: Space)
-3730: Ident           "__abs" at 360:19-360:24 (leading: Space)
-3731: LParen          "(" at 360:24-360:25
-3732: Ident           "self" at 360:25-360:29
-3733: Colon           ":" at 360:29-360:30
-3734: Ident           "int8" at 360:31-360:35 (leading: Space)
-3735: RParen          ")" at 360:35-360:36
-3736: Arrow           "->" at 360:37-360:39 (leading: Space)
-3737: Ident           "int8" at 360:40-360:44 (leading: Space)
-3738: Semicolon       ";" at 360:44-360:45
-3739: At              "@" at 361:5-361:6 (leading: Newline, Space)
-3740: Ident           "intrinsic" at 361:6-361:15
-3741: KwFn            "fn" at 361:16-361:18 (leading: Space)
-3742: Ident           "__to" at 361:19-361:23 (leading: Space)
-3743: LParen          "(" at 361:23-361:24
-3744: Ident           "self" at 361:24-361:28
-3745: Colon           ":" at 361:28-361:29
-3746: Ident           "int8" at 361:30-361:34 (leading: Space)
-3747: Comma           "," at 361:34-361:35
-3748: Ident           "target" at 361:36-361:42 (leading: Space)
-3749: Colon           ":" at 361:42-361:43
-3750: Ident           "int" at 361:44-361:47 (leading: Space)
-3751: RParen          ")" at 361:47-361:48
-3752: Arrow           "->" at 361:49-361:51 (leading: Space)
-3753: Ident           "int" at 361:52-361:55 (leading: Space)
-3754: Semicolon       ";" at 361:55-361:56
-3755: At              "@" at 362:5-362:6 (leading: Newline, Space)
-3756: Ident           "intrinsic" at 362:6-362:15
-3757: At              "@" at 362:16-362:17 (leading: Space)
-3758: Ident           "overload" at 362:17-362:25
-3759: KwFn            "fn" at 362:26-362:28 (leading: Space)
-3760: Ident           "__to" at 362:29-362:33 (leading: Space)
-3761: LParen          "(" at 362:33-362:34
-3762: Ident           "self" at 362:34-362:38
-3763: Colon           ":" at 362:38-362:39
-3764: Ident           "int8" at 362:40-362:44 (leading: Space)
-3765: Comma           "," at 362:44-362:45
-3766: Ident           "target" at 362:46-362:52 (leading: Space)
-3767: Colon           ":" at 362:52-362:53
-3768: Ident           "int16" at 362:54-362:59 (leading: Space)
-3769: RParen          ")" at 362:59-362:60
-3770: Arrow           "->" at 362:61-362:63 (leading: Space)
-3771: Ident           "int16" at 362:64-362:69 (leading: Space)
-3772: Semicolon       ";" at 362:69-362:70
-3773: At              "@" at 363:5-363:6 (leading: Newline, Space)
-3774: Ident           "intrinsic" at 363:6-363:15
-3775: At              "@" at 363:16-363:17 (leading: Space)
-3776: Ident           "overload" at 363:17-363:25
-3777: KwFn            "fn" at 363:26-363:28 (leading: Space)
-3778: Ident           "__to" at 363:29-363:33 (leading: Space)
-3779: LParen          "(" at 363:33-363:34
-3780: Ident           "self" at 363:34-363:38
-3781: Colon           ":" at 363:38-363:39
-3782: Ident           "int8" at 363:40-363:44 (leading: Space)
-3783: Comma           "," at 363:44-363:45
-3784: Ident           "target" at 363:46-363:52 (leading: Space)
-3785: Colon           ":" at 363:52-363:53
-3786: Ident           "int32" at 363:54-363:59 (leading: Space)
-3787: RParen          ")" at 363:59-363:60
-3788: Arrow           "->" at 363:61-363:63 (leading: Space)
-3789: Ident           "int32" at 363:64-363:69 (leading: Space)
-3790: Semicolon       ";" at 363:69-363:70
-3791: At              "@" at 364:5-364:6 (leading: Newline, Space)
-3792: Ident           "intrinsic" at 364:6-364:15
-3793: At              "@" at 364:16-364:17 (leading: Space)
-3794: Ident           "overload" at 364:17-364:25
-3795: KwFn            "fn" at 364:26-364:28 (leading: Space)
-3796: Ident           "__to" at 364:29-364:33 (leading: Space)
-3797: LParen          "(" at 364:33-364:34
-3798: Ident           "self" at 364:34-364:38
-3799: Colon           ":" at 364:38-364:39
-3800: Ident           "int8" at 364:40-364:44 (leading: Space)
-3801: Comma           "," at 364:44-364:45
-3802: Ident           "target" at 364:46-364:52 (leading: Space)
-3803: Colon           ":" at 364:52-364:53
-3804: Ident           "int64" at 364:54-364:59 (leading: Space)
-3805: RParen          ")" at 364:59-364:60
-3806: Arrow           "->" at 364:61-364:63 (leading: Space)
-3807: Ident           "int64" at 364:64-364:69 (leading: Space)
-3808: Semicolon       ";" at 364:69-364:70
-3809: At              "@" at 365:5-365:6 (leading: Newline, Space)
-3810: Ident           "intrinsic" at 365:6-365:15
-3811: KwPub           "pub" at 365:16-365:19 (leading: Space)
-3812: KwFn            "fn" at 365:20-365:22 (leading: Space)
-3813: Ident           "from_str" at 365:23-365:31 (leading: Space)
-3814: LParen          "(" at 365:31-365:32
-3815: Ident           "s" at 365:32-365:33
-3816: Colon           ":" at 365:33-365:34
-3817: Amp             "&" at 365:35-365:36 (leading: Space)
-3818: Ident           "string" at 365:36-365:42
-3819: RParen          ")" at 365:42-365:43
-3820: Arrow           "->" at 365:44-365:46 (leading: Space)
-3821: Ident           "Erring" at 365:47-365:53 (leading: Space)
-3822: Lt              "<" at 365:53-365:54
-3823: Ident           "int8" at 365:54-365:58
-3824: Comma           "," at 365:58-365:59
-3825: Ident           "Error" at 365:60-365:65 (leading: Space)
-3826: Gt              ">" at 365:65-365:66
-3827: Semicolon       ";" at 365:66-365:67
-3828: RBrace          "}" at 366:1-366:2 (leading: Newline)
-3829: KwExtern        "extern" at 368:1-368:7 (leading: Newline)
-3830: Lt              "<" at 368:7-368:8
-3831: Ident           "int16" at 368:8-368:13
-3832: Gt              ">" at 368:13-368:14
-3833: LBrace          "{" at 368:15-368:16 (leading: Space)
-3834: KwPub           "pub" at 369:5-369:8 (leading: Newline, Space)
-3835: KwFn            "fn" at 369:9-369:11 (leading: Space)
-3836: Ident           "__min_value" at 369:12-369:23 (leading: Space)
-3837: LParen          "(" at 369:23-369:24
-3838: RParen          ")" at 369:24-369:25
-3839: Arrow           "->" at 369:26-369:28 (leading: Space)
-3840: Ident           "int16" at 369:29-369:34 (leading: Space)
-3841: LBrace          "{" at 369:35-369:36 (leading: Space)
-3842: KwReturn        "return" at 369:37-369:43 (leading: Space)
-3843: LParen          "(" at 369:44-369:45 (leading: Space)
-3844: Minus           "-" at 369:45-369:46
-3845: IntLit          "32_768" at 369:46-369:52
-3846: RParen          ")" at 369:52-369:53
-3847: Colon           ":" at 369:53-369:54
-3848: Ident           "int16" at 369:54-369:59
-3849: Semicolon       ";" at 369:59-369:60
-3850: RBrace          "}" at 369:61-369:62 (leading: Space)
-3851: KwPub           "pub" at 370:5-370:8 (leading: Newline, Space)
-3852: KwFn            "fn" at 370:9-370:11 (leading: Space)
-3853: Ident           "__max_value" at 370:12-370:23 (leading: Space)
-3854: LParen          "(" at 370:23-370:24
-3855: RParen          ")" at 370:24-370:25
-3856: Arrow           "->" at 370:26-370:28 (leading: Space)
-3857: Ident           "int16" at 370:29-370:34 (leading: Space)
-3858: LBrace          "{" at 370:35-370:36 (leading: Space)
-3859: KwReturn        "return" at 370:37-370:43 (leading: Space)
-3860: LParen          "(" at 370:44-370:45 (leading: Space)
-3861: IntLit          "32_767" at 370:45-370:51
-3862: RParen          ")" at 370:51-370:52
-3863: Colon           ":" at 370:52-370:53
-3864: Ident           "int16" at 370:53-370:58
-3865: Semicolon       ";" at 370:58-370:59
-3866: RBrace          "}" at 370:60-370:61 (leading: Space)
-3867: At              "@" at 371:5-371:6 (leading: Newline, Space)
-3868: Ident           "intrinsic" at 371:6-371:15
-3869: KwFn            "fn" at 371:16-371:18 (leading: Space)
-3870: Ident           "__add" at 371:19-371:24 (leading: Space)
-3871: LParen          "(" at 371:24-371:25
-3872: Ident           "self" at 371:25-371:29
-3873: Colon           ":" at 371:29-371:30
-3874: Ident           "int16" at 371:31-371:36 (leading: Space)
-3875: Comma           "," at 371:36-371:37
-3876: Ident           "other" at 371:38-371:43 (leading: Space)
-3877: Colon           ":" at 371:43-371:44
-3878: Ident           "int16" at 371:45-371:50 (leading: Space)
-3879: RParen          ")" at 371:50-371:51
-3880: Arrow           "->" at 371:52-371:54 (leading: Space)
-3881: Ident           "int16" at 371:55-371:60 (leading: Space)
-3882: Semicolon       ";" at 371:60-371:61
-3883: At              "@" at 372:5-372:6 (leading: Newline, Space)
-3884: Ident           "intrinsic" at 372:6-372:15
-3885: KwFn            "fn" at 372:16-372:18 (leading: Space)
-3886: Ident           "__sub" at 372:19-372:24 (leading: Space)
-3887: LParen          "(" at 372:24-372:25
-3888: Ident           "self" at 372:25-372:29
-3889: Colon           ":" at 372:29-372:30
-3890: Ident           "int16" at 372:31-372:36 (leading: Space)
-3891: Comma           "," at 372:36-372:37
-3892: Ident           "other" at 372:38-372:43 (leading: Space)
-3893: Colon           ":" at 372:43-372:44
-3894: Ident           "int16" at 372:45-372:50 (leading: Space)
-3895: RParen          ")" at 372:50-372:51
-3896: Arrow           "->" at 372:52-372:54 (leading: Space)
-3897: Ident           "int16" at 372:55-372:60 (leading: Space)
-3898: Semicolon       ";" at 372:60-372:61
-3899: At              "@" at 373:5-373:6 (leading: Newline, Space)
-3900: Ident           "intrinsic" at 373:6-373:15
-3901: KwFn            "fn" at 373:16-373:18 (leading: Space)
-3902: Ident           "__mul" at 373:19-373:24 (leading: Space)
-3903: LParen          "(" at 373:24-373:25
-3904: Ident           "self" at 373:25-373:29
-3905: Colon           ":" at 373:29-373:30
-3906: Ident           "int16" at 373:31-373:36 (leading: Space)
-3907: Comma           "," at 373:36-373:37
-3908: Ident           "other" at 373:38-373:43 (leading: Space)
-3909: Colon           ":" at 373:43-373:44
-3910: Ident           "int16" at 373:45-373:50 (leading: Space)
-3911: RParen          ")" at 373:50-373:51
-3912: Arrow           "->" at 373:52-373:54 (leading: Space)
-3913: Ident           "int16" at 373:55-373:60 (leading: Space)
-3914: Semicolon       ";" at 373:60-373:61
-3915: At              "@" at 374:5-374:6 (leading: Newline, Space)
-3916: Ident           "intrinsic" at 374:6-374:15
-3917: KwFn            "fn" at 374:16-374:18 (leading: Space)
-3918: Ident           "__div" at 374:19-374:24 (leading: Space)
-3919: LParen          "(" at 374:24-374:25
-3920: Ident           "self" at 374:25-374:29
-3921: Colon           ":" at 374:29-374:30
-3922: Ident           "int16" at 374:31-374:36 (leading: Space)
-3923: Comma           "," at 374:36-374:37
-3924: Ident           "other" at 374:38-374:43 (leading: Space)
-3925: Colon           ":" at 374:43-374:44
-3926: Ident           "int16" at 374:45-374:50 (leading: Space)
-3927: RParen          ")" at 374:50-374:51
-3928: Arrow           "->" at 374:52-374:54 (leading: Space)
-3929: Ident           "int16" at 374:55-374:60 (leading: Space)
-3930: Semicolon       ";" at 374:60-374:61
-3931: At              "@" at 375:5-375:6 (leading: Newline, Space)
-3932: Ident           "intrinsic" at 375:6-375:15
-3933: KwFn            "fn" at 375:16-375:18 (leading: Space)
-3934: Ident           "__mod" at 375:19-375:24 (leading: Space)
-3935: LParen          "(" at 375:24-375:25
-3936: Ident           "self" at 375:25-375:29
-3937: Colon           ":" at 375:29-375:30
-3938: Ident           "int16" at 375:31-375:36 (leading: Space)
-3939: Comma           "," at 375:36-375:37
-3940: Ident           "other" at 375:38-375:43 (leading: Space)
-3941: Colon           ":" at 375:43-375:44
-3942: Ident           "int16" at 375:45-375:50 (leading: Space)
-3943: RParen          ")" at 375:50-375:51
-3944: Arrow           "->" at 375:52-375:54 (leading: Space)
-3945: Ident           "int16" at 375:55-375:60 (leading: Space)
-3946: Semicolon       ";" at 375:60-375:61
-3947: At              "@" at 376:5-376:6 (leading: Newline, Space)
-3948: Ident           "intrinsic" at 376:6-376:15
-3949: KwFn            "fn" at 376:16-376:18 (leading: Space)
-3950: Ident           "__bit_and" at 376:19-376:28 (leading: Space)
-3951: LParen          "(" at 376:28-376:29
-3952: Ident           "self" at 376:29-376:33
-3953: Colon           ":" at 376:33-376:34
-3954: Ident           "int16" at 376:35-376:40 (leading: Space)
-3955: Comma           "," at 376:40-376:41
-3956: Ident           "other" at 376:42-376:47 (leading: Space)
-3957: Colon           ":" at 376:47-376:48
-3958: Ident           "int16" at 376:49-376:54 (leading: Space)
-3959: RParen          ")" at 376:54-376:55
-3960: Arrow           "->" at 376:56-376:58 (leading: Space)
-3961: Ident           "int16" at 376:59-376:64 (leading: Space)
-3962: Semicolon       ";" at 376:64-376:65
-3963: At              "@" at 377:5-377:6 (leading: Newline, Space)
-3964: Ident           "intrinsic" at 377:6-377:15
-3965: KwFn            "fn" at 377:16-377:18 (leading: Space)
-3966: Ident           "__bit_or" at 377:19-377:27 (leading: Space)
-3967: LParen          "(" at 377:27-377:28
-3968: Ident           "self" at 377:28-377:32
-3969: Colon           ":" at 377:32-377:33
-3970: Ident           "int16" at 377:34-377:39 (leading: Space)
-3971: Comma           "," at 377:39-377:40
-3972: Ident           "other" at 377:41-377:46 (leading: Space)
-3973: Colon           ":" at 377:46-377:47
-3974: Ident           "int16" at 377:48-377:53 (leading: Space)
-3975: RParen          ")" at 377:53-377:54
-3976: Arrow           "->" at 377:55-377:57 (leading: Space)
-3977: Ident           "int16" at 377:58-377:63 (leading: Space)
-3978: Semicolon       ";" at 377:63-377:64
-3979: At              "@" at 378:5-378:6 (leading: Newline, Space)
-3980: Ident           "intrinsic" at 378:6-378:15
-3981: KwFn            "fn" at 378:16-378:18 (leading: Space)
-3982: Ident           "__bit_xor" at 378:19-378:28 (leading: Space)
-3983: LParen          "(" at 378:28-378:29
-3984: Ident           "self" at 378:29-378:33
-3985: Colon           ":" at 378:33-378:34
-3986: Ident           "int16" at 378:35-378:40 (leading: Space)
-3987: Comma           "," at 378:40-378:41
-3988: Ident           "other" at 378:42-378:47 (leading: Space)
-3989: Colon           ":" at 378:47-378:48
-3990: Ident           "int16" at 378:49-378:54 (leading: Space)
-3991: RParen          ")" at 378:54-378:55
-3992: Arrow           "->" at 378:56-378:58 (leading: Space)
-3993: Ident           "int16" at 378:59-378:64 (leading: Space)
-3994: Semicolon       ";" at 378:64-378:65
-3995: At              "@" at 379:5-379:6 (leading: Newline, Space)
-3996: Ident           "intrinsic" at 379:6-379:15
-3997: KwFn            "fn" at 379:16-379:18 (leading: Space)
-3998: Ident           "__shl" at 379:19-379:24 (leading: Space)
-3999: LParen          "(" at 379:24-379:25
-4000: Ident           "self" at 379:25-379:29
-4001: Colon           ":" at 379:29-379:30
-4002: Ident           "int16" at 379:31-379:36 (leading: Space)
-4003: Comma           "," at 379:36-379:37
-4004: Ident           "other" at 379:38-379:43 (leading: Space)
-4005: Colon           ":" at 379:43-379:44
-4006: Ident           "int16" at 379:45-379:50 (leading: Space)
-4007: RParen          ")" at 379:50-379:51
-4008: Arrow           "->" at 379:52-379:54 (leading: Space)
-4009: Ident           "int16" at 379:55-379:60 (leading: Space)
-4010: Semicolon       ";" at 379:60-379:61
-4011: At              "@" at 380:5-380:6 (leading: Newline, Space)
-4012: Ident           "intrinsic" at 380:6-380:15
-4013: KwFn            "fn" at 380:16-380:18 (leading: Space)
-4014: Ident           "__shr" at 380:19-380:24 (leading: Space)
-4015: LParen          "(" at 380:24-380:25
-4016: Ident           "self" at 380:25-380:29
-4017: Colon           ":" at 380:29-380:30
-4018: Ident           "int16" at 380:31-380:36 (leading: Space)
-4019: Comma           "," at 380:36-380:37
-4020: Ident           "other" at 380:38-380:43 (leading: Space)
-4021: Colon           ":" at 380:43-380:44
-4022: Ident           "int16" at 380:45-380:50 (leading: Space)
-4023: RParen          ")" at 380:50-380:51
-4024: Arrow           "->" at 380:52-380:54 (leading: Space)
-4025: Ident           "int16" at 380:55-380:60 (leading: Space)
-4026: Semicolon       ";" at 380:60-380:61
-4027: At              "@" at 381:5-381:6 (leading: Newline, Space)
-4028: Ident           "intrinsic" at 381:6-381:15
-4029: KwFn            "fn" at 381:16-381:18 (leading: Space)
-4030: Ident           "__lt" at 381:19-381:23 (leading: Space)
-4031: LParen          "(" at 381:23-381:24
-4032: Ident           "self" at 381:24-381:28
-4033: Colon           ":" at 381:28-381:29
-4034: Ident           "int16" at 381:30-381:35 (leading: Space)
-4035: Comma           "," at 381:35-381:36
-4036: Ident           "other" at 381:37-381:42 (leading: Space)
-4037: Colon           ":" at 381:42-381:43
-4038: Ident           "int16" at 381:44-381:49 (leading: Space)
-4039: RParen          ")" at 381:49-381:50
-4040: Arrow           "->" at 381:51-381:53 (leading: Space)
-4041: Ident           "bool" at 381:54-381:58 (leading: Space)
-4042: Semicolon       ";" at 381:58-381:59
-4043: At              "@" at 382:5-382:6 (leading: Newline, Space)
-4044: Ident           "intrinsic" at 382:6-382:15
-4045: KwFn            "fn" at 382:16-382:18 (leading: Space)
-4046: Ident           "__le" at 382:19-382:23 (leading: Space)
-4047: LParen          "(" at 382:23-382:24
-4048: Ident           "self" at 382:24-382:28
-4049: Colon           ":" at 382:28-382:29
-4050: Ident           "int16" at 382:30-382:35 (leading: Space)
-4051: Comma           "," at 382:35-382:36
-4052: Ident           "other" at 382:37-382:42 (leading: Space)
-4053: Colon           ":" at 382:42-382:43
-4054: Ident           "int16" at 382:44-382:49 (leading: Space)
-4055: RParen          ")" at 382:49-382:50
-4056: Arrow           "->" at 382:51-382:53 (leading: Space)
-4057: Ident           "bool" at 382:54-382:58 (leading: Space)
-4058: Semicolon       ";" at 382:58-382:59
-4059: At              "@" at 383:5-383:6 (leading: Newline, Space)
-4060: Ident           "intrinsic" at 383:6-383:15
-4061: KwFn            "fn" at 383:16-383:18 (leading: Space)
-4062: Ident           "__eq" at 383:19-383:23 (leading: Space)
-4063: LParen          "(" at 383:23-383:24
-4064: Ident           "self" at 383:24-383:28
-4065: Colon           ":" at 383:28-383:29
-4066: Ident           "int16" at 383:30-383:35 (leading: Space)
-4067: Comma           "," at 383:35-383:36
-4068: Ident           "other" at 383:37-383:42 (leading: Space)
-4069: Colon           ":" at 383:42-383:43
-4070: Ident           "int16" at 383:44-383:49 (leading: Space)
-4071: RParen          ")" at 383:49-383:50
-4072: Arrow           "->" at 383:51-383:53 (leading: Space)
-4073: Ident           "bool" at 383:54-383:58 (leading: Space)
-4074: Semicolon       ";" at 383:58-383:59
-4075: At              "@" at 384:5-384:6 (leading: Newline, Space)
-4076: Ident           "intrinsic" at 384:6-384:15
-4077: KwFn            "fn" at 384:16-384:18 (leading: Space)
-4078: Ident           "__ne" at 384:19-384:23 (leading: Space)
-4079: LParen          "(" at 384:23-384:24
-4080: Ident           "self" at 384:24-384:28
-4081: Colon           ":" at 384:28-384:29
-4082: Ident           "int16" at 384:30-384:35 (leading: Space)
-4083: Comma           "," at 384:35-384:36
-4084: Ident           "other" at 384:37-384:42 (leading: Space)
-4085: Colon           ":" at 384:42-384:43
-4086: Ident           "int16" at 384:44-384:49 (leading: Space)
-4087: RParen          ")" at 384:49-384:50
-4088: Arrow           "->" at 384:51-384:53 (leading: Space)
-4089: Ident           "bool" at 384:54-384:58 (leading: Space)
-4090: Semicolon       ";" at 384:58-384:59
-4091: At              "@" at 385:5-385:6 (leading: Newline, Space)
-4092: Ident           "intrinsic" at 385:6-385:15
-4093: KwFn            "fn" at 385:16-385:18 (leading: Space)
-4094: Ident           "__ge" at 385:19-385:23 (leading: Space)
-4095: LParen          "(" at 385:23-385:24
-4096: Ident           "self" at 385:24-385:28
-4097: Colon           ":" at 385:28-385:29
-4098: Ident           "int16" at 385:30-385:35 (leading: Space)
-4099: Comma           "," at 385:35-385:36
-4100: Ident           "other" at 385:37-385:42 (leading: Space)
-4101: Colon           ":" at 385:42-385:43
-4102: Ident           "int16" at 385:44-385:49 (leading: Space)
-4103: RParen          ")" at 385:49-385:50
-4104: Arrow           "->" at 385:51-385:53 (leading: Space)
-4105: Ident           "bool" at 385:54-385:58 (leading: Space)
-4106: Semicolon       ";" at 385:58-385:59
-4107: At              "@" at 386:5-386:6 (leading: Newline, Space)
-4108: Ident           "intrinsic" at 386:6-386:15
-4109: KwFn            "fn" at 386:16-386:18 (leading: Space)
-4110: Ident           "__gt" at 386:19-386:23 (leading: Space)
-4111: LParen          "(" at 386:23-386:24
-4112: Ident           "self" at 386:24-386:28
-4113: Colon           ":" at 386:28-386:29
-4114: Ident           "int16" at 386:30-386:35 (leading: Space)
-4115: Comma           "," at 386:35-386:36
-4116: Ident           "other" at 386:37-386:42 (leading: Space)
-4117: Colon           ":" at 386:42-386:43
-4118: Ident           "int16" at 386:44-386:49 (leading: Space)
-4119: RParen          ")" at 386:49-386:50
-4120: Arrow           "->" at 386:51-386:53 (leading: Space)
-4121: Ident           "bool" at 386:54-386:58 (leading: Space)
-4122: Semicolon       ";" at 386:58-386:59
-4123: At              "@" at 387:5-387:6 (leading: Newline, Space)
-4124: Ident           "intrinsic" at 387:6-387:15
-4125: KwFn            "fn" at 387:16-387:18 (leading: Space)
-4126: Ident           "__pos" at 387:19-387:24 (leading: Space)
-4127: LParen          "(" at 387:24-387:25
-4128: Ident           "self" at 387:25-387:29
-4129: Colon           ":" at 387:29-387:30
-4130: Ident           "int16" at 387:31-387:36 (leading: Space)
-4131: RParen          ")" at 387:36-387:37
-4132: Arrow           "->" at 387:38-387:40 (leading: Space)
-4133: Ident           "int16" at 387:41-387:46 (leading: Space)
-4134: Semicolon       ";" at 387:46-387:47
-4135: At              "@" at 388:5-388:6 (leading: Newline, Space)
-4136: Ident           "intrinsic" at 388:6-388:15
-4137: KwFn            "fn" at 388:16-388:18 (leading: Space)
-4138: Ident           "__neg" at 388:19-388:24 (leading: Space)
-4139: LParen          "(" at 388:24-388:25
-4140: Ident           "self" at 388:25-388:29
-4141: Colon           ":" at 388:29-388:30
-4142: Ident           "int16" at 388:31-388:36 (leading: Space)
-4143: RParen          ")" at 388:36-388:37
-4144: Arrow           "->" at 388:38-388:40 (leading: Space)
-4145: Ident           "int16" at 388:41-388:46 (leading: Space)
-4146: Semicolon       ";" at 388:46-388:47
-4147: At              "@" at 389:5-389:6 (leading: Newline, Space)
-4148: Ident           "intrinsic" at 389:6-389:15
-4149: KwFn            "fn" at 389:16-389:18 (leading: Space)
-4150: Ident           "__abs" at 389:19-389:24 (leading: Space)
-4151: LParen          "(" at 389:24-389:25
-4152: Ident           "self" at 389:25-389:29
-4153: Colon           ":" at 389:29-389:30
-4154: Ident           "int16" at 389:31-389:36 (leading: Space)
-4155: RParen          ")" at 389:36-389:37
-4156: Arrow           "->" at 389:38-389:40 (leading: Space)
-4157: Ident           "int16" at 389:41-389:46 (leading: Space)
-4158: Semicolon       ";" at 389:46-389:47
-4159: At              "@" at 390:5-390:6 (leading: Newline, Space)
-4160: Ident           "intrinsic" at 390:6-390:15
-4161: KwFn            "fn" at 390:16-390:18 (leading: Space)
-4162: Ident           "__to" at 390:19-390:23 (leading: Space)
-4163: LParen          "(" at 390:23-390:24
-4164: Ident           "self" at 390:24-390:28
-4165: Colon           ":" at 390:28-390:29
-4166: Ident           "int16" at 390:30-390:35 (leading: Space)
-4167: Comma           "," at 390:35-390:36
-4168: Ident           "target" at 390:37-390:43 (leading: Space)
-4169: Colon           ":" at 390:43-390:44
-4170: Ident           "int" at 390:45-390:48 (leading: Space)
-4171: RParen          ")" at 390:48-390:49
-4172: Arrow           "->" at 390:50-390:52 (leading: Space)
-4173: Ident           "int" at 390:53-390:56 (leading: Space)
-4174: Semicolon       ";" at 390:56-390:57
-4175: At              "@" at 391:5-391:6 (leading: Newline, Space)
-4176: Ident           "intrinsic" at 391:6-391:15
-4177: At              "@" at 391:16-391:17 (leading: Space)
-4178: Ident           "overload" at 391:17-391:25
-4179: KwFn            "fn" at 391:26-391:28 (leading: Space)
-4180: Ident           "__to" at 391:29-391:33 (leading: Space)
-4181: LParen          "(" at 391:33-391:34
-4182: Ident           "self" at 391:34-391:38
-4183: Colon           ":" at 391:38-391:39
-4184: Ident           "int16" at 391:40-391:45 (leading: Space)
-4185: Comma           "," at 391:45-391:46
-4186: Ident           "target" at 391:47-391:53 (leading: Space)
-4187: Colon           ":" at 391:53-391:54
-4188: Ident           "int8" at 391:55-391:59 (leading: Space)
-4189: RParen          ")" at 391:59-391:60
-4190: Arrow           "->" at 391:61-391:63 (leading: Space)
-4191: Ident           "int8" at 391:64-391:68 (leading: Space)
-4192: Semicolon       ";" at 391:68-391:69
-4193: At              "@" at 392:5-392:6 (leading: Newline, Space)
-4194: Ident           "intrinsic" at 392:6-392:15
-4195: At              "@" at 392:16-392:17 (leading: Space)
-4196: Ident           "overload" at 392:17-392:25
-4197: KwFn            "fn" at 392:26-392:28 (leading: Space)
-4198: Ident           "__to" at 392:29-392:33 (leading: Space)
-4199: LParen          "(" at 392:33-392:34
-4200: Ident           "self" at 392:34-392:38
-4201: Colon           ":" at 392:38-392:39
-4202: Ident           "int16" at 392:40-392:45 (leading: Space)
-4203: Comma           "," at 392:45-392:46
-4204: Ident           "target" at 392:47-392:53 (leading: Space)
-4205: Colon           ":" at 392:53-392:54
-4206: Ident           "int32" at 392:55-392:60 (leading: Space)
-4207: RParen          ")" at 392:60-392:61
-4208: Arrow           "->" at 392:62-392:64 (leading: Space)
-4209: Ident           "int32" at 392:65-392:70 (leading: Space)
-4210: Semicolon       ";" at 392:70-392:71
-4211: At              "@" at 393:5-393:6 (leading: Newline, Space)
-4212: Ident           "intrinsic" at 393:6-393:15
-4213: At              "@" at 393:16-393:17 (leading: Space)
-4214: Ident           "overload" at 393:17-393:25
-4215: KwFn            "fn" at 393:26-393:28 (leading: Space)
-4216: Ident           "__to" at 393:29-393:33 (leading: Space)
-4217: LParen          "(" at 393:33-393:34
-4218: Ident           "self" at 393:34-393:38
-4219: Colon           ":" at 393:38-393:39
-4220: Ident           "int16" at 393:40-393:45 (leading: Space)
-4221: Comma           "," at 393:45-393:46
-4222: Ident           "target" at 393:47-393:53 (leading: Space)
-4223: Colon           ":" at 393:53-393:54
-4224: Ident           "int64" at 393:55-393:60 (leading: Space)
-4225: RParen          ")" at 393:60-393:61
-4226: Arrow           "->" at 393:62-393:64 (leading: Space)
-4227: Ident           "int64" at 393:65-393:70 (leading: Space)
-4228: Semicolon       ";" at 393:70-393:71
-4229: At              "@" at 394:5-394:6 (leading: Newline, Space)
-4230: Ident           "intrinsic" at 394:6-394:15
-4231: KwPub           "pub" at 394:16-394:19 (leading: Space)
-4232: KwFn            "fn" at 394:20-394:22 (leading: Space)
-4233: Ident           "from_str" at 394:23-394:31 (leading: Space)
-4234: LParen          "(" at 394:31-394:32
-4235: Ident           "s" at 394:32-394:33
-4236: Colon           ":" at 394:33-394:34
-4237: Amp             "&" at 394:35-394:36 (leading: Space)
-4238: Ident           "string" at 394:36-394:42
-4239: RParen          ")" at 394:42-394:43
-4240: Arrow           "->" at 394:44-394:46 (leading: Space)
-4241: Ident           "Erring" at 394:47-394:53 (leading: Space)
-4242: Lt              "<" at 394:53-394:54
-4243: Ident           "int16" at 394:54-394:59
-4244: Comma           "," at 394:59-394:60
-4245: Ident           "Error" at 394:61-394:66 (leading: Space)
-4246: Gt              ">" at 394:66-394:67
-4247: Semicolon       ";" at 394:67-394:68
-4248: RBrace          "}" at 395:1-395:2 (leading: Newline)
-4249: KwExtern        "extern" at 397:1-397:7 (leading: Newline)
-4250: Lt              "<" at 397:7-397:8
-4251: Ident           "int32" at 397:8-397:13
-4252: Gt              ">" at 397:13-397:14
-4253: LBrace          "{" at 397:15-397:16 (leading: Space)
-4254: KwPub           "pub" at 398:5-398:8 (leading: Newline, Space)
-4255: KwFn            "fn" at 398:9-398:11 (leading: Space)
-4256: Ident           "__min_value" at 398:12-398:23 (leading: Space)
-4257: LParen          "(" at 398:23-398:24
-4258: RParen          ")" at 398:24-398:25
-4259: Arrow           "->" at 398:26-398:28 (leading: Space)
-4260: Ident           "int32" at 398:29-398:34 (leading: Space)
-4261: LBrace          "{" at 398:35-398:36 (leading: Space)
-4262: KwReturn        "return" at 398:37-398:43 (leading: Space)
-4263: LParen          "(" at 398:44-398:45 (leading: Space)
-4264: Minus           "-" at 398:45-398:46
-4265: IntLit          "2_147_483_648" at 398:46-398:59
-4266: RParen          ")" at 398:59-398:60
-4267: Colon           ":" at 398:60-398:61
-4268: Ident           "int32" at 398:61-398:66
-4269: Semicolon       ";" at 398:66-398:67
-4270: RBrace          "}" at 398:68-398:69 (leading: Space)
-4271: KwPub           "pub" at 399:5-399:8 (leading: Newline, Space)
-4272: KwFn            "fn" at 399:9-399:11 (leading: Space)
-4273: Ident           "__max_value" at 399:12-399:23 (leading: Space)
-4274: LParen          "(" at 399:23-399:24
-4275: RParen          ")" at 399:24-399:25
-4276: Arrow           "->" at 399:26-399:28 (leading: Space)
-4277: Ident           "int32" at 399:29-399:34 (leading: Space)
-4278: LBrace          "{" at 399:35-399:36 (leading: Space)
-4279: KwReturn        "return" at 399:37-399:43 (leading: Space)
-4280: LParen          "(" at 399:44-399:45 (leading: Space)
-4281: IntLit          "2_147_483_647" at 399:45-399:58
-4282: RParen          ")" at 399:58-399:59
-4283: Colon           ":" at 399:59-399:60
-4284: Ident           "int32" at 399:60-399:65
-4285: Semicolon       ";" at 399:65-399:66
-4286: RBrace          "}" at 399:67-399:68 (leading: Space)
-4287: At              "@" at 400:5-400:6 (leading: Newline, Space)
-4288: Ident           "intrinsic" at 400:6-400:15
-4289: KwFn            "fn" at 400:16-400:18 (leading: Space)
-4290: Ident           "__add" at 400:19-400:24 (leading: Space)
-4291: LParen          "(" at 400:24-400:25
-4292: Ident           "self" at 400:25-400:29
-4293: Colon           ":" at 400:29-400:30
-4294: Ident           "int32" at 400:31-400:36 (leading: Space)
-4295: Comma           "," at 400:36-400:37
-4296: Ident           "other" at 400:38-400:43 (leading: Space)
-4297: Colon           ":" at 400:43-400:44
-4298: Ident           "int32" at 400:45-400:50 (leading: Space)
-4299: RParen          ")" at 400:50-400:51
-4300: Arrow           "->" at 400:52-400:54 (leading: Space)
-4301: Ident           "int32" at 400:55-400:60 (leading: Space)
-4302: Semicolon       ";" at 400:60-400:61
-4303: At              "@" at 401:5-401:6 (leading: Newline, Space)
-4304: Ident           "intrinsic" at 401:6-401:15
-4305: KwFn            "fn" at 401:16-401:18 (leading: Space)
-4306: Ident           "__sub" at 401:19-401:24 (leading: Space)
-4307: LParen          "(" at 401:24-401:25
-4308: Ident           "self" at 401:25-401:29
-4309: Colon           ":" at 401:29-401:30
-4310: Ident           "int32" at 401:31-401:36 (leading: Space)
-4311: Comma           "," at 401:36-401:37
-4312: Ident           "other" at 401:38-401:43 (leading: Space)
-4313: Colon           ":" at 401:43-401:44
-4314: Ident           "int32" at 401:45-401:50 (leading: Space)
-4315: RParen          ")" at 401:50-401:51
-4316: Arrow           "->" at 401:52-401:54 (leading: Space)
-4317: Ident           "int32" at 401:55-401:60 (leading: Space)
-4318: Semicolon       ";" at 401:60-401:61
-4319: At              "@" at 402:5-402:6 (leading: Newline, Space)
-4320: Ident           "intrinsic" at 402:6-402:15
-4321: KwFn            "fn" at 402:16-402:18 (leading: Space)
-4322: Ident           "__mul" at 402:19-402:24 (leading: Space)
-4323: LParen          "(" at 402:24-402:25
-4324: Ident           "self" at 402:25-402:29
-4325: Colon           ":" at 402:29-402:30
-4326: Ident           "int32" at 402:31-402:36 (leading: Space)
-4327: Comma           "," at 402:36-402:37
-4328: Ident           "other" at 402:38-402:43 (leading: Space)
-4329: Colon           ":" at 402:43-402:44
-4330: Ident           "int32" at 402:45-402:50 (leading: Space)
-4331: RParen          ")" at 402:50-402:51
-4332: Arrow           "->" at 402:52-402:54 (leading: Space)
-4333: Ident           "int32" at 402:55-402:60 (leading: Space)
-4334: Semicolon       ";" at 402:60-402:61
-4335: At              "@" at 403:5-403:6 (leading: Newline, Space)
-4336: Ident           "intrinsic" at 403:6-403:15
-4337: KwFn            "fn" at 403:16-403:18 (leading: Space)
-4338: Ident           "__div" at 403:19-403:24 (leading: Space)
-4339: LParen          "(" at 403:24-403:25
-4340: Ident           "self" at 403:25-403:29
-4341: Colon           ":" at 403:29-403:30
-4342: Ident           "int32" at 403:31-403:36 (leading: Space)
-4343: Comma           "," at 403:36-403:37
-4344: Ident           "other" at 403:38-403:43 (leading: Space)
-4345: Colon           ":" at 403:43-403:44
-4346: Ident           "int32" at 403:45-403:50 (leading: Space)
-4347: RParen          ")" at 403:50-403:51
-4348: Arrow           "->" at 403:52-403:54 (leading: Space)
-4349: Ident           "int32" at 403:55-403:60 (leading: Space)
-4350: Semicolon       ";" at 403:60-403:61
-4351: At              "@" at 404:5-404:6 (leading: Newline, Space)
-4352: Ident           "intrinsic" at 404:6-404:15
-4353: KwFn            "fn" at 404:16-404:18 (leading: Space)
-4354: Ident           "__mod" at 404:19-404:24 (leading: Space)
-4355: LParen          "(" at 404:24-404:25
-4356: Ident           "self" at 404:25-404:29
-4357: Colon           ":" at 404:29-404:30
-4358: Ident           "int32" at 404:31-404:36 (leading: Space)
-4359: Comma           "," at 404:36-404:37
-4360: Ident           "other" at 404:38-404:43 (leading: Space)
-4361: Colon           ":" at 404:43-404:44
-4362: Ident           "int32" at 404:45-404:50 (leading: Space)
-4363: RParen          ")" at 404:50-404:51
-4364: Arrow           "->" at 404:52-404:54 (leading: Space)
-4365: Ident           "int32" at 404:55-404:60 (leading: Space)
-4366: Semicolon       ";" at 404:60-404:61
-4367: At              "@" at 405:5-405:6 (leading: Newline, Space)
-4368: Ident           "intrinsic" at 405:6-405:15
-4369: KwFn            "fn" at 405:16-405:18 (leading: Space)
-4370: Ident           "__bit_and" at 405:19-405:28 (leading: Space)
-4371: LParen          "(" at 405:28-405:29
-4372: Ident           "self" at 405:29-405:33
-4373: Colon           ":" at 405:33-405:34
-4374: Ident           "int32" at 405:35-405:40 (leading: Space)
-4375: Comma           "," at 405:40-405:41
-4376: Ident           "other" at 405:42-405:47 (leading: Space)
-4377: Colon           ":" at 405:47-405:48
-4378: Ident           "int32" at 405:49-405:54 (leading: Space)
-4379: RParen          ")" at 405:54-405:55
-4380: Arrow           "->" at 405:56-405:58 (leading: Space)
-4381: Ident           "int32" at 405:59-405:64 (leading: Space)
-4382: Semicolon       ";" at 405:64-405:65
-4383: At              "@" at 406:5-406:6 (leading: Newline, Space)
-4384: Ident           "intrinsic" at 406:6-406:15
-4385: KwFn            "fn" at 406:16-406:18 (leading: Space)
-4386: Ident           "__bit_or" at 406:19-406:27 (leading: Space)
-4387: LParen          "(" at 406:27-406:28
-4388: Ident           "self" at 406:28-406:32
-4389: Colon           ":" at 406:32-406:33
-4390: Ident           "int32" at 406:34-406:39 (leading: Space)
-4391: Comma           "," at 406:39-406:40
-4392: Ident           "other" at 406:41-406:46 (leading: Space)
-4393: Colon           ":" at 406:46-406:47
-4394: Ident           "int32" at 406:48-406:53 (leading: Space)
-4395: RParen          ")" at 406:53-406:54
-4396: Arrow           "->" at 406:55-406:57 (leading: Space)
-4397: Ident           "int32" at 406:58-406:63 (leading: Space)
-4398: Semicolon       ";" at 406:63-406:64
-4399: At              "@" at 407:5-407:6 (leading: Newline, Space)
-4400: Ident           "intrinsic" at 407:6-407:15
-4401: KwFn            "fn" at 407:16-407:18 (leading: Space)
-4402: Ident           "__bit_xor" at 407:19-407:28 (leading: Space)
-4403: LParen          "(" at 407:28-407:29
-4404: Ident           "self" at 407:29-407:33
-4405: Colon           ":" at 407:33-407:34
-4406: Ident           "int32" at 407:35-407:40 (leading: Space)
-4407: Comma           "," at 407:40-407:41
-4408: Ident           "other" at 407:42-407:47 (leading: Space)
-4409: Colon           ":" at 407:47-407:48
-4410: Ident           "int32" at 407:49-407:54 (leading: Space)
-4411: RParen          ")" at 407:54-407:55
-4412: Arrow           "->" at 407:56-407:58 (leading: Space)
-4413: Ident           "int32" at 407:59-407:64 (leading: Space)
-4414: Semicolon       ";" at 407:64-407:65
-4415: At              "@" at 408:5-408:6 (leading: Newline, Space)
-4416: Ident           "intrinsic" at 408:6-408:15
-4417: KwFn            "fn" at 408:16-408:18 (leading: Space)
-4418: Ident           "__shl" at 408:19-408:24 (leading: Space)
-4419: LParen          "(" at 408:24-408:25
-4420: Ident           "self" at 408:25-408:29
-4421: Colon           ":" at 408:29-408:30
-4422: Ident           "int32" at 408:31-408:36 (leading: Space)
-4423: Comma           "," at 408:36-408:37
-4424: Ident           "other" at 408:38-408:43 (leading: Space)
-4425: Colon           ":" at 408:43-408:44
-4426: Ident           "int32" at 408:45-408:50 (leading: Space)
-4427: RParen          ")" at 408:50-408:51
-4428: Arrow           "->" at 408:52-408:54 (leading: Space)
-4429: Ident           "int32" at 408:55-408:60 (leading: Space)
-4430: Semicolon       ";" at 408:60-408:61
-4431: At              "@" at 409:5-409:6 (leading: Newline, Space)
-4432: Ident           "intrinsic" at 409:6-409:15
-4433: KwFn            "fn" at 409:16-409:18 (leading: Space)
-4434: Ident           "__shr" at 409:19-409:24 (leading: Space)
-4435: LParen          "(" at 409:24-409:25
-4436: Ident           "self" at 409:25-409:29
-4437: Colon           ":" at 409:29-409:30
-4438: Ident           "int32" at 409:31-409:36 (leading: Space)
-4439: Comma           "," at 409:36-409:37
-4440: Ident           "other" at 409:38-409:43 (leading: Space)
-4441: Colon           ":" at 409:43-409:44
-4442: Ident           "int32" at 409:45-409:50 (leading: Space)
-4443: RParen          ")" at 409:50-409:51
-4444: Arrow           "->" at 409:52-409:54 (leading: Space)
-4445: Ident           "int32" at 409:55-409:60 (leading: Space)
-4446: Semicolon       ";" at 409:60-409:61
-4447: At              "@" at 410:5-410:6 (leading: Newline, Space)
-4448: Ident           "intrinsic" at 410:6-410:15
-4449: KwFn            "fn" at 410:16-410:18 (leading: Space)
-4450: Ident           "__lt" at 410:19-410:23 (leading: Space)
-4451: LParen          "(" at 410:23-410:24
-4452: Ident           "self" at 410:24-410:28
-4453: Colon           ":" at 410:28-410:29
-4454: Ident           "int32" at 410:30-410:35 (leading: Space)
-4455: Comma           "," at 410:35-410:36
-4456: Ident           "other" at 410:37-410:42 (leading: Space)
-4457: Colon           ":" at 410:42-410:43
-4458: Ident           "int32" at 410:44-410:49 (leading: Space)
-4459: RParen          ")" at 410:49-410:50
-4460: Arrow           "->" at 410:51-410:53 (leading: Space)
-4461: Ident           "bool" at 410:54-410:58 (leading: Space)
-4462: Semicolon       ";" at 410:58-410:59
-4463: At              "@" at 411:5-411:6 (leading: Newline, Space)
-4464: Ident           "intrinsic" at 411:6-411:15
-4465: KwFn            "fn" at 411:16-411:18 (leading: Space)
-4466: Ident           "__le" at 411:19-411:23 (leading: Space)
-4467: LParen          "(" at 411:23-411:24
-4468: Ident           "self" at 411:24-411:28
-4469: Colon           ":" at 411:28-411:29
-4470: Ident           "int32" at 411:30-411:35 (leading: Space)
-4471: Comma           "," at 411:35-411:36
-4472: Ident           "other" at 411:37-411:42 (leading: Space)
-4473: Colon           ":" at 411:42-411:43
-4474: Ident           "int32" at 411:44-411:49 (leading: Space)
-4475: RParen          ")" at 411:49-411:50
-4476: Arrow           "->" at 411:51-411:53 (leading: Space)
-4477: Ident           "bool" at 411:54-411:58 (leading: Space)
-4478: Semicolon       ";" at 411:58-411:59
-4479: At              "@" at 412:5-412:6 (leading: Newline, Space)
-4480: Ident           "intrinsic" at 412:6-412:15
-4481: KwFn            "fn" at 412:16-412:18 (leading: Space)
-4482: Ident           "__eq" at 412:19-412:23 (leading: Space)
-4483: LParen          "(" at 412:23-412:24
-4484: Ident           "self" at 412:24-412:28
-4485: Colon           ":" at 412:28-412:29
-4486: Ident           "int32" at 412:30-412:35 (leading: Space)
-4487: Comma           "," at 412:35-412:36
-4488: Ident           "other" at 412:37-412:42 (leading: Space)
-4489: Colon           ":" at 412:42-412:43
-4490: Ident           "int32" at 412:44-412:49 (leading: Space)
-4491: RParen          ")" at 412:49-412:50
-4492: Arrow           "->" at 412:51-412:53 (leading: Space)
-4493: Ident           "bool" at 412:54-412:58 (leading: Space)
-4494: Semicolon       ";" at 412:58-412:59
-4495: At              "@" at 413:5-413:6 (leading: Newline, Space)
-4496: Ident           "intrinsic" at 413:6-413:15
-4497: KwFn            "fn" at 413:16-413:18 (leading: Space)
-4498: Ident           "__ne" at 413:19-413:23 (leading: Space)
-4499: LParen          "(" at 413:23-413:24
-4500: Ident           "self" at 413:24-413:28
-4501: Colon           ":" at 413:28-413:29
-4502: Ident           "int32" at 413:30-413:35 (leading: Space)
-4503: Comma           "," at 413:35-413:36
-4504: Ident           "other" at 413:37-413:42 (leading: Space)
-4505: Colon           ":" at 413:42-413:43
-4506: Ident           "int32" at 413:44-413:49 (leading: Space)
-4507: RParen          ")" at 413:49-413:50
-4508: Arrow           "->" at 413:51-413:53 (leading: Space)
-4509: Ident           "bool" at 413:54-413:58 (leading: Space)
-4510: Semicolon       ";" at 413:58-413:59
-4511: At              "@" at 414:5-414:6 (leading: Newline, Space)
-4512: Ident           "intrinsic" at 414:6-414:15
-4513: KwFn            "fn" at 414:16-414:18 (leading: Space)
-4514: Ident           "__ge" at 414:19-414:23 (leading: Space)
-4515: LParen          "(" at 414:23-414:24
-4516: Ident           "self" at 414:24-414:28
-4517: Colon           ":" at 414:28-414:29
-4518: Ident           "int32" at 414:30-414:35 (leading: Space)
-4519: Comma           "," at 414:35-414:36
-4520: Ident           "other" at 414:37-414:42 (leading: Space)
-4521: Colon           ":" at 414:42-414:43
-4522: Ident           "int32" at 414:44-414:49 (leading: Space)
-4523: RParen          ")" at 414:49-414:50
-4524: Arrow           "->" at 414:51-414:53 (leading: Space)
-4525: Ident           "bool" at 414:54-414:58 (leading: Space)
-4526: Semicolon       ";" at 414:58-414:59
-4527: At              "@" at 415:5-415:6 (leading: Newline, Space)
-4528: Ident           "intrinsic" at 415:6-415:15
-4529: KwFn            "fn" at 415:16-415:18 (leading: Space)
-4530: Ident           "__gt" at 415:19-415:23 (leading: Space)
-4531: LParen          "(" at 415:23-415:24
-4532: Ident           "self" at 415:24-415:28
-4533: Colon           ":" at 415:28-415:29
-4534: Ident           "int32" at 415:30-415:35 (leading: Space)
-4535: Comma           "," at 415:35-415:36
-4536: Ident           "other" at 415:37-415:42 (leading: Space)
-4537: Colon           ":" at 415:42-415:43
-4538: Ident           "int32" at 415:44-415:49 (leading: Space)
-4539: RParen          ")" at 415:49-415:50
-4540: Arrow           "->" at 415:51-415:53 (leading: Space)
-4541: Ident           "bool" at 415:54-415:58 (leading: Space)
-4542: Semicolon       ";" at 415:58-415:59
-4543: At              "@" at 416:5-416:6 (leading: Newline, Space)
-4544: Ident           "intrinsic" at 416:6-416:15
-4545: KwFn            "fn" at 416:16-416:18 (leading: Space)
-4546: Ident           "__pos" at 416:19-416:24 (leading: Space)
-4547: LParen          "(" at 416:24-416:25
-4548: Ident           "self" at 416:25-416:29
-4549: Colon           ":" at 416:29-416:30
-4550: Ident           "int32" at 416:31-416:36 (leading: Space)
-4551: RParen          ")" at 416:36-416:37
-4552: Arrow           "->" at 416:38-416:40 (leading: Space)
-4553: Ident           "int32" at 416:41-416:46 (leading: Space)
-4554: Semicolon       ";" at 416:46-416:47
-4555: At              "@" at 417:5-417:6 (leading: Newline, Space)
-4556: Ident           "intrinsic" at 417:6-417:15
-4557: KwFn            "fn" at 417:16-417:18 (leading: Space)
-4558: Ident           "__neg" at 417:19-417:24 (leading: Space)
-4559: LParen          "(" at 417:24-417:25
-4560: Ident           "self" at 417:25-417:29
-4561: Colon           ":" at 417:29-417:30
-4562: Ident           "int32" at 417:31-417:36 (leading: Space)
-4563: RParen          ")" at 417:36-417:37
-4564: Arrow           "->" at 417:38-417:40 (leading: Space)
-4565: Ident           "int32" at 417:41-417:46 (leading: Space)
-4566: Semicolon       ";" at 417:46-417:47
-4567: At              "@" at 418:5-418:6 (leading: Newline, Space)
-4568: Ident           "intrinsic" at 418:6-418:15
-4569: KwFn            "fn" at 418:16-418:18 (leading: Space)
-4570: Ident           "__abs" at 418:19-418:24 (leading: Space)
-4571: LParen          "(" at 418:24-418:25
-4572: Ident           "self" at 418:25-418:29
-4573: Colon           ":" at 418:29-418:30
-4574: Ident           "int32" at 418:31-418:36 (leading: Space)
-4575: RParen          ")" at 418:36-418:37
-4576: Arrow           "->" at 418:38-418:40 (leading: Space)
-4577: Ident           "int32" at 418:41-418:46 (leading: Space)
-4578: Semicolon       ";" at 418:46-418:47
-4579: At              "@" at 419:5-419:6 (leading: Newline, Space)
-4580: Ident           "intrinsic" at 419:6-419:15
-4581: KwFn            "fn" at 419:16-419:18 (leading: Space)
-4582: Ident           "__to" at 419:19-419:23 (leading: Space)
-4583: LParen          "(" at 419:23-419:24
-4584: Ident           "self" at 419:24-419:28
-4585: Colon           ":" at 419:28-419:29
-4586: Ident           "int32" at 419:30-419:35 (leading: Space)
-4587: Comma           "," at 419:35-419:36
-4588: Ident           "target" at 419:37-419:43 (leading: Space)
-4589: Colon           ":" at 419:43-419:44
-4590: Ident           "int" at 419:45-419:48 (leading: Space)
-4591: RParen          ")" at 419:48-419:49
-4592: Arrow           "->" at 419:50-419:52 (leading: Space)
-4593: Ident           "int" at 419:53-419:56 (leading: Space)
-4594: Semicolon       ";" at 419:56-419:57
-4595: At              "@" at 420:5-420:6 (leading: Newline, Space)
-4596: Ident           "intrinsic" at 420:6-420:15
-4597: At              "@" at 420:16-420:17 (leading: Space)
-4598: Ident           "overload" at 420:17-420:25
-4599: KwFn            "fn" at 420:26-420:28 (leading: Space)
-4600: Ident           "__to" at 420:29-420:33 (leading: Space)
-4601: LParen          "(" at 420:33-420:34
-4602: Ident           "self" at 420:34-420:38
-4603: Colon           ":" at 420:38-420:39
-4604: Ident           "int32" at 420:40-420:45 (leading: Space)
-4605: Comma           "," at 420:45-420:46
-4606: Ident           "target" at 420:47-420:53 (leading: Space)
-4607: Colon           ":" at 420:53-420:54
-4608: Ident           "int8" at 420:55-420:59 (leading: Space)
-4609: RParen          ")" at 420:59-420:60
-4610: Arrow           "->" at 420:61-420:63 (leading: Space)
-4611: Ident           "int8" at 420:64-420:68 (leading: Space)
-4612: Semicolon       ";" at 420:68-420:69
-4613: At              "@" at 421:5-421:6 (leading: Newline, Space)
-4614: Ident           "intrinsic" at 421:6-421:15
-4615: At              "@" at 421:16-421:17 (leading: Space)
-4616: Ident           "overload" at 421:17-421:25
-4617: KwFn            "fn" at 421:26-421:28 (leading: Space)
-4618: Ident           "__to" at 421:29-421:33 (leading: Space)
-4619: LParen          "(" at 421:33-421:34
-4620: Ident           "self" at 421:34-421:38
-4621: Colon           ":" at 421:38-421:39
-4622: Ident           "int32" at 421:40-421:45 (leading: Space)
-4623: Comma           "," at 421:45-421:46
-4624: Ident           "target" at 421:47-421:53 (leading: Space)
-4625: Colon           ":" at 421:53-421:54
-4626: Ident           "int16" at 421:55-421:60 (leading: Space)
-4627: RParen          ")" at 421:60-421:61
-4628: Arrow           "->" at 421:62-421:64 (leading: Space)
-4629: Ident           "int16" at 421:65-421:70 (leading: Space)
-4630: Semicolon       ";" at 421:70-421:71
-4631: At              "@" at 422:5-422:6 (leading: Newline, Space)
-4632: Ident           "intrinsic" at 422:6-422:15
-4633: At              "@" at 422:16-422:17 (leading: Space)
-4634: Ident           "overload" at 422:17-422:25
-4635: KwFn            "fn" at 422:26-422:28 (leading: Space)
-4636: Ident           "__to" at 422:29-422:33 (leading: Space)
-4637: LParen          "(" at 422:33-422:34
-4638: Ident           "self" at 422:34-422:38
-4639: Colon           ":" at 422:38-422:39
-4640: Ident           "int32" at 422:40-422:45 (leading: Space)
-4641: Comma           "," at 422:45-422:46
-4642: Ident           "target" at 422:47-422:53 (leading: Space)
-4643: Colon           ":" at 422:53-422:54
-4644: Ident           "int64" at 422:55-422:60 (leading: Space)
-4645: RParen          ")" at 422:60-422:61
-4646: Arrow           "->" at 422:62-422:64 (leading: Space)
-4647: Ident           "int64" at 422:65-422:70 (leading: Space)
-4648: Semicolon       ";" at 422:70-422:71
-4649: At              "@" at 423:5-423:6 (leading: Newline, Space)
-4650: Ident           "intrinsic" at 423:6-423:15
-4651: KwPub           "pub" at 423:16-423:19 (leading: Space)
-4652: KwFn            "fn" at 423:20-423:22 (leading: Space)
-4653: Ident           "from_str" at 423:23-423:31 (leading: Space)
-4654: LParen          "(" at 423:31-423:32
-4655: Ident           "s" at 423:32-423:33
-4656: Colon           ":" at 423:33-423:34
-4657: Amp             "&" at 423:35-423:36 (leading: Space)
-4658: Ident           "string" at 423:36-423:42
-4659: RParen          ")" at 423:42-423:43
-4660: Arrow           "->" at 423:44-423:46 (leading: Space)
-4661: Ident           "Erring" at 423:47-423:53 (leading: Space)
-4662: Lt              "<" at 423:53-423:54
-4663: Ident           "int32" at 423:54-423:59
-4664: Comma           "," at 423:59-423:60
-4665: Ident           "Error" at 423:61-423:66 (leading: Space)
-4666: Gt              ">" at 423:66-423:67
-4667: Semicolon       ";" at 423:67-423:68
-4668: RBrace          "}" at 424:1-424:2 (leading: Newline)
-4669: KwExtern        "extern" at 426:1-426:7 (leading: Newline)
-4670: Lt              "<" at 426:7-426:8
-4671: Ident           "int64" at 426:8-426:13
-4672: Gt              ">" at 426:13-426:14
-4673: LBrace          "{" at 426:15-426:16 (leading: Space)
-4674: KwPub           "pub" at 427:5-427:8 (leading: Newline, Space)
-4675: KwFn            "fn" at 427:9-427:11 (leading: Space)
-4676: Ident           "__min_value" at 427:12-427:23 (leading: Space)
-4677: LParen          "(" at 427:23-427:24
-4678: RParen          ")" at 427:24-427:25
-4679: Arrow           "->" at 427:26-427:28 (leading: Space)
-4680: Ident           "int64" at 427:29-427:34 (leading: Space)
-4681: LBrace          "{" at 427:35-427:36 (leading: Space)
-4682: KwReturn        "return" at 427:37-427:43 (leading: Space)
-4683: LParen          "(" at 427:44-427:45 (leading: Space)
-4684: Minus           "-" at 427:45-427:46
-4685: IntLit          "9_223_372_036_854_775_808" at 427:46-427:71
-4686: RParen          ")" at 427:71-427:72
-4687: Colon           ":" at 427:72-427:73
-4688: Ident           "int64" at 427:73-427:78
-4689: Semicolon       ";" at 427:78-427:79
-4690: RBrace          "}" at 427:80-427:81 (leading: Space)
-4691: KwPub           "pub" at 428:5-428:8 (leading: Newline, Space)
-4692: KwFn            "fn" at 428:9-428:11 (leading: Space)
-4693: Ident           "__max_value" at 428:12-428:23 (leading: Space)
-4694: LParen          "(" at 428:23-428:24
-4695: RParen          ")" at 428:24-428:25
-4696: Arrow           "->" at 428:26-428:28 (leading: Space)
-4697: Ident           "int64" at 428:29-428:34 (leading: Space)
-4698: LBrace          "{" at 428:35-428:36 (leading: Space)
-4699: KwReturn        "return" at 428:37-428:43 (leading: Space)
-4700: LParen          "(" at 428:44-428:45 (leading: Space)
-4701: IntLit          "9_223_372_036_854_775_807" at 428:45-428:70
-4702: RParen          ")" at 428:70-428:71
-4703: Colon           ":" at 428:71-428:72
-4704: Ident           "int64" at 428:72-428:77
-4705: Semicolon       ";" at 428:77-428:78
-4706: RBrace          "}" at 428:79-428:80 (leading: Space)
-4707: At              "@" at 429:5-429:6 (leading: Newline, Space)
-4708: Ident           "intrinsic" at 429:6-429:15
-4709: KwFn            "fn" at 429:16-429:18 (leading: Space)
-4710: Ident           "__add" at 429:19-429:24 (leading: Space)
-4711: LParen          "(" at 429:24-429:25
-4712: Ident           "self" at 429:25-429:29
-4713: Colon           ":" at 429:29-429:30
-4714: Ident           "int64" at 429:31-429:36 (leading: Space)
-4715: Comma           "," at 429:36-429:37
-4716: Ident           "other" at 429:38-429:43 (leading: Space)
-4717: Colon           ":" at 429:43-429:44
-4718: Ident           "int64" at 429:45-429:50 (leading: Space)
-4719: RParen          ")" at 429:50-429:51
-4720: Arrow           "->" at 429:52-429:54 (leading: Space)
-4721: Ident           "int64" at 429:55-429:60 (leading: Space)
-4722: Semicolon       ";" at 429:60-429:61
-4723: At              "@" at 430:5-430:6 (leading: Newline, Space)
-4724: Ident           "intrinsic" at 430:6-430:15
-4725: KwFn            "fn" at 430:16-430:18 (leading: Space)
-4726: Ident           "__sub" at 430:19-430:24 (leading: Space)
-4727: LParen          "(" at 430:24-430:25
-4728: Ident           "self" at 430:25-430:29
-4729: Colon           ":" at 430:29-430:30
-4730: Ident           "int64" at 430:31-430:36 (leading: Space)
-4731: Comma           "," at 430:36-430:37
-4732: Ident           "other" at 430:38-430:43 (leading: Space)
-4733: Colon           ":" at 430:43-430:44
-4734: Ident           "int64" at 430:45-430:50 (leading: Space)
-4735: RParen          ")" at 430:50-430:51
-4736: Arrow           "->" at 430:52-430:54 (leading: Space)
-4737: Ident           "int64" at 430:55-430:60 (leading: Space)
-4738: Semicolon       ";" at 430:60-430:61
-4739: At              "@" at 431:5-431:6 (leading: Newline, Space)
-4740: Ident           "intrinsic" at 431:6-431:15
-4741: KwFn            "fn" at 431:16-431:18 (leading: Space)
-4742: Ident           "__mul" at 431:19-431:24 (leading: Space)
-4743: LParen          "(" at 431:24-431:25
-4744: Ident           "self" at 431:25-431:29
-4745: Colon           ":" at 431:29-431:30
-4746: Ident           "int64" at 431:31-431:36 (leading: Space)
-4747: Comma           "," at 431:36-431:37
-4748: Ident           "other" at 431:38-431:43 (leading: Space)
-4749: Colon           ":" at 431:43-431:44
-4750: Ident           "int64" at 431:45-431:50 (leading: Space)
-4751: RParen          ")" at 431:50-431:51
-4752: Arrow           "->" at 431:52-431:54 (leading: Space)
-4753: Ident           "int64" at 431:55-431:60 (leading: Space)
-4754: Semicolon       ";" at 431:60-431:61
-4755: At              "@" at 432:5-432:6 (leading: Newline, Space)
-4756: Ident           "intrinsic" at 432:6-432:15
-4757: KwFn            "fn" at 432:16-432:18 (leading: Space)
-4758: Ident           "__div" at 432:19-432:24 (leading: Space)
-4759: LParen          "(" at 432:24-432:25
-4760: Ident           "self" at 432:25-432:29
-4761: Colon           ":" at 432:29-432:30
-4762: Ident           "int64" at 432:31-432:36 (leading: Space)
-4763: Comma           "," at 432:36-432:37
-4764: Ident           "other" at 432:38-432:43 (leading: Space)
-4765: Colon           ":" at 432:43-432:44
-4766: Ident           "int64" at 432:45-432:50 (leading: Space)
-4767: RParen          ")" at 432:50-432:51
-4768: Arrow           "->" at 432:52-432:54 (leading: Space)
-4769: Ident           "int64" at 432:55-432:60 (leading: Space)
-4770: Semicolon       ";" at 432:60-432:61
-4771: At              "@" at 433:5-433:6 (leading: Newline, Space)
-4772: Ident           "intrinsic" at 433:6-433:15
-4773: KwFn            "fn" at 433:16-433:18 (leading: Space)
-4774: Ident           "__mod" at 433:19-433:24 (leading: Space)
-4775: LParen          "(" at 433:24-433:25
-4776: Ident           "self" at 433:25-433:29
-4777: Colon           ":" at 433:29-433:30
-4778: Ident           "int64" at 433:31-433:36 (leading: Space)
-4779: Comma           "," at 433:36-433:37
-4780: Ident           "other" at 433:38-433:43 (leading: Space)
-4781: Colon           ":" at 433:43-433:44
-4782: Ident           "int64" at 433:45-433:50 (leading: Space)
-4783: RParen          ")" at 433:50-433:51
-4784: Arrow           "->" at 433:52-433:54 (leading: Space)
-4785: Ident           "int64" at 433:55-433:60 (leading: Space)
-4786: Semicolon       ";" at 433:60-433:61
-4787: At              "@" at 434:5-434:6 (leading: Newline, Space)
-4788: Ident           "intrinsic" at 434:6-434:15
-4789: KwFn            "fn" at 434:16-434:18 (leading: Space)
-4790: Ident           "__bit_and" at 434:19-434:28 (leading: Space)
-4791: LParen          "(" at 434:28-434:29
-4792: Ident           "self" at 434:29-434:33
-4793: Colon           ":" at 434:33-434:34
-4794: Ident           "int64" at 434:35-434:40 (leading: Space)
-4795: Comma           "," at 434:40-434:41
-4796: Ident           "other" at 434:42-434:47 (leading: Space)
-4797: Colon           ":" at 434:47-434:48
-4798: Ident           "int64" at 434:49-434:54 (leading: Space)
-4799: RParen          ")" at 434:54-434:55
-4800: Arrow           "->" at 434:56-434:58 (leading: Space)
-4801: Ident           "int64" at 434:59-434:64 (leading: Space)
-4802: Semicolon       ";" at 434:64-434:65
-4803: At              "@" at 435:5-435:6 (leading: Newline, Space)
-4804: Ident           "intrinsic" at 435:6-435:15
-4805: KwFn            "fn" at 435:16-435:18 (leading: Space)
-4806: Ident           "__bit_or" at 435:19-435:27 (leading: Space)
-4807: LParen          "(" at 435:27-435:28
-4808: Ident           "self" at 435:28-435:32
-4809: Colon           ":" at 435:32-435:33
-4810: Ident           "int64" at 435:34-435:39 (leading: Space)
-4811: Comma           "," at 435:39-435:40
-4812: Ident           "other" at 435:41-435:46 (leading: Space)
-4813: Colon           ":" at 435:46-435:47
-4814: Ident           "int64" at 435:48-435:53 (leading: Space)
-4815: RParen          ")" at 435:53-435:54
-4816: Arrow           "->" at 435:55-435:57 (leading: Space)
-4817: Ident           "int64" at 435:58-435:63 (leading: Space)
-4818: Semicolon       ";" at 435:63-435:64
-4819: At              "@" at 436:5-436:6 (leading: Newline, Space)
-4820: Ident           "intrinsic" at 436:6-436:15
-4821: KwFn            "fn" at 436:16-436:18 (leading: Space)
-4822: Ident           "__bit_xor" at 436:19-436:28 (leading: Space)
-4823: LParen          "(" at 436:28-436:29
-4824: Ident           "self" at 436:29-436:33
-4825: Colon           ":" at 436:33-436:34
-4826: Ident           "int64" at 436:35-436:40 (leading: Space)
-4827: Comma           "," at 436:40-436:41
-4828: Ident           "other" at 436:42-436:47 (leading: Space)
-4829: Colon           ":" at 436:47-436:48
-4830: Ident           "int64" at 436:49-436:54 (leading: Space)
-4831: RParen          ")" at 436:54-436:55
-4832: Arrow           "->" at 436:56-436:58 (leading: Space)
-4833: Ident           "int64" at 436:59-436:64 (leading: Space)
-4834: Semicolon       ";" at 436:64-436:65
-4835: At              "@" at 437:5-437:6 (leading: Newline, Space)
-4836: Ident           "intrinsic" at 437:6-437:15
-4837: KwFn            "fn" at 437:16-437:18 (leading: Space)
-4838: Ident           "__shl" at 437:19-437:24 (leading: Space)
-4839: LParen          "(" at 437:24-437:25
-4840: Ident           "self" at 437:25-437:29
-4841: Colon           ":" at 437:29-437:30
-4842: Ident           "int64" at 437:31-437:36 (leading: Space)
-4843: Comma           "," at 437:36-437:37
-4844: Ident           "other" at 437:38-437:43 (leading: Space)
-4845: Colon           ":" at 437:43-437:44
-4846: Ident           "int64" at 437:45-437:50 (leading: Space)
-4847: RParen          ")" at 437:50-437:51
-4848: Arrow           "->" at 437:52-437:54 (leading: Space)
-4849: Ident           "int64" at 437:55-437:60 (leading: Space)
-4850: Semicolon       ";" at 437:60-437:61
-4851: At              "@" at 438:5-438:6 (leading: Newline, Space)
-4852: Ident           "intrinsic" at 438:6-438:15
-4853: KwFn            "fn" at 438:16-438:18 (leading: Space)
-4854: Ident           "__shr" at 438:19-438:24 (leading: Space)
-4855: LParen          "(" at 438:24-438:25
-4856: Ident           "self" at 438:25-438:29
-4857: Colon           ":" at 438:29-438:30
-4858: Ident           "int64" at 438:31-438:36 (leading: Space)
-4859: Comma           "," at 438:36-438:37
-4860: Ident           "other" at 438:38-438:43 (leading: Space)
-4861: Colon           ":" at 438:43-438:44
-4862: Ident           "int64" at 438:45-438:50 (leading: Space)
-4863: RParen          ")" at 438:50-438:51
-4864: Arrow           "->" at 438:52-438:54 (leading: Space)
-4865: Ident           "int64" at 438:55-438:60 (leading: Space)
-4866: Semicolon       ";" at 438:60-438:61
-4867: At              "@" at 439:5-439:6 (leading: Newline, Space)
-4868: Ident           "intrinsic" at 439:6-439:15
-4869: KwFn            "fn" at 439:16-439:18 (leading: Space)
-4870: Ident           "__lt" at 439:19-439:23 (leading: Space)
-4871: LParen          "(" at 439:23-439:24
-4872: Ident           "self" at 439:24-439:28
-4873: Colon           ":" at 439:28-439:29
-4874: Ident           "int64" at 439:30-439:35 (leading: Space)
-4875: Comma           "," at 439:35-439:36
-4876: Ident           "other" at 439:37-439:42 (leading: Space)
-4877: Colon           ":" at 439:42-439:43
-4878: Ident           "int64" at 439:44-439:49 (leading: Space)
-4879: RParen          ")" at 439:49-439:50
-4880: Arrow           "->" at 439:51-439:53 (leading: Space)
-4881: Ident           "bool" at 439:54-439:58 (leading: Space)
-4882: Semicolon       ";" at 439:58-439:59
-4883: At              "@" at 440:5-440:6 (leading: Newline, Space)
-4884: Ident           "intrinsic" at 440:6-440:15
-4885: KwFn            "fn" at 440:16-440:18 (leading: Space)
-4886: Ident           "__le" at 440:19-440:23 (leading: Space)
-4887: LParen          "(" at 440:23-440:24
-4888: Ident           "self" at 440:24-440:28
-4889: Colon           ":" at 440:28-440:29
-4890: Ident           "int64" at 440:30-440:35 (leading: Space)
-4891: Comma           "," at 440:35-440:36
-4892: Ident           "other" at 440:37-440:42 (leading: Space)
-4893: Colon           ":" at 440:42-440:43
-4894: Ident           "int64" at 440:44-440:49 (leading: Space)
-4895: RParen          ")" at 440:49-440:50
-4896: Arrow           "->" at 440:51-440:53 (leading: Space)
-4897: Ident           "bool" at 440:54-440:58 (leading: Space)
-4898: Semicolon       ";" at 440:58-440:59
-4899: At              "@" at 441:5-441:6 (leading: Newline, Space)
-4900: Ident           "intrinsic" at 441:6-441:15
-4901: KwFn            "fn" at 441:16-441:18 (leading: Space)
-4902: Ident           "__eq" at 441:19-441:23 (leading: Space)
-4903: LParen          "(" at 441:23-441:24
-4904: Ident           "self" at 441:24-441:28
-4905: Colon           ":" at 441:28-441:29
-4906: Ident           "int64" at 441:30-441:35 (leading: Space)
-4907: Comma           "," at 441:35-441:36
-4908: Ident           "other" at 441:37-441:42 (leading: Space)
-4909: Colon           ":" at 441:42-441:43
-4910: Ident           "int64" at 441:44-441:49 (leading: Space)
-4911: RParen          ")" at 441:49-441:50
-4912: Arrow           "->" at 441:51-441:53 (leading: Space)
-4913: Ident           "bool" at 441:54-441:58 (leading: Space)
-4914: Semicolon       ";" at 441:58-441:59
-4915: At              "@" at 442:5-442:6 (leading: Newline, Space)
-4916: Ident           "intrinsic" at 442:6-442:15
-4917: KwFn            "fn" at 442:16-442:18 (leading: Space)
-4918: Ident           "__ne" at 442:19-442:23 (leading: Space)
-4919: LParen          "(" at 442:23-442:24
-4920: Ident           "self" at 442:24-442:28
-4921: Colon           ":" at 442:28-442:29
-4922: Ident           "int64" at 442:30-442:35 (leading: Space)
-4923: Comma           "," at 442:35-442:36
-4924: Ident           "other" at 442:37-442:42 (leading: Space)
-4925: Colon           ":" at 442:42-442:43
-4926: Ident           "int64" at 442:44-442:49 (leading: Space)
-4927: RParen          ")" at 442:49-442:50
-4928: Arrow           "->" at 442:51-442:53 (leading: Space)
-4929: Ident           "bool" at 442:54-442:58 (leading: Space)
-4930: Semicolon       ";" at 442:58-442:59
-4931: At              "@" at 443:5-443:6 (leading: Newline, Space)
-4932: Ident           "intrinsic" at 443:6-443:15
-4933: KwFn            "fn" at 443:16-443:18 (leading: Space)
-4934: Ident           "__ge" at 443:19-443:23 (leading: Space)
-4935: LParen          "(" at 443:23-443:24
-4936: Ident           "self" at 443:24-443:28
-4937: Colon           ":" at 443:28-443:29
-4938: Ident           "int64" at 443:30-443:35 (leading: Space)
-4939: Comma           "," at 443:35-443:36
-4940: Ident           "other" at 443:37-443:42 (leading: Space)
-4941: Colon           ":" at 443:42-443:43
-4942: Ident           "int64" at 443:44-443:49 (leading: Space)
-4943: RParen          ")" at 443:49-443:50
-4944: Arrow           "->" at 443:51-443:53 (leading: Space)
-4945: Ident           "bool" at 443:54-443:58 (leading: Space)
-4946: Semicolon       ";" at 443:58-443:59
-4947: At              "@" at 444:5-444:6 (leading: Newline, Space)
-4948: Ident           "intrinsic" at 444:6-444:15
-4949: KwFn            "fn" at 444:16-444:18 (leading: Space)
-4950: Ident           "__gt" at 444:19-444:23 (leading: Space)
-4951: LParen          "(" at 444:23-444:24
-4952: Ident           "self" at 444:24-444:28
-4953: Colon           ":" at 444:28-444:29
-4954: Ident           "int64" at 444:30-444:35 (leading: Space)
-4955: Comma           "," at 444:35-444:36
-4956: Ident           "other" at 444:37-444:42 (leading: Space)
-4957: Colon           ":" at 444:42-444:43
-4958: Ident           "int64" at 444:44-444:49 (leading: Space)
-4959: RParen          ")" at 444:49-444:50
-4960: Arrow           "->" at 444:51-444:53 (leading: Space)
-4961: Ident           "bool" at 444:54-444:58 (leading: Space)
-4962: Semicolon       ";" at 444:58-444:59
-4963: At              "@" at 445:5-445:6 (leading: Newline, Space)
-4964: Ident           "intrinsic" at 445:6-445:15
-4965: KwFn            "fn" at 445:16-445:18 (leading: Space)
-4966: Ident           "__pos" at 445:19-445:24 (leading: Space)
-4967: LParen          "(" at 445:24-445:25
-4968: Ident           "self" at 445:25-445:29
-4969: Colon           ":" at 445:29-445:30
-4970: Ident           "int64" at 445:31-445:36 (leading: Space)
-4971: RParen          ")" at 445:36-445:37
-4972: Arrow           "->" at 445:38-445:40 (leading: Space)
-4973: Ident           "int64" at 445:41-445:46 (leading: Space)
-4974: Semicolon       ";" at 445:46-445:47
-4975: At              "@" at 446:5-446:6 (leading: Newline, Space)
-4976: Ident           "intrinsic" at 446:6-446:15
-4977: KwFn            "fn" at 446:16-446:18 (leading: Space)
-4978: Ident           "__neg" at 446:19-446:24 (leading: Space)
-4979: LParen          "(" at 446:24-446:25
-4980: Ident           "self" at 446:25-446:29
-4981: Colon           ":" at 446:29-446:30
-4982: Ident           "int64" at 446:31-446:36 (leading: Space)
-4983: RParen          ")" at 446:36-446:37
-4984: Arrow           "->" at 446:38-446:40 (leading: Space)
-4985: Ident           "int64" at 446:41-446:46 (leading: Space)
-4986: Semicolon       ";" at 446:46-446:47
-4987: At              "@" at 447:5-447:6 (leading: Newline, Space)
-4988: Ident           "intrinsic" at 447:6-447:15
-4989: KwFn            "fn" at 447:16-447:18 (leading: Space)
-4990: Ident           "__abs" at 447:19-447:24 (leading: Space)
-4991: LParen          "(" at 447:24-447:25
-4992: Ident           "self" at 447:25-447:29
-4993: Colon           ":" at 447:29-447:30
-4994: Ident           "int64" at 447:31-447:36 (leading: Space)
-4995: RParen          ")" at 447:36-447:37
-4996: Arrow           "->" at 447:38-447:40 (leading: Space)
-4997: Ident           "int64" at 447:41-447:46 (leading: Space)
-4998: Semicolon       ";" at 447:46-447:47
-4999: At              "@" at 448:5-448:6 (leading: Newline, Space)
-5000: Ident           "intrinsic" at 448:6-448:15
-5001: KwFn            "fn" at 448:16-448:18 (leading: Space)
-5002: Ident           "__to" at 448:19-448:23 (leading: Space)
-5003: LParen          "(" at 448:23-448:24
-5004: Ident           "self" at 448:24-448:28
-5005: Colon           ":" at 448:28-448:29
-5006: Ident           "int64" at 448:30-448:35 (leading: Space)
-5007: Comma           "," at 448:35-448:36
-5008: Ident           "target" at 448:37-448:43 (leading: Space)
-5009: Colon           ":" at 448:43-448:44
-5010: Ident           "int" at 448:45-448:48 (leading: Space)
-5011: RParen          ")" at 448:48-448:49
-5012: Arrow           "->" at 448:50-448:52 (leading: Space)
-5013: Ident           "int" at 448:53-448:56 (leading: Space)
-5014: Semicolon       ";" at 448:56-448:57
-5015: At              "@" at 449:5-449:6 (leading: Newline, Space)
-5016: Ident           "intrinsic" at 449:6-449:15
-5017: At              "@" at 449:16-449:17 (leading: Space)
-5018: Ident           "overload" at 449:17-449:25
-5019: KwFn            "fn" at 449:26-449:28 (leading: Space)
-5020: Ident           "__to" at 449:29-449:33 (leading: Space)
-5021: LParen          "(" at 449:33-449:34
-5022: Ident           "self" at 449:34-449:38
-5023: Colon           ":" at 449:38-449:39
-5024: Ident           "int64" at 449:40-449:45 (leading: Space)
-5025: Comma           "," at 449:45-449:46
-5026: Ident           "target" at 449:47-449:53 (leading: Space)
-5027: Colon           ":" at 449:53-449:54
-5028: Ident           "int8" at 449:55-449:59 (leading: Space)
-5029: RParen          ")" at 449:59-449:60
-5030: Arrow           "->" at 449:61-449:63 (leading: Space)
-5031: Ident           "int8" at 449:64-449:68 (leading: Space)
-5032: Semicolon       ";" at 449:68-449:69
-5033: At              "@" at 450:5-450:6 (leading: Newline, Space)
-5034: Ident           "intrinsic" at 450:6-450:15
-5035: At              "@" at 450:16-450:17 (leading: Space)
-5036: Ident           "overload" at 450:17-450:25
-5037: KwFn            "fn" at 450:26-450:28 (leading: Space)
-5038: Ident           "__to" at 450:29-450:33 (leading: Space)
-5039: LParen          "(" at 450:33-450:34
-5040: Ident           "self" at 450:34-450:38
-5041: Colon           ":" at 450:38-450:39
-5042: Ident           "int64" at 450:40-450:45 (leading: Space)
-5043: Comma           "," at 450:45-450:46
-5044: Ident           "target" at 450:47-450:53 (leading: Space)
-5045: Colon           ":" at 450:53-450:54
-5046: Ident           "int16" at 450:55-450:60 (leading: Space)
-5047: RParen          ")" at 450:60-450:61
-5048: Arrow           "->" at 450:62-450:64 (leading: Space)
-5049: Ident           "int16" at 450:65-450:70 (leading: Space)
-5050: Semicolon       ";" at 450:70-450:71
-5051: At              "@" at 451:5-451:6 (leading: Newline, Space)
-5052: Ident           "intrinsic" at 451:6-451:15
-5053: At              "@" at 451:16-451:17 (leading: Space)
-5054: Ident           "overload" at 451:17-451:25
-5055: KwFn            "fn" at 451:26-451:28 (leading: Space)
-5056: Ident           "__to" at 451:29-451:33 (leading: Space)
-5057: LParen          "(" at 451:33-451:34
-5058: Ident           "self" at 451:34-451:38
-5059: Colon           ":" at 451:38-451:39
-5060: Ident           "int64" at 451:40-451:45 (leading: Space)
-5061: Comma           "," at 451:45-451:46
-5062: Ident           "target" at 451:47-451:53 (leading: Space)
-5063: Colon           ":" at 451:53-451:54
-5064: Ident           "int32" at 451:55-451:60 (leading: Space)
-5065: RParen          ")" at 451:60-451:61
-5066: Arrow           "->" at 451:62-451:64 (leading: Space)
-5067: Ident           "int32" at 451:65-451:70 (leading: Space)
-5068: Semicolon       ";" at 451:70-451:71
-5069: At              "@" at 452:5-452:6 (leading: Newline, Space)
-5070: Ident           "intrinsic" at 452:6-452:15
-5071: KwPub           "pub" at 452:16-452:19 (leading: Space)
-5072: KwFn            "fn" at 452:20-452:22 (leading: Space)
-5073: Ident           "from_str" at 452:23-452:31 (leading: Space)
-5074: LParen          "(" at 452:31-452:32
-5075: Ident           "s" at 452:32-452:33
-5076: Colon           ":" at 452:33-452:34
-5077: Amp             "&" at 452:35-452:36 (leading: Space)
-5078: Ident           "string" at 452:36-452:42
-5079: RParen          ")" at 452:42-452:43
-5080: Arrow           "->" at 452:44-452:46 (leading: Space)
-5081: Ident           "Erring" at 452:47-452:53 (leading: Space)
-5082: Lt              "<" at 452:53-452:54
-5083: Ident           "int64" at 452:54-452:59
-5084: Comma           "," at 452:59-452:60
-5085: Ident           "Error" at 452:61-452:66 (leading: Space)
-5086: Gt              ">" at 452:66-452:67
-5087: Semicolon       ";" at 452:67-452:68
-5088: RBrace          "}" at 453:1-453:2 (leading: Newline)
-5089: KwExtern        "extern" at 455:1-455:7 (leading: Newline)
-5090: Lt              "<" at 455:7-455:8
-5091: Ident           "uint8" at 455:8-455:13
-5092: Gt              ">" at 455:13-455:14
-5093: LBrace          "{" at 455:15-455:16 (leading: Space)
-5094: KwPub           "pub" at 456:5-456:8 (leading: Newline, Space)
-5095: KwFn            "fn" at 456:9-456:11 (leading: Space)
-5096: Ident           "__min_value" at 456:12-456:23 (leading: Space)
-5097: LParen          "(" at 456:23-456:24
-5098: RParen          ")" at 456:24-456:25
-5099: Arrow           "->" at 456:26-456:28 (leading: Space)
-5100: Ident           "uint8" at 456:29-456:34 (leading: Space)
-5101: LBrace          "{" at 456:35-456:36 (leading: Space)
-5102: KwReturn        "return" at 456:37-456:43 (leading: Space)
-5103: LParen          "(" at 456:44-456:45 (leading: Space)
-5104: IntLit          "0" at 456:45-456:46
-5105: RParen          ")" at 456:46-456:47
-5106: Colon           ":" at 456:47-456:48
-5107: Ident           "uint8" at 456:48-456:53
-5108: Semicolon       ";" at 456:53-456:54
-5109: RBrace          "}" at 456:55-456:56 (leading: Space)
-5110: KwPub           "pub" at 457:5-457:8 (leading: Newline, Space)
-5111: KwFn            "fn" at 457:9-457:11 (leading: Space)
-5112: Ident           "__max_value" at 457:12-457:23 (leading: Space)
-5113: LParen          "(" at 457:23-457:24
-5114: RParen          ")" at 457:24-457:25
-5115: Arrow           "->" at 457:26-457:28 (leading: Space)
-5116: Ident           "uint8" at 457:29-457:34 (leading: Space)
-5117: LBrace          "{" at 457:35-457:36 (leading: Space)
-5118: KwReturn        "return" at 457:37-457:43 (leading: Space)
-5119: LParen          "(" at 457:44-457:45 (leading: Space)
-5120: IntLit          "255" at 457:45-457:48
-5121: RParen          ")" at 457:48-457:49
-5122: Colon           ":" at 457:49-457:50
-5123: Ident           "uint8" at 457:50-457:55
-5124: Semicolon       ";" at 457:55-457:56
-5125: RBrace          "}" at 457:57-457:58 (leading: Space)
-5126: At              "@" at 458:5-458:6 (leading: Newline, Space)
-5127: Ident           "intrinsic" at 458:6-458:15
-5128: KwFn            "fn" at 458:16-458:18 (leading: Space)
-5129: Ident           "__add" at 458:19-458:24 (leading: Space)
-5130: LParen          "(" at 458:24-458:25
-5131: Ident           "self" at 458:25-458:29
-5132: Colon           ":" at 458:29-458:30
-5133: Ident           "uint8" at 458:31-458:36 (leading: Space)
-5134: Comma           "," at 458:36-458:37
-5135: Ident           "other" at 458:38-458:43 (leading: Space)
-5136: Colon           ":" at 458:43-458:44
-5137: Ident           "uint8" at 458:45-458:50 (leading: Space)
-5138: RParen          ")" at 458:50-458:51
-5139: Arrow           "->" at 458:52-458:54 (leading: Space)
-5140: Ident           "uint8" at 458:55-458:60 (leading: Space)
-5141: Semicolon       ";" at 458:60-458:61
-5142: At              "@" at 459:5-459:6 (leading: Newline, Space)
-5143: Ident           "intrinsic" at 459:6-459:15
-5144: KwFn            "fn" at 459:16-459:18 (leading: Space)
-5145: Ident           "__sub" at 459:19-459:24 (leading: Space)
-5146: LParen          "(" at 459:24-459:25
-5147: Ident           "self" at 459:25-459:29
-5148: Colon           ":" at 459:29-459:30
-5149: Ident           "uint8" at 459:31-459:36 (leading: Space)
-5150: Comma           "," at 459:36-459:37
-5151: Ident           "other" at 459:38-459:43 (leading: Space)
-5152: Colon           ":" at 459:43-459:44
-5153: Ident           "uint8" at 459:45-459:50 (leading: Space)
-5154: RParen          ")" at 459:50-459:51
-5155: Arrow           "->" at 459:52-459:54 (leading: Space)
-5156: Ident           "uint8" at 459:55-459:60 (leading: Space)
-5157: Semicolon       ";" at 459:60-459:61
-5158: At              "@" at 460:5-460:6 (leading: Newline, Space)
-5159: Ident           "intrinsic" at 460:6-460:15
-5160: KwFn            "fn" at 460:16-460:18 (leading: Space)
-5161: Ident           "__mul" at 460:19-460:24 (leading: Space)
-5162: LParen          "(" at 460:24-460:25
-5163: Ident           "self" at 460:25-460:29
-5164: Colon           ":" at 460:29-460:30
-5165: Ident           "uint8" at 460:31-460:36 (leading: Space)
-5166: Comma           "," at 460:36-460:37
-5167: Ident           "other" at 460:38-460:43 (leading: Space)
-5168: Colon           ":" at 460:43-460:44
-5169: Ident           "uint8" at 460:45-460:50 (leading: Space)
-5170: RParen          ")" at 460:50-460:51
-5171: Arrow           "->" at 460:52-460:54 (leading: Space)
-5172: Ident           "uint8" at 460:55-460:60 (leading: Space)
-5173: Semicolon       ";" at 460:60-460:61
-5174: At              "@" at 461:5-461:6 (leading: Newline, Space)
-5175: Ident           "intrinsic" at 461:6-461:15
-5176: KwFn            "fn" at 461:16-461:18 (leading: Space)
-5177: Ident           "__div" at 461:19-461:24 (leading: Space)
-5178: LParen          "(" at 461:24-461:25
-5179: Ident           "self" at 461:25-461:29
-5180: Colon           ":" at 461:29-461:30
-5181: Ident           "uint8" at 461:31-461:36 (leading: Space)
-5182: Comma           "," at 461:36-461:37
-5183: Ident           "other" at 461:38-461:43 (leading: Space)
-5184: Colon           ":" at 461:43-461:44
-5185: Ident           "uint8" at 461:45-461:50 (leading: Space)
-5186: RParen          ")" at 461:50-461:51
-5187: Arrow           "->" at 461:52-461:54 (leading: Space)
-5188: Ident           "uint8" at 461:55-461:60 (leading: Space)
-5189: Semicolon       ";" at 461:60-461:61
-5190: At              "@" at 462:5-462:6 (leading: Newline, Space)
-5191: Ident           "intrinsic" at 462:6-462:15
-5192: KwFn            "fn" at 462:16-462:18 (leading: Space)
-5193: Ident           "__mod" at 462:19-462:24 (leading: Space)
-5194: LParen          "(" at 462:24-462:25
-5195: Ident           "self" at 462:25-462:29
-5196: Colon           ":" at 462:29-462:30
-5197: Ident           "uint8" at 462:31-462:36 (leading: Space)
-5198: Comma           "," at 462:36-462:37
-5199: Ident           "other" at 462:38-462:43 (leading: Space)
-5200: Colon           ":" at 462:43-462:44
-5201: Ident           "uint8" at 462:45-462:50 (leading: Space)
-5202: RParen          ")" at 462:50-462:51
-5203: Arrow           "->" at 462:52-462:54 (leading: Space)
-5204: Ident           "uint8" at 462:55-462:60 (leading: Space)
-5205: Semicolon       ";" at 462:60-462:61
-5206: At              "@" at 463:5-463:6 (leading: Newline, Space)
-5207: Ident           "intrinsic" at 463:6-463:15
-5208: KwFn            "fn" at 463:16-463:18 (leading: Space)
-5209: Ident           "__bit_and" at 463:19-463:28 (leading: Space)
-5210: LParen          "(" at 463:28-463:29
-5211: Ident           "self" at 463:29-463:33
-5212: Colon           ":" at 463:33-463:34
-5213: Ident           "uint8" at 463:35-463:40 (leading: Space)
-5214: Comma           "," at 463:40-463:41
-5215: Ident           "other" at 463:42-463:47 (leading: Space)
-5216: Colon           ":" at 463:47-463:48
-5217: Ident           "uint8" at 463:49-463:54 (leading: Space)
-5218: RParen          ")" at 463:54-463:55
-5219: Arrow           "->" at 463:56-463:58 (leading: Space)
-5220: Ident           "uint8" at 463:59-463:64 (leading: Space)
-5221: Semicolon       ";" at 463:64-463:65
-5222: At              "@" at 464:5-464:6 (leading: Newline, Space)
-5223: Ident           "intrinsic" at 464:6-464:15
-5224: KwFn            "fn" at 464:16-464:18 (leading: Space)
-5225: Ident           "__bit_or" at 464:19-464:27 (leading: Space)
-5226: LParen          "(" at 464:27-464:28
-5227: Ident           "self" at 464:28-464:32
-5228: Colon           ":" at 464:32-464:33
-5229: Ident           "uint8" at 464:34-464:39 (leading: Space)
-5230: Comma           "," at 464:39-464:40
-5231: Ident           "other" at 464:41-464:46 (leading: Space)
-5232: Colon           ":" at 464:46-464:47
-5233: Ident           "uint8" at 464:48-464:53 (leading: Space)
-5234: RParen          ")" at 464:53-464:54
-5235: Arrow           "->" at 464:55-464:57 (leading: Space)
-5236: Ident           "uint8" at 464:58-464:63 (leading: Space)
-5237: Semicolon       ";" at 464:63-464:64
-5238: At              "@" at 465:5-465:6 (leading: Newline, Space)
-5239: Ident           "intrinsic" at 465:6-465:15
-5240: KwFn            "fn" at 465:16-465:18 (leading: Space)
-5241: Ident           "__bit_xor" at 465:19-465:28 (leading: Space)
-5242: LParen          "(" at 465:28-465:29
-5243: Ident           "self" at 465:29-465:33
-5244: Colon           ":" at 465:33-465:34
-5245: Ident           "uint8" at 465:35-465:40 (leading: Space)
-5246: Comma           "," at 465:40-465:41
-5247: Ident           "other" at 465:42-465:47 (leading: Space)
-5248: Colon           ":" at 465:47-465:48
-5249: Ident           "uint8" at 465:49-465:54 (leading: Space)
-5250: RParen          ")" at 465:54-465:55
-5251: Arrow           "->" at 465:56-465:58 (leading: Space)
-5252: Ident           "uint8" at 465:59-465:64 (leading: Space)
-5253: Semicolon       ";" at 465:64-465:65
-5254: At              "@" at 466:5-466:6 (leading: Newline, Space)
-5255: Ident           "intrinsic" at 466:6-466:15
-5256: KwFn            "fn" at 466:16-466:18 (leading: Space)
-5257: Ident           "__shl" at 466:19-466:24 (leading: Space)
-5258: LParen          "(" at 466:24-466:25
-5259: Ident           "self" at 466:25-466:29
-5260: Colon           ":" at 466:29-466:30
-5261: Ident           "uint8" at 466:31-466:36 (leading: Space)
-5262: Comma           "," at 466:36-466:37
-5263: Ident           "other" at 466:38-466:43 (leading: Space)
-5264: Colon           ":" at 466:43-466:44
-5265: Ident           "uint8" at 466:45-466:50 (leading: Space)
-5266: RParen          ")" at 466:50-466:51
-5267: Arrow           "->" at 466:52-466:54 (leading: Space)
-5268: Ident           "uint8" at 466:55-466:60 (leading: Space)
-5269: Semicolon       ";" at 466:60-466:61
-5270: At              "@" at 467:5-467:6 (leading: Newline, Space)
-5271: Ident           "intrinsic" at 467:6-467:15
-5272: KwFn            "fn" at 467:16-467:18 (leading: Space)
-5273: Ident           "__shr" at 467:19-467:24 (leading: Space)
-5274: LParen          "(" at 467:24-467:25
-5275: Ident           "self" at 467:25-467:29
-5276: Colon           ":" at 467:29-467:30
-5277: Ident           "uint8" at 467:31-467:36 (leading: Space)
-5278: Comma           "," at 467:36-467:37
-5279: Ident           "other" at 467:38-467:43 (leading: Space)
-5280: Colon           ":" at 467:43-467:44
-5281: Ident           "uint8" at 467:45-467:50 (leading: Space)
-5282: RParen          ")" at 467:50-467:51
-5283: Arrow           "->" at 467:52-467:54 (leading: Space)
-5284: Ident           "uint8" at 467:55-467:60 (leading: Space)
-5285: Semicolon       ";" at 467:60-467:61
-5286: At              "@" at 468:5-468:6 (leading: Newline, Space)
-5287: Ident           "intrinsic" at 468:6-468:15
-5288: KwFn            "fn" at 468:16-468:18 (leading: Space)
-5289: Ident           "__lt" at 468:19-468:23 (leading: Space)
-5290: LParen          "(" at 468:23-468:24
-5291: Ident           "self" at 468:24-468:28
-5292: Colon           ":" at 468:28-468:29
-5293: Ident           "uint8" at 468:30-468:35 (leading: Space)
-5294: Comma           "," at 468:35-468:36
-5295: Ident           "other" at 468:37-468:42 (leading: Space)
-5296: Colon           ":" at 468:42-468:43
-5297: Ident           "uint8" at 468:44-468:49 (leading: Space)
-5298: RParen          ")" at 468:49-468:50
-5299: Arrow           "->" at 468:51-468:53 (leading: Space)
-5300: Ident           "bool" at 468:54-468:58 (leading: Space)
-5301: Semicolon       ";" at 468:58-468:59
-5302: At              "@" at 469:5-469:6 (leading: Newline, Space)
-5303: Ident           "intrinsic" at 469:6-469:15
-5304: KwFn            "fn" at 469:16-469:18 (leading: Space)
-5305: Ident           "__le" at 469:19-469:23 (leading: Space)
-5306: LParen          "(" at 469:23-469:24
-5307: Ident           "self" at 469:24-469:28
-5308: Colon           ":" at 469:28-469:29
-5309: Ident           "uint8" at 469:30-469:35 (leading: Space)
-5310: Comma           "," at 469:35-469:36
-5311: Ident           "other" at 469:37-469:42 (leading: Space)
-5312: Colon           ":" at 469:42-469:43
-5313: Ident           "uint8" at 469:44-469:49 (leading: Space)
-5314: RParen          ")" at 469:49-469:50
-5315: Arrow           "->" at 469:51-469:53 (leading: Space)
-5316: Ident           "bool" at 469:54-469:58 (leading: Space)
-5317: Semicolon       ";" at 469:58-469:59
-5318: At              "@" at 470:5-470:6 (leading: Newline, Space)
-5319: Ident           "intrinsic" at 470:6-470:15
-5320: KwFn            "fn" at 470:16-470:18 (leading: Space)
-5321: Ident           "__eq" at 470:19-470:23 (leading: Space)
-5322: LParen          "(" at 470:23-470:24
-5323: Ident           "self" at 470:24-470:28
-5324: Colon           ":" at 470:28-470:29
-5325: Ident           "uint8" at 470:30-470:35 (leading: Space)
-5326: Comma           "," at 470:35-470:36
-5327: Ident           "other" at 470:37-470:42 (leading: Space)
-5328: Colon           ":" at 470:42-470:43
-5329: Ident           "uint8" at 470:44-470:49 (leading: Space)
-5330: RParen          ")" at 470:49-470:50
-5331: Arrow           "->" at 470:51-470:53 (leading: Space)
-5332: Ident           "bool" at 470:54-470:58 (leading: Space)
-5333: Semicolon       ";" at 470:58-470:59
-5334: At              "@" at 471:5-471:6 (leading: Newline, Space)
-5335: Ident           "intrinsic" at 471:6-471:15
-5336: KwFn            "fn" at 471:16-471:18 (leading: Space)
-5337: Ident           "__ne" at 471:19-471:23 (leading: Space)
-5338: LParen          "(" at 471:23-471:24
-5339: Ident           "self" at 471:24-471:28
-5340: Colon           ":" at 471:28-471:29
-5341: Ident           "uint8" at 471:30-471:35 (leading: Space)
-5342: Comma           "," at 471:35-471:36
-5343: Ident           "other" at 471:37-471:42 (leading: Space)
-5344: Colon           ":" at 471:42-471:43
-5345: Ident           "uint8" at 471:44-471:49 (leading: Space)
-5346: RParen          ")" at 471:49-471:50
-5347: Arrow           "->" at 471:51-471:53 (leading: Space)
-5348: Ident           "bool" at 471:54-471:58 (leading: Space)
-5349: Semicolon       ";" at 471:58-471:59
-5350: At              "@" at 472:5-472:6 (leading: Newline, Space)
-5351: Ident           "intrinsic" at 472:6-472:15
-5352: KwFn            "fn" at 472:16-472:18 (leading: Space)
-5353: Ident           "__ge" at 472:19-472:23 (leading: Space)
-5354: LParen          "(" at 472:23-472:24
-5355: Ident           "self" at 472:24-472:28
-5356: Colon           ":" at 472:28-472:29
-5357: Ident           "uint8" at 472:30-472:35 (leading: Space)
-5358: Comma           "," at 472:35-472:36
-5359: Ident           "other" at 472:37-472:42 (leading: Space)
-5360: Colon           ":" at 472:42-472:43
-5361: Ident           "uint8" at 472:44-472:49 (leading: Space)
-5362: RParen          ")" at 472:49-472:50
-5363: Arrow           "->" at 472:51-472:53 (leading: Space)
-5364: Ident           "bool" at 472:54-472:58 (leading: Space)
-5365: Semicolon       ";" at 472:58-472:59
-5366: At              "@" at 473:5-473:6 (leading: Newline, Space)
-5367: Ident           "intrinsic" at 473:6-473:15
-5368: KwFn            "fn" at 473:16-473:18 (leading: Space)
-5369: Ident           "__gt" at 473:19-473:23 (leading: Space)
-5370: LParen          "(" at 473:23-473:24
-5371: Ident           "self" at 473:24-473:28
-5372: Colon           ":" at 473:28-473:29
-5373: Ident           "uint8" at 473:30-473:35 (leading: Space)
-5374: Comma           "," at 473:35-473:36
-5375: Ident           "other" at 473:37-473:42 (leading: Space)
-5376: Colon           ":" at 473:42-473:43
-5377: Ident           "uint8" at 473:44-473:49 (leading: Space)
-5378: RParen          ")" at 473:49-473:50
-5379: Arrow           "->" at 473:51-473:53 (leading: Space)
-5380: Ident           "bool" at 473:54-473:58 (leading: Space)
-5381: Semicolon       ";" at 473:58-473:59
-5382: At              "@" at 474:5-474:6 (leading: Newline, Space)
-5383: Ident           "intrinsic" at 474:6-474:15
-5384: KwFn            "fn" at 474:16-474:18 (leading: Space)
-5385: Ident           "__pos" at 474:19-474:24 (leading: Space)
-5386: LParen          "(" at 474:24-474:25
-5387: Ident           "self" at 474:25-474:29
-5388: Colon           ":" at 474:29-474:30
-5389: Ident           "uint8" at 474:31-474:36 (leading: Space)
-5390: RParen          ")" at 474:36-474:37
-5391: Arrow           "->" at 474:38-474:40 (leading: Space)
-5392: Ident           "uint8" at 474:41-474:46 (leading: Space)
-5393: Semicolon       ";" at 474:46-474:47
-5394: At              "@" at 475:5-475:6 (leading: Newline, Space)
-5395: Ident           "intrinsic" at 475:6-475:15
-5396: KwFn            "fn" at 475:16-475:18 (leading: Space)
-5397: Ident           "__abs" at 475:19-475:24 (leading: Space)
-5398: LParen          "(" at 475:24-475:25
-5399: Ident           "self" at 475:25-475:29
-5400: Colon           ":" at 475:29-475:30
-5401: Ident           "uint8" at 475:31-475:36 (leading: Space)
-5402: RParen          ")" at 475:36-475:37
-5403: Arrow           "->" at 475:38-475:40 (leading: Space)
-5404: Ident           "uint8" at 475:41-475:46 (leading: Space)
-5405: Semicolon       ";" at 475:46-475:47
-5406: At              "@" at 476:5-476:6 (leading: Newline, Space)
-5407: Ident           "intrinsic" at 476:6-476:15
-5408: KwFn            "fn" at 476:16-476:18 (leading: Space)
-5409: Ident           "__to" at 476:19-476:23 (leading: Space)
-5410: LParen          "(" at 476:23-476:24
-5411: Ident           "self" at 476:24-476:28
-5412: Colon           ":" at 476:28-476:29
-5413: Ident           "uint8" at 476:30-476:35 (leading: Space)
-5414: Comma           "," at 476:35-476:36
-5415: Ident           "target" at 476:37-476:43 (leading: Space)
-5416: Colon           ":" at 476:43-476:44
-5417: Ident           "uint" at 476:45-476:49 (leading: Space)
-5418: RParen          ")" at 476:49-476:50
-5419: Arrow           "->" at 476:51-476:53 (leading: Space)
-5420: Ident           "uint" at 476:54-476:58 (leading: Space)
-5421: Semicolon       ";" at 476:58-476:59
-5422: At              "@" at 477:5-477:6 (leading: Newline, Space)
-5423: Ident           "intrinsic" at 477:6-477:15
-5424: At              "@" at 477:16-477:17 (leading: Space)
-5425: Ident           "overload" at 477:17-477:25
-5426: KwFn            "fn" at 477:26-477:28 (leading: Space)
-5427: Ident           "__to" at 477:29-477:33 (leading: Space)
-5428: LParen          "(" at 477:33-477:34
-5429: Ident           "self" at 477:34-477:38
-5430: Colon           ":" at 477:38-477:39
-5431: Ident           "uint8" at 477:40-477:45 (leading: Space)
-5432: Comma           "," at 477:45-477:46
-5433: Ident           "target" at 477:47-477:53 (leading: Space)
-5434: Colon           ":" at 477:53-477:54
-5435: Ident           "uint16" at 477:55-477:61 (leading: Space)
-5436: RParen          ")" at 477:61-477:62
-5437: Arrow           "->" at 477:63-477:65 (leading: Space)
-5438: Ident           "uint16" at 477:66-477:72 (leading: Space)
-5439: Semicolon       ";" at 477:72-477:73
-5440: At              "@" at 478:5-478:6 (leading: Newline, Space)
-5441: Ident           "intrinsic" at 478:6-478:15
-5442: At              "@" at 478:16-478:17 (leading: Space)
-5443: Ident           "overload" at 478:17-478:25
-5444: KwFn            "fn" at 478:26-478:28 (leading: Space)
-5445: Ident           "__to" at 478:29-478:33 (leading: Space)
-5446: LParen          "(" at 478:33-478:34
-5447: Ident           "self" at 478:34-478:38
-5448: Colon           ":" at 478:38-478:39
-5449: Ident           "uint8" at 478:40-478:45 (leading: Space)
-5450: Comma           "," at 478:45-478:46
-5451: Ident           "target" at 478:47-478:53 (leading: Space)
-5452: Colon           ":" at 478:53-478:54
-5453: Ident           "uint32" at 478:55-478:61 (leading: Space)
-5454: RParen          ")" at 478:61-478:62
-5455: Arrow           "->" at 478:63-478:65 (leading: Space)
-5456: Ident           "uint32" at 478:66-478:72 (leading: Space)
-5457: Semicolon       ";" at 478:72-478:73
-5458: At              "@" at 479:5-479:6 (leading: Newline, Space)
-5459: Ident           "intrinsic" at 479:6-479:15
-5460: At              "@" at 479:16-479:17 (leading: Space)
-5461: Ident           "overload" at 479:17-479:25
-5462: KwFn            "fn" at 479:26-479:28 (leading: Space)
-5463: Ident           "__to" at 479:29-479:33 (leading: Space)
-5464: LParen          "(" at 479:33-479:34
-5465: Ident           "self" at 479:34-479:38
-5466: Colon           ":" at 479:38-479:39
-5467: Ident           "uint8" at 479:40-479:45 (leading: Space)
-5468: Comma           "," at 479:45-479:46
-5469: Ident           "target" at 479:47-479:53 (leading: Space)
-5470: Colon           ":" at 479:53-479:54
-5471: Ident           "uint64" at 479:55-479:61 (leading: Space)
-5472: RParen          ")" at 479:61-479:62
-5473: Arrow           "->" at 479:63-479:65 (leading: Space)
-5474: Ident           "uint64" at 479:66-479:72 (leading: Space)
-5475: Semicolon       ";" at 479:72-479:73
-5476: At              "@" at 480:5-480:6 (leading: Newline, Space)
-5477: Ident           "intrinsic" at 480:6-480:15
-5478: KwPub           "pub" at 480:16-480:19 (leading: Space)
-5479: KwFn            "fn" at 480:20-480:22 (leading: Space)
-5480: Ident           "from_str" at 480:23-480:31 (leading: Space)
-5481: LParen          "(" at 480:31-480:32
-5482: Ident           "s" at 480:32-480:33
-5483: Colon           ":" at 480:33-480:34
-5484: Amp             "&" at 480:35-480:36 (leading: Space)
-5485: Ident           "string" at 480:36-480:42
-5486: RParen          ")" at 480:42-480:43
-5487: Arrow           "->" at 480:44-480:46 (leading: Space)
-5488: Ident           "Erring" at 480:47-480:53 (leading: Space)
-5489: Lt              "<" at 480:53-480:54
-5490: Ident           "uint8" at 480:54-480:59
-5491: Comma           "," at 480:59-480:60
-5492: Ident           "Error" at 480:61-480:66 (leading: Space)
-5493: Gt              ">" at 480:66-480:67
-5494: Semicolon       ";" at 480:67-480:68
-5495: RBrace          "}" at 481:1-481:2 (leading: Newline)
-5496: KwExtern        "extern" at 483:1-483:7 (leading: Newline)
-5497: Lt              "<" at 483:7-483:8
-5498: Ident           "uint16" at 483:8-483:14
-5499: Gt              ">" at 483:14-483:15
-5500: LBrace          "{" at 483:16-483:17 (leading: Space)
-5501: KwPub           "pub" at 484:5-484:8 (leading: Newline, Space)
-5502: KwFn            "fn" at 484:9-484:11 (leading: Space)
-5503: Ident           "__min_value" at 484:12-484:23 (leading: Space)
-5504: LParen          "(" at 484:23-484:24
-5505: RParen          ")" at 484:24-484:25
-5506: Arrow           "->" at 484:26-484:28 (leading: Space)
-5507: Ident           "uint16" at 484:29-484:35 (leading: Space)
-5508: LBrace          "{" at 484:36-484:37 (leading: Space)
-5509: KwReturn        "return" at 484:38-484:44 (leading: Space)
-5510: LParen          "(" at 484:45-484:46 (leading: Space)
-5511: IntLit          "0" at 484:46-484:47
-5512: RParen          ")" at 484:47-484:48
-5513: Colon           ":" at 484:48-484:49
-5514: Ident           "uint16" at 484:49-484:55
-5515: Semicolon       ";" at 484:55-484:56
-5516: RBrace          "}" at 484:57-484:58 (leading: Space)
-5517: KwPub           "pub" at 485:5-485:8 (leading: Newline, Space)
-5518: KwFn            "fn" at 485:9-485:11 (leading: Space)
-5519: Ident           "__max_value" at 485:12-485:23 (leading: Space)
-5520: LParen          "(" at 485:23-485:24
-5521: RParen          ")" at 485:24-485:25
-5522: Arrow           "->" at 485:26-485:28 (leading: Space)
-5523: Ident           "uint16" at 485:29-485:35 (leading: Space)
-5524: LBrace          "{" at 485:36-485:37 (leading: Space)
-5525: KwReturn        "return" at 485:38-485:44 (leading: Space)
-5526: LParen          "(" at 485:45-485:46 (leading: Space)
-5527: IntLit          "65_535" at 485:46-485:52
-5528: RParen          ")" at 485:52-485:53
-5529: Colon           ":" at 485:53-485:54
-5530: Ident           "uint16" at 485:54-485:60
-5531: Semicolon       ";" at 485:60-485:61
-5532: RBrace          "}" at 485:62-485:63 (leading: Space)
-5533: At              "@" at 486:5-486:6 (leading: Newline, Space)
-5534: Ident           "intrinsic" at 486:6-486:15
-5535: KwFn            "fn" at 486:16-486:18 (leading: Space)
-5536: Ident           "__add" at 486:19-486:24 (leading: Space)
-5537: LParen          "(" at 486:24-486:25
-5538: Ident           "self" at 486:25-486:29
-5539: Colon           ":" at 486:29-486:30
-5540: Ident           "uint16" at 486:31-486:37 (leading: Space)
-5541: Comma           "," at 486:37-486:38
-5542: Ident           "other" at 486:39-486:44 (leading: Space)
-5543: Colon           ":" at 486:44-486:45
-5544: Ident           "uint16" at 486:46-486:52 (leading: Space)
-5545: RParen          ")" at 486:52-486:53
-5546: Arrow           "->" at 486:54-486:56 (leading: Space)
-5547: Ident           "uint16" at 486:57-486:63 (leading: Space)
-5548: Semicolon       ";" at 486:63-486:64
-5549: At              "@" at 487:5-487:6 (leading: Newline, Space)
-5550: Ident           "intrinsic" at 487:6-487:15
-5551: KwFn            "fn" at 487:16-487:18 (leading: Space)
-5552: Ident           "__sub" at 487:19-487:24 (leading: Space)
-5553: LParen          "(" at 487:24-487:25
-5554: Ident           "self" at 487:25-487:29
-5555: Colon           ":" at 487:29-487:30
-5556: Ident           "uint16" at 487:31-487:37 (leading: Space)
-5557: Comma           "," at 487:37-487:38
-5558: Ident           "other" at 487:39-487:44 (leading: Space)
-5559: Colon           ":" at 487:44-487:45
-5560: Ident           "uint16" at 487:46-487:52 (leading: Space)
-5561: RParen          ")" at 487:52-487:53
-5562: Arrow           "->" at 487:54-487:56 (leading: Space)
-5563: Ident           "uint16" at 487:57-487:63 (leading: Space)
-5564: Semicolon       ";" at 487:63-487:64
-5565: At              "@" at 488:5-488:6 (leading: Newline, Space)
-5566: Ident           "intrinsic" at 488:6-488:15
-5567: KwFn            "fn" at 488:16-488:18 (leading: Space)
-5568: Ident           "__mul" at 488:19-488:24 (leading: Space)
-5569: LParen          "(" at 488:24-488:25
-5570: Ident           "self" at 488:25-488:29
-5571: Colon           ":" at 488:29-488:30
-5572: Ident           "uint16" at 488:31-488:37 (leading: Space)
-5573: Comma           "," at 488:37-488:38
-5574: Ident           "other" at 488:39-488:44 (leading: Space)
-5575: Colon           ":" at 488:44-488:45
-5576: Ident           "uint16" at 488:46-488:52 (leading: Space)
-5577: RParen          ")" at 488:52-488:53
-5578: Arrow           "->" at 488:54-488:56 (leading: Space)
-5579: Ident           "uint16" at 488:57-488:63 (leading: Space)
-5580: Semicolon       ";" at 488:63-488:64
-5581: At              "@" at 489:5-489:6 (leading: Newline, Space)
-5582: Ident           "intrinsic" at 489:6-489:15
-5583: KwFn            "fn" at 489:16-489:18 (leading: Space)
-5584: Ident           "__div" at 489:19-489:24 (leading: Space)
-5585: LParen          "(" at 489:24-489:25
-5586: Ident           "self" at 489:25-489:29
-5587: Colon           ":" at 489:29-489:30
-5588: Ident           "uint16" at 489:31-489:37 (leading: Space)
-5589: Comma           "," at 489:37-489:38
-5590: Ident           "other" at 489:39-489:44 (leading: Space)
-5591: Colon           ":" at 489:44-489:45
-5592: Ident           "uint16" at 489:46-489:52 (leading: Space)
-5593: RParen          ")" at 489:52-489:53
-5594: Arrow           "->" at 489:54-489:56 (leading: Space)
-5595: Ident           "uint16" at 489:57-489:63 (leading: Space)
-5596: Semicolon       ";" at 489:63-489:64
-5597: At              "@" at 490:5-490:6 (leading: Newline, Space)
-5598: Ident           "intrinsic" at 490:6-490:15
-5599: KwFn            "fn" at 490:16-490:18 (leading: Space)
-5600: Ident           "__mod" at 490:19-490:24 (leading: Space)
-5601: LParen          "(" at 490:24-490:25
-5602: Ident           "self" at 490:25-490:29
-5603: Colon           ":" at 490:29-490:30
-5604: Ident           "uint16" at 490:31-490:37 (leading: Space)
-5605: Comma           "," at 490:37-490:38
-5606: Ident           "other" at 490:39-490:44 (leading: Space)
-5607: Colon           ":" at 490:44-490:45
-5608: Ident           "uint16" at 490:46-490:52 (leading: Space)
-5609: RParen          ")" at 490:52-490:53
-5610: Arrow           "->" at 490:54-490:56 (leading: Space)
-5611: Ident           "uint16" at 490:57-490:63 (leading: Space)
-5612: Semicolon       ";" at 490:63-490:64
-5613: At              "@" at 491:5-491:6 (leading: Newline, Space)
-5614: Ident           "intrinsic" at 491:6-491:15
-5615: KwFn            "fn" at 491:16-491:18 (leading: Space)
-5616: Ident           "__bit_and" at 491:19-491:28 (leading: Space)
-5617: LParen          "(" at 491:28-491:29
-5618: Ident           "self" at 491:29-491:33
-5619: Colon           ":" at 491:33-491:34
-5620: Ident           "uint16" at 491:35-491:41 (leading: Space)
-5621: Comma           "," at 491:41-491:42
-5622: Ident           "other" at 491:43-491:48 (leading: Space)
-5623: Colon           ":" at 491:48-491:49
-5624: Ident           "uint16" at 491:50-491:56 (leading: Space)
-5625: RParen          ")" at 491:56-491:57
-5626: Arrow           "->" at 491:58-491:60 (leading: Space)
-5627: Ident           "uint16" at 491:61-491:67 (leading: Space)
-5628: Semicolon       ";" at 491:67-491:68
-5629: At              "@" at 492:5-492:6 (leading: Newline, Space)
-5630: Ident           "intrinsic" at 492:6-492:15
-5631: KwFn            "fn" at 492:16-492:18 (leading: Space)
-5632: Ident           "__bit_or" at 492:19-492:27 (leading: Space)
-5633: LParen          "(" at 492:27-492:28
-5634: Ident           "self" at 492:28-492:32
-5635: Colon           ":" at 492:32-492:33
-5636: Ident           "uint16" at 492:34-492:40 (leading: Space)
-5637: Comma           "," at 492:40-492:41
-5638: Ident           "other" at 492:42-492:47 (leading: Space)
-5639: Colon           ":" at 492:47-492:48
-5640: Ident           "uint16" at 492:49-492:55 (leading: Space)
-5641: RParen          ")" at 492:55-492:56
-5642: Arrow           "->" at 492:57-492:59 (leading: Space)
-5643: Ident           "uint16" at 492:60-492:66 (leading: Space)
-5644: Semicolon       ";" at 492:66-492:67
-5645: At              "@" at 493:5-493:6 (leading: Newline, Space)
-5646: Ident           "intrinsic" at 493:6-493:15
-5647: KwFn            "fn" at 493:16-493:18 (leading: Space)
-5648: Ident           "__bit_xor" at 493:19-493:28 (leading: Space)
-5649: LParen          "(" at 493:28-493:29
-5650: Ident           "self" at 493:29-493:33
-5651: Colon           ":" at 493:33-493:34
-5652: Ident           "uint16" at 493:35-493:41 (leading: Space)
-5653: Comma           "," at 493:41-493:42
-5654: Ident           "other" at 493:43-493:48 (leading: Space)
-5655: Colon           ":" at 493:48-493:49
-5656: Ident           "uint16" at 493:50-493:56 (leading: Space)
-5657: RParen          ")" at 493:56-493:57
-5658: Arrow           "->" at 493:58-493:60 (leading: Space)
-5659: Ident           "uint16" at 493:61-493:67 (leading: Space)
-5660: Semicolon       ";" at 493:67-493:68
-5661: At              "@" at 494:5-494:6 (leading: Newline, Space)
-5662: Ident           "intrinsic" at 494:6-494:15
-5663: KwFn            "fn" at 494:16-494:18 (leading: Space)
-5664: Ident           "__shl" at 494:19-494:24 (leading: Space)
-5665: LParen          "(" at 494:24-494:25
-5666: Ident           "self" at 494:25-494:29
-5667: Colon           ":" at 494:29-494:30
-5668: Ident           "uint16" at 494:31-494:37 (leading: Space)
-5669: Comma           "," at 494:37-494:38
-5670: Ident           "other" at 494:39-494:44 (leading: Space)
-5671: Colon           ":" at 494:44-494:45
-5672: Ident           "uint16" at 494:46-494:52 (leading: Space)
-5673: RParen          ")" at 494:52-494:53
-5674: Arrow           "->" at 494:54-494:56 (leading: Space)
-5675: Ident           "uint16" at 494:57-494:63 (leading: Space)
-5676: Semicolon       ";" at 494:63-494:64
-5677: At              "@" at 495:5-495:6 (leading: Newline, Space)
-5678: Ident           "intrinsic" at 495:6-495:15
-5679: KwFn            "fn" at 495:16-495:18 (leading: Space)
-5680: Ident           "__shr" at 495:19-495:24 (leading: Space)
-5681: LParen          "(" at 495:24-495:25
-5682: Ident           "self" at 495:25-495:29
-5683: Colon           ":" at 495:29-495:30
-5684: Ident           "uint16" at 495:31-495:37 (leading: Space)
-5685: Comma           "," at 495:37-495:38
-5686: Ident           "other" at 495:39-495:44 (leading: Space)
-5687: Colon           ":" at 495:44-495:45
-5688: Ident           "uint16" at 495:46-495:52 (leading: Space)
-5689: RParen          ")" at 495:52-495:53
-5690: Arrow           "->" at 495:54-495:56 (leading: Space)
-5691: Ident           "uint16" at 495:57-495:63 (leading: Space)
-5692: Semicolon       ";" at 495:63-495:64
-5693: At              "@" at 496:5-496:6 (leading: Newline, Space)
-5694: Ident           "intrinsic" at 496:6-496:15
-5695: KwFn            "fn" at 496:16-496:18 (leading: Space)
-5696: Ident           "__lt" at 496:19-496:23 (leading: Space)
-5697: LParen          "(" at 496:23-496:24
-5698: Ident           "self" at 496:24-496:28
-5699: Colon           ":" at 496:28-496:29
-5700: Ident           "uint16" at 496:30-496:36 (leading: Space)
-5701: Comma           "," at 496:36-496:37
-5702: Ident           "other" at 496:38-496:43 (leading: Space)
-5703: Colon           ":" at 496:43-496:44
-5704: Ident           "uint16" at 496:45-496:51 (leading: Space)
-5705: RParen          ")" at 496:51-496:52
-5706: Arrow           "->" at 496:53-496:55 (leading: Space)
-5707: Ident           "bool" at 496:56-496:60 (leading: Space)
-5708: Semicolon       ";" at 496:60-496:61
-5709: At              "@" at 497:5-497:6 (leading: Newline, Space)
-5710: Ident           "intrinsic" at 497:6-497:15
-5711: KwFn            "fn" at 497:16-497:18 (leading: Space)
-5712: Ident           "__le" at 497:19-497:23 (leading: Space)
-5713: LParen          "(" at 497:23-497:24
-5714: Ident           "self" at 497:24-497:28
-5715: Colon           ":" at 497:28-497:29
-5716: Ident           "uint16" at 497:30-497:36 (leading: Space)
-5717: Comma           "," at 497:36-497:37
-5718: Ident           "other" at 497:38-497:43 (leading: Space)
-5719: Colon           ":" at 497:43-497:44
-5720: Ident           "uint16" at 497:45-497:51 (leading: Space)
-5721: RParen          ")" at 497:51-497:52
-5722: Arrow           "->" at 497:53-497:55 (leading: Space)
-5723: Ident           "bool" at 497:56-497:60 (leading: Space)
-5724: Semicolon       ";" at 497:60-497:61
-5725: At              "@" at 498:5-498:6 (leading: Newline, Space)
-5726: Ident           "intrinsic" at 498:6-498:15
-5727: KwFn            "fn" at 498:16-498:18 (leading: Space)
-5728: Ident           "__eq" at 498:19-498:23 (leading: Space)
-5729: LParen          "(" at 498:23-498:24
-5730: Ident           "self" at 498:24-498:28
-5731: Colon           ":" at 498:28-498:29
-5732: Ident           "uint16" at 498:30-498:36 (leading: Space)
-5733: Comma           "," at 498:36-498:37
-5734: Ident           "other" at 498:38-498:43 (leading: Space)
-5735: Colon           ":" at 498:43-498:44
-5736: Ident           "uint16" at 498:45-498:51 (leading: Space)
-5737: RParen          ")" at 498:51-498:52
-5738: Arrow           "->" at 498:53-498:55 (leading: Space)
-5739: Ident           "bool" at 498:56-498:60 (leading: Space)
-5740: Semicolon       ";" at 498:60-498:61
-5741: At              "@" at 499:5-499:6 (leading: Newline, Space)
-5742: Ident           "intrinsic" at 499:6-499:15
-5743: KwFn            "fn" at 499:16-499:18 (leading: Space)
-5744: Ident           "__ne" at 499:19-499:23 (leading: Space)
-5745: LParen          "(" at 499:23-499:24
-5746: Ident           "self" at 499:24-499:28
-5747: Colon           ":" at 499:28-499:29
-5748: Ident           "uint16" at 499:30-499:36 (leading: Space)
-5749: Comma           "," at 499:36-499:37
-5750: Ident           "other" at 499:38-499:43 (leading: Space)
-5751: Colon           ":" at 499:43-499:44
-5752: Ident           "uint16" at 499:45-499:51 (leading: Space)
-5753: RParen          ")" at 499:51-499:52
-5754: Arrow           "->" at 499:53-499:55 (leading: Space)
-5755: Ident           "bool" at 499:56-499:60 (leading: Space)
-5756: Semicolon       ";" at 499:60-499:61
-5757: At              "@" at 500:5-500:6 (leading: Newline, Space)
-5758: Ident           "intrinsic" at 500:6-500:15
-5759: KwFn            "fn" at 500:16-500:18 (leading: Space)
-5760: Ident           "__ge" at 500:19-500:23 (leading: Space)
-5761: LParen          "(" at 500:23-500:24
-5762: Ident           "self" at 500:24-500:28
-5763: Colon           ":" at 500:28-500:29
-5764: Ident           "uint16" at 500:30-500:36 (leading: Space)
-5765: Comma           "," at 500:36-500:37
-5766: Ident           "other" at 500:38-500:43 (leading: Space)
-5767: Colon           ":" at 500:43-500:44
-5768: Ident           "uint16" at 500:45-500:51 (leading: Space)
-5769: RParen          ")" at 500:51-500:52
-5770: Arrow           "->" at 500:53-500:55 (leading: Space)
-5771: Ident           "bool" at 500:56-500:60 (leading: Space)
-5772: Semicolon       ";" at 500:60-500:61
-5773: At              "@" at 501:5-501:6 (leading: Newline, Space)
-5774: Ident           "intrinsic" at 501:6-501:15
-5775: KwFn            "fn" at 501:16-501:18 (leading: Space)
-5776: Ident           "__gt" at 501:19-501:23 (leading: Space)
-5777: LParen          "(" at 501:23-501:24
-5778: Ident           "self" at 501:24-501:28
-5779: Colon           ":" at 501:28-501:29
-5780: Ident           "uint16" at 501:30-501:36 (leading: Space)
-5781: Comma           "," at 501:36-501:37
-5782: Ident           "other" at 501:38-501:43 (leading: Space)
-5783: Colon           ":" at 501:43-501:44
-5784: Ident           "uint16" at 501:45-501:51 (leading: Space)
-5785: RParen          ")" at 501:51-501:52
-5786: Arrow           "->" at 501:53-501:55 (leading: Space)
-5787: Ident           "bool" at 501:56-501:60 (leading: Space)
-5788: Semicolon       ";" at 501:60-501:61
-5789: At              "@" at 502:5-502:6 (leading: Newline, Space)
-5790: Ident           "intrinsic" at 502:6-502:15
-5791: KwFn            "fn" at 502:16-502:18 (leading: Space)
-5792: Ident           "__pos" at 502:19-502:24 (leading: Space)
-5793: LParen          "(" at 502:24-502:25
-5794: Ident           "self" at 502:25-502:29
-5795: Colon           ":" at 502:29-502:30
-5796: Ident           "uint16" at 502:31-502:37 (leading: Space)
-5797: RParen          ")" at 502:37-502:38
-5798: Arrow           "->" at 502:39-502:41 (leading: Space)
-5799: Ident           "uint16" at 502:42-502:48 (leading: Space)
-5800: Semicolon       ";" at 502:48-502:49
-5801: At              "@" at 503:5-503:6 (leading: Newline, Space)
-5802: Ident           "intrinsic" at 503:6-503:15
-5803: KwFn            "fn" at 503:16-503:18 (leading: Space)
-5804: Ident           "__abs" at 503:19-503:24 (leading: Space)
-5805: LParen          "(" at 503:24-503:25
-5806: Ident           "self" at 503:25-503:29
-5807: Colon           ":" at 503:29-503:30
-5808: Ident           "uint16" at 503:31-503:37 (leading: Space)
-5809: RParen          ")" at 503:37-503:38
-5810: Arrow           "->" at 503:39-503:41 (leading: Space)
-5811: Ident           "uint16" at 503:42-503:48 (leading: Space)
-5812: Semicolon       ";" at 503:48-503:49
-5813: At              "@" at 504:5-504:6 (leading: Newline, Space)
-5814: Ident           "intrinsic" at 504:6-504:15
-5815: KwFn            "fn" at 504:16-504:18 (leading: Space)
-5816: Ident           "__to" at 504:19-504:23 (leading: Space)
-5817: LParen          "(" at 504:23-504:24
-5818: Ident           "self" at 504:24-504:28
-5819: Colon           ":" at 504:28-504:29
-5820: Ident           "uint16" at 504:30-504:36 (leading: Space)
-5821: Comma           "," at 504:36-504:37
-5822: Ident           "target" at 504:38-504:44 (leading: Space)
-5823: Colon           ":" at 504:44-504:45
-5824: Ident           "uint" at 504:46-504:50 (leading: Space)
-5825: RParen          ")" at 504:50-504:51
-5826: Arrow           "->" at 504:52-504:54 (leading: Space)
-5827: Ident           "uint" at 504:55-504:59 (leading: Space)
-5828: Semicolon       ";" at 504:59-504:60
-5829: At              "@" at 505:5-505:6 (leading: Newline, Space)
-5830: Ident           "intrinsic" at 505:6-505:15
-5831: At              "@" at 505:16-505:17 (leading: Space)
-5832: Ident           "overload" at 505:17-505:25
-5833: KwFn            "fn" at 505:26-505:28 (leading: Space)
-5834: Ident           "__to" at 505:29-505:33 (leading: Space)
-5835: LParen          "(" at 505:33-505:34
-5836: Ident           "self" at 505:34-505:38
-5837: Colon           ":" at 505:38-505:39
-5838: Ident           "uint16" at 505:40-505:46 (leading: Space)
-5839: Comma           "," at 505:46-505:47
-5840: Ident           "target" at 505:48-505:54 (leading: Space)
-5841: Colon           ":" at 505:54-505:55
-5842: Ident           "uint8" at 505:56-505:61 (leading: Space)
-5843: RParen          ")" at 505:61-505:62
-5844: Arrow           "->" at 505:63-505:65 (leading: Space)
-5845: Ident           "uint8" at 505:66-505:71 (leading: Space)
-5846: Semicolon       ";" at 505:71-505:72
-5847: At              "@" at 506:5-506:6 (leading: Newline, Space)
-5848: Ident           "intrinsic" at 506:6-506:15
-5849: At              "@" at 506:16-506:17 (leading: Space)
-5850: Ident           "overload" at 506:17-506:25
-5851: KwFn            "fn" at 506:26-506:28 (leading: Space)
-5852: Ident           "__to" at 506:29-506:33 (leading: Space)
-5853: LParen          "(" at 506:33-506:34
-5854: Ident           "self" at 506:34-506:38
-5855: Colon           ":" at 506:38-506:39
-5856: Ident           "uint16" at 506:40-506:46 (leading: Space)
-5857: Comma           "," at 506:46-506:47
-5858: Ident           "target" at 506:48-506:54 (leading: Space)
-5859: Colon           ":" at 506:54-506:55
-5860: Ident           "uint32" at 506:56-506:62 (leading: Space)
-5861: RParen          ")" at 506:62-506:63
-5862: Arrow           "->" at 506:64-506:66 (leading: Space)
-5863: Ident           "uint32" at 506:67-506:73 (leading: Space)
-5864: Semicolon       ";" at 506:73-506:74
-5865: At              "@" at 507:5-507:6 (leading: Newline, Space)
-5866: Ident           "intrinsic" at 507:6-507:15
-5867: At              "@" at 507:16-507:17 (leading: Space)
-5868: Ident           "overload" at 507:17-507:25
-5869: KwFn            "fn" at 507:26-507:28 (leading: Space)
-5870: Ident           "__to" at 507:29-507:33 (leading: Space)
-5871: LParen          "(" at 507:33-507:34
-5872: Ident           "self" at 507:34-507:38
-5873: Colon           ":" at 507:38-507:39
-5874: Ident           "uint16" at 507:40-507:46 (leading: Space)
-5875: Comma           "," at 507:46-507:47
-5876: Ident           "target" at 507:48-507:54 (leading: Space)
-5877: Colon           ":" at 507:54-507:55
-5878: Ident           "uint64" at 507:56-507:62 (leading: Space)
-5879: RParen          ")" at 507:62-507:63
-5880: Arrow           "->" at 507:64-507:66 (leading: Space)
-5881: Ident           "uint64" at 507:67-507:73 (leading: Space)
-5882: Semicolon       ";" at 507:73-507:74
-5883: At              "@" at 508:5-508:6 (leading: Newline, Space)
-5884: Ident           "intrinsic" at 508:6-508:15
-5885: KwPub           "pub" at 508:16-508:19 (leading: Space)
-5886: KwFn            "fn" at 508:20-508:22 (leading: Space)
-5887: Ident           "from_str" at 508:23-508:31 (leading: Space)
-5888: LParen          "(" at 508:31-508:32
-5889: Ident           "s" at 508:32-508:33
-5890: Colon           ":" at 508:33-508:34
-5891: Amp             "&" at 508:35-508:36 (leading: Space)
-5892: Ident           "string" at 508:36-508:42
-5893: RParen          ")" at 508:42-508:43
-5894: Arrow           "->" at 508:44-508:46 (leading: Space)
-5895: Ident           "Erring" at 508:47-508:53 (leading: Space)
-5896: Lt              "<" at 508:53-508:54
-5897: Ident           "uint16" at 508:54-508:60
-5898: Comma           "," at 508:60-508:61
-5899: Ident           "Error" at 508:62-508:67 (leading: Space)
-5900: Gt              ">" at 508:67-508:68
-5901: Semicolon       ";" at 508:68-508:69
-5902: RBrace          "}" at 509:1-509:2 (leading: Newline)
-5903: KwExtern        "extern" at 511:1-511:7 (leading: Newline)
-5904: Lt              "<" at 511:7-511:8
-5905: Ident           "uint32" at 511:8-511:14
-5906: Gt              ">" at 511:14-511:15
-5907: LBrace          "{" at 511:16-511:17 (leading: Space)
-5908: KwPub           "pub" at 512:5-512:8 (leading: Newline, Space)
-5909: KwFn            "fn" at 512:9-512:11 (leading: Space)
-5910: Ident           "__min_value" at 512:12-512:23 (leading: Space)
-5911: LParen          "(" at 512:23-512:24
-5912: RParen          ")" at 512:24-512:25
-5913: Arrow           "->" at 512:26-512:28 (leading: Space)
-5914: Ident           "uint32" at 512:29-512:35 (leading: Space)
-5915: LBrace          "{" at 512:36-512:37 (leading: Space)
-5916: KwReturn        "return" at 512:38-512:44 (leading: Space)
-5917: LParen          "(" at 512:45-512:46 (leading: Space)
-5918: IntLit          "0" at 512:46-512:47
-5919: RParen          ")" at 512:47-512:48
-5920: Colon           ":" at 512:48-512:49
-5921: Ident           "uint32" at 512:49-512:55
-5922: Semicolon       ";" at 512:55-512:56
-5923: RBrace          "}" at 512:57-512:58 (leading: Space)
-5924: KwPub           "pub" at 513:5-513:8 (leading: Newline, Space)
-5925: KwFn            "fn" at 513:9-513:11 (leading: Space)
-5926: Ident           "__max_value" at 513:12-513:23 (leading: Space)
-5927: LParen          "(" at 513:23-513:24
-5928: RParen          ")" at 513:24-513:25
-5929: Arrow           "->" at 513:26-513:28 (leading: Space)
-5930: Ident           "uint32" at 513:29-513:35 (leading: Space)
-5931: LBrace          "{" at 513:36-513:37 (leading: Space)
-5932: KwReturn        "return" at 513:38-513:44 (leading: Space)
-5933: LParen          "(" at 513:45-513:46 (leading: Space)
-5934: IntLit          "4_294_967_295" at 513:46-513:59
-5935: RParen          ")" at 513:59-513:60
-5936: Colon           ":" at 513:60-513:61
-5937: Ident           "uint32" at 513:61-513:67
-5938: Semicolon       ";" at 513:67-513:68
-5939: RBrace          "}" at 513:69-513:70 (leading: Space)
-5940: At              "@" at 514:5-514:6 (leading: Newline, Space)
-5941: Ident           "intrinsic" at 514:6-514:15
-5942: KwFn            "fn" at 514:16-514:18 (leading: Space)
-5943: Ident           "__add" at 514:19-514:24 (leading: Space)
-5944: LParen          "(" at 514:24-514:25
-5945: Ident           "self" at 514:25-514:29
-5946: Colon           ":" at 514:29-514:30
-5947: Ident           "uint32" at 514:31-514:37 (leading: Space)
-5948: Comma           "," at 514:37-514:38
-5949: Ident           "other" at 514:39-514:44 (leading: Space)
-5950: Colon           ":" at 514:44-514:45
-5951: Ident           "uint32" at 514:46-514:52 (leading: Space)
-5952: RParen          ")" at 514:52-514:53
-5953: Arrow           "->" at 514:54-514:56 (leading: Space)
-5954: Ident           "uint32" at 514:57-514:63 (leading: Space)
-5955: Semicolon       ";" at 514:63-514:64
-5956: At              "@" at 515:5-515:6 (leading: Newline, Space)
-5957: Ident           "intrinsic" at 515:6-515:15
-5958: KwFn            "fn" at 515:16-515:18 (leading: Space)
-5959: Ident           "__sub" at 515:19-515:24 (leading: Space)
-5960: LParen          "(" at 515:24-515:25
-5961: Ident           "self" at 515:25-515:29
-5962: Colon           ":" at 515:29-515:30
-5963: Ident           "uint32" at 515:31-515:37 (leading: Space)
-5964: Comma           "," at 515:37-515:38
-5965: Ident           "other" at 515:39-515:44 (leading: Space)
-5966: Colon           ":" at 515:44-515:45
-5967: Ident           "uint32" at 515:46-515:52 (leading: Space)
-5968: RParen          ")" at 515:52-515:53
-5969: Arrow           "->" at 515:54-515:56 (leading: Space)
-5970: Ident           "uint32" at 515:57-515:63 (leading: Space)
-5971: Semicolon       ";" at 515:63-515:64
-5972: At              "@" at 516:5-516:6 (leading: Newline, Space)
-5973: Ident           "intrinsic" at 516:6-516:15
-5974: KwFn            "fn" at 516:16-516:18 (leading: Space)
-5975: Ident           "__mul" at 516:19-516:24 (leading: Space)
-5976: LParen          "(" at 516:24-516:25
-5977: Ident           "self" at 516:25-516:29
-5978: Colon           ":" at 516:29-516:30
-5979: Ident           "uint32" at 516:31-516:37 (leading: Space)
-5980: Comma           "," at 516:37-516:38
-5981: Ident           "other" at 516:39-516:44 (leading: Space)
-5982: Colon           ":" at 516:44-516:45
-5983: Ident           "uint32" at 516:46-516:52 (leading: Space)
-5984: RParen          ")" at 516:52-516:53
-5985: Arrow           "->" at 516:54-516:56 (leading: Space)
-5986: Ident           "uint32" at 516:57-516:63 (leading: Space)
-5987: Semicolon       ";" at 516:63-516:64
-5988: At              "@" at 517:5-517:6 (leading: Newline, Space)
-5989: Ident           "intrinsic" at 517:6-517:15
-5990: KwFn            "fn" at 517:16-517:18 (leading: Space)
-5991: Ident           "__div" at 517:19-517:24 (leading: Space)
-5992: LParen          "(" at 517:24-517:25
-5993: Ident           "self" at 517:25-517:29
-5994: Colon           ":" at 517:29-517:30
-5995: Ident           "uint32" at 517:31-517:37 (leading: Space)
-5996: Comma           "," at 517:37-517:38
-5997: Ident           "other" at 517:39-517:44 (leading: Space)
-5998: Colon           ":" at 517:44-517:45
-5999: Ident           "uint32" at 517:46-517:52 (leading: Space)
-6000: RParen          ")" at 517:52-517:53
-6001: Arrow           "->" at 517:54-517:56 (leading: Space)
-6002: Ident           "uint32" at 517:57-517:63 (leading: Space)
-6003: Semicolon       ";" at 517:63-517:64
-6004: At              "@" at 518:5-518:6 (leading: Newline, Space)
-6005: Ident           "intrinsic" at 518:6-518:15
-6006: KwFn            "fn" at 518:16-518:18 (leading: Space)
-6007: Ident           "__mod" at 518:19-518:24 (leading: Space)
-6008: LParen          "(" at 518:24-518:25
-6009: Ident           "self" at 518:25-518:29
-6010: Colon           ":" at 518:29-518:30
-6011: Ident           "uint32" at 518:31-518:37 (leading: Space)
-6012: Comma           "," at 518:37-518:38
-6013: Ident           "other" at 518:39-518:44 (leading: Space)
-6014: Colon           ":" at 518:44-518:45
-6015: Ident           "uint32" at 518:46-518:52 (leading: Space)
-6016: RParen          ")" at 518:52-518:53
-6017: Arrow           "->" at 518:54-518:56 (leading: Space)
-6018: Ident           "uint32" at 518:57-518:63 (leading: Space)
-6019: Semicolon       ";" at 518:63-518:64
-6020: At              "@" at 519:5-519:6 (leading: Newline, Space)
-6021: Ident           "intrinsic" at 519:6-519:15
-6022: KwFn            "fn" at 519:16-519:18 (leading: Space)
-6023: Ident           "__bit_and" at 519:19-519:28 (leading: Space)
-6024: LParen          "(" at 519:28-519:29
-6025: Ident           "self" at 519:29-519:33
-6026: Colon           ":" at 519:33-519:34
-6027: Ident           "uint32" at 519:35-519:41 (leading: Space)
-6028: Comma           "," at 519:41-519:42
-6029: Ident           "other" at 519:43-519:48 (leading: Space)
-6030: Colon           ":" at 519:48-519:49
-6031: Ident           "uint32" at 519:50-519:56 (leading: Space)
-6032: RParen          ")" at 519:56-519:57
-6033: Arrow           "->" at 519:58-519:60 (leading: Space)
-6034: Ident           "uint32" at 519:61-519:67 (leading: Space)
-6035: Semicolon       ";" at 519:67-519:68
-6036: At              "@" at 520:5-520:6 (leading: Newline, Space)
-6037: Ident           "intrinsic" at 520:6-520:15
-6038: KwFn            "fn" at 520:16-520:18 (leading: Space)
-6039: Ident           "__bit_or" at 520:19-520:27 (leading: Space)
-6040: LParen          "(" at 520:27-520:28
-6041: Ident           "self" at 520:28-520:32
-6042: Colon           ":" at 520:32-520:33
-6043: Ident           "uint32" at 520:34-520:40 (leading: Space)
-6044: Comma           "," at 520:40-520:41
-6045: Ident           "other" at 520:42-520:47 (leading: Space)
-6046: Colon           ":" at 520:47-520:48
-6047: Ident           "uint32" at 520:49-520:55 (leading: Space)
-6048: RParen          ")" at 520:55-520:56
-6049: Arrow           "->" at 520:57-520:59 (leading: Space)
-6050: Ident           "uint32" at 520:60-520:66 (leading: Space)
-6051: Semicolon       ";" at 520:66-520:67
-6052: At              "@" at 521:5-521:6 (leading: Newline, Space)
-6053: Ident           "intrinsic" at 521:6-521:15
-6054: KwFn            "fn" at 521:16-521:18 (leading: Space)
-6055: Ident           "__bit_xor" at 521:19-521:28 (leading: Space)
-6056: LParen          "(" at 521:28-521:29
-6057: Ident           "self" at 521:29-521:33
-6058: Colon           ":" at 521:33-521:34
-6059: Ident           "uint32" at 521:35-521:41 (leading: Space)
-6060: Comma           "," at 521:41-521:42
-6061: Ident           "other" at 521:43-521:48 (leading: Space)
-6062: Colon           ":" at 521:48-521:49
-6063: Ident           "uint32" at 521:50-521:56 (leading: Space)
-6064: RParen          ")" at 521:56-521:57
-6065: Arrow           "->" at 521:58-521:60 (leading: Space)
-6066: Ident           "uint32" at 521:61-521:67 (leading: Space)
-6067: Semicolon       ";" at 521:67-521:68
-6068: At              "@" at 522:5-522:6 (leading: Newline, Space)
-6069: Ident           "intrinsic" at 522:6-522:15
-6070: KwFn            "fn" at 522:16-522:18 (leading: Space)
-6071: Ident           "__shl" at 522:19-522:24 (leading: Space)
-6072: LParen          "(" at 522:24-522:25
-6073: Ident           "self" at 522:25-522:29
-6074: Colon           ":" at 522:29-522:30
-6075: Ident           "uint32" at 522:31-522:37 (leading: Space)
-6076: Comma           "," at 522:37-522:38
-6077: Ident           "other" at 522:39-522:44 (leading: Space)
-6078: Colon           ":" at 522:44-522:45
-6079: Ident           "uint32" at 522:46-522:52 (leading: Space)
-6080: RParen          ")" at 522:52-522:53
-6081: Arrow           "->" at 522:54-522:56 (leading: Space)
-6082: Ident           "uint32" at 522:57-522:63 (leading: Space)
-6083: Semicolon       ";" at 522:63-522:64
-6084: At              "@" at 523:5-523:6 (leading: Newline, Space)
-6085: Ident           "intrinsic" at 523:6-523:15
-6086: KwFn            "fn" at 523:16-523:18 (leading: Space)
-6087: Ident           "__shr" at 523:19-523:24 (leading: Space)
-6088: LParen          "(" at 523:24-523:25
-6089: Ident           "self" at 523:25-523:29
-6090: Colon           ":" at 523:29-523:30
-6091: Ident           "uint32" at 523:31-523:37 (leading: Space)
-6092: Comma           "," at 523:37-523:38
-6093: Ident           "other" at 523:39-523:44 (leading: Space)
-6094: Colon           ":" at 523:44-523:45
-6095: Ident           "uint32" at 523:46-523:52 (leading: Space)
-6096: RParen          ")" at 523:52-523:53
-6097: Arrow           "->" at 523:54-523:56 (leading: Space)
-6098: Ident           "uint32" at 523:57-523:63 (leading: Space)
-6099: Semicolon       ";" at 523:63-523:64
-6100: At              "@" at 524:5-524:6 (leading: Newline, Space)
-6101: Ident           "intrinsic" at 524:6-524:15
-6102: KwFn            "fn" at 524:16-524:18 (leading: Space)
-6103: Ident           "__lt" at 524:19-524:23 (leading: Space)
-6104: LParen          "(" at 524:23-524:24
-6105: Ident           "self" at 524:24-524:28
-6106: Colon           ":" at 524:28-524:29
-6107: Ident           "uint32" at 524:30-524:36 (leading: Space)
-6108: Comma           "," at 524:36-524:37
-6109: Ident           "other" at 524:38-524:43 (leading: Space)
-6110: Colon           ":" at 524:43-524:44
-6111: Ident           "uint32" at 524:45-524:51 (leading: Space)
-6112: RParen          ")" at 524:51-524:52
-6113: Arrow           "->" at 524:53-524:55 (leading: Space)
-6114: Ident           "bool" at 524:56-524:60 (leading: Space)
-6115: Semicolon       ";" at 524:60-524:61
-6116: At              "@" at 525:5-525:6 (leading: Newline, Space)
-6117: Ident           "intrinsic" at 525:6-525:15
-6118: KwFn            "fn" at 525:16-525:18 (leading: Space)
-6119: Ident           "__le" at 525:19-525:23 (leading: Space)
-6120: LParen          "(" at 525:23-525:24
-6121: Ident           "self" at 525:24-525:28
-6122: Colon           ":" at 525:28-525:29
-6123: Ident           "uint32" at 525:30-525:36 (leading: Space)
-6124: Comma           "," at 525:36-525:37
-6125: Ident           "other" at 525:38-525:43 (leading: Space)
-6126: Colon           ":" at 525:43-525:44
-6127: Ident           "uint32" at 525:45-525:51 (leading: Space)
-6128: RParen          ")" at 525:51-525:52
-6129: Arrow           "->" at 525:53-525:55 (leading: Space)
-6130: Ident           "bool" at 525:56-525:60 (leading: Space)
-6131: Semicolon       ";" at 525:60-525:61
-6132: At              "@" at 526:5-526:6 (leading: Newline, Space)
-6133: Ident           "intrinsic" at 526:6-526:15
-6134: KwFn            "fn" at 526:16-526:18 (leading: Space)
-6135: Ident           "__eq" at 526:19-526:23 (leading: Space)
-6136: LParen          "(" at 526:23-526:24
-6137: Ident           "self" at 526:24-526:28
-6138: Colon           ":" at 526:28-526:29
-6139: Ident           "uint32" at 526:30-526:36 (leading: Space)
-6140: Comma           "," at 526:36-526:37
-6141: Ident           "other" at 526:38-526:43 (leading: Space)
-6142: Colon           ":" at 526:43-526:44
-6143: Ident           "uint32" at 526:45-526:51 (leading: Space)
-6144: RParen          ")" at 526:51-526:52
-6145: Arrow           "->" at 526:53-526:55 (leading: Space)
-6146: Ident           "bool" at 526:56-526:60 (leading: Space)
-6147: Semicolon       ";" at 526:60-526:61
-6148: At              "@" at 527:5-527:6 (leading: Newline, Space)
-6149: Ident           "intrinsic" at 527:6-527:15
-6150: KwFn            "fn" at 527:16-527:18 (leading: Space)
-6151: Ident           "__ne" at 527:19-527:23 (leading: Space)
-6152: LParen          "(" at 527:23-527:24
-6153: Ident           "self" at 527:24-527:28
-6154: Colon           ":" at 527:28-527:29
-6155: Ident           "uint32" at 527:30-527:36 (leading: Space)
-6156: Comma           "," at 527:36-527:37
-6157: Ident           "other" at 527:38-527:43 (leading: Space)
-6158: Colon           ":" at 527:43-527:44
-6159: Ident           "uint32" at 527:45-527:51 (leading: Space)
-6160: RParen          ")" at 527:51-527:52
-6161: Arrow           "->" at 527:53-527:55 (leading: Space)
-6162: Ident           "bool" at 527:56-527:60 (leading: Space)
-6163: Semicolon       ";" at 527:60-527:61
-6164: At              "@" at 528:5-528:6 (leading: Newline, Space)
-6165: Ident           "intrinsic" at 528:6-528:15
-6166: KwFn            "fn" at 528:16-528:18 (leading: Space)
-6167: Ident           "__ge" at 528:19-528:23 (leading: Space)
-6168: LParen          "(" at 528:23-528:24
-6169: Ident           "self" at 528:24-528:28
-6170: Colon           ":" at 528:28-528:29
-6171: Ident           "uint32" at 528:30-528:36 (leading: Space)
-6172: Comma           "," at 528:36-528:37
-6173: Ident           "other" at 528:38-528:43 (leading: Space)
-6174: Colon           ":" at 528:43-528:44
-6175: Ident           "uint32" at 528:45-528:51 (leading: Space)
-6176: RParen          ")" at 528:51-528:52
-6177: Arrow           "->" at 528:53-528:55 (leading: Space)
-6178: Ident           "bool" at 528:56-528:60 (leading: Space)
-6179: Semicolon       ";" at 528:60-528:61
-6180: At              "@" at 529:5-529:6 (leading: Newline, Space)
-6181: Ident           "intrinsic" at 529:6-529:15
-6182: KwFn            "fn" at 529:16-529:18 (leading: Space)
-6183: Ident           "__gt" at 529:19-529:23 (leading: Space)
-6184: LParen          "(" at 529:23-529:24
-6185: Ident           "self" at 529:24-529:28
-6186: Colon           ":" at 529:28-529:29
-6187: Ident           "uint32" at 529:30-529:36 (leading: Space)
-6188: Comma           "," at 529:36-529:37
-6189: Ident           "other" at 529:38-529:43 (leading: Space)
-6190: Colon           ":" at 529:43-529:44
-6191: Ident           "uint32" at 529:45-529:51 (leading: Space)
-6192: RParen          ")" at 529:51-529:52
-6193: Arrow           "->" at 529:53-529:55 (leading: Space)
-6194: Ident           "bool" at 529:56-529:60 (leading: Space)
-6195: Semicolon       ";" at 529:60-529:61
-6196: At              "@" at 530:5-530:6 (leading: Newline, Space)
-6197: Ident           "intrinsic" at 530:6-530:15
-6198: KwFn            "fn" at 530:16-530:18 (leading: Space)
-6199: Ident           "__pos" at 530:19-530:24 (leading: Space)
-6200: LParen          "(" at 530:24-530:25
-6201: Ident           "self" at 530:25-530:29
-6202: Colon           ":" at 530:29-530:30
-6203: Ident           "uint32" at 530:31-530:37 (leading: Space)
-6204: RParen          ")" at 530:37-530:38
-6205: Arrow           "->" at 530:39-530:41 (leading: Space)
-6206: Ident           "uint32" at 530:42-530:48 (leading: Space)
-6207: Semicolon       ";" at 530:48-530:49
-6208: At              "@" at 531:5-531:6 (leading: Newline, Space)
-6209: Ident           "intrinsic" at 531:6-531:15
-6210: KwFn            "fn" at 531:16-531:18 (leading: Space)
-6211: Ident           "__abs" at 531:19-531:24 (leading: Space)
-6212: LParen          "(" at 531:24-531:25
-6213: Ident           "self" at 531:25-531:29
-6214: Colon           ":" at 531:29-531:30
-6215: Ident           "uint32" at 531:31-531:37 (leading: Space)
-6216: RParen          ")" at 531:37-531:38
-6217: Arrow           "->" at 531:39-531:41 (leading: Space)
-6218: Ident           "uint32" at 531:42-531:48 (leading: Space)
-6219: Semicolon       ";" at 531:48-531:49
-6220: At              "@" at 532:5-532:6 (leading: Newline, Space)
-6221: Ident           "intrinsic" at 532:6-532:15
-6222: KwFn            "fn" at 532:16-532:18 (leading: Space)
-6223: Ident           "__to" at 532:19-532:23 (leading: Space)
-6224: LParen          "(" at 532:23-532:24
-6225: Ident           "self" at 532:24-532:28
-6226: Colon           ":" at 532:28-532:29
-6227: Ident           "uint32" at 532:30-532:36 (leading: Space)
-6228: Comma           "," at 532:36-532:37
-6229: Ident           "target" at 532:38-532:44 (leading: Space)
-6230: Colon           ":" at 532:44-532:45
-6231: Ident           "uint" at 532:46-532:50 (leading: Space)
-6232: RParen          ")" at 532:50-532:51
-6233: Arrow           "->" at 532:52-532:54 (leading: Space)
-6234: Ident           "uint" at 532:55-532:59 (leading: Space)
-6235: Semicolon       ";" at 532:59-532:60
-6236: At              "@" at 533:5-533:6 (leading: Newline, Space)
-6237: Ident           "intrinsic" at 533:6-533:15
-6238: At              "@" at 533:16-533:17 (leading: Space)
-6239: Ident           "overload" at 533:17-533:25
-6240: KwFn            "fn" at 533:26-533:28 (leading: Space)
-6241: Ident           "__to" at 533:29-533:33 (leading: Space)
-6242: LParen          "(" at 533:33-533:34
-6243: Ident           "self" at 533:34-533:38
-6244: Colon           ":" at 533:38-533:39
-6245: Ident           "uint32" at 533:40-533:46 (leading: Space)
-6246: Comma           "," at 533:46-533:47
-6247: Ident           "target" at 533:48-533:54 (leading: Space)
-6248: Colon           ":" at 533:54-533:55
-6249: Ident           "uint8" at 533:56-533:61 (leading: Space)
-6250: RParen          ")" at 533:61-533:62
-6251: Arrow           "->" at 533:63-533:65 (leading: Space)
-6252: Ident           "uint8" at 533:66-533:71 (leading: Space)
-6253: Semicolon       ";" at 533:71-533:72
-6254: At              "@" at 534:5-534:6 (leading: Newline, Space)
-6255: Ident           "intrinsic" at 534:6-534:15
-6256: At              "@" at 534:16-534:17 (leading: Space)
-6257: Ident           "overload" at 534:17-534:25
-6258: KwFn            "fn" at 534:26-534:28 (leading: Space)
-6259: Ident           "__to" at 534:29-534:33 (leading: Space)
-6260: LParen          "(" at 534:33-534:34
-6261: Ident           "self" at 534:34-534:38
-6262: Colon           ":" at 534:38-534:39
-6263: Ident           "uint32" at 534:40-534:46 (leading: Space)
-6264: Comma           "," at 534:46-534:47
-6265: Ident           "target" at 534:48-534:54 (leading: Space)
-6266: Colon           ":" at 534:54-534:55
-6267: Ident           "uint16" at 534:56-534:62 (leading: Space)
-6268: RParen          ")" at 534:62-534:63
-6269: Arrow           "->" at 534:64-534:66 (leading: Space)
-6270: Ident           "uint16" at 534:67-534:73 (leading: Space)
-6271: Semicolon       ";" at 534:73-534:74
-6272: At              "@" at 535:5-535:6 (leading: Newline, Space)
-6273: Ident           "intrinsic" at 535:6-535:15
-6274: At              "@" at 535:16-535:17 (leading: Space)
-6275: Ident           "overload" at 535:17-535:25
-6276: KwFn            "fn" at 535:26-535:28 (leading: Space)
-6277: Ident           "__to" at 535:29-535:33 (leading: Space)
-6278: LParen          "(" at 535:33-535:34
-6279: Ident           "self" at 535:34-535:38
-6280: Colon           ":" at 535:38-535:39
-6281: Ident           "uint32" at 535:40-535:46 (leading: Space)
-6282: Comma           "," at 535:46-535:47
-6283: Ident           "target" at 535:48-535:54 (leading: Space)
-6284: Colon           ":" at 535:54-535:55
-6285: Ident           "uint64" at 535:56-535:62 (leading: Space)
-6286: RParen          ")" at 535:62-535:63
-6287: Arrow           "->" at 535:64-535:66 (leading: Space)
-6288: Ident           "uint64" at 535:67-535:73 (leading: Space)
-6289: Semicolon       ";" at 535:73-535:74
-6290: At              "@" at 536:5-536:6 (leading: Newline, Space)
-6291: Ident           "intrinsic" at 536:6-536:15
-6292: KwPub           "pub" at 536:16-536:19 (leading: Space)
-6293: KwFn            "fn" at 536:20-536:22 (leading: Space)
-6294: Ident           "from_str" at 536:23-536:31 (leading: Space)
-6295: LParen          "(" at 536:31-536:32
-6296: Ident           "s" at 536:32-536:33
-6297: Colon           ":" at 536:33-536:34
-6298: Amp             "&" at 536:35-536:36 (leading: Space)
-6299: Ident           "string" at 536:36-536:42
-6300: RParen          ")" at 536:42-536:43
-6301: Arrow           "->" at 536:44-536:46 (leading: Space)
-6302: Ident           "Erring" at 536:47-536:53 (leading: Space)
-6303: Lt              "<" at 536:53-536:54
-6304: Ident           "uint32" at 536:54-536:60
-6305: Comma           "," at 536:60-536:61
-6306: Ident           "Error" at 536:62-536:67 (leading: Space)
-6307: Gt              ">" at 536:67-536:68
-6308: Semicolon       ";" at 536:68-536:69
-6309: RBrace          "}" at 537:1-537:2 (leading: Newline)
-6310: KwExtern        "extern" at 539:1-539:7 (leading: Newline)
-6311: Lt              "<" at 539:7-539:8
-6312: Ident           "uint64" at 539:8-539:14
-6313: Gt              ">" at 539:14-539:15
-6314: LBrace          "{" at 539:16-539:17 (leading: Space)
-6315: KwPub           "pub" at 540:5-540:8 (leading: Newline, Space)
-6316: KwFn            "fn" at 540:9-540:11 (leading: Space)
-6317: Ident           "__min_value" at 540:12-540:23 (leading: Space)
-6318: LParen          "(" at 540:23-540:24
-6319: RParen          ")" at 540:24-540:25
-6320: Arrow           "->" at 540:26-540:28 (leading: Space)
-6321: Ident           "uint64" at 540:29-540:35 (leading: Space)
-6322: LBrace          "{" at 540:36-540:37 (leading: Space)
-6323: KwReturn        "return" at 540:38-540:44 (leading: Space)
-6324: LParen          "(" at 540:45-540:46 (leading: Space)
-6325: IntLit          "0" at 540:46-540:47
-6326: RParen          ")" at 540:47-540:48
-6327: Colon           ":" at 540:48-540:49
-6328: Ident           "uint64" at 540:49-540:55
-6329: Semicolon       ";" at 540:55-540:56
-6330: RBrace          "}" at 540:57-540:58 (leading: Space)
-6331: KwPub           "pub" at 541:5-541:8 (leading: Newline, Space)
-6332: KwFn            "fn" at 541:9-541:11 (leading: Space)
-6333: Ident           "__max_value" at 541:12-541:23 (leading: Space)
-6334: LParen          "(" at 541:23-541:24
-6335: RParen          ")" at 541:24-541:25
-6336: Arrow           "->" at 541:26-541:28 (leading: Space)
-6337: Ident           "uint64" at 541:29-541:35 (leading: Space)
-6338: LBrace          "{" at 541:36-541:37 (leading: Space)
-6339: KwReturn        "return" at 541:38-541:44 (leading: Space)
-6340: LParen          "(" at 541:45-541:46 (leading: Space)
-6341: IntLit          "18_446_744_073_709_551_615" at 541:46-541:72
-6342: RParen          ")" at 541:72-541:73
-6343: Colon           ":" at 541:73-541:74
-6344: Ident           "uint64" at 541:74-541:80
-6345: Semicolon       ";" at 541:80-541:81
-6346: RBrace          "}" at 541:82-541:83 (leading: Space)
-6347: At              "@" at 542:5-542:6 (leading: Newline, Space)
-6348: Ident           "intrinsic" at 542:6-542:15
-6349: KwFn            "fn" at 542:16-542:18 (leading: Space)
-6350: Ident           "__add" at 542:19-542:24 (leading: Space)
-6351: LParen          "(" at 542:24-542:25
-6352: Ident           "self" at 542:25-542:29
-6353: Colon           ":" at 542:29-542:30
-6354: Ident           "uint64" at 542:31-542:37 (leading: Space)
-6355: Comma           "," at 542:37-542:38
-6356: Ident           "other" at 542:39-542:44 (leading: Space)
-6357: Colon           ":" at 542:44-542:45
-6358: Ident           "uint64" at 542:46-542:52 (leading: Space)
-6359: RParen          ")" at 542:52-542:53
-6360: Arrow           "->" at 542:54-542:56 (leading: Space)
-6361: Ident           "uint64" at 542:57-542:63 (leading: Space)
-6362: Semicolon       ";" at 542:63-542:64
-6363: At              "@" at 543:5-543:6 (leading: Newline, Space)
-6364: Ident           "intrinsic" at 543:6-543:15
-6365: KwFn            "fn" at 543:16-543:18 (leading: Space)
-6366: Ident           "__sub" at 543:19-543:24 (leading: Space)
-6367: LParen          "(" at 543:24-543:25
-6368: Ident           "self" at 543:25-543:29
-6369: Colon           ":" at 543:29-543:30
-6370: Ident           "uint64" at 543:31-543:37 (leading: Space)
-6371: Comma           "," at 543:37-543:38
-6372: Ident           "other" at 543:39-543:44 (leading: Space)
-6373: Colon           ":" at 543:44-543:45
-6374: Ident           "uint64" at 543:46-543:52 (leading: Space)
-6375: RParen          ")" at 543:52-543:53
-6376: Arrow           "->" at 543:54-543:56 (leading: Space)
-6377: Ident           "uint64" at 543:57-543:63 (leading: Space)
-6378: Semicolon       ";" at 543:63-543:64
-6379: At              "@" at 544:5-544:6 (leading: Newline, Space)
-6380: Ident           "intrinsic" at 544:6-544:15
-6381: KwFn            "fn" at 544:16-544:18 (leading: Space)
-6382: Ident           "__mul" at 544:19-544:24 (leading: Space)
-6383: LParen          "(" at 544:24-544:25
-6384: Ident           "self" at 544:25-544:29
-6385: Colon           ":" at 544:29-544:30
-6386: Ident           "uint64" at 544:31-544:37 (leading: Space)
-6387: Comma           "," at 544:37-544:38
-6388: Ident           "other" at 544:39-544:44 (leading: Space)
-6389: Colon           ":" at 544:44-544:45
-6390: Ident           "uint64" at 544:46-544:52 (leading: Space)
-6391: RParen          ")" at 544:52-544:53
-6392: Arrow           "->" at 544:54-544:56 (leading: Space)
-6393: Ident           "uint64" at 544:57-544:63 (leading: Space)
-6394: Semicolon       ";" at 544:63-544:64
-6395: At              "@" at 545:5-545:6 (leading: Newline, Space)
-6396: Ident           "intrinsic" at 545:6-545:15
-6397: KwFn            "fn" at 545:16-545:18 (leading: Space)
-6398: Ident           "__div" at 545:19-545:24 (leading: Space)
-6399: LParen          "(" at 545:24-545:25
-6400: Ident           "self" at 545:25-545:29
-6401: Colon           ":" at 545:29-545:30
-6402: Ident           "uint64" at 545:31-545:37 (leading: Space)
-6403: Comma           "," at 545:37-545:38
-6404: Ident           "other" at 545:39-545:44 (leading: Space)
-6405: Colon           ":" at 545:44-545:45
-6406: Ident           "uint64" at 545:46-545:52 (leading: Space)
-6407: RParen          ")" at 545:52-545:53
-6408: Arrow           "->" at 545:54-545:56 (leading: Space)
-6409: Ident           "uint64" at 545:57-545:63 (leading: Space)
-6410: Semicolon       ";" at 545:63-545:64
-6411: At              "@" at 546:5-546:6 (leading: Newline, Space)
-6412: Ident           "intrinsic" at 546:6-546:15
-6413: KwFn            "fn" at 546:16-546:18 (leading: Space)
-6414: Ident           "__mod" at 546:19-546:24 (leading: Space)
-6415: LParen          "(" at 546:24-546:25
-6416: Ident           "self" at 546:25-546:29
-6417: Colon           ":" at 546:29-546:30
-6418: Ident           "uint64" at 546:31-546:37 (leading: Space)
-6419: Comma           "," at 546:37-546:38
-6420: Ident           "other" at 546:39-546:44 (leading: Space)
-6421: Colon           ":" at 546:44-546:45
-6422: Ident           "uint64" at 546:46-546:52 (leading: Space)
-6423: RParen          ")" at 546:52-546:53
-6424: Arrow           "->" at 546:54-546:56 (leading: Space)
-6425: Ident           "uint64" at 546:57-546:63 (leading: Space)
-6426: Semicolon       ";" at 546:63-546:64
-6427: At              "@" at 547:5-547:6 (leading: Newline, Space)
-6428: Ident           "intrinsic" at 547:6-547:15
-6429: KwFn            "fn" at 547:16-547:18 (leading: Space)
-6430: Ident           "__bit_and" at 547:19-547:28 (leading: Space)
-6431: LParen          "(" at 547:28-547:29
-6432: Ident           "self" at 547:29-547:33
-6433: Colon           ":" at 547:33-547:34
-6434: Ident           "uint64" at 547:35-547:41 (leading: Space)
-6435: Comma           "," at 547:41-547:42
-6436: Ident           "other" at 547:43-547:48 (leading: Space)
-6437: Colon           ":" at 547:48-547:49
-6438: Ident           "uint64" at 547:50-547:56 (leading: Space)
-6439: RParen          ")" at 547:56-547:57
-6440: Arrow           "->" at 547:58-547:60 (leading: Space)
-6441: Ident           "uint64" at 547:61-547:67 (leading: Space)
-6442: Semicolon       ";" at 547:67-547:68
-6443: At              "@" at 548:5-548:6 (leading: Newline, Space)
-6444: Ident           "intrinsic" at 548:6-548:15
-6445: KwFn            "fn" at 548:16-548:18 (leading: Space)
-6446: Ident           "__bit_or" at 548:19-548:27 (leading: Space)
-6447: LParen          "(" at 548:27-548:28
-6448: Ident           "self" at 548:28-548:32
-6449: Colon           ":" at 548:32-548:33
-6450: Ident           "uint64" at 548:34-548:40 (leading: Space)
-6451: Comma           "," at 548:40-548:41
-6452: Ident           "other" at 548:42-548:47 (leading: Space)
-6453: Colon           ":" at 548:47-548:48
-6454: Ident           "uint64" at 548:49-548:55 (leading: Space)
-6455: RParen          ")" at 548:55-548:56
-6456: Arrow           "->" at 548:57-548:59 (leading: Space)
-6457: Ident           "uint64" at 548:60-548:66 (leading: Space)
-6458: Semicolon       ";" at 548:66-548:67
-6459: At              "@" at 549:5-549:6 (leading: Newline, Space)
-6460: Ident           "intrinsic" at 549:6-549:15
-6461: KwFn            "fn" at 549:16-549:18 (leading: Space)
-6462: Ident           "__bit_xor" at 549:19-549:28 (leading: Space)
-6463: LParen          "(" at 549:28-549:29
-6464: Ident           "self" at 549:29-549:33
-6465: Colon           ":" at 549:33-549:34
-6466: Ident           "uint64" at 549:35-549:41 (leading: Space)
-6467: Comma           "," at 549:41-549:42
-6468: Ident           "other" at 549:43-549:48 (leading: Space)
-6469: Colon           ":" at 549:48-549:49
-6470: Ident           "uint64" at 549:50-549:56 (leading: Space)
-6471: RParen          ")" at 549:56-549:57
-6472: Arrow           "->" at 549:58-549:60 (leading: Space)
-6473: Ident           "uint64" at 549:61-549:67 (leading: Space)
-6474: Semicolon       ";" at 549:67-549:68
-6475: At              "@" at 550:5-550:6 (leading: Newline, Space)
-6476: Ident           "intrinsic" at 550:6-550:15
-6477: KwFn            "fn" at 550:16-550:18 (leading: Space)
-6478: Ident           "__shl" at 550:19-550:24 (leading: Space)
-6479: LParen          "(" at 550:24-550:25
-6480: Ident           "self" at 550:25-550:29
-6481: Colon           ":" at 550:29-550:30
-6482: Ident           "uint64" at 550:31-550:37 (leading: Space)
-6483: Comma           "," at 550:37-550:38
-6484: Ident           "other" at 550:39-550:44 (leading: Space)
-6485: Colon           ":" at 550:44-550:45
-6486: Ident           "uint64" at 550:46-550:52 (leading: Space)
-6487: RParen          ")" at 550:52-550:53
-6488: Arrow           "->" at 550:54-550:56 (leading: Space)
-6489: Ident           "uint64" at 550:57-550:63 (leading: Space)
-6490: Semicolon       ";" at 550:63-550:64
-6491: At              "@" at 551:5-551:6 (leading: Newline, Space)
-6492: Ident           "intrinsic" at 551:6-551:15
-6493: KwFn            "fn" at 551:16-551:18 (leading: Space)
-6494: Ident           "__shr" at 551:19-551:24 (leading: Space)
-6495: LParen          "(" at 551:24-551:25
-6496: Ident           "self" at 551:25-551:29
-6497: Colon           ":" at 551:29-551:30
-6498: Ident           "uint64" at 551:31-551:37 (leading: Space)
-6499: Comma           "," at 551:37-551:38
-6500: Ident           "other" at 551:39-551:44 (leading: Space)
-6501: Colon           ":" at 551:44-551:45
-6502: Ident           "uint64" at 551:46-551:52 (leading: Space)
-6503: RParen          ")" at 551:52-551:53
-6504: Arrow           "->" at 551:54-551:56 (leading: Space)
-6505: Ident           "uint64" at 551:57-551:63 (leading: Space)
-6506: Semicolon       ";" at 551:63-551:64
-6507: At              "@" at 552:5-552:6 (leading: Newline, Space)
-6508: Ident           "intrinsic" at 552:6-552:15
-6509: KwFn            "fn" at 552:16-552:18 (leading: Space)
-6510: Ident           "__lt" at 552:19-552:23 (leading: Space)
-6511: LParen          "(" at 552:23-552:24
-6512: Ident           "self" at 552:24-552:28
-6513: Colon           ":" at 552:28-552:29
-6514: Ident           "uint64" at 552:30-552:36 (leading: Space)
-6515: Comma           "," at 552:36-552:37
-6516: Ident           "other" at 552:38-552:43 (leading: Space)
-6517: Colon           ":" at 552:43-552:44
-6518: Ident           "uint64" at 552:45-552:51 (leading: Space)
-6519: RParen          ")" at 552:51-552:52
-6520: Arrow           "->" at 552:53-552:55 (leading: Space)
-6521: Ident           "bool" at 552:56-552:60 (leading: Space)
-6522: Semicolon       ";" at 552:60-552:61
-6523: At              "@" at 553:5-553:6 (leading: Newline, Space)
-6524: Ident           "intrinsic" at 553:6-553:15
-6525: KwFn            "fn" at 553:16-553:18 (leading: Space)
-6526: Ident           "__le" at 553:19-553:23 (leading: Space)
-6527: LParen          "(" at 553:23-553:24
-6528: Ident           "self" at 553:24-553:28
-6529: Colon           ":" at 553:28-553:29
-6530: Ident           "uint64" at 553:30-553:36 (leading: Space)
-6531: Comma           "," at 553:36-553:37
-6532: Ident           "other" at 553:38-553:43 (leading: Space)
-6533: Colon           ":" at 553:43-553:44
-6534: Ident           "uint64" at 553:45-553:51 (leading: Space)
-6535: RParen          ")" at 553:51-553:52
-6536: Arrow           "->" at 553:53-553:55 (leading: Space)
-6537: Ident           "bool" at 553:56-553:60 (leading: Space)
-6538: Semicolon       ";" at 553:60-553:61
-6539: At              "@" at 554:5-554:6 (leading: Newline, Space)
-6540: Ident           "intrinsic" at 554:6-554:15
-6541: KwFn            "fn" at 554:16-554:18 (leading: Space)
-6542: Ident           "__eq" at 554:19-554:23 (leading: Space)
-6543: LParen          "(" at 554:23-554:24
-6544: Ident           "self" at 554:24-554:28
-6545: Colon           ":" at 554:28-554:29
-6546: Ident           "uint64" at 554:30-554:36 (leading: Space)
-6547: Comma           "," at 554:36-554:37
-6548: Ident           "other" at 554:38-554:43 (leading: Space)
-6549: Colon           ":" at 554:43-554:44
-6550: Ident           "uint64" at 554:45-554:51 (leading: Space)
-6551: RParen          ")" at 554:51-554:52
-6552: Arrow           "->" at 554:53-554:55 (leading: Space)
-6553: Ident           "bool" at 554:56-554:60 (leading: Space)
-6554: Semicolon       ";" at 554:60-554:61
-6555: At              "@" at 555:5-555:6 (leading: Newline, Space)
-6556: Ident           "intrinsic" at 555:6-555:15
-6557: KwFn            "fn" at 555:16-555:18 (leading: Space)
-6558: Ident           "__ne" at 555:19-555:23 (leading: Space)
-6559: LParen          "(" at 555:23-555:24
-6560: Ident           "self" at 555:24-555:28
-6561: Colon           ":" at 555:28-555:29
-6562: Ident           "uint64" at 555:30-555:36 (leading: Space)
-6563: Comma           "," at 555:36-555:37
-6564: Ident           "other" at 555:38-555:43 (leading: Space)
-6565: Colon           ":" at 555:43-555:44
-6566: Ident           "uint64" at 555:45-555:51 (leading: Space)
-6567: RParen          ")" at 555:51-555:52
-6568: Arrow           "->" at 555:53-555:55 (leading: Space)
-6569: Ident           "bool" at 555:56-555:60 (leading: Space)
-6570: Semicolon       ";" at 555:60-555:61
-6571: At              "@" at 556:5-556:6 (leading: Newline, Space)
-6572: Ident           "intrinsic" at 556:6-556:15
-6573: KwFn            "fn" at 556:16-556:18 (leading: Space)
-6574: Ident           "__ge" at 556:19-556:23 (leading: Space)
-6575: LParen          "(" at 556:23-556:24
-6576: Ident           "self" at 556:24-556:28
-6577: Colon           ":" at 556:28-556:29
-6578: Ident           "uint64" at 556:30-556:36 (leading: Space)
-6579: Comma           "," at 556:36-556:37
-6580: Ident           "other" at 556:38-556:43 (leading: Space)
-6581: Colon           ":" at 556:43-556:44
-6582: Ident           "uint64" at 556:45-556:51 (leading: Space)
-6583: RParen          ")" at 556:51-556:52
-6584: Arrow           "->" at 556:53-556:55 (leading: Space)
-6585: Ident           "bool" at 556:56-556:60 (leading: Space)
-6586: Semicolon       ";" at 556:60-556:61
-6587: At              "@" at 557:5-557:6 (leading: Newline, Space)
-6588: Ident           "intrinsic" at 557:6-557:15
-6589: KwFn            "fn" at 557:16-557:18 (leading: Space)
-6590: Ident           "__gt" at 557:19-557:23 (leading: Space)
-6591: LParen          "(" at 557:23-557:24
-6592: Ident           "self" at 557:24-557:28
-6593: Colon           ":" at 557:28-557:29
-6594: Ident           "uint64" at 557:30-557:36 (leading: Space)
-6595: Comma           "," at 557:36-557:37
-6596: Ident           "other" at 557:38-557:43 (leading: Space)
-6597: Colon           ":" at 557:43-557:44
-6598: Ident           "uint64" at 557:45-557:51 (leading: Space)
-6599: RParen          ")" at 557:51-557:52
-6600: Arrow           "->" at 557:53-557:55 (leading: Space)
-6601: Ident           "bool" at 557:56-557:60 (leading: Space)
-6602: Semicolon       ";" at 557:60-557:61
-6603: At              "@" at 558:5-558:6 (leading: Newline, Space)
-6604: Ident           "intrinsic" at 558:6-558:15
-6605: KwFn            "fn" at 558:16-558:18 (leading: Space)
-6606: Ident           "__pos" at 558:19-558:24 (leading: Space)
-6607: LParen          "(" at 558:24-558:25
-6608: Ident           "self" at 558:25-558:29
-6609: Colon           ":" at 558:29-558:30
-6610: Ident           "uint64" at 558:31-558:37 (leading: Space)
-6611: RParen          ")" at 558:37-558:38
-6612: Arrow           "->" at 558:39-558:41 (leading: Space)
-6613: Ident           "uint64" at 558:42-558:48 (leading: Space)
-6614: Semicolon       ";" at 558:48-558:49
-6615: At              "@" at 559:5-559:6 (leading: Newline, Space)
-6616: Ident           "intrinsic" at 559:6-559:15
-6617: KwFn            "fn" at 559:16-559:18 (leading: Space)
-6618: Ident           "__abs" at 559:19-559:24 (leading: Space)
-6619: LParen          "(" at 559:24-559:25
-6620: Ident           "self" at 559:25-559:29
-6621: Colon           ":" at 559:29-559:30
-6622: Ident           "uint64" at 559:31-559:37 (leading: Space)
-6623: RParen          ")" at 559:37-559:38
-6624: Arrow           "->" at 559:39-559:41 (leading: Space)
-6625: Ident           "uint64" at 559:42-559:48 (leading: Space)
-6626: Semicolon       ";" at 559:48-559:49
-6627: At              "@" at 560:5-560:6 (leading: Newline, Space)
-6628: Ident           "intrinsic" at 560:6-560:15
-6629: KwFn            "fn" at 560:16-560:18 (leading: Space)
-6630: Ident           "__to" at 560:19-560:23 (leading: Space)
-6631: LParen          "(" at 560:23-560:24
-6632: Ident           "self" at 560:24-560:28
-6633: Colon           ":" at 560:28-560:29
-6634: Ident           "uint64" at 560:30-560:36 (leading: Space)
-6635: Comma           "," at 560:36-560:37
-6636: Ident           "target" at 560:38-560:44 (leading: Space)
-6637: Colon           ":" at 560:44-560:45
-6638: Ident           "uint" at 560:46-560:50 (leading: Space)
-6639: RParen          ")" at 560:50-560:51
-6640: Arrow           "->" at 560:52-560:54 (leading: Space)
-6641: Ident           "uint" at 560:55-560:59 (leading: Space)
-6642: Semicolon       ";" at 560:59-560:60
-6643: At              "@" at 561:5-561:6 (leading: Newline, Space)
-6644: Ident           "intrinsic" at 561:6-561:15
-6645: At              "@" at 561:16-561:17 (leading: Space)
-6646: Ident           "overload" at 561:17-561:25
-6647: KwFn            "fn" at 561:26-561:28 (leading: Space)
-6648: Ident           "__to" at 561:29-561:33 (leading: Space)
-6649: LParen          "(" at 561:33-561:34
-6650: Ident           "self" at 561:34-561:38
-6651: Colon           ":" at 561:38-561:39
-6652: Ident           "uint64" at 561:40-561:46 (leading: Space)
-6653: Comma           "," at 561:46-561:47
-6654: Ident           "target" at 561:48-561:54 (leading: Space)
-6655: Colon           ":" at 561:54-561:55
-6656: Ident           "uint8" at 561:56-561:61 (leading: Space)
-6657: RParen          ")" at 561:61-561:62
-6658: Arrow           "->" at 561:63-561:65 (leading: Space)
-6659: Ident           "uint8" at 561:66-561:71 (leading: Space)
-6660: Semicolon       ";" at 561:71-561:72
-6661: At              "@" at 562:5-562:6 (leading: Newline, Space)
-6662: Ident           "intrinsic" at 562:6-562:15
-6663: At              "@" at 562:16-562:17 (leading: Space)
-6664: Ident           "overload" at 562:17-562:25
-6665: KwFn            "fn" at 562:26-562:28 (leading: Space)
-6666: Ident           "__to" at 562:29-562:33 (leading: Space)
-6667: LParen          "(" at 562:33-562:34
-6668: Ident           "self" at 562:34-562:38
-6669: Colon           ":" at 562:38-562:39
-6670: Ident           "uint64" at 562:40-562:46 (leading: Space)
-6671: Comma           "," at 562:46-562:47
-6672: Ident           "target" at 562:48-562:54 (leading: Space)
-6673: Colon           ":" at 562:54-562:55
-6674: Ident           "uint16" at 562:56-562:62 (leading: Space)
-6675: RParen          ")" at 562:62-562:63
-6676: Arrow           "->" at 562:64-562:66 (leading: Space)
-6677: Ident           "uint16" at 562:67-562:73 (leading: Space)
-6678: Semicolon       ";" at 562:73-562:74
-6679: At              "@" at 563:5-563:6 (leading: Newline, Space)
-6680: Ident           "intrinsic" at 563:6-563:15
-6681: At              "@" at 563:16-563:17 (leading: Space)
-6682: Ident           "overload" at 563:17-563:25
-6683: KwFn            "fn" at 563:26-563:28 (leading: Space)
-6684: Ident           "__to" at 563:29-563:33 (leading: Space)
-6685: LParen          "(" at 563:33-563:34
-6686: Ident           "self" at 563:34-563:38
-6687: Colon           ":" at 563:38-563:39
-6688: Ident           "uint64" at 563:40-563:46 (leading: Space)
-6689: Comma           "," at 563:46-563:47
-6690: Ident           "target" at 563:48-563:54 (leading: Space)
-6691: Colon           ":" at 563:54-563:55
-6692: Ident           "uint32" at 563:56-563:62 (leading: Space)
-6693: RParen          ")" at 563:62-563:63
-6694: Arrow           "->" at 563:64-563:66 (leading: Space)
-6695: Ident           "uint32" at 563:67-563:73 (leading: Space)
-6696: Semicolon       ";" at 563:73-563:74
-6697: At              "@" at 564:5-564:6 (leading: Newline, Space)
-6698: Ident           "intrinsic" at 564:6-564:15
-6699: KwPub           "pub" at 564:16-564:19 (leading: Space)
-6700: KwFn            "fn" at 564:20-564:22 (leading: Space)
-6701: Ident           "from_str" at 564:23-564:31 (leading: Space)
-6702: LParen          "(" at 564:31-564:32
-6703: Ident           "s" at 564:32-564:33
-6704: Colon           ":" at 564:33-564:34
-6705: Amp             "&" at 564:35-564:36 (leading: Space)
-6706: Ident           "string" at 564:36-564:42
-6707: RParen          ")" at 564:42-564:43
-6708: Arrow           "->" at 564:44-564:46 (leading: Space)
-6709: Ident           "Erring" at 564:47-564:53 (leading: Space)
-6710: Lt              "<" at 564:53-564:54
-6711: Ident           "uint64" at 564:54-564:60
-6712: Comma           "," at 564:60-564:61
-6713: Ident           "Error" at 564:62-564:67 (leading: Space)
-6714: Gt              ">" at 564:67-564:68
-6715: Semicolon       ";" at 564:68-564:69
-6716: RBrace          "}" at 565:1-565:2 (leading: Newline)
-6717: KwExtern        "extern" at 567:1-567:7 (leading: Newline)
-6718: Lt              "<" at 567:7-567:8
-6719: Ident           "float16" at 567:8-567:15
-6720: Gt              ">" at 567:15-567:16
-6721: LBrace          "{" at 567:17-567:18 (leading: Space)
-6722: KwPub           "pub" at 568:5-568:8 (leading: Newline, Space)
-6723: KwFn            "fn" at 568:9-568:11 (leading: Space)
-6724: Ident           "__min_value" at 568:12-568:23 (leading: Space)
-6725: LParen          "(" at 568:23-568:24
-6726: RParen          ")" at 568:24-568:25
-6727: Arrow           "->" at 568:26-568:28 (leading: Space)
-6728: Ident           "float16" at 568:29-568:36 (leading: Space)
-6729: LBrace          "{" at 568:37-568:38 (leading: Space)
-6730: KwReturn        "return" at 568:39-568:45 (leading: Space)
-6731: LParen          "(" at 568:46-568:47 (leading: Space)
-6732: Minus           "-" at 568:47-568:48
-6733: FloatLit        "65504.0" at 568:48-568:55
-6734: RParen          ")" at 568:55-568:56
-6735: Colon           ":" at 568:56-568:57
-6736: Ident           "float16" at 568:57-568:64
-6737: Semicolon       ";" at 568:64-568:65
-6738: RBrace          "}" at 568:66-568:67 (leading: Space)
-6739: KwPub           "pub" at 569:5-569:8 (leading: Newline, Space)
-6740: KwFn            "fn" at 569:9-569:11 (leading: Space)
-6741: Ident           "__max_value" at 569:12-569:23 (leading: Space)
-6742: LParen          "(" at 569:23-569:24
-6743: RParen          ")" at 569:24-569:25
-6744: Arrow           "->" at 569:26-569:28 (leading: Space)
-6745: Ident           "float16" at 569:29-569:36 (leading: Space)
-6746: LBrace          "{" at 569:37-569:38 (leading: Space)
-6747: KwReturn        "return" at 569:39-569:45 (leading: Space)
-6748: LParen          "(" at 569:46-569:47 (leading: Space)
-6749: FloatLit        "65504.0" at 569:47-569:54
-6750: RParen          ")" at 569:54-569:55
-6751: Colon           ":" at 569:55-569:56
-6752: Ident           "float16" at 569:56-569:63
-6753: Semicolon       ";" at 569:63-569:64
-6754: RBrace          "}" at 569:65-569:66 (leading: Space)
-6755: At              "@" at 570:5-570:6 (leading: Newline, Space)
-6756: Ident           "intrinsic" at 570:6-570:15
-6757: KwFn            "fn" at 570:16-570:18 (leading: Space)
-6758: Ident           "__add" at 570:19-570:24 (leading: Space)
-6759: LParen          "(" at 570:24-570:25
-6760: Ident           "self" at 570:25-570:29
-6761: Colon           ":" at 570:29-570:30
-6762: Ident           "float16" at 570:31-570:38 (leading: Space)
-6763: Comma           "," at 570:38-570:39
-6764: Ident           "other" at 570:40-570:45 (leading: Space)
-6765: Colon           ":" at 570:45-570:46
-6766: Ident           "float16" at 570:47-570:54 (leading: Space)
-6767: RParen          ")" at 570:54-570:55
-6768: Arrow           "->" at 570:56-570:58 (leading: Space)
-6769: Ident           "float16" at 570:59-570:66 (leading: Space)
-6770: Semicolon       ";" at 570:66-570:67
-6771: At              "@" at 571:5-571:6 (leading: Newline, Space)
-6772: Ident           "intrinsic" at 571:6-571:15
-6773: KwFn            "fn" at 571:16-571:18 (leading: Space)
-6774: Ident           "__sub" at 571:19-571:24 (leading: Space)
-6775: LParen          "(" at 571:24-571:25
-6776: Ident           "self" at 571:25-571:29
-6777: Colon           ":" at 571:29-571:30
-6778: Ident           "float16" at 571:31-571:38 (leading: Space)
-6779: Comma           "," at 571:38-571:39
-6780: Ident           "other" at 571:40-571:45 (leading: Space)
-6781: Colon           ":" at 571:45-571:46
-6782: Ident           "float16" at 571:47-571:54 (leading: Space)
-6783: RParen          ")" at 571:54-571:55
-6784: Arrow           "->" at 571:56-571:58 (leading: Space)
-6785: Ident           "float16" at 571:59-571:66 (leading: Space)
-6786: Semicolon       ";" at 571:66-571:67
-6787: At              "@" at 572:5-572:6 (leading: Newline, Space)
-6788: Ident           "intrinsic" at 572:6-572:15
-6789: KwFn            "fn" at 572:16-572:18 (leading: Space)
-6790: Ident           "__mul" at 572:19-572:24 (leading: Space)
-6791: LParen          "(" at 572:24-572:25
-6792: Ident           "self" at 572:25-572:29
-6793: Colon           ":" at 572:29-572:30
-6794: Ident           "float16" at 572:31-572:38 (leading: Space)
-6795: Comma           "," at 572:38-572:39
-6796: Ident           "other" at 572:40-572:45 (leading: Space)
-6797: Colon           ":" at 572:45-572:46
-6798: Ident           "float16" at 572:47-572:54 (leading: Space)
-6799: RParen          ")" at 572:54-572:55
-6800: Arrow           "->" at 572:56-572:58 (leading: Space)
-6801: Ident           "float16" at 572:59-572:66 (leading: Space)
-6802: Semicolon       ";" at 572:66-572:67
-6803: At              "@" at 573:5-573:6 (leading: Newline, Space)
-6804: Ident           "intrinsic" at 573:6-573:15
-6805: KwFn            "fn" at 573:16-573:18 (leading: Space)
-6806: Ident           "__div" at 573:19-573:24 (leading: Space)
-6807: LParen          "(" at 573:24-573:25
-6808: Ident           "self" at 573:25-573:29
-6809: Colon           ":" at 573:29-573:30
-6810: Ident           "float16" at 573:31-573:38 (leading: Space)
-6811: Comma           "," at 573:38-573:39
-6812: Ident           "other" at 573:40-573:45 (leading: Space)
-6813: Colon           ":" at 573:45-573:46
-6814: Ident           "float16" at 573:47-573:54 (leading: Space)
-6815: RParen          ")" at 573:54-573:55
-6816: Arrow           "->" at 573:56-573:58 (leading: Space)
-6817: Ident           "float16" at 573:59-573:66 (leading: Space)
-6818: Semicolon       ";" at 573:66-573:67
-6819: At              "@" at 574:5-574:6 (leading: Newline, Space)
-6820: Ident           "intrinsic" at 574:6-574:15
-6821: KwFn            "fn" at 574:16-574:18 (leading: Space)
-6822: Ident           "__mod" at 574:19-574:24 (leading: Space)
-6823: LParen          "(" at 574:24-574:25
-6824: Ident           "self" at 574:25-574:29
-6825: Colon           ":" at 574:29-574:30
-6826: Ident           "float16" at 574:31-574:38 (leading: Space)
-6827: Comma           "," at 574:38-574:39
-6828: Ident           "other" at 574:40-574:45 (leading: Space)
-6829: Colon           ":" at 574:45-574:46
-6830: Ident           "float16" at 574:47-574:54 (leading: Space)
-6831: RParen          ")" at 574:54-574:55
-6832: Arrow           "->" at 574:56-574:58 (leading: Space)
-6833: Ident           "float16" at 574:59-574:66 (leading: Space)
-6834: Semicolon       ";" at 574:66-574:67
-6835: At              "@" at 575:5-575:6 (leading: Newline, Space)
-6836: Ident           "intrinsic" at 575:6-575:15
-6837: KwFn            "fn" at 575:16-575:18 (leading: Space)
-6838: Ident           "__lt" at 575:19-575:23 (leading: Space)
-6839: LParen          "(" at 575:23-575:24
-6840: Ident           "self" at 575:24-575:28
-6841: Colon           ":" at 575:28-575:29
-6842: Ident           "float16" at 575:30-575:37 (leading: Space)
-6843: Comma           "," at 575:37-575:38
-6844: Ident           "other" at 575:39-575:44 (leading: Space)
-6845: Colon           ":" at 575:44-575:45
-6846: Ident           "float16" at 575:46-575:53 (leading: Space)
-6847: RParen          ")" at 575:53-575:54
-6848: Arrow           "->" at 575:55-575:57 (leading: Space)
-6849: Ident           "bool" at 575:58-575:62 (leading: Space)
-6850: Semicolon       ";" at 575:62-575:63
-6851: At              "@" at 576:5-576:6 (leading: Newline, Space)
-6852: Ident           "intrinsic" at 576:6-576:15
-6853: KwFn            "fn" at 576:16-576:18 (leading: Space)
-6854: Ident           "__le" at 576:19-576:23 (leading: Space)
-6855: LParen          "(" at 576:23-576:24
-6856: Ident           "self" at 576:24-576:28
-6857: Colon           ":" at 576:28-576:29
-6858: Ident           "float16" at 576:30-576:37 (leading: Space)
-6859: Comma           "," at 576:37-576:38
-6860: Ident           "other" at 576:39-576:44 (leading: Space)
-6861: Colon           ":" at 576:44-576:45
-6862: Ident           "float16" at 576:46-576:53 (leading: Space)
-6863: RParen          ")" at 576:53-576:54
-6864: Arrow           "->" at 576:55-576:57 (leading: Space)
-6865: Ident           "bool" at 576:58-576:62 (leading: Space)
-6866: Semicolon       ";" at 576:62-576:63
-6867: At              "@" at 577:5-577:6 (leading: Newline, Space)
-6868: Ident           "intrinsic" at 577:6-577:15
-6869: KwFn            "fn" at 577:16-577:18 (leading: Space)
-6870: Ident           "__eq" at 577:19-577:23 (leading: Space)
-6871: LParen          "(" at 577:23-577:24
-6872: Ident           "self" at 577:24-577:28
-6873: Colon           ":" at 577:28-577:29
-6874: Ident           "float16" at 577:30-577:37 (leading: Space)
-6875: Comma           "," at 577:37-577:38
-6876: Ident           "other" at 577:39-577:44 (leading: Space)
-6877: Colon           ":" at 577:44-577:45
-6878: Ident           "float16" at 577:46-577:53 (leading: Space)
-6879: RParen          ")" at 577:53-577:54
-6880: Arrow           "->" at 577:55-577:57 (leading: Space)
-6881: Ident           "bool" at 577:58-577:62 (leading: Space)
-6882: Semicolon       ";" at 577:62-577:63
-6883: At              "@" at 578:5-578:6 (leading: Newline, Space)
-6884: Ident           "intrinsic" at 578:6-578:15
-6885: KwFn            "fn" at 578:16-578:18 (leading: Space)
-6886: Ident           "__ne" at 578:19-578:23 (leading: Space)
-6887: LParen          "(" at 578:23-578:24
-6888: Ident           "self" at 578:24-578:28
-6889: Colon           ":" at 578:28-578:29
-6890: Ident           "float16" at 578:30-578:37 (leading: Space)
-6891: Comma           "," at 578:37-578:38
-6892: Ident           "other" at 578:39-578:44 (leading: Space)
-6893: Colon           ":" at 578:44-578:45
-6894: Ident           "float16" at 578:46-578:53 (leading: Space)
-6895: RParen          ")" at 578:53-578:54
-6896: Arrow           "->" at 578:55-578:57 (leading: Space)
-6897: Ident           "bool" at 578:58-578:62 (leading: Space)
-6898: Semicolon       ";" at 578:62-578:63
-6899: At              "@" at 579:5-579:6 (leading: Newline, Space)
-6900: Ident           "intrinsic" at 579:6-579:15
-6901: KwFn            "fn" at 579:16-579:18 (leading: Space)
-6902: Ident           "__ge" at 579:19-579:23 (leading: Space)
-6903: LParen          "(" at 579:23-579:24
-6904: Ident           "self" at 579:24-579:28
-6905: Colon           ":" at 579:28-579:29
-6906: Ident           "float16" at 579:30-579:37 (leading: Space)
-6907: Comma           "," at 579:37-579:38
-6908: Ident           "other" at 579:39-579:44 (leading: Space)
-6909: Colon           ":" at 579:44-579:45
-6910: Ident           "float16" at 579:46-579:53 (leading: Space)
-6911: RParen          ")" at 579:53-579:54
-6912: Arrow           "->" at 579:55-579:57 (leading: Space)
-6913: Ident           "bool" at 579:58-579:62 (leading: Space)
-6914: Semicolon       ";" at 579:62-579:63
-6915: At              "@" at 580:5-580:6 (leading: Newline, Space)
-6916: Ident           "intrinsic" at 580:6-580:15
-6917: KwFn            "fn" at 580:16-580:18 (leading: Space)
-6918: Ident           "__gt" at 580:19-580:23 (leading: Space)
-6919: LParen          "(" at 580:23-580:24
-6920: Ident           "self" at 580:24-580:28
-6921: Colon           ":" at 580:28-580:29
-6922: Ident           "float16" at 580:30-580:37 (leading: Space)
-6923: Comma           "," at 580:37-580:38
-6924: Ident           "other" at 580:39-580:44 (leading: Space)
-6925: Colon           ":" at 580:44-580:45
-6926: Ident           "float16" at 580:46-580:53 (leading: Space)
-6927: RParen          ")" at 580:53-580:54
-6928: Arrow           "->" at 580:55-580:57 (leading: Space)
-6929: Ident           "bool" at 580:58-580:62 (leading: Space)
-6930: Semicolon       ";" at 580:62-580:63
-6931: At              "@" at 581:5-581:6 (leading: Newline, Space)
-6932: Ident           "intrinsic" at 581:6-581:15
-6933: KwFn            "fn" at 581:16-581:18 (leading: Space)
-6934: Ident           "__pos" at 581:19-581:24 (leading: Space)
-6935: LParen          "(" at 581:24-581:25
-6936: Ident           "self" at 581:25-581:29
-6937: Colon           ":" at 581:29-581:30
-6938: Ident           "float16" at 581:31-581:38 (leading: Space)
-6939: RParen          ")" at 581:38-581:39
-6940: Arrow           "->" at 581:40-581:42 (leading: Space)
-6941: Ident           "float16" at 581:43-581:50 (leading: Space)
-6942: Semicolon       ";" at 581:50-581:51
-6943: At              "@" at 582:5-582:6 (leading: Newline, Space)
-6944: Ident           "intrinsic" at 582:6-582:15
-6945: KwFn            "fn" at 582:16-582:18 (leading: Space)
-6946: Ident           "__neg" at 582:19-582:24 (leading: Space)
-6947: LParen          "(" at 582:24-582:25
-6948: Ident           "self" at 582:25-582:29
-6949: Colon           ":" at 582:29-582:30
-6950: Ident           "float16" at 582:31-582:38 (leading: Space)
-6951: RParen          ")" at 582:38-582:39
-6952: Arrow           "->" at 582:40-582:42 (leading: Space)
-6953: Ident           "float16" at 582:43-582:50 (leading: Space)
-6954: Semicolon       ";" at 582:50-582:51
-6955: At              "@" at 583:5-583:6 (leading: Newline, Space)
-6956: Ident           "intrinsic" at 583:6-583:15
-6957: KwFn            "fn" at 583:16-583:18 (leading: Space)
-6958: Ident           "__abs" at 583:19-583:24 (leading: Space)
-6959: LParen          "(" at 583:24-583:25
-6960: Ident           "self" at 583:25-583:29
-6961: Colon           ":" at 583:29-583:30
-6962: Ident           "float16" at 583:31-583:38 (leading: Space)
-6963: RParen          ")" at 583:38-583:39
-6964: Arrow           "->" at 583:40-583:42 (leading: Space)
-6965: Ident           "float16" at 583:43-583:50 (leading: Space)
-6966: Semicolon       ";" at 583:50-583:51
-6967: At              "@" at 584:5-584:6 (leading: Newline, Space)
-6968: Ident           "intrinsic" at 584:6-584:15
-6969: KwFn            "fn" at 584:16-584:18 (leading: Space)
-6970: Ident           "__to" at 584:19-584:23 (leading: Space)
-6971: LParen          "(" at 584:23-584:24
-6972: Ident           "self" at 584:24-584:28
-6973: Colon           ":" at 584:28-584:29
-6974: Ident           "float16" at 584:30-584:37 (leading: Space)
-6975: Comma           "," at 584:37-584:38
-6976: Ident           "target" at 584:39-584:45 (leading: Space)
-6977: Colon           ":" at 584:45-584:46
-6978: Ident           "float" at 584:47-584:52 (leading: Space)
-6979: RParen          ")" at 584:52-584:53
-6980: Arrow           "->" at 584:54-584:56 (leading: Space)
-6981: Ident           "float" at 584:57-584:62 (leading: Space)
-6982: Semicolon       ";" at 584:62-584:63
-6983: At              "@" at 585:5-585:6 (leading: Newline, Space)
-6984: Ident           "intrinsic" at 585:6-585:15
-6985: At              "@" at 585:16-585:17 (leading: Space)
-6986: Ident           "overload" at 585:17-585:25
-6987: KwFn            "fn" at 585:26-585:28 (leading: Space)
-6988: Ident           "__to" at 585:29-585:33 (leading: Space)
-6989: LParen          "(" at 585:33-585:34
-6990: Ident           "self" at 585:34-585:38
-6991: Colon           ":" at 585:38-585:39
-6992: Ident           "float16" at 585:40-585:47 (leading: Space)
-6993: Comma           "," at 585:47-585:48
-6994: Ident           "target" at 585:49-585:55 (leading: Space)
-6995: Colon           ":" at 585:55-585:56
-6996: Ident           "float32" at 585:57-585:64 (leading: Space)
-6997: RParen          ")" at 585:64-585:65
-6998: Arrow           "->" at 585:66-585:68 (leading: Space)
-6999: Ident           "float32" at 585:69-585:76 (leading: Space)
-7000: Semicolon       ";" at 585:76-585:77
-7001: At              "@" at 586:5-586:6 (leading: Newline, Space)
-7002: Ident           "intrinsic" at 586:6-586:15
-7003: At              "@" at 586:16-586:17 (leading: Space)
-7004: Ident           "overload" at 586:17-586:25
-7005: KwFn            "fn" at 586:26-586:28 (leading: Space)
-7006: Ident           "__to" at 586:29-586:33 (leading: Space)
-7007: LParen          "(" at 586:33-586:34
-7008: Ident           "self" at 586:34-586:38
-7009: Colon           ":" at 586:38-586:39
-7010: Ident           "float16" at 586:40-586:47 (leading: Space)
-7011: Comma           "," at 586:47-586:48
-7012: Ident           "target" at 586:49-586:55 (leading: Space)
-7013: Colon           ":" at 586:55-586:56
-7014: Ident           "float64" at 586:57-586:64 (leading: Space)
-7015: RParen          ")" at 586:64-586:65
-7016: Arrow           "->" at 586:66-586:68 (leading: Space)
-7017: Ident           "float64" at 586:69-586:76 (leading: Space)
-7018: Semicolon       ";" at 586:76-586:77
-7019: At              "@" at 587:5-587:6 (leading: Newline, Space)
-7020: Ident           "intrinsic" at 587:6-587:15
-7021: KwPub           "pub" at 587:16-587:19 (leading: Space)
-7022: KwFn            "fn" at 587:20-587:22 (leading: Space)
-7023: Ident           "from_str" at 587:23-587:31 (leading: Space)
-7024: LParen          "(" at 587:31-587:32
-7025: Ident           "s" at 587:32-587:33
-7026: Colon           ":" at 587:33-587:34
-7027: Amp             "&" at 587:35-587:36 (leading: Space)
-7028: Ident           "string" at 587:36-587:42
-7029: RParen          ")" at 587:42-587:43
-7030: Arrow           "->" at 587:44-587:46 (leading: Space)
-7031: Ident           "Erring" at 587:47-587:53 (leading: Space)
-7032: Lt              "<" at 587:53-587:54
-7033: Ident           "float16" at 587:54-587:61
-7034: Comma           "," at 587:61-587:62
-7035: Ident           "Error" at 587:63-587:68 (leading: Space)
-7036: Gt              ">" at 587:68-587:69
-7037: Semicolon       ";" at 587:69-587:70
-7038: RBrace          "}" at 588:1-588:2 (leading: Newline)
-7039: KwExtern        "extern" at 590:1-590:7 (leading: Newline)
-7040: Lt              "<" at 590:7-590:8
-7041: Ident           "float32" at 590:8-590:15
-7042: Gt              ">" at 590:15-590:16
-7043: LBrace          "{" at 590:17-590:18 (leading: Space)
-7044: KwPub           "pub" at 591:5-591:8 (leading: Newline, Space)
-7045: KwFn            "fn" at 591:9-591:11 (leading: Space)
-7046: Ident           "__min_value" at 591:12-591:23 (leading: Space)
-7047: LParen          "(" at 591:23-591:24
-7048: RParen          ")" at 591:24-591:25
-7049: Arrow           "->" at 591:26-591:28 (leading: Space)
-7050: Ident           "float32" at 591:29-591:36 (leading: Space)
-7051: LBrace          "{" at 591:37-591:38 (leading: Space)
-7052: KwReturn        "return" at 591:39-591:45 (leading: Space)
-7053: LParen          "(" at 591:46-591:47 (leading: Space)
-7054: Minus           "-" at 591:47-591:48
-7055: FloatLit        "3.402_823_466_385_2886e+38" at 591:48-591:74
-7056: RParen          ")" at 591:74-591:75
-7057: Colon           ":" at 591:75-591:76
-7058: Ident           "float32" at 591:76-591:83
-7059: Semicolon       ";" at 591:83-591:84
-7060: RBrace          "}" at 591:85-591:86 (leading: Space)
-7061: KwPub           "pub" at 592:5-592:8 (leading: Newline, Space)
-7062: KwFn            "fn" at 592:9-592:11 (leading: Space)
-7063: Ident           "__max_value" at 592:12-592:23 (leading: Space)
-7064: LParen          "(" at 592:23-592:24
-7065: RParen          ")" at 592:24-592:25
-7066: Arrow           "->" at 592:26-592:28 (leading: Space)
-7067: Ident           "float32" at 592:29-592:36 (leading: Space)
-7068: LBrace          "{" at 592:37-592:38 (leading: Space)
-7069: KwReturn        "return" at 592:39-592:45 (leading: Space)
-7070: LParen          "(" at 592:46-592:47 (leading: Space)
-7071: FloatLit        "3.402_823_466_385_2886e+38" at 592:47-592:73
-7072: RParen          ")" at 592:73-592:74
-7073: Colon           ":" at 592:74-592:75
-7074: Ident           "float32" at 592:75-592:82
-7075: Semicolon       ";" at 592:82-592:83
-7076: RBrace          "}" at 592:84-592:85 (leading: Space)
-7077: At              "@" at 593:5-593:6 (leading: Newline, Space)
-7078: Ident           "intrinsic" at 593:6-593:15
-7079: KwFn            "fn" at 593:16-593:18 (leading: Space)
-7080: Ident           "__add" at 593:19-593:24 (leading: Space)
-7081: LParen          "(" at 593:24-593:25
-7082: Ident           "self" at 593:25-593:29
-7083: Colon           ":" at 593:29-593:30
-7084: Ident           "float32" at 593:31-593:38 (leading: Space)
-7085: Comma           "," at 593:38-593:39
-7086: Ident           "other" at 593:40-593:45 (leading: Space)
-7087: Colon           ":" at 593:45-593:46
-7088: Ident           "float32" at 593:47-593:54 (leading: Space)
-7089: RParen          ")" at 593:54-593:55
-7090: Arrow           "->" at 593:56-593:58 (leading: Space)
-7091: Ident           "float32" at 593:59-593:66 (leading: Space)
-7092: Semicolon       ";" at 593:66-593:67
-7093: At              "@" at 594:5-594:6 (leading: Newline, Space)
-7094: Ident           "intrinsic" at 594:6-594:15
-7095: KwFn            "fn" at 594:16-594:18 (leading: Space)
-7096: Ident           "__sub" at 594:19-594:24 (leading: Space)
-7097: LParen          "(" at 594:24-594:25
-7098: Ident           "self" at 594:25-594:29
-7099: Colon           ":" at 594:29-594:30
-7100: Ident           "float32" at 594:31-594:38 (leading: Space)
-7101: Comma           "," at 594:38-594:39
-7102: Ident           "other" at 594:40-594:45 (leading: Space)
-7103: Colon           ":" at 594:45-594:46
-7104: Ident           "float32" at 594:47-594:54 (leading: Space)
-7105: RParen          ")" at 594:54-594:55
-7106: Arrow           "->" at 594:56-594:58 (leading: Space)
-7107: Ident           "float32" at 594:59-594:66 (leading: Space)
-7108: Semicolon       ";" at 594:66-594:67
-7109: At              "@" at 595:5-595:6 (leading: Newline, Space)
-7110: Ident           "intrinsic" at 595:6-595:15
-7111: KwFn            "fn" at 595:16-595:18 (leading: Space)
-7112: Ident           "__mul" at 595:19-595:24 (leading: Space)
-7113: LParen          "(" at 595:24-595:25
-7114: Ident           "self" at 595:25-595:29
-7115: Colon           ":" at 595:29-595:30
-7116: Ident           "float32" at 595:31-595:38 (leading: Space)
-7117: Comma           "," at 595:38-595:39
-7118: Ident           "other" at 595:40-595:45 (leading: Space)
-7119: Colon           ":" at 595:45-595:46
-7120: Ident           "float32" at 595:47-595:54 (leading: Space)
-7121: RParen          ")" at 595:54-595:55
-7122: Arrow           "->" at 595:56-595:58 (leading: Space)
-7123: Ident           "float32" at 595:59-595:66 (leading: Space)
-7124: Semicolon       ";" at 595:66-595:67
-7125: At              "@" at 596:5-596:6 (leading: Newline, Space)
-7126: Ident           "intrinsic" at 596:6-596:15
-7127: KwFn            "fn" at 596:16-596:18 (leading: Space)
-7128: Ident           "__div" at 596:19-596:24 (leading: Space)
-7129: LParen          "(" at 596:24-596:25
-7130: Ident           "self" at 596:25-596:29
-7131: Colon           ":" at 596:29-596:30
-7132: Ident           "float32" at 596:31-596:38 (leading: Space)
-7133: Comma           "," at 596:38-596:39
-7134: Ident           "other" at 596:40-596:45 (leading: Space)
-7135: Colon           ":" at 596:45-596:46
-7136: Ident           "float32" at 596:47-596:54 (leading: Space)
-7137: RParen          ")" at 596:54-596:55
-7138: Arrow           "->" at 596:56-596:58 (leading: Space)
-7139: Ident           "float32" at 596:59-596:66 (leading: Space)
-7140: Semicolon       ";" at 596:66-596:67
-7141: At              "@" at 597:5-597:6 (leading: Newline, Space)
-7142: Ident           "intrinsic" at 597:6-597:15
-7143: KwFn            "fn" at 597:16-597:18 (leading: Space)
-7144: Ident           "__mod" at 597:19-597:24 (leading: Space)
-7145: LParen          "(" at 597:24-597:25
-7146: Ident           "self" at 597:25-597:29
-7147: Colon           ":" at 597:29-597:30
-7148: Ident           "float32" at 597:31-597:38 (leading: Space)
-7149: Comma           "," at 597:38-597:39
-7150: Ident           "other" at 597:40-597:45 (leading: Space)
-7151: Colon           ":" at 597:45-597:46
-7152: Ident           "float32" at 597:47-597:54 (leading: Space)
-7153: RParen          ")" at 597:54-597:55
-7154: Arrow           "->" at 597:56-597:58 (leading: Space)
-7155: Ident           "float32" at 597:59-597:66 (leading: Space)
-7156: Semicolon       ";" at 597:66-597:67
-7157: At              "@" at 598:5-598:6 (leading: Newline, Space)
-7158: Ident           "intrinsic" at 598:6-598:15
-7159: KwFn            "fn" at 598:16-598:18 (leading: Space)
-7160: Ident           "__lt" at 598:19-598:23 (leading: Space)
-7161: LParen          "(" at 598:23-598:24
-7162: Ident           "self" at 598:24-598:28
-7163: Colon           ":" at 598:28-598:29
-7164: Ident           "float32" at 598:30-598:37 (leading: Space)
-7165: Comma           "," at 598:37-598:38
-7166: Ident           "other" at 598:39-598:44 (leading: Space)
-7167: Colon           ":" at 598:44-598:45
-7168: Ident           "float32" at 598:46-598:53 (leading: Space)
-7169: RParen          ")" at 598:53-598:54
-7170: Arrow           "->" at 598:55-598:57 (leading: Space)
-7171: Ident           "bool" at 598:58-598:62 (leading: Space)
-7172: Semicolon       ";" at 598:62-598:63
-7173: At              "@" at 599:5-599:6 (leading: Newline, Space)
-7174: Ident           "intrinsic" at 599:6-599:15
-7175: KwFn            "fn" at 599:16-599:18 (leading: Space)
-7176: Ident           "__le" at 599:19-599:23 (leading: Space)
-7177: LParen          "(" at 599:23-599:24
-7178: Ident           "self" at 599:24-599:28
-7179: Colon           ":" at 599:28-599:29
-7180: Ident           "float32" at 599:30-599:37 (leading: Space)
-7181: Comma           "," at 599:37-599:38
-7182: Ident           "other" at 599:39-599:44 (leading: Space)
-7183: Colon           ":" at 599:44-599:45
-7184: Ident           "float32" at 599:46-599:53 (leading: Space)
-7185: RParen          ")" at 599:53-599:54
-7186: Arrow           "->" at 599:55-599:57 (leading: Space)
-7187: Ident           "bool" at 599:58-599:62 (leading: Space)
-7188: Semicolon       ";" at 599:62-599:63
-7189: At              "@" at 600:5-600:6 (leading: Newline, Space)
-7190: Ident           "intrinsic" at 600:6-600:15
-7191: KwFn            "fn" at 600:16-600:18 (leading: Space)
-7192: Ident           "__eq" at 600:19-600:23 (leading: Space)
-7193: LParen          "(" at 600:23-600:24
-7194: Ident           "self" at 600:24-600:28
-7195: Colon           ":" at 600:28-600:29
-7196: Ident           "float32" at 600:30-600:37 (leading: Space)
-7197: Comma           "," at 600:37-600:38
-7198: Ident           "other" at 600:39-600:44 (leading: Space)
-7199: Colon           ":" at 600:44-600:45
-7200: Ident           "float32" at 600:46-600:53 (leading: Space)
-7201: RParen          ")" at 600:53-600:54
-7202: Arrow           "->" at 600:55-600:57 (leading: Space)
-7203: Ident           "bool" at 600:58-600:62 (leading: Space)
-7204: Semicolon       ";" at 600:62-600:63
-7205: At              "@" at 601:5-601:6 (leading: Newline, Space)
-7206: Ident           "intrinsic" at 601:6-601:15
-7207: KwFn            "fn" at 601:16-601:18 (leading: Space)
-7208: Ident           "__ne" at 601:19-601:23 (leading: Space)
-7209: LParen          "(" at 601:23-601:24
-7210: Ident           "self" at 601:24-601:28
-7211: Colon           ":" at 601:28-601:29
-7212: Ident           "float32" at 601:30-601:37 (leading: Space)
-7213: Comma           "," at 601:37-601:38
-7214: Ident           "other" at 601:39-601:44 (leading: Space)
-7215: Colon           ":" at 601:44-601:45
-7216: Ident           "float32" at 601:46-601:53 (leading: Space)
-7217: RParen          ")" at 601:53-601:54
-7218: Arrow           "->" at 601:55-601:57 (leading: Space)
-7219: Ident           "bool" at 601:58-601:62 (leading: Space)
-7220: Semicolon       ";" at 601:62-601:63
-7221: At              "@" at 602:5-602:6 (leading: Newline, Space)
-7222: Ident           "intrinsic" at 602:6-602:15
-7223: KwFn            "fn" at 602:16-602:18 (leading: Space)
-7224: Ident           "__ge" at 602:19-602:23 (leading: Space)
-7225: LParen          "(" at 602:23-602:24
-7226: Ident           "self" at 602:24-602:28
-7227: Colon           ":" at 602:28-602:29
-7228: Ident           "float32" at 602:30-602:37 (leading: Space)
-7229: Comma           "," at 602:37-602:38
-7230: Ident           "other" at 602:39-602:44 (leading: Space)
-7231: Colon           ":" at 602:44-602:45
-7232: Ident           "float32" at 602:46-602:53 (leading: Space)
-7233: RParen          ")" at 602:53-602:54
-7234: Arrow           "->" at 602:55-602:57 (leading: Space)
-7235: Ident           "bool" at 602:58-602:62 (leading: Space)
-7236: Semicolon       ";" at 602:62-602:63
-7237: At              "@" at 603:5-603:6 (leading: Newline, Space)
-7238: Ident           "intrinsic" at 603:6-603:15
-7239: KwFn            "fn" at 603:16-603:18 (leading: Space)
-7240: Ident           "__gt" at 603:19-603:23 (leading: Space)
-7241: LParen          "(" at 603:23-603:24
-7242: Ident           "self" at 603:24-603:28
-7243: Colon           ":" at 603:28-603:29
-7244: Ident           "float32" at 603:30-603:37 (leading: Space)
-7245: Comma           "," at 603:37-603:38
-7246: Ident           "other" at 603:39-603:44 (leading: Space)
-7247: Colon           ":" at 603:44-603:45
-7248: Ident           "float32" at 603:46-603:53 (leading: Space)
-7249: RParen          ")" at 603:53-603:54
-7250: Arrow           "->" at 603:55-603:57 (leading: Space)
-7251: Ident           "bool" at 603:58-603:62 (leading: Space)
-7252: Semicolon       ";" at 603:62-603:63
-7253: At              "@" at 604:5-604:6 (leading: Newline, Space)
-7254: Ident           "intrinsic" at 604:6-604:15
-7255: KwFn            "fn" at 604:16-604:18 (leading: Space)
-7256: Ident           "__pos" at 604:19-604:24 (leading: Space)
-7257: LParen          "(" at 604:24-604:25
-7258: Ident           "self" at 604:25-604:29
-7259: Colon           ":" at 604:29-604:30
-7260: Ident           "float32" at 604:31-604:38 (leading: Space)
-7261: RParen          ")" at 604:38-604:39
-7262: Arrow           "->" at 604:40-604:42 (leading: Space)
-7263: Ident           "float32" at 604:43-604:50 (leading: Space)
-7264: Semicolon       ";" at 604:50-604:51
-7265: At              "@" at 605:5-605:6 (leading: Newline, Space)
-7266: Ident           "intrinsic" at 605:6-605:15
-7267: KwFn            "fn" at 605:16-605:18 (leading: Space)
-7268: Ident           "__neg" at 605:19-605:24 (leading: Space)
-7269: LParen          "(" at 605:24-605:25
-7270: Ident           "self" at 605:25-605:29
-7271: Colon           ":" at 605:29-605:30
-7272: Ident           "float32" at 605:31-605:38 (leading: Space)
-7273: RParen          ")" at 605:38-605:39
-7274: Arrow           "->" at 605:40-605:42 (leading: Space)
-7275: Ident           "float32" at 605:43-605:50 (leading: Space)
-7276: Semicolon       ";" at 605:50-605:51
-7277: At              "@" at 606:5-606:6 (leading: Newline, Space)
-7278: Ident           "intrinsic" at 606:6-606:15
-7279: KwFn            "fn" at 606:16-606:18 (leading: Space)
-7280: Ident           "__abs" at 606:19-606:24 (leading: Space)
-7281: LParen          "(" at 606:24-606:25
-7282: Ident           "self" at 606:25-606:29
-7283: Colon           ":" at 606:29-606:30
-7284: Ident           "float32" at 606:31-606:38 (leading: Space)
-7285: RParen          ")" at 606:38-606:39
-7286: Arrow           "->" at 606:40-606:42 (leading: Space)
-7287: Ident           "float32" at 606:43-606:50 (leading: Space)
-7288: Semicolon       ";" at 606:50-606:51
-7289: At              "@" at 607:5-607:6 (leading: Newline, Space)
-7290: Ident           "intrinsic" at 607:6-607:15
-7291: KwFn            "fn" at 607:16-607:18 (leading: Space)
-7292: Ident           "__to" at 607:19-607:23 (leading: Space)
-7293: LParen          "(" at 607:23-607:24
-7294: Ident           "self" at 607:24-607:28
-7295: Colon           ":" at 607:28-607:29
-7296: Ident           "float32" at 607:30-607:37 (leading: Space)
-7297: Comma           "," at 607:37-607:38
-7298: Ident           "target" at 607:39-607:45 (leading: Space)
-7299: Colon           ":" at 607:45-607:46
-7300: Ident           "float" at 607:47-607:52 (leading: Space)
-7301: RParen          ")" at 607:52-607:53
-7302: Arrow           "->" at 607:54-607:56 (leading: Space)
-7303: Ident           "float" at 607:57-607:62 (leading: Space)
-7304: Semicolon       ";" at 607:62-607:63
-7305: At              "@" at 608:5-608:6 (leading: Newline, Space)
-7306: Ident           "intrinsic" at 608:6-608:15
-7307: At              "@" at 608:16-608:17 (leading: Space)
-7308: Ident           "overload" at 608:17-608:25
-7309: KwFn            "fn" at 608:26-608:28 (leading: Space)
-7310: Ident           "__to" at 608:29-608:33 (leading: Space)
-7311: LParen          "(" at 608:33-608:34
-7312: Ident           "self" at 608:34-608:38
-7313: Colon           ":" at 608:38-608:39
-7314: Ident           "float32" at 608:40-608:47 (leading: Space)
-7315: Comma           "," at 608:47-608:48
-7316: Ident           "target" at 608:49-608:55 (leading: Space)
-7317: Colon           ":" at 608:55-608:56
-7318: Ident           "float16" at 608:57-608:64 (leading: Space)
-7319: RParen          ")" at 608:64-608:65
-7320: Arrow           "->" at 608:66-608:68 (leading: Space)
-7321: Ident           "float16" at 608:69-608:76 (leading: Space)
-7322: Semicolon       ";" at 608:76-608:77
-7323: At              "@" at 609:5-609:6 (leading: Newline, Space)
-7324: Ident           "intrinsic" at 609:6-609:15
-7325: At              "@" at 609:16-609:17 (leading: Space)
-7326: Ident           "overload" at 609:17-609:25
-7327: KwFn            "fn" at 609:26-609:28 (leading: Space)
-7328: Ident           "__to" at 609:29-609:33 (leading: Space)
-7329: LParen          "(" at 609:33-609:34
-7330: Ident           "self" at 609:34-609:38
-7331: Colon           ":" at 609:38-609:39
-7332: Ident           "float32" at 609:40-609:47 (leading: Space)
-7333: Comma           "," at 609:47-609:48
-7334: Ident           "target" at 609:49-609:55 (leading: Space)
-7335: Colon           ":" at 609:55-609:56
-7336: Ident           "float64" at 609:57-609:64 (leading: Space)
-7337: RParen          ")" at 609:64-609:65
-7338: Arrow           "->" at 609:66-609:68 (leading: Space)
-7339: Ident           "float64" at 609:69-609:76 (leading: Space)
-7340: Semicolon       ";" at 609:76-609:77
-7341: At              "@" at 610:5-610:6 (leading: Newline, Space)
-7342: Ident           "intrinsic" at 610:6-610:15
-7343: KwPub           "pub" at 610:16-610:19 (leading: Space)
-7344: KwFn            "fn" at 610:20-610:22 (leading: Space)
-7345: Ident           "from_str" at 610:23-610:31 (leading: Space)
-7346: LParen          "(" at 610:31-610:32
-7347: Ident           "s" at 610:32-610:33
-7348: Colon           ":" at 610:33-610:34
-7349: Amp             "&" at 610:35-610:36 (leading: Space)
-7350: Ident           "string" at 610:36-610:42
-7351: RParen          ")" at 610:42-610:43
-7352: Arrow           "->" at 610:44-610:46 (leading: Space)
-7353: Ident           "Erring" at 610:47-610:53 (leading: Space)
-7354: Lt              "<" at 610:53-610:54
-7355: Ident           "float32" at 610:54-610:61
-7356: Comma           "," at 610:61-610:62
-7357: Ident           "Error" at 610:63-610:68 (leading: Space)
-7358: Gt              ">" at 610:68-610:69
-7359: Semicolon       ";" at 610:69-610:70
-7360: RBrace          "}" at 611:1-611:2 (leading: Newline)
-7361: KwExtern        "extern" at 613:1-613:7 (leading: Newline)
-7362: Lt              "<" at 613:7-613:8
-7363: Ident           "float64" at 613:8-613:15
-7364: Gt              ">" at 613:15-613:16
-7365: LBrace          "{" at 613:17-613:18 (leading: Space)
-7366: KwPub           "pub" at 614:5-614:8 (leading: Newline, Space)
-7367: KwFn            "fn" at 614:9-614:11 (leading: Space)
-7368: Ident           "__min_value" at 614:12-614:23 (leading: Space)
-7369: LParen          "(" at 614:23-614:24
-7370: RParen          ")" at 614:24-614:25
-7371: Arrow           "->" at 614:26-614:28 (leading: Space)
-7372: Ident           "float64" at 614:29-614:36 (leading: Space)
-7373: LBrace          "{" at 614:37-614:38 (leading: Space)
-7374: KwReturn        "return" at 614:39-614:45 (leading: Space)
-7375: LParen          "(" at 614:46-614:47 (leading: Space)
-7376: Minus           "-" at 614:47-614:48
-7377: FloatLit        "1.797_693_134_862_3157e+308" at 614:48-614:75
-7378: RParen          ")" at 614:75-614:76
-7379: Colon           ":" at 614:76-614:77
-7380: Ident           "float64" at 614:77-614:84
-7381: Semicolon       ";" at 614:84-614:85
-7382: RBrace          "}" at 614:86-614:87 (leading: Space)
-7383: KwPub           "pub" at 615:5-615:8 (leading: Newline, Space)
-7384: KwFn            "fn" at 615:9-615:11 (leading: Space)
-7385: Ident           "__max_value" at 615:12-615:23 (leading: Space)
-7386: LParen          "(" at 615:23-615:24
-7387: RParen          ")" at 615:24-615:25
-7388: Arrow           "->" at 615:26-615:28 (leading: Space)
-7389: Ident           "float64" at 615:29-615:36 (leading: Space)
-7390: LBrace          "{" at 615:37-615:38 (leading: Space)
-7391: KwReturn        "return" at 615:39-615:45 (leading: Space)
-7392: LParen          "(" at 615:46-615:47 (leading: Space)
-7393: FloatLit        "1.797_693_134_862_3157e+308" at 615:47-615:74
-7394: RParen          ")" at 615:74-615:75
-7395: Colon           ":" at 615:75-615:76
-7396: Ident           "float64" at 615:76-615:83
-7397: Semicolon       ";" at 615:83-615:84
-7398: RBrace          "}" at 615:85-615:86 (leading: Space)
-7399: At              "@" at 616:5-616:6 (leading: Newline, Space)
-7400: Ident           "intrinsic" at 616:6-616:15
-7401: KwFn            "fn" at 616:16-616:18 (leading: Space)
-7402: Ident           "__add" at 616:19-616:24 (leading: Space)
-7403: LParen          "(" at 616:24-616:25
-7404: Ident           "self" at 616:25-616:29
-7405: Colon           ":" at 616:29-616:30
-7406: Ident           "float64" at 616:31-616:38 (leading: Space)
-7407: Comma           "," at 616:38-616:39
-7408: Ident           "other" at 616:40-616:45 (leading: Space)
-7409: Colon           ":" at 616:45-616:46
-7410: Ident           "float64" at 616:47-616:54 (leading: Space)
-7411: RParen          ")" at 616:54-616:55
-7412: Arrow           "->" at 616:56-616:58 (leading: Space)
-7413: Ident           "float64" at 616:59-616:66 (leading: Space)
-7414: Semicolon       ";" at 616:66-616:67
-7415: At              "@" at 617:5-617:6 (leading: Newline, Space)
-7416: Ident           "intrinsic" at 617:6-617:15
-7417: KwFn            "fn" at 617:16-617:18 (leading: Space)
-7418: Ident           "__sub" at 617:19-617:24 (leading: Space)
-7419: LParen          "(" at 617:24-617:25
-7420: Ident           "self" at 617:25-617:29
-7421: Colon           ":" at 617:29-617:30
-7422: Ident           "float64" at 617:31-617:38 (leading: Space)
-7423: Comma           "," at 617:38-617:39
-7424: Ident           "other" at 617:40-617:45 (leading: Space)
-7425: Colon           ":" at 617:45-617:46
-7426: Ident           "float64" at 617:47-617:54 (leading: Space)
-7427: RParen          ")" at 617:54-617:55
-7428: Arrow           "->" at 617:56-617:58 (leading: Space)
-7429: Ident           "float64" at 617:59-617:66 (leading: Space)
-7430: Semicolon       ";" at 617:66-617:67
-7431: At              "@" at 618:5-618:6 (leading: Newline, Space)
-7432: Ident           "intrinsic" at 618:6-618:15
-7433: KwFn            "fn" at 618:16-618:18 (leading: Space)
-7434: Ident           "__mul" at 618:19-618:24 (leading: Space)
-7435: LParen          "(" at 618:24-618:25
-7436: Ident           "self" at 618:25-618:29
-7437: Colon           ":" at 618:29-618:30
-7438: Ident           "float64" at 618:31-618:38 (leading: Space)
-7439: Comma           "," at 618:38-618:39
-7440: Ident           "other" at 618:40-618:45 (leading: Space)
-7441: Colon           ":" at 618:45-618:46
-7442: Ident           "float64" at 618:47-618:54 (leading: Space)
-7443: RParen          ")" at 618:54-618:55
-7444: Arrow           "->" at 618:56-618:58 (leading: Space)
-7445: Ident           "float64" at 618:59-618:66 (leading: Space)
-7446: Semicolon       ";" at 618:66-618:67
-7447: At              "@" at 619:5-619:6 (leading: Newline, Space)
-7448: Ident           "intrinsic" at 619:6-619:15
-7449: KwFn            "fn" at 619:16-619:18 (leading: Space)
-7450: Ident           "__div" at 619:19-619:24 (leading: Space)
-7451: LParen          "(" at 619:24-619:25
-7452: Ident           "self" at 619:25-619:29
-7453: Colon           ":" at 619:29-619:30
-7454: Ident           "float64" at 619:31-619:38 (leading: Space)
-7455: Comma           "," at 619:38-619:39
-7456: Ident           "other" at 619:40-619:45 (leading: Space)
-7457: Colon           ":" at 619:45-619:46
-7458: Ident           "float64" at 619:47-619:54 (leading: Space)
-7459: RParen          ")" at 619:54-619:55
-7460: Arrow           "->" at 619:56-619:58 (leading: Space)
-7461: Ident           "float64" at 619:59-619:66 (leading: Space)
-7462: Semicolon       ";" at 619:66-619:67
-7463: At              "@" at 620:5-620:6 (leading: Newline, Space)
-7464: Ident           "intrinsic" at 620:6-620:15
-7465: KwFn            "fn" at 620:16-620:18 (leading: Space)
-7466: Ident           "__mod" at 620:19-620:24 (leading: Space)
-7467: LParen          "(" at 620:24-620:25
-7468: Ident           "self" at 620:25-620:29
-7469: Colon           ":" at 620:29-620:30
-7470: Ident           "float64" at 620:31-620:38 (leading: Space)
-7471: Comma           "," at 620:38-620:39
-7472: Ident           "other" at 620:40-620:45 (leading: Space)
-7473: Colon           ":" at 620:45-620:46
-7474: Ident           "float64" at 620:47-620:54 (leading: Space)
-7475: RParen          ")" at 620:54-620:55
-7476: Arrow           "->" at 620:56-620:58 (leading: Space)
-7477: Ident           "float64" at 620:59-620:66 (leading: Space)
-7478: Semicolon       ";" at 620:66-620:67
-7479: At              "@" at 621:5-621:6 (leading: Newline, Space)
-7480: Ident           "intrinsic" at 621:6-621:15
-7481: KwFn            "fn" at 621:16-621:18 (leading: Space)
-7482: Ident           "__lt" at 621:19-621:23 (leading: Space)
-7483: LParen          "(" at 621:23-621:24
-7484: Ident           "self" at 621:24-621:28
-7485: Colon           ":" at 621:28-621:29
-7486: Ident           "float64" at 621:30-621:37 (leading: Space)
-7487: Comma           "," at 621:37-621:38
-7488: Ident           "other" at 621:39-621:44 (leading: Space)
-7489: Colon           ":" at 621:44-621:45
-7490: Ident           "float64" at 621:46-621:53 (leading: Space)
-7491: RParen          ")" at 621:53-621:54
-7492: Arrow           "->" at 621:55-621:57 (leading: Space)
-7493: Ident           "bool" at 621:58-621:62 (leading: Space)
-7494: Semicolon       ";" at 621:62-621:63
-7495: At              "@" at 622:5-622:6 (leading: Newline, Space)
-7496: Ident           "intrinsic" at 622:6-622:15
-7497: KwFn            "fn" at 622:16-622:18 (leading: Space)
-7498: Ident           "__le" at 622:19-622:23 (leading: Space)
-7499: LParen          "(" at 622:23-622:24
-7500: Ident           "self" at 622:24-622:28
-7501: Colon           ":" at 622:28-622:29
-7502: Ident           "float64" at 622:30-622:37 (leading: Space)
-7503: Comma           "," at 622:37-622:38
-7504: Ident           "other" at 622:39-622:44 (leading: Space)
-7505: Colon           ":" at 622:44-622:45
-7506: Ident           "float64" at 622:46-622:53 (leading: Space)
-7507: RParen          ")" at 622:53-622:54
-7508: Arrow           "->" at 622:55-622:57 (leading: Space)
-7509: Ident           "bool" at 622:58-622:62 (leading: Space)
-7510: Semicolon       ";" at 622:62-622:63
-7511: At              "@" at 623:5-623:6 (leading: Newline, Space)
-7512: Ident           "intrinsic" at 623:6-623:15
-7513: KwFn            "fn" at 623:16-623:18 (leading: Space)
-7514: Ident           "__eq" at 623:19-623:23 (leading: Space)
-7515: LParen          "(" at 623:23-623:24
-7516: Ident           "self" at 623:24-623:28
-7517: Colon           ":" at 623:28-623:29
-7518: Ident           "float64" at 623:30-623:37 (leading: Space)
-7519: Comma           "," at 623:37-623:38
-7520: Ident           "other" at 623:39-623:44 (leading: Space)
-7521: Colon           ":" at 623:44-623:45
-7522: Ident           "float64" at 623:46-623:53 (leading: Space)
-7523: RParen          ")" at 623:53-623:54
-7524: Arrow           "->" at 623:55-623:57 (leading: Space)
-7525: Ident           "bool" at 623:58-623:62 (leading: Space)
-7526: Semicolon       ";" at 623:62-623:63
-7527: At              "@" at 624:5-624:6 (leading: Newline, Space)
-7528: Ident           "intrinsic" at 624:6-624:15
-7529: KwFn            "fn" at 624:16-624:18 (leading: Space)
-7530: Ident           "__ne" at 624:19-624:23 (leading: Space)
-7531: LParen          "(" at 624:23-624:24
-7532: Ident           "self" at 624:24-624:28
-7533: Colon           ":" at 624:28-624:29
-7534: Ident           "float64" at 624:30-624:37 (leading: Space)
-7535: Comma           "," at 624:37-624:38
-7536: Ident           "other" at 624:39-624:44 (leading: Space)
-7537: Colon           ":" at 624:44-624:45
-7538: Ident           "float64" at 624:46-624:53 (leading: Space)
-7539: RParen          ")" at 624:53-624:54
-7540: Arrow           "->" at 624:55-624:57 (leading: Space)
-7541: Ident           "bool" at 624:58-624:62 (leading: Space)
-7542: Semicolon       ";" at 624:62-624:63
-7543: At              "@" at 625:5-625:6 (leading: Newline, Space)
-7544: Ident           "intrinsic" at 625:6-625:15
-7545: KwFn            "fn" at 625:16-625:18 (leading: Space)
-7546: Ident           "__ge" at 625:19-625:23 (leading: Space)
-7547: LParen          "(" at 625:23-625:24
-7548: Ident           "self" at 625:24-625:28
-7549: Colon           ":" at 625:28-625:29
-7550: Ident           "float64" at 625:30-625:37 (leading: Space)
-7551: Comma           "," at 625:37-625:38
-7552: Ident           "other" at 625:39-625:44 (leading: Space)
-7553: Colon           ":" at 625:44-625:45
-7554: Ident           "float64" at 625:46-625:53 (leading: Space)
-7555: RParen          ")" at 625:53-625:54
-7556: Arrow           "->" at 625:55-625:57 (leading: Space)
-7557: Ident           "bool" at 625:58-625:62 (leading: Space)
-7558: Semicolon       ";" at 625:62-625:63
-7559: At              "@" at 626:5-626:6 (leading: Newline, Space)
-7560: Ident           "intrinsic" at 626:6-626:15
-7561: KwFn            "fn" at 626:16-626:18 (leading: Space)
-7562: Ident           "__gt" at 626:19-626:23 (leading: Space)
-7563: LParen          "(" at 626:23-626:24
-7564: Ident           "self" at 626:24-626:28
-7565: Colon           ":" at 626:28-626:29
-7566: Ident           "float64" at 626:30-626:37 (leading: Space)
-7567: Comma           "," at 626:37-626:38
-7568: Ident           "other" at 626:39-626:44 (leading: Space)
-7569: Colon           ":" at 626:44-626:45
-7570: Ident           "float64" at 626:46-626:53 (leading: Space)
-7571: RParen          ")" at 626:53-626:54
-7572: Arrow           "->" at 626:55-626:57 (leading: Space)
-7573: Ident           "bool" at 626:58-626:62 (leading: Space)
-7574: Semicolon       ";" at 626:62-626:63
-7575: At              "@" at 627:5-627:6 (leading: Newline, Space)
-7576: Ident           "intrinsic" at 627:6-627:15
-7577: KwFn            "fn" at 627:16-627:18 (leading: Space)
-7578: Ident           "__pos" at 627:19-627:24 (leading: Space)
-7579: LParen          "(" at 627:24-627:25
-7580: Ident           "self" at 627:25-627:29
-7581: Colon           ":" at 627:29-627:30
-7582: Ident           "float64" at 627:31-627:38 (leading: Space)
-7583: RParen          ")" at 627:38-627:39
-7584: Arrow           "->" at 627:40-627:42 (leading: Space)
-7585: Ident           "float64" at 627:43-627:50 (leading: Space)
-7586: Semicolon       ";" at 627:50-627:51
-7587: At              "@" at 628:5-628:6 (leading: Newline, Space)
-7588: Ident           "intrinsic" at 628:6-628:15
-7589: KwFn            "fn" at 628:16-628:18 (leading: Space)
-7590: Ident           "__neg" at 628:19-628:24 (leading: Space)
-7591: LParen          "(" at 628:24-628:25
-7592: Ident           "self" at 628:25-628:29
-7593: Colon           ":" at 628:29-628:30
-7594: Ident           "float64" at 628:31-628:38 (leading: Space)
-7595: RParen          ")" at 628:38-628:39
-7596: Arrow           "->" at 628:40-628:42 (leading: Space)
-7597: Ident           "float64" at 628:43-628:50 (leading: Space)
-7598: Semicolon       ";" at 628:50-628:51
-7599: At              "@" at 629:5-629:6 (leading: Newline, Space)
-7600: Ident           "intrinsic" at 629:6-629:15
-7601: KwFn            "fn" at 629:16-629:18 (leading: Space)
-7602: Ident           "__abs" at 629:19-629:24 (leading: Space)
-7603: LParen          "(" at 629:24-629:25
-7604: Ident           "self" at 629:25-629:29
-7605: Colon           ":" at 629:29-629:30
-7606: Ident           "float64" at 629:31-629:38 (leading: Space)
-7607: RParen          ")" at 629:38-629:39
-7608: Arrow           "->" at 629:40-629:42 (leading: Space)
-7609: Ident           "float64" at 629:43-629:50 (leading: Space)
-7610: Semicolon       ";" at 629:50-629:51
-7611: At              "@" at 630:5-630:6 (leading: Newline, Space)
-7612: Ident           "intrinsic" at 630:6-630:15
-7613: KwFn            "fn" at 630:16-630:18 (leading: Space)
-7614: Ident           "__to" at 630:19-630:23 (leading: Space)
-7615: LParen          "(" at 630:23-630:24
-7616: Ident           "self" at 630:24-630:28
-7617: Colon           ":" at 630:28-630:29
-7618: Ident           "float64" at 630:30-630:37 (leading: Space)
-7619: Comma           "," at 630:37-630:38
-7620: Ident           "target" at 630:39-630:45 (leading: Space)
-7621: Colon           ":" at 630:45-630:46
-7622: Ident           "float" at 630:47-630:52 (leading: Space)
-7623: RParen          ")" at 630:52-630:53
-7624: Arrow           "->" at 630:54-630:56 (leading: Space)
-7625: Ident           "float" at 630:57-630:62 (leading: Space)
-7626: Semicolon       ";" at 630:62-630:63
-7627: At              "@" at 631:5-631:6 (leading: Newline, Space)
-7628: Ident           "intrinsic" at 631:6-631:15
-7629: At              "@" at 631:16-631:17 (leading: Space)
-7630: Ident           "overload" at 631:17-631:25
-7631: KwFn            "fn" at 631:26-631:28 (leading: Space)
-7632: Ident           "__to" at 631:29-631:33 (leading: Space)
-7633: LParen          "(" at 631:33-631:34
-7634: Ident           "self" at 631:34-631:38
-7635: Colon           ":" at 631:38-631:39
-7636: Ident           "float64" at 631:40-631:47 (leading: Space)
-7637: Comma           "," at 631:47-631:48
-7638: Ident           "target" at 631:49-631:55 (leading: Space)
-7639: Colon           ":" at 631:55-631:56
-7640: Ident           "float16" at 631:57-631:64 (leading: Space)
-7641: RParen          ")" at 631:64-631:65
-7642: Arrow           "->" at 631:66-631:68 (leading: Space)
-7643: Ident           "float16" at 631:69-631:76 (leading: Space)
-7644: Semicolon       ";" at 631:76-631:77
-7645: At              "@" at 632:5-632:6 (leading: Newline, Space)
-7646: Ident           "intrinsic" at 632:6-632:15
-7647: At              "@" at 632:16-632:17 (leading: Space)
-7648: Ident           "overload" at 632:17-632:25
-7649: KwFn            "fn" at 632:26-632:28 (leading: Space)
-7650: Ident           "__to" at 632:29-632:33 (leading: Space)
-7651: LParen          "(" at 632:33-632:34
-7652: Ident           "self" at 632:34-632:38
-7653: Colon           ":" at 632:38-632:39
-7654: Ident           "float64" at 632:40-632:47 (leading: Space)
-7655: Comma           "," at 632:47-632:48
-7656: Ident           "target" at 632:49-632:55 (leading: Space)
-7657: Colon           ":" at 632:55-632:56
-7658: Ident           "float32" at 632:57-632:64 (leading: Space)
-7659: RParen          ")" at 632:64-632:65
-7660: Arrow           "->" at 632:66-632:68 (leading: Space)
-7661: Ident           "float32" at 632:69-632:76 (leading: Space)
-7662: Semicolon       ";" at 632:76-632:77
-7663: At              "@" at 633:5-633:6 (leading: Newline, Space)
-7664: Ident           "intrinsic" at 633:6-633:15
-7665: KwPub           "pub" at 633:16-633:19 (leading: Space)
-7666: KwFn            "fn" at 633:20-633:22 (leading: Space)
-7667: Ident           "from_str" at 633:23-633:31 (leading: Space)
-7668: LParen          "(" at 633:31-633:32
-7669: Ident           "s" at 633:32-633:33
-7670: Colon           ":" at 633:33-633:34
-7671: Amp             "&" at 633:35-633:36 (leading: Space)
-7672: Ident           "string" at 633:36-633:42
-7673: RParen          ")" at 633:42-633:43
-7674: Arrow           "->" at 633:44-633:46 (leading: Space)
-7675: Ident           "Erring" at 633:47-633:53 (leading: Space)
-7676: Lt              "<" at 633:53-633:54
-7677: Ident           "float64" at 633:54-633:61
-7678: Comma           "," at 633:61-633:62
-7679: Ident           "Error" at 633:63-633:68 (leading: Space)
-7680: Gt              ">" at 633:68-633:69
-7681: Semicolon       ";" at 633:69-633:70
-7682: RBrace          "}" at 634:1-634:2 (leading: Newline)
-7683: KwExtern        "extern" at 636:1-636:7 (leading: Newline)
-7684: Lt              "<" at 636:7-636:8
-7685: Ident           "float" at 636:8-636:13
-7686: Gt              ">" at 636:13-636:14
-7687: LBrace          "{" at 636:15-636:16 (leading: Space)
-7688: At              "@" at 637:5-637:6 (leading: Newline, Space)
-7689: Ident           "intrinsic" at 637:6-637:15
-7690: KwFn            "fn" at 637:16-637:18 (leading: Space)
-7691: Ident           "__add" at 637:19-637:24 (leading: Space)
-7692: LParen          "(" at 637:24-637:25
-7693: Ident           "self" at 637:25-637:29
-7694: Colon           ":" at 637:29-637:30
-7695: Ident           "float" at 637:31-637:36 (leading: Space)
-7696: Comma           "," at 637:36-637:37
-7697: Ident           "other" at 637:38-637:43 (leading: Space)
-7698: Colon           ":" at 637:43-637:44
-7699: Ident           "float" at 637:45-637:50 (leading: Space)
-7700: RParen          ")" at 637:50-637:51
-7701: Arrow           "->" at 637:52-637:54 (leading: Space)
-7702: Ident           "float" at 637:55-637:60 (leading: Space)
-7703: Semicolon       ";" at 637:60-637:61
-7704: At              "@" at 638:5-638:6 (leading: Newline, Space)
-7705: Ident           "intrinsic" at 638:6-638:15
-7706: KwFn            "fn" at 638:16-638:18 (leading: Space)
-7707: Ident           "__sub" at 638:19-638:24 (leading: Space)
-7708: LParen          "(" at 638:24-638:25
-7709: Ident           "self" at 638:25-638:29
-7710: Colon           ":" at 638:29-638:30
-7711: Ident           "float" at 638:31-638:36 (leading: Space)
-7712: Comma           "," at 638:36-638:37
-7713: Ident           "other" at 638:38-638:43 (leading: Space)
-7714: Colon           ":" at 638:43-638:44
-7715: Ident           "float" at 638:45-638:50 (leading: Space)
-7716: RParen          ")" at 638:50-638:51
-7717: Arrow           "->" at 638:52-638:54 (leading: Space)
-7718: Ident           "float" at 638:55-638:60 (leading: Space)
-7719: Semicolon       ";" at 638:60-638:61
-7720: At              "@" at 639:5-639:6 (leading: Newline, Space)
-7721: Ident           "intrinsic" at 639:6-639:15
-7722: KwFn            "fn" at 639:16-639:18 (leading: Space)
-7723: Ident           "__mul" at 639:19-639:24 (leading: Space)
-7724: LParen          "(" at 639:24-639:25
-7725: Ident           "self" at 639:25-639:29
-7726: Colon           ":" at 639:29-639:30
-7727: Ident           "float" at 639:31-639:36 (leading: Space)
-7728: Comma           "," at 639:36-639:37
-7729: Ident           "other" at 639:38-639:43 (leading: Space)
-7730: Colon           ":" at 639:43-639:44
-7731: Ident           "float" at 639:45-639:50 (leading: Space)
-7732: RParen          ")" at 639:50-639:51
-7733: Arrow           "->" at 639:52-639:54 (leading: Space)
-7734: Ident           "float" at 639:55-639:60 (leading: Space)
-7735: Semicolon       ";" at 639:60-639:61
-7736: At              "@" at 640:5-640:6 (leading: Newline, Space)
-7737: Ident           "intrinsic" at 640:6-640:15
-7738: KwFn            "fn" at 640:16-640:18 (leading: Space)
-7739: Ident           "__div" at 640:19-640:24 (leading: Space)
-7740: LParen          "(" at 640:24-640:25
-7741: Ident           "self" at 640:25-640:29
-7742: Colon           ":" at 640:29-640:30
-7743: Ident           "float" at 640:31-640:36 (leading: Space)
-7744: Comma           "," at 640:36-640:37
-7745: Ident           "other" at 640:38-640:43 (leading: Space)
-7746: Colon           ":" at 640:43-640:44
-7747: Ident           "float" at 640:45-640:50 (leading: Space)
-7748: RParen          ")" at 640:50-640:51
-7749: Arrow           "->" at 640:52-640:54 (leading: Space)
-7750: Ident           "float" at 640:55-640:60 (leading: Space)
-7751: Semicolon       ";" at 640:60-640:61
-7752: At              "@" at 641:5-641:6 (leading: Newline, Space)
-7753: Ident           "intrinsic" at 641:6-641:15
-7754: KwFn            "fn" at 641:16-641:18 (leading: Space)
-7755: Ident           "__mod" at 641:19-641:24 (leading: Space)
-7756: LParen          "(" at 641:24-641:25
-7757: Ident           "self" at 641:25-641:29
-7758: Colon           ":" at 641:29-641:30
-7759: Ident           "float" at 641:31-641:36 (leading: Space)
-7760: Comma           "," at 641:36-641:37
-7761: Ident           "other" at 641:38-641:43 (leading: Space)
-7762: Colon           ":" at 641:43-641:44
-7763: Ident           "float" at 641:45-641:50 (leading: Space)
-7764: RParen          ")" at 641:50-641:51
-7765: Arrow           "->" at 641:52-641:54 (leading: Space)
-7766: Ident           "float" at 641:55-641:60 (leading: Space)
-7767: Semicolon       ";" at 641:60-641:61
-7768: At              "@" at 642:5-642:6 (leading: Newline, Space)
-7769: Ident           "intrinsic" at 642:6-642:15
-7770: KwFn            "fn" at 642:16-642:18 (leading: Space)
-7771: Ident           "__lt" at 642:19-642:23 (leading: Space)
-7772: LParen          "(" at 642:23-642:24
-7773: Ident           "self" at 642:24-642:28
-7774: Colon           ":" at 642:28-642:29
-7775: Ident           "float" at 642:30-642:35 (leading: Space)
-7776: Comma           "," at 642:35-642:36
-7777: Ident           "other" at 642:37-642:42 (leading: Space)
-7778: Colon           ":" at 642:42-642:43
-7779: Ident           "float" at 642:44-642:49 (leading: Space)
-7780: RParen          ")" at 642:49-642:50
-7781: Arrow           "->" at 642:51-642:53 (leading: Space)
-7782: Ident           "bool" at 642:54-642:58 (leading: Space)
-7783: Semicolon       ";" at 642:58-642:59
-7784: At              "@" at 643:5-643:6 (leading: Newline, Space)
-7785: Ident           "intrinsic" at 643:6-643:15
-7786: KwFn            "fn" at 643:16-643:18 (leading: Space)
-7787: Ident           "__le" at 643:19-643:23 (leading: Space)
-7788: LParen          "(" at 643:23-643:24
-7789: Ident           "self" at 643:24-643:28
-7790: Colon           ":" at 643:28-643:29
-7791: Ident           "float" at 643:30-643:35 (leading: Space)
-7792: Comma           "," at 643:35-643:36
-7793: Ident           "other" at 643:37-643:42 (leading: Space)
-7794: Colon           ":" at 643:42-643:43
-7795: Ident           "float" at 643:44-643:49 (leading: Space)
-7796: RParen          ")" at 643:49-643:50
-7797: Arrow           "->" at 643:51-643:53 (leading: Space)
-7798: Ident           "bool" at 643:54-643:58 (leading: Space)
-7799: Semicolon       ";" at 643:58-643:59
-7800: At              "@" at 644:5-644:6 (leading: Newline, Space)
-7801: Ident           "intrinsic" at 644:6-644:15
-7802: KwFn            "fn" at 644:16-644:18 (leading: Space)
-7803: Ident           "__eq" at 644:19-644:23 (leading: Space)
-7804: LParen          "(" at 644:23-644:24
-7805: Ident           "self" at 644:24-644:28
-7806: Colon           ":" at 644:28-644:29
-7807: Ident           "float" at 644:30-644:35 (leading: Space)
-7808: Comma           "," at 644:35-644:36
-7809: Ident           "other" at 644:37-644:42 (leading: Space)
-7810: Colon           ":" at 644:42-644:43
-7811: Ident           "float" at 644:44-644:49 (leading: Space)
-7812: RParen          ")" at 644:49-644:50
-7813: Arrow           "->" at 644:51-644:53 (leading: Space)
-7814: Ident           "bool" at 644:54-644:58 (leading: Space)
-7815: Semicolon       ";" at 644:58-644:59
-7816: At              "@" at 645:5-645:6 (leading: Newline, Space)
-7817: Ident           "intrinsic" at 645:6-645:15
-7818: KwFn            "fn" at 645:16-645:18 (leading: Space)
-7819: Ident           "__ne" at 645:19-645:23 (leading: Space)
-7820: LParen          "(" at 645:23-645:24
-7821: Ident           "self" at 645:24-645:28
-7822: Colon           ":" at 645:28-645:29
-7823: Ident           "float" at 645:30-645:35 (leading: Space)
-7824: Comma           "," at 645:35-645:36
-7825: Ident           "other" at 645:37-645:42 (leading: Space)
-7826: Colon           ":" at 645:42-645:43
-7827: Ident           "float" at 645:44-645:49 (leading: Space)
-7828: RParen          ")" at 645:49-645:50
-7829: Arrow           "->" at 645:51-645:53 (leading: Space)
-7830: Ident           "bool" at 645:54-645:58 (leading: Space)
-7831: Semicolon       ";" at 645:58-645:59
-7832: At              "@" at 646:5-646:6 (leading: Newline, Space)
-7833: Ident           "intrinsic" at 646:6-646:15
-7834: KwFn            "fn" at 646:16-646:18 (leading: Space)
-7835: Ident           "__ge" at 646:19-646:23 (leading: Space)
-7836: LParen          "(" at 646:23-646:24
-7837: Ident           "self" at 646:24-646:28
-7838: Colon           ":" at 646:28-646:29
-7839: Ident           "float" at 646:30-646:35 (leading: Space)
-7840: Comma           "," at 646:35-646:36
-7841: Ident           "other" at 646:37-646:42 (leading: Space)
-7842: Colon           ":" at 646:42-646:43
-7843: Ident           "float" at 646:44-646:49 (leading: Space)
-7844: RParen          ")" at 646:49-646:50
-7845: Arrow           "->" at 646:51-646:53 (leading: Space)
-7846: Ident           "bool" at 646:54-646:58 (leading: Space)
-7847: Semicolon       ";" at 646:58-646:59
-7848: At              "@" at 647:5-647:6 (leading: Newline, Space)
-7849: Ident           "intrinsic" at 647:6-647:15
-7850: KwFn            "fn" at 647:16-647:18 (leading: Space)
-7851: Ident           "__gt" at 647:19-647:23 (leading: Space)
-7852: LParen          "(" at 647:23-647:24
-7853: Ident           "self" at 647:24-647:28
-7854: Colon           ":" at 647:28-647:29
-7855: Ident           "float" at 647:30-647:35 (leading: Space)
-7856: Comma           "," at 647:35-647:36
-7857: Ident           "other" at 647:37-647:42 (leading: Space)
-7858: Colon           ":" at 647:42-647:43
-7859: Ident           "float" at 647:44-647:49 (leading: Space)
-7860: RParen          ")" at 647:49-647:50
-7861: Arrow           "->" at 647:51-647:53 (leading: Space)
-7862: Ident           "bool" at 647:54-647:58 (leading: Space)
-7863: Semicolon       ";" at 647:58-647:59
-7864: At              "@" at 648:5-648:6 (leading: Newline, Space)
-7865: Ident           "intrinsic" at 648:6-648:15
-7866: KwFn            "fn" at 648:16-648:18 (leading: Space)
-7867: Ident           "__pos" at 648:19-648:24 (leading: Space)
-7868: LParen          "(" at 648:24-648:25
-7869: Ident           "self" at 648:25-648:29
-7870: Colon           ":" at 648:29-648:30
-7871: Ident           "float" at 648:31-648:36 (leading: Space)
-7872: RParen          ")" at 648:36-648:37
-7873: Arrow           "->" at 648:38-648:40 (leading: Space)
-7874: Ident           "float" at 648:41-648:46 (leading: Space)
-7875: Semicolon       ";" at 648:46-648:47
-7876: At              "@" at 649:5-649:6 (leading: Newline, Space)
-7877: Ident           "intrinsic" at 649:6-649:15
-7878: KwFn            "fn" at 649:16-649:18 (leading: Space)
-7879: Ident           "__neg" at 649:19-649:24 (leading: Space)
-7880: LParen          "(" at 649:24-649:25
-7881: Ident           "self" at 649:25-649:29
-7882: Colon           ":" at 649:29-649:30
-7883: Ident           "float" at 649:31-649:36 (leading: Space)
-7884: RParen          ")" at 649:36-649:37
-7885: Arrow           "->" at 649:38-649:40 (leading: Space)
-7886: Ident           "float" at 649:41-649:46 (leading: Space)
-7887: Semicolon       ";" at 649:46-649:47
-7888: At              "@" at 650:5-650:6 (leading: Newline, Space)
-7889: Ident           "intrinsic" at 650:6-650:15
-7890: KwFn            "fn" at 650:16-650:18 (leading: Space)
-7891: Ident           "__abs" at 650:19-650:24 (leading: Space)
-7892: LParen          "(" at 650:24-650:25
-7893: Ident           "self" at 650:25-650:29
-7894: Colon           ":" at 650:29-650:30
-7895: Ident           "float" at 650:31-650:36 (leading: Space)
-7896: RParen          ")" at 650:36-650:37
-7897: Arrow           "->" at 650:38-650:40 (leading: Space)
-7898: Ident           "float" at 650:41-650:46 (leading: Space)
-7899: Semicolon       ";" at 650:46-650:47
-7900: At              "@" at 651:5-651:6 (leading: Newline, Space)
-7901: Ident           "intrinsic" at 651:6-651:15
-7902: KwFn            "fn" at 651:16-651:18 (leading: Space)
-7903: Ident           "__to" at 651:19-651:23 (leading: Space)
-7904: LParen          "(" at 651:23-651:24
-7905: Ident           "self" at 651:24-651:28
-7906: Colon           ":" at 651:28-651:29
-7907: Ident           "float" at 651:30-651:35 (leading: Space)
-7908: Comma           "," at 651:35-651:36
-7909: Ident           "target" at 651:37-651:43 (leading: Space)
-7910: Colon           ":" at 651:43-651:44
-7911: Ident           "string" at 651:45-651:51 (leading: Space)
-7912: RParen          ")" at 651:51-651:52
-7913: Arrow           "->" at 651:53-651:55 (leading: Space)
-7914: Ident           "string" at 651:56-651:62 (leading: Space)
-7915: Semicolon       ";" at 651:62-651:63
-7916: At              "@" at 652:5-652:6 (leading: Newline, Space)
-7917: Ident           "overload" at 652:6-652:14
-7918: KwPub           "pub" at 652:15-652:18 (leading: Space)
-7919: KwFn            "fn" at 652:19-652:21 (leading: Space)
-7920: Ident           "__to" at 652:22-652:26 (leading: Space)
-7921: LParen          "(" at 652:26-652:27
-7922: Ident           "self" at 652:27-652:31
-7923: Colon           ":" at 652:31-652:32
-7924: Amp             "&" at 652:33-652:34 (leading: Space)
-7925: Ident           "float" at 652:34-652:39
-7926: Comma           "," at 652:39-652:40
-7927: Underscore      "_" at 652:41-652:42 (leading: Space)
-7928: Colon           ":" at 652:42-652:43
-7929: Ident           "string" at 652:44-652:50 (leading: Space)
-7930: RParen          ")" at 652:50-652:51
-7931: Arrow           "->" at 652:52-652:54 (leading: Space)
-7932: Ident           "string" at 652:55-652:61 (leading: Space)
-7933: LBrace          "{" at 652:62-652:63 (leading: Space)
-7934: KwReturn        "return" at 653:9-653:15 (leading: Newline, Space)
-7935: LParen          "(" at 653:16-653:17 (leading: Space)
-7936: Star            "*" at 653:17-653:18
-7937: Ident           "self" at 653:18-653:22
-7938: RParen          ")" at 653:22-653:23
-7939: KwTo            "to" at 653:24-653:26 (leading: Space)
-7940: Ident           "string" at 653:27-653:33 (leading: Space)
-7941: Semicolon       ";" at 653:33-653:34
-7942: RBrace          "}" at 654:5-654:6 (leading: Newline, Space)
-7943: At              "@" at 655:5-655:6 (leading: Newline, Space)
-7944: Ident           "intrinsic" at 655:6-655:15
-7945: At              "@" at 655:16-655:17 (leading: Space)
-7946: Ident           "overload" at 655:17-655:25
-7947: KwFn            "fn" at 655:26-655:28 (leading: Space)
-7948: Ident           "__to" at 655:29-655:33 (leading: Space)
-7949: LParen          "(" at 655:33-655:34
-7950: Ident           "self" at 655:34-655:38
-7951: Colon           ":" at 655:38-655:39
-7952: Ident           "float" at 655:40-655:45 (leading: Space)
-7953: Comma           "," at 655:45-655:46
-7954: Ident           "target" at 655:47-655:53 (leading: Space)
-7955: Colon           ":" at 655:53-655:54
-7956: Ident           "int" at 655:55-655:58 (leading: Space)
-7957: RParen          ")" at 655:58-655:59
-7958: Arrow           "->" at 655:60-655:62 (leading: Space)
-7959: Ident           "int" at 655:63-655:66 (leading: Space)
-7960: Semicolon       ";" at 655:66-655:67
-7961: At              "@" at 656:5-656:6 (leading: Newline, Space)
-7962: Ident           "intrinsic" at 656:6-656:15
-7963: At              "@" at 656:16-656:17 (leading: Space)
-7964: Ident           "overload" at 656:17-656:25
-7965: KwFn            "fn" at 656:26-656:28 (leading: Space)
-7966: Ident           "__to" at 656:29-656:33 (leading: Space)
-7967: LParen          "(" at 656:33-656:34
-7968: Ident           "self" at 656:34-656:38
-7969: Colon           ":" at 656:38-656:39
-7970: Ident           "float" at 656:40-656:45 (leading: Space)
-7971: Comma           "," at 656:45-656:46
-7972: Ident           "target" at 656:47-656:53 (leading: Space)
-7973: Colon           ":" at 656:53-656:54
-7974: Ident           "uint" at 656:55-656:59 (leading: Space)
-7975: RParen          ")" at 656:59-656:60
-7976: Arrow           "->" at 656:61-656:63 (leading: Space)
-7977: Ident           "uint" at 656:64-656:68 (leading: Space)
-7978: Semicolon       ";" at 656:68-656:69
-7979: At              "@" at 657:5-657:6 (leading: Newline, Space)
-7980: Ident           "intrinsic" at 657:6-657:15
-7981: At              "@" at 657:16-657:17 (leading: Space)
-7982: Ident           "overload" at 657:17-657:25
-7983: KwFn            "fn" at 657:26-657:28 (leading: Space)
-7984: Ident           "__to" at 657:29-657:33 (leading: Space)
-7985: LParen          "(" at 657:33-657:34
-7986: Ident           "self" at 657:34-657:38
-7987: Colon           ":" at 657:38-657:39
-7988: Ident           "float" at 657:40-657:45 (leading: Space)
-7989: Comma           "," at 657:45-657:46
-7990: Ident           "target" at 657:47-657:53 (leading: Space)
-7991: Colon           ":" at 657:53-657:54
-7992: Ident           "int8" at 657:55-657:59 (leading: Space)
-7993: RParen          ")" at 657:59-657:60
-7994: Arrow           "->" at 657:61-657:63 (leading: Space)
-7995: Ident           "int8" at 657:64-657:68 (leading: Space)
-7996: Semicolon       ";" at 657:68-657:69
-7997: At              "@" at 658:5-658:6 (leading: Newline, Space)
-7998: Ident           "intrinsic" at 658:6-658:15
-7999: At              "@" at 658:16-658:17 (leading: Space)
-8000: Ident           "overload" at 658:17-658:25
-8001: KwFn            "fn" at 658:26-658:28 (leading: Space)
-8002: Ident           "__to" at 658:29-658:33 (leading: Space)
-8003: LParen          "(" at 658:33-658:34
-8004: Ident           "self" at 658:34-658:38
-8005: Colon           ":" at 658:38-658:39
-8006: Ident           "float" at 658:40-658:45 (leading: Space)
-8007: Comma           "," at 658:45-658:46
-8008: Ident           "target" at 658:47-658:53 (leading: Space)
-8009: Colon           ":" at 658:53-658:54
-8010: Ident           "int16" at 658:55-658:60 (leading: Space)
-8011: RParen          ")" at 658:60-658:61
-8012: Arrow           "->" at 658:62-658:64 (leading: Space)
-8013: Ident           "int16" at 658:65-658:70 (leading: Space)
-8014: Semicolon       ";" at 658:70-658:71
-8015: At              "@" at 659:5-659:6 (leading: Newline, Space)
-8016: Ident           "intrinsic" at 659:6-659:15
-8017: At              "@" at 659:16-659:17 (leading: Space)
-8018: Ident           "overload" at 659:17-659:25
-8019: KwFn            "fn" at 659:26-659:28 (leading: Space)
-8020: Ident           "__to" at 659:29-659:33 (leading: Space)
-8021: LParen          "(" at 659:33-659:34
-8022: Ident           "self" at 659:34-659:38
-8023: Colon           ":" at 659:38-659:39
-8024: Ident           "float" at 659:40-659:45 (leading: Space)
-8025: Comma           "," at 659:45-659:46
-8026: Ident           "target" at 659:47-659:53 (leading: Space)
-8027: Colon           ":" at 659:53-659:54
-8028: Ident           "int32" at 659:55-659:60 (leading: Space)
-8029: RParen          ")" at 659:60-659:61
-8030: Arrow           "->" at 659:62-659:64 (leading: Space)
-8031: Ident           "int32" at 659:65-659:70 (leading: Space)
-8032: Semicolon       ";" at 659:70-659:71
-8033: At              "@" at 660:5-660:6 (leading: Newline, Space)
-8034: Ident           "intrinsic" at 660:6-660:15
-8035: At              "@" at 660:16-660:17 (leading: Space)
-8036: Ident           "overload" at 660:17-660:25
-8037: KwFn            "fn" at 660:26-660:28 (leading: Space)
-8038: Ident           "__to" at 660:29-660:33 (leading: Space)
-8039: LParen          "(" at 660:33-660:34
-8040: Ident           "self" at 660:34-660:38
-8041: Colon           ":" at 660:38-660:39
-8042: Ident           "float" at 660:40-660:45 (leading: Space)
-8043: Comma           "," at 660:45-660:46
-8044: Ident           "target" at 660:47-660:53 (leading: Space)
-8045: Colon           ":" at 660:53-660:54
-8046: Ident           "int64" at 660:55-660:60 (leading: Space)
-8047: RParen          ")" at 660:60-660:61
-8048: Arrow           "->" at 660:62-660:64 (leading: Space)
-8049: Ident           "int64" at 660:65-660:70 (leading: Space)
-8050: Semicolon       ";" at 660:70-660:71
-8051: At              "@" at 661:5-661:6 (leading: Newline, Space)
-8052: Ident           "intrinsic" at 661:6-661:15
-8053: At              "@" at 661:16-661:17 (leading: Space)
-8054: Ident           "overload" at 661:17-661:25
-8055: KwFn            "fn" at 661:26-661:28 (leading: Space)
-8056: Ident           "__to" at 661:29-661:33 (leading: Space)
-8057: LParen          "(" at 661:33-661:34
-8058: Ident           "self" at 661:34-661:38
-8059: Colon           ":" at 661:38-661:39
-8060: Ident           "float" at 661:40-661:45 (leading: Space)
-8061: Comma           "," at 661:45-661:46
-8062: Ident           "target" at 661:47-661:53 (leading: Space)
-8063: Colon           ":" at 661:53-661:54
-8064: Ident           "uint8" at 661:55-661:60 (leading: Space)
-8065: RParen          ")" at 661:60-661:61
-8066: Arrow           "->" at 661:62-661:64 (leading: Space)
-8067: Ident           "uint8" at 661:65-661:70 (leading: Space)
-8068: Semicolon       ";" at 661:70-661:71
-8069: At              "@" at 662:5-662:6 (leading: Newline, Space)
-8070: Ident           "intrinsic" at 662:6-662:15
-8071: At              "@" at 662:16-662:17 (leading: Space)
-8072: Ident           "overload" at 662:17-662:25
-8073: KwFn            "fn" at 662:26-662:28 (leading: Space)
-8074: Ident           "__to" at 662:29-662:33 (leading: Space)
-8075: LParen          "(" at 662:33-662:34
-8076: Ident           "self" at 662:34-662:38
-8077: Colon           ":" at 662:38-662:39
-8078: Ident           "float" at 662:40-662:45 (leading: Space)
-8079: Comma           "," at 662:45-662:46
-8080: Ident           "target" at 662:47-662:53 (leading: Space)
-8081: Colon           ":" at 662:53-662:54
-8082: Ident           "uint16" at 662:55-662:61 (leading: Space)
-8083: RParen          ")" at 662:61-662:62
-8084: Arrow           "->" at 662:63-662:65 (leading: Space)
-8085: Ident           "uint16" at 662:66-662:72 (leading: Space)
-8086: Semicolon       ";" at 662:72-662:73
-8087: At              "@" at 663:5-663:6 (leading: Newline, Space)
-8088: Ident           "intrinsic" at 663:6-663:15
-8089: At              "@" at 663:16-663:17 (leading: Space)
-8090: Ident           "overload" at 663:17-663:25
-8091: KwFn            "fn" at 663:26-663:28 (leading: Space)
-8092: Ident           "__to" at 663:29-663:33 (leading: Space)
-8093: LParen          "(" at 663:33-663:34
-8094: Ident           "self" at 663:34-663:38
-8095: Colon           ":" at 663:38-663:39
-8096: Ident           "float" at 663:40-663:45 (leading: Space)
-8097: Comma           "," at 663:45-663:46
-8098: Ident           "target" at 663:47-663:53 (leading: Space)
-8099: Colon           ":" at 663:53-663:54
-8100: Ident           "uint32" at 663:55-663:61 (leading: Space)
-8101: RParen          ")" at 663:61-663:62
-8102: Arrow           "->" at 663:63-663:65 (leading: Space)
-8103: Ident           "uint32" at 663:66-663:72 (leading: Space)
-8104: Semicolon       ";" at 663:72-663:73
-8105: At              "@" at 664:5-664:6 (leading: Newline, Space)
-8106: Ident           "intrinsic" at 664:6-664:15
-8107: At              "@" at 664:16-664:17 (leading: Space)
-8108: Ident           "overload" at 664:17-664:25
-8109: KwFn            "fn" at 664:26-664:28 (leading: Space)
-8110: Ident           "__to" at 664:29-664:33 (leading: Space)
-8111: LParen          "(" at 664:33-664:34
-8112: Ident           "self" at 664:34-664:38
-8113: Colon           ":" at 664:38-664:39
-8114: Ident           "float" at 664:40-664:45 (leading: Space)
-8115: Comma           "," at 664:45-664:46
-8116: Ident           "target" at 664:47-664:53 (leading: Space)
-8117: Colon           ":" at 664:53-664:54
-8118: Ident           "uint64" at 664:55-664:61 (leading: Space)
-8119: RParen          ")" at 664:61-664:62
-8120: Arrow           "->" at 664:63-664:65 (leading: Space)
-8121: Ident           "uint64" at 664:66-664:72 (leading: Space)
-8122: Semicolon       ";" at 664:72-664:73
-8123: At              "@" at 665:5-665:6 (leading: Newline, Space)
-8124: Ident           "intrinsic" at 665:6-665:15
-8125: At              "@" at 665:16-665:17 (leading: Space)
-8126: Ident           "overload" at 665:17-665:25
-8127: KwFn            "fn" at 665:26-665:28 (leading: Space)
-8128: Ident           "__to" at 665:29-665:33 (leading: Space)
-8129: LParen          "(" at 665:33-665:34
-8130: Ident           "self" at 665:34-665:38
-8131: Colon           ":" at 665:38-665:39
-8132: Ident           "float" at 665:40-665:45 (leading: Space)
-8133: Comma           "," at 665:45-665:46
-8134: Ident           "target" at 665:47-665:53 (leading: Space)
-8135: Colon           ":" at 665:53-665:54
-8136: Ident           "float16" at 665:55-665:62 (leading: Space)
-8137: RParen          ")" at 665:62-665:63
-8138: Arrow           "->" at 665:64-665:66 (leading: Space)
-8139: Ident           "float16" at 665:67-665:74 (leading: Space)
-8140: Semicolon       ";" at 665:74-665:75
-8141: At              "@" at 666:5-666:6 (leading: Newline, Space)
-8142: Ident           "intrinsic" at 666:6-666:15
-8143: At              "@" at 666:16-666:17 (leading: Space)
-8144: Ident           "overload" at 666:17-666:25
-8145: KwFn            "fn" at 666:26-666:28 (leading: Space)
-8146: Ident           "__to" at 666:29-666:33 (leading: Space)
-8147: LParen          "(" at 666:33-666:34
-8148: Ident           "self" at 666:34-666:38
-8149: Colon           ":" at 666:38-666:39
-8150: Ident           "float" at 666:40-666:45 (leading: Space)
-8151: Comma           "," at 666:45-666:46
-8152: Ident           "target" at 666:47-666:53 (leading: Space)
-8153: Colon           ":" at 666:53-666:54
-8154: Ident           "float32" at 666:55-666:62 (leading: Space)
-8155: RParen          ")" at 666:62-666:63
-8156: Arrow           "->" at 666:64-666:66 (leading: Space)
-8157: Ident           "float32" at 666:67-666:74 (leading: Space)
-8158: Semicolon       ";" at 666:74-666:75
-8159: At              "@" at 667:5-667:6 (leading: Newline, Space)
-8160: Ident           "intrinsic" at 667:6-667:15
-8161: At              "@" at 667:16-667:17 (leading: Space)
-8162: Ident           "overload" at 667:17-667:25
-8163: KwFn            "fn" at 667:26-667:28 (leading: Space)
-8164: Ident           "__to" at 667:29-667:33 (leading: Space)
-8165: LParen          "(" at 667:33-667:34
-8166: Ident           "self" at 667:34-667:38
-8167: Colon           ":" at 667:38-667:39
-8168: Ident           "float" at 667:40-667:45 (leading: Space)
-8169: Comma           "," at 667:45-667:46
-8170: Ident           "target" at 667:47-667:53 (leading: Space)
-8171: Colon           ":" at 667:53-667:54
-8172: Ident           "float64" at 667:55-667:62 (leading: Space)
-8173: RParen          ")" at 667:62-667:63
-8174: Arrow           "->" at 667:64-667:66 (leading: Space)
-8175: Ident           "float64" at 667:67-667:74 (leading: Space)
-8176: Semicolon       ";" at 667:74-667:75
-8177: At              "@" at 669:5-669:6 (leading: Newline, Space, LineComment, Newline, Space)
-8178: Ident           "intrinsic" at 669:6-669:15
-8179: KwPub           "pub" at 669:16-669:19 (leading: Space)
-8180: KwFn            "fn" at 669:20-669:22 (leading: Space)
-8181: Ident           "from_str" at 669:23-669:31 (leading: Space)
-8182: LParen          "(" at 669:31-669:32
-8183: Ident           "s" at 669:32-669:33
-8184: Colon           ":" at 669:33-669:34
-8185: Amp             "&" at 669:35-669:36 (leading: Space)
-8186: Ident           "string" at 669:36-669:42
-8187: RParen          ")" at 669:42-669:43
-8188: Arrow           "->" at 669:44-669:46 (leading: Space)
-8189: Ident           "Erring" at 669:47-669:53 (leading: Space)
-8190: Lt              "<" at 669:53-669:54
-8191: Ident           "float" at 669:54-669:59
-8192: Comma           "," at 669:59-669:60
-8193: Ident           "Error" at 669:61-669:66 (leading: Space)
-8194: Gt              ">" at 669:66-669:67
-8195: Semicolon       ";" at 669:67-669:68
-8196: RBrace          "}" at 670:1-670:2 (leading: Newline)
-8197: KwExtern        "extern" at 672:1-672:7 (leading: Newline)
-8198: Lt              "<" at 672:7-672:8
-8199: Ident           "string" at 672:8-672:14
-8200: Gt              ">" at 672:14-672:15
-8201: LBrace          "{" at 672:16-672:17 (leading: Space)
-8202: At              "@" at 673:5-673:6 (leading: Newline, Space)
-8203: Ident           "intrinsic" at 673:6-673:15
-8204: KwFn            "fn" at 673:16-673:18 (leading: Space)
-8205: Ident           "__add" at 673:19-673:24 (leading: Space)
-8206: LParen          "(" at 673:24-673:25
-8207: Ident           "self" at 673:25-673:29
-8208: Colon           ":" at 673:29-673:30
-8209: Amp             "&" at 673:31-673:32 (leading: Space)
-8210: Ident           "string" at 673:32-673:38
-8211: Comma           "," at 673:38-673:39
-8212: Ident           "other" at 673:40-673:45 (leading: Space)
-8213: Colon           ":" at 673:45-673:46
-8214: Amp             "&" at 673:47-673:48 (leading: Space)
-8215: Ident           "string" at 673:48-673:54
-8216: RParen          ")" at 673:54-673:55
-8217: Arrow           "->" at 673:56-673:58 (leading: Space)
-8218: Ident           "string" at 673:59-673:65 (leading: Space)
-8219: Semicolon       ";" at 673:65-673:66
-8220: At              "@" at 674:5-674:6 (leading: Newline, Space)
-8221: Ident           "intrinsic" at 674:6-674:15
-8222: KwFn            "fn" at 674:16-674:18 (leading: Space)
-8223: Ident           "__mul" at 674:19-674:24 (leading: Space)
-8224: LParen          "(" at 674:24-674:25
-8225: Ident           "self" at 674:25-674:29
-8226: Colon           ":" at 674:29-674:30
-8227: Amp             "&" at 674:31-674:32 (leading: Space)
-8228: Ident           "string" at 674:32-674:38
-8229: Comma           "," at 674:38-674:39
-8230: Ident           "other" at 674:40-674:45 (leading: Space)
-8231: Colon           ":" at 674:45-674:46
-8232: Ident           "int" at 674:47-674:50 (leading: Space)
-8233: RParen          ")" at 674:50-674:51
-8234: Arrow           "->" at 674:52-674:54 (leading: Space)
-8235: Ident           "string" at 674:55-674:61 (leading: Space)
-8236: Semicolon       ";" at 674:61-674:62
-8237: At              "@" at 675:5-675:6 (leading: Newline, Space)
-8238: Ident           "overload" at 675:6-675:14
-8239: KwPub           "pub" at 675:15-675:18 (leading: Space)
-8240: KwFn            "fn" at 675:19-675:21 (leading: Space)
-8241: Ident           "__mul" at 675:22-675:27 (leading: Space)
-8242: LParen          "(" at 675:27-675:28
-8243: Ident           "self" at 675:28-675:32
-8244: Colon           ":" at 675:32-675:33
-8245: Amp             "&" at 675:34-675:35 (leading: Space)
-8246: Ident           "string" at 675:35-675:41
-8247: Comma           "," at 675:41-675:42
-8248: Ident           "other" at 675:43-675:48 (leading: Space)
-8249: Colon           ":" at 675:48-675:49
-8250: Ident           "uint" at 675:50-675:54 (leading: Space)
-8251: RParen          ")" at 675:54-675:55
-8252: Arrow           "->" at 675:56-675:58 (leading: Space)
-8253: Ident           "string" at 675:59-675:65 (leading: Space)
-8254: LBrace          "{" at 675:66-675:67 (leading: Space)
-8255: KwReturn        "return" at 676:9-676:15 (leading: Newline, Space)
-8256: Ident           "self" at 676:16-676:20 (leading: Space)
-8257: Star            "*" at 676:21-676:22 (leading: Space)
-8258: LParen          "(" at 676:23-676:24 (leading: Space)
-8259: Ident           "other" at 676:24-676:29
-8260: KwTo            "to" at 676:30-676:32 (leading: Space)
-8261: Ident           "int" at 676:33-676:36 (leading: Space)
-8262: RParen          ")" at 676:36-676:37
-8263: Semicolon       ";" at 676:37-676:38
-8264: RBrace          "}" at 677:5-677:6 (leading: Newline, Space)
-8265: At              "@" at 678:5-678:6 (leading: Newline, Space)
-8266: Ident           "intrinsic" at 678:6-678:15
-8267: KwFn            "fn" at 678:16-678:18 (leading: Space)
-8268: Ident           "__eq" at 678:19-678:23 (leading: Space)
-8269: LParen          "(" at 678:23-678:24
-8270: Ident           "self" at 678:24-678:28
-8271: Colon           ":" at 678:28-678:29
-8272: Amp             "&" at 678:30-678:31 (leading: Space)
-8273: Ident           "string" at 678:31-678:37
-8274: Comma           "," at 678:37-678:38
-8275: Ident           "other" at 678:39-678:44 (leading: Space)
-8276: Colon           ":" at 678:44-678:45
-8277: Amp             "&" at 678:46-678:47 (leading: Space)
-8278: Ident           "string" at 678:47-678:53
-8279: RParen          ")" at 678:53-678:54
-8280: Arrow           "->" at 678:55-678:57 (leading: Space)
-8281: Ident           "bool" at 678:58-678:62 (leading: Space)
-8282: Semicolon       ";" at 678:62-678:63
-8283: At              "@" at 679:5-679:6 (leading: Newline, Space)
-8284: Ident           "intrinsic" at 679:6-679:15
-8285: KwFn            "fn" at 679:16-679:18 (leading: Space)
-8286: Ident           "__ne" at 679:19-679:23 (leading: Space)
-8287: LParen          "(" at 679:23-679:24
-8288: Ident           "self" at 679:24-679:28
-8289: Colon           ":" at 679:28-679:29
-8290: Amp             "&" at 679:30-679:31 (leading: Space)
-8291: Ident           "string" at 679:31-679:37
-8292: Comma           "," at 679:37-679:38
-8293: Ident           "other" at 679:39-679:44 (leading: Space)
-8294: Colon           ":" at 679:44-679:45
-8295: Amp             "&" at 679:46-679:47 (leading: Space)
-8296: Ident           "string" at 679:47-679:53
-8297: RParen          ")" at 679:53-679:54
-8298: Arrow           "->" at 679:55-679:57 (leading: Space)
-8299: Ident           "bool" at 679:58-679:62 (leading: Space)
-8300: Semicolon       ";" at 679:62-679:63
-8301: At              "@" at 680:5-680:6 (leading: Newline, Space)
-8302: Ident           "intrinsic" at 680:6-680:15
-8303: KwFn            "fn" at 680:16-680:18 (leading: Space)
-8304: Ident           "__to" at 680:19-680:23 (leading: Space)
-8305: LParen          "(" at 680:23-680:24
-8306: Ident           "self" at 680:24-680:28
-8307: Colon           ":" at 680:28-680:29
-8308: Amp             "&" at 680:30-680:31 (leading: Space)
-8309: Ident           "string" at 680:31-680:37
-8310: Comma           "," at 680:37-680:38
-8311: Ident           "target" at 680:39-680:45 (leading: Space)
-8312: Colon           ":" at 680:45-680:46
-8313: Ident           "int" at 680:47-680:50 (leading: Space)
-8314: RParen          ")" at 680:50-680:51
-8315: Arrow           "->" at 680:52-680:54 (leading: Space)
-8316: Ident           "int" at 680:55-680:58 (leading: Space)
-8317: Semicolon       ";" at 680:58-680:59
-8318: At              "@" at 681:5-681:6 (leading: Newline, Space)
-8319: Ident           "intrinsic" at 681:6-681:15
-8320: At              "@" at 681:16-681:17 (leading: Space)
-8321: Ident           "overload" at 681:17-681:25
-8322: KwFn            "fn" at 681:26-681:28 (leading: Space)
-8323: Ident           "__to" at 681:29-681:33 (leading: Space)
-8324: LParen          "(" at 681:33-681:34
-8325: Ident           "self" at 681:34-681:38
-8326: Colon           ":" at 681:38-681:39
-8327: Amp             "&" at 681:40-681:41 (leading: Space)
-8328: Ident           "string" at 681:41-681:47
-8329: Comma           "," at 681:47-681:48
-8330: Ident           "target" at 681:49-681:55 (leading: Space)
-8331: Colon           ":" at 681:55-681:56
-8332: Ident           "uint" at 681:57-681:61 (leading: Space)
-8333: RParen          ")" at 681:61-681:62
-8334: Arrow           "->" at 681:63-681:65 (leading: Space)
-8335: Ident           "uint" at 681:66-681:70 (leading: Space)
-8336: Semicolon       ";" at 681:70-681:71
-8337: At              "@" at 682:5-682:6 (leading: Newline, Space)
-8338: Ident           "intrinsic" at 682:6-682:15
-8339: At              "@" at 682:16-682:17 (leading: Space)
-8340: Ident           "overload" at 682:17-682:25
-8341: KwFn            "fn" at 682:26-682:28 (leading: Space)
-8342: Ident           "__to" at 682:29-682:33 (leading: Space)
-8343: LParen          "(" at 682:33-682:34
-8344: Ident           "self" at 682:34-682:38
-8345: Colon           ":" at 682:38-682:39
-8346: Amp             "&" at 682:40-682:41 (leading: Space)
-8347: Ident           "string" at 682:41-682:47
-8348: Comma           "," at 682:47-682:48
-8349: Ident           "target" at 682:49-682:55 (leading: Space)
-8350: Colon           ":" at 682:55-682:56
-8351: Ident           "float" at 682:57-682:62 (leading: Space)
-8352: RParen          ")" at 682:62-682:63
-8353: Arrow           "->" at 682:64-682:66 (leading: Space)
-8354: Ident           "float" at 682:67-682:72 (leading: Space)
-8355: Semicolon       ";" at 682:72-682:73
-8356: At              "@" at 683:5-683:6 (leading: Newline, Space)
-8357: Ident           "overload" at 683:6-683:14
-8358: KwPub           "pub" at 683:15-683:18 (leading: Space)
-8359: KwFn            "fn" at 683:19-683:21 (leading: Space)
-8360: Ident           "__to" at 683:22-683:26 (leading: Space)
-8361: LParen          "(" at 683:26-683:27
-8362: Ident           "self" at 683:27-683:31
-8363: Colon           ":" at 683:31-683:32
-8364: Amp             "&" at 683:33-683:34 (leading: Space)
-8365: Ident           "string" at 683:34-683:40
-8366: Comma           "," at 683:40-683:41
-8367: Underscore      "_" at 683:42-683:43 (leading: Space)
-8368: Colon           ":" at 683:43-683:44
-8369: Ident           "string" at 683:45-683:51 (leading: Space)
-8370: RParen          ")" at 683:51-683:52
-8371: Arrow           "->" at 683:53-683:55 (leading: Space)
-8372: Ident           "string" at 683:56-683:62 (leading: Space)
-8373: LBrace          "{" at 683:63-683:64 (leading: Space)
-8374: KwReturn        "return" at 684:9-684:15 (leading: Newline, Space)
-8375: Ident           "self" at 684:16-684:20 (leading: Space)
-8376: Dot             "." at 684:20-684:21
-8377: Ident           "__clone" at 684:21-684:28
-8378: LParen          "(" at 684:28-684:29
-8379: RParen          ")" at 684:29-684:30
-8380: Semicolon       ";" at 684:30-684:31
-8381: RBrace          "}" at 685:5-685:6 (leading: Newline, Space)
-8382: At              "@" at 686:5-686:6 (leading: Newline, Space)
-8383: Ident           "overload" at 686:6-686:14
-8384: KwPub           "pub" at 687:5-687:8 (leading: Newline, Space)
-8385: KwFn            "fn" at 687:9-687:11 (leading: Space)
-8386: Ident           "__to" at 687:12-687:16 (leading: Space)
-8387: LParen          "(" at 687:16-687:17
-8388: Ident           "self" at 687:17-687:21
-8389: Colon           ":" at 687:21-687:22
-8390: Amp             "&" at 687:23-687:24 (leading: Space)
-8391: Ident           "string" at 687:24-687:30
-8392: Comma           "," at 687:30-687:31
-8393: Underscore      "_" at 687:32-687:33 (leading: Space)
-8394: Colon           ":" at 687:33-687:34
-8395: Ident           "byte" at 687:35-687:39 (leading: Space)
-8396: LBracket        "[" at 687:39-687:40
-8397: RBracket        "]" at 687:40-687:41
-8398: RParen          ")" at 687:41-687:42
-8399: Arrow           "->" at 687:43-687:45 (leading: Space)
-8400: Ident           "byte" at 687:46-687:50 (leading: Space)
-8401: LBracket        "[" at 687:50-687:51
-8402: RBracket        "]" at 687:51-687:52
-8403: LBrace          "{" at 687:53-687:54 (leading: Space)
-8404: KwLet           "let" at 688:9-688:12 (leading: Newline, Space)
-8405: Ident           "view" at 688:13-688:17 (leading: Space)
-8406: Assign          "=" at 688:18-688:19 (leading: Space)
-8407: Ident           "self" at 688:20-688:24 (leading: Space)
-8408: Dot             "." at 688:24-688:25
-8409: Ident           "bytes" at 688:25-688:30
-8410: LParen          "(" at 688:30-688:31
-8411: RParen          ")" at 688:31-688:32
-8412: Semicolon       ";" at 688:32-688:33
-8413: KwLet           "let" at 689:9-689:12 (leading: Newline, Space)
-8414: Ident           "length" at 689:13-689:19 (leading: Space)
-8415: Colon           ":" at 689:19-689:20
-8416: Ident           "uint" at 689:21-689:25 (leading: Space)
-8417: Assign          "=" at 689:26-689:27 (leading: Space)
-8418: Ident           "view" at 689:28-689:32 (leading: Space)
-8419: Dot             "." at 689:32-689:33
-8420: Ident           "__len" at 689:33-689:38
-8421: LParen          "(" at 689:38-689:39
-8422: RParen          ")" at 689:39-689:40
-8423: Semicolon       ";" at 689:40-689:41
-8424: KwLet           "let" at 690:9-690:12 (leading: Newline, Space)
-8425: KwMut           "mut" at 690:13-690:16 (leading: Space)
-8426: Ident           "out" at 690:17-690:20 (leading: Space)
-8427: Colon           ":" at 690:20-690:21
-8428: Ident           "byte" at 690:22-690:26 (leading: Space)
-8429: LBracket        "[" at 690:26-690:27
-8430: RBracket        "]" at 690:27-690:28
-8431: Assign          "=" at 690:29-690:30 (leading: Space)
-8432: LBracket        "[" at 690:31-690:32 (leading: Space)
-8433: RBracket        "]" at 690:32-690:33
-8434: Semicolon       ";" at 690:33-690:34
-8435: Ident           "out" at 691:9-691:12 (leading: Newline, Space)
-8436: Dot             "." at 691:12-691:13
-8437: Ident           "reserve" at 691:13-691:20
-8438: LParen          "(" at 691:20-691:21
-8439: Ident           "length" at 691:21-691:27
-8440: RParen          ")" at 691:27-691:28
-8441: Semicolon       ";" at 691:28-691:29
-8442: KwLet           "let" at 692:9-692:12 (leading: Newline, Space)
-8443: Ident           "len_i" at 692:13-692:18 (leading: Space)
-8444: Colon           ":" at 692:18-692:19
-8445: Ident           "int" at 692:20-692:23 (leading: Space)
-8446: Assign          "=" at 692:24-692:25 (leading: Space)
-8447: Ident           "length" at 692:26-692:32 (leading: Space)
-8448: KwTo            "to" at 692:33-692:35 (leading: Space)
-8449: Ident           "int" at 692:36-692:39 (leading: Space)
-8450: Semicolon       ";" at 692:39-692:40
-8451: KwLet           "let" at 693:9-693:12 (leading: Newline, Space)
-8452: KwMut           "mut" at 693:13-693:16 (leading: Space)
-8453: Ident           "i" at 693:17-693:18 (leading: Space)
-8454: Colon           ":" at 693:18-693:19
-8455: Ident           "int" at 693:20-693:23 (leading: Space)
-8456: Assign          "=" at 693:24-693:25 (leading: Space)
-8457: IntLit          "0" at 693:26-693:27 (leading: Space)
-8458: Semicolon       ";" at 693:27-693:28
-8459: KwWhile         "while" at 694:9-694:14 (leading: Newline, Space)
-8460: Ident           "i" at 694:15-694:16 (leading: Space)
-8461: Lt              "<" at 694:17-694:18 (leading: Space)
-8462: Ident           "len_i" at 694:19-694:24 (leading: Space)
-8463: LBrace          "{" at 694:25-694:26 (leading: Space)
-8464: KwLet           "let" at 695:13-695:16 (leading: Newline, Space)
-8465: Ident           "b" at 695:17-695:18 (leading: Space)
-8466: Colon           ":" at 695:18-695:19
-8467: Ident           "byte" at 695:20-695:24 (leading: Space)
-8468: Assign          "=" at 695:25-695:26 (leading: Space)
-8469: Ident           "view" at 695:27-695:31 (leading: Space)
-8470: LBracket        "[" at 695:31-695:32
-8471: Ident           "i" at 695:32-695:33
-8472: RBracket        "]" at 695:33-695:34
-8473: Semicolon       ";" at 695:34-695:35
-8474: Ident           "out" at 696:13-696:16 (leading: Newline, Space)
-8475: Dot             "." at 696:16-696:17
-8476: Ident           "push" at 696:17-696:21
-8477: LParen          "(" at 696:21-696:22
-8478: Ident           "b" at 696:22-696:23
-8479: RParen          ")" at 696:23-696:24
-8480: Semicolon       ";" at 696:24-696:25
-8481: Ident           "i" at 697:13-697:14 (leading: Newline, Space)
-8482: Assign          "=" at 697:15-697:16 (leading: Space)
-8483: Ident           "i" at 697:17-697:18 (leading: Space)
-8484: Plus            "+" at 697:19-697:20 (leading: Space)
-8485: IntLit          "1" at 697:21-697:22 (leading: Space)
-8486: Semicolon       ";" at 697:22-697:23
-8487: RBrace          "}" at 698:9-698:10 (leading: Newline, Space)
-8488: KwReturn        "return" at 699:9-699:15 (leading: Newline, Space)
-8489: Ident           "out" at 699:16-699:19 (leading: Space)
-8490: Semicolon       ";" at 699:19-699:20
-8491: RBrace          "}" at 700:5-700:6 (leading: Newline, Space)
-8492: At              "@" at 701:5-701:6 (leading: Newline, Space)
-8493: Ident           "intrinsic" at 701:6-701:15
-8494: KwFn            "fn" at 701:16-701:18 (leading: Space)
-8495: Ident           "__len" at 701:19-701:24 (leading: Space)
-8496: LParen          "(" at 701:24-701:25
-8497: Ident           "self" at 701:25-701:29
-8498: Colon           ":" at 701:29-701:30
-8499: Amp             "&" at 701:31-701:32 (leading: Space)
-8500: Ident           "string" at 701:32-701:38
-8501: RParen          ")" at 701:38-701:39
-8502: Arrow           "->" at 701:40-701:42 (leading: Space)
-8503: Ident           "uint" at 701:43-701:47 (leading: Space)
-8504: Semicolon       ";" at 701:47-701:48
-8505: At              "@" at 702:5-702:6 (leading: Newline, Space)
-8506: Ident           "intrinsic" at 702:6-702:15
-8507: KwFn            "fn" at 702:16-702:18 (leading: Space)
-8508: Ident           "__clone" at 702:19-702:26 (leading: Space)
-8509: LParen          "(" at 702:26-702:27
-8510: Ident           "self" at 702:27-702:31
-8511: Colon           ":" at 702:31-702:32
-8512: Amp             "&" at 702:33-702:34 (leading: Space)
-8513: Ident           "string" at 702:34-702:40
-8514: RParen          ")" at 702:40-702:41
-8515: Arrow           "->" at 702:42-702:44 (leading: Space)
-8516: Ident           "string" at 702:45-702:51 (leading: Space)
-8517: Semicolon       ";" at 702:51-702:52
-8518: At              "@" at 703:5-703:6 (leading: Newline, Space)
-8519: Ident           "intrinsic" at 703:6-703:15
-8520: At              "@" at 703:16-703:17 (leading: Space)
-8521: Ident           "overload" at 703:17-703:25
-8522: KwFn            "fn" at 703:26-703:28 (leading: Space)
-8523: Ident           "__index" at 703:29-703:36 (leading: Space)
-8524: LParen          "(" at 703:36-703:37
-8525: Ident           "self" at 703:37-703:41
-8526: Colon           ":" at 703:41-703:42
-8527: Amp             "&" at 703:43-703:44 (leading: Space)
-8528: Ident           "string" at 703:44-703:50
-8529: Comma           "," at 703:50-703:51
-8530: Ident           "index" at 703:52-703:57 (leading: Space)
-8531: Colon           ":" at 703:57-703:58
-8532: Ident           "int" at 703:59-703:62 (leading: Space)
-8533: RParen          ")" at 703:62-703:63
-8534: Arrow           "->" at 703:64-703:66 (leading: Space)
-8535: Ident           "uint32" at 703:67-703:73 (leading: Space)
-8536: Semicolon       ";" at 703:73-703:74
-8537: At              "@" at 704:5-704:6 (leading: Newline, Space)
-8538: Ident           "intrinsic" at 704:6-704:15
-8539: At              "@" at 704:16-704:17 (leading: Space)
-8540: Ident           "overload" at 704:17-704:25
-8541: KwFn            "fn" at 704:26-704:28 (leading: Space)
-8542: Ident           "__index" at 704:29-704:36 (leading: Space)
-8543: LParen          "(" at 704:36-704:37
-8544: Ident           "self" at 704:37-704:41
-8545: Colon           ":" at 704:41-704:42
-8546: Amp             "&" at 704:43-704:44 (leading: Space)
-8547: Ident           "string" at 704:44-704:50
-8548: Comma           "," at 704:50-704:51
-8549: Ident           "index" at 704:52-704:57 (leading: Space)
-8550: Colon           ":" at 704:57-704:58
-8551: Ident           "Range" at 704:59-704:64 (leading: Space)
-8552: Lt              "<" at 704:64-704:65
-8553: Ident           "int" at 704:65-704:68
-8554: Gt              ">" at 704:68-704:69
-8555: RParen          ")" at 704:69-704:70
-8556: Arrow           "->" at 704:71-704:73 (leading: Space)
-8557: Ident           "string" at 704:74-704:80 (leading: Space)
-8558: Semicolon       ";" at 704:80-704:81
-8559: RBrace          "}" at 705:1-705:2 (leading: Newline)
-8560: At              "@" at 707:1-707:2 (leading: Newline)
-8561: Ident           "intrinsic" at 707:2-707:11
-8562: KwPub           "pub" at 708:1-708:4 (leading: Newline)
-8563: KwType          "type" at 708:5-708:9 (leading: Space)
-8564: Ident           "BytesView" at 708:10-708:19 (leading: Space)
-8565: Assign          "=" at 708:20-708:21 (leading: Space)
-8566: LBrace          "{" at 708:22-708:23 (leading: Space)
-8567: Ident           "owner" at 709:5-709:10 (leading: Newline, Space)
-8568: Colon           ":" at 709:10-709:11
-8569: Ident           "string" at 709:12-709:18 (leading: Space)
-8570: Comma           "," at 709:18-709:19
-8571: Ident           "ptr" at 710:5-710:8 (leading: Newline, Space)
-8572: Colon           ":" at 710:8-710:9
-8573: Star            "*" at 710:10-710:11 (leading: Space)
-8574: Ident           "byte" at 710:11-710:15
-8575: Comma           "," at 710:15-710:16
-8576: Ident           "len" at 711:5-711:8 (leading: Newline, Space)
-8577: Colon           ":" at 711:8-711:9
-8578: Ident           "uint" at 711:10-711:14 (leading: Space)
-8579: Comma           "," at 711:14-711:15
-8580: RBrace          "}" at 712:1-712:2 (leading: Newline)
-8581: Semicolon       ";" at 712:2-712:3
-8582: KwExtern        "extern" at 714:1-714:7 (leading: Newline)
-8583: Lt              "<" at 714:7-714:8
-8584: Ident           "BytesView" at 714:8-714:17
-8585: Gt              ">" at 714:17-714:18
-8586: LBrace          "{" at 714:19-714:20 (leading: Space)
-8587: At              "@" at 715:5-715:6 (leading: Newline, Space)
-8588: Ident           "intrinsic" at 715:6-715:15
-8589: KwFn            "fn" at 715:16-715:18 (leading: Space)
-8590: Ident           "__len" at 715:19-715:24 (leading: Space)
-8591: LParen          "(" at 715:24-715:25
-8592: Ident           "self" at 715:25-715:29
-8593: Colon           ":" at 715:29-715:30
-8594: Amp             "&" at 715:31-715:32 (leading: Space)
-8595: Ident           "BytesView" at 715:32-715:41
-8596: RParen          ")" at 715:41-715:42
-8597: Arrow           "->" at 715:43-715:45 (leading: Space)
-8598: Ident           "uint" at 715:46-715:50 (leading: Space)
-8599: Semicolon       ";" at 715:50-715:51
-8600: At              "@" at 716:5-716:6 (leading: Newline, Space)
-8601: Ident           "intrinsic" at 716:6-716:15
-8602: KwFn            "fn" at 716:16-716:18 (leading: Space)
-8603: Ident           "__index" at 716:19-716:26 (leading: Space)
-8604: LParen          "(" at 716:26-716:27
-8605: Ident           "self" at 716:27-716:31
-8606: Colon           ":" at 716:31-716:32
-8607: Amp             "&" at 716:33-716:34 (leading: Space)
-8608: Ident           "BytesView" at 716:34-716:43
-8609: Comma           "," at 716:43-716:44
-8610: Ident           "index" at 716:45-716:50 (leading: Space)
-8611: Colon           ":" at 716:50-716:51
-8612: Ident           "int" at 716:52-716:55 (leading: Space)
-8613: RParen          ")" at 716:55-716:56
-8614: Arrow           "->" at 716:57-716:59 (leading: Space)
-8615: Ident           "uint8" at 716:60-716:65 (leading: Space)
-8616: Semicolon       ";" at 716:65-716:66
-8617: At              "@" at 717:5-717:6 (leading: Newline, Space)
-8618: Ident           "intrinsic" at 717:6-717:15
-8619: At              "@" at 717:16-717:17 (leading: Space)
-8620: Ident           "overload" at 717:17-717:25
-8621: KwFn            "fn" at 717:26-717:28 (leading: Space)
-8622: Ident           "__index" at 717:29-717:36 (leading: Space)
-8623: LParen          "(" at 717:36-717:37
-8624: Ident           "self" at 717:37-717:41
-8625: Colon           ":" at 717:41-717:42
-8626: Amp             "&" at 717:43-717:44 (leading: Space)
-8627: Ident           "BytesView" at 717:44-717:53
-8628: Comma           "," at 717:53-717:54
-8629: Ident           "index" at 717:55-717:60 (leading: Space)
-8630: Colon           ":" at 717:60-717:61
-8631: Ident           "int64" at 717:62-717:67 (leading: Space)
-8632: RParen          ")" at 717:67-717:68
-8633: Arrow           "->" at 717:69-717:71 (leading: Space)
-8634: Ident           "uint8" at 717:72-717:77 (leading: Space)
-8635: Semicolon       ";" at 717:77-717:78
-8636: RBrace          "}" at 718:1-718:2 (leading: Newline)
-8637: KwExtern        "extern" at 720:1-720:7 (leading: Newline)
-8638: Lt              "<" at 720:7-720:8
-8639: Ident           "bool" at 720:8-720:12
-8640: Gt              ">" at 720:12-720:13
-8641: LBrace          "{" at 720:14-720:15 (leading: Space)
-8642: At              "@" at 721:5-721:6 (leading: Newline, Space)
-8643: Ident           "intrinsic" at 721:6-721:15
-8644: KwFn            "fn" at 721:16-721:18 (leading: Space)
-8645: Ident           "__eq" at 721:19-721:23 (leading: Space)
-8646: LParen          "(" at 721:23-721:24
-8647: Ident           "self" at 721:24-721:28
-8648: Colon           ":" at 721:28-721:29
-8649: Ident           "bool" at 721:30-721:34 (leading: Space)
-8650: Comma           "," at 721:34-721:35
-8651: Ident           "other" at 721:36-721:41 (leading: Space)
-8652: Colon           ":" at 721:41-721:42
-8653: Ident           "bool" at 721:43-721:47 (leading: Space)
-8654: RParen          ")" at 721:47-721:48
-8655: Arrow           "->" at 721:49-721:51 (leading: Space)
-8656: Ident           "bool" at 721:52-721:56 (leading: Space)
-8657: Semicolon       ";" at 721:56-721:57
-8658: At              "@" at 722:5-722:6 (leading: Newline, Space)
-8659: Ident           "intrinsic" at 722:6-722:15
-8660: KwFn            "fn" at 722:16-722:18 (leading: Space)
-8661: Ident           "__ne" at 722:19-722:23 (leading: Space)
-8662: LParen          "(" at 722:23-722:24
-8663: Ident           "self" at 722:24-722:28
-8664: Colon           ":" at 722:28-722:29
-8665: Ident           "bool" at 722:30-722:34 (leading: Space)
-8666: Comma           "," at 722:34-722:35
-8667: Ident           "other" at 722:36-722:41 (leading: Space)
-8668: Colon           ":" at 722:41-722:42
-8669: Ident           "bool" at 722:43-722:47 (leading: Space)
-8670: RParen          ")" at 722:47-722:48
-8671: Arrow           "->" at 722:49-722:51 (leading: Space)
-8672: Ident           "bool" at 722:52-722:56 (leading: Space)
-8673: Semicolon       ";" at 722:56-722:57
-8674: At              "@" at 723:5-723:6 (leading: Newline, Space)
-8675: Ident           "intrinsic" at 723:6-723:15
-8676: KwFn            "fn" at 723:16-723:18 (leading: Space)
-8677: Ident           "__not" at 723:19-723:24 (leading: Space)
-8678: LParen          "(" at 723:24-723:25
-8679: Ident           "self" at 723:25-723:29
-8680: Colon           ":" at 723:29-723:30
-8681: Ident           "bool" at 723:31-723:35 (leading: Space)
-8682: RParen          ")" at 723:35-723:36
-8683: Arrow           "->" at 723:37-723:39 (leading: Space)
-8684: Ident           "bool" at 723:40-723:44 (leading: Space)
-8685: Semicolon       ";" at 723:44-723:45
-8686: At              "@" at 724:5-724:6 (leading: Newline, Space)
-8687: Ident           "intrinsic" at 724:6-724:15
-8688: KwFn            "fn" at 724:16-724:18 (leading: Space)
-8689: Ident           "__to" at 724:19-724:23 (leading: Space)
-8690: LParen          "(" at 724:23-724:24
-8691: Ident           "self" at 724:24-724:28
-8692: Colon           ":" at 724:28-724:29
-8693: Ident           "bool" at 724:30-724:34 (leading: Space)
-8694: Comma           "," at 724:34-724:35
-8695: Ident           "target" at 724:36-724:42 (leading: Space)
-8696: Colon           ":" at 724:42-724:43
-8697: Ident           "string" at 724:44-724:50 (leading: Space)
-8698: RParen          ")" at 724:50-724:51
-8699: Arrow           "->" at 724:52-724:54 (leading: Space)
-8700: Ident           "string" at 724:55-724:61 (leading: Space)
-8701: Semicolon       ";" at 724:61-724:62
-8702: At              "@" at 725:5-725:6 (leading: Newline, Space)
-8703: Ident           "overload" at 725:6-725:14
-8704: KwPub           "pub" at 725:15-725:18 (leading: Space)
-8705: KwFn            "fn" at 725:19-725:21 (leading: Space)
-8706: Ident           "__to" at 725:22-725:26 (leading: Space)
-8707: LParen          "(" at 725:26-725:27
-8708: Ident           "self" at 725:27-725:31
-8709: Colon           ":" at 725:31-725:32
-8710: Amp             "&" at 725:33-725:34 (leading: Space)
-8711: Ident           "bool" at 725:34-725:38
-8712: Comma           "," at 725:38-725:39
-8713: Underscore      "_" at 725:40-725:41 (leading: Space)
-8714: Colon           ":" at 725:41-725:42
-8715: Ident           "string" at 725:43-725:49 (leading: Space)
-8716: RParen          ")" at 725:49-725:50
-8717: Arrow           "->" at 725:51-725:53 (leading: Space)
-8718: Ident           "string" at 725:54-725:60 (leading: Space)
-8719: LBrace          "{" at 725:61-725:62 (leading: Space)
-8720: KwReturn        "return" at 726:9-726:15 (leading: Newline, Space)
-8721: LParen          "(" at 726:16-726:17 (leading: Space)
-8722: Star            "*" at 726:17-726:18
-8723: Ident           "self" at 726:18-726:22
-8724: RParen          ")" at 726:22-726:23
-8725: KwTo            "to" at 726:24-726:26 (leading: Space)
-8726: Ident           "string" at 726:27-726:33 (leading: Space)
-8727: Semicolon       ";" at 726:33-726:34
-8728: RBrace          "}" at 727:5-727:6 (leading: Newline, Space)
-8729: At              "@" at 728:5-728:6 (leading: Newline, Space)
-8730: Ident           "intrinsic" at 728:6-728:15
-8731: At              "@" at 728:16-728:17 (leading: Space)
-8732: Ident           "overload" at 728:17-728:25
-8733: KwFn            "fn" at 728:26-728:28 (leading: Space)
-8734: Ident           "__to" at 728:29-728:33 (leading: Space)
-8735: LParen          "(" at 728:33-728:34
-8736: Ident           "self" at 728:34-728:38
-8737: Colon           ":" at 728:38-728:39
-8738: Ident           "bool" at 728:40-728:44 (leading: Space)
-8739: Comma           "," at 728:44-728:45
-8740: Ident           "target" at 728:46-728:52 (leading: Space)
-8741: Colon           ":" at 728:52-728:53
-8742: Ident           "int" at 728:54-728:57 (leading: Space)
-8743: RParen          ")" at 728:57-728:58
-8744: Arrow           "->" at 728:59-728:61 (leading: Space)
-8745: Ident           "int" at 728:62-728:65 (leading: Space)
-8746: Semicolon       ";" at 728:65-728:66
-8747: At              "@" at 730:5-730:6 (leading: Newline, Space, LineComment, Newline, Space)
-8748: Ident           "intrinsic" at 730:6-730:15
-8749: KwPub           "pub" at 730:16-730:19 (leading: Space)
-8750: KwFn            "fn" at 730:20-730:22 (leading: Space)
-8751: Ident           "from_str" at 730:23-730:31 (leading: Space)
-8752: LParen          "(" at 730:31-730:32
-8753: Ident           "s" at 730:32-730:33
-8754: Colon           ":" at 730:33-730:34
-8755: Amp             "&" at 730:35-730:36 (leading: Space)
-8756: Ident           "string" at 730:36-730:42
-8757: RParen          ")" at 730:42-730:43
-8758: Arrow           "->" at 730:44-730:46 (leading: Space)
-8759: Ident           "Erring" at 730:47-730:53 (leading: Space)
-8760: Lt              "<" at 730:53-730:54
-8761: Ident           "bool" at 730:54-730:58
-8762: Comma           "," at 730:58-730:59
-8763: Ident           "Error" at 730:60-730:65 (leading: Space)
-8764: Gt              ">" at 730:65-730:66
-8765: Semicolon       ";" at 730:66-730:67
-8766: RBrace          "}" at 731:1-731:2 (leading: Newline)
-8767: KwExtern        "extern" at 733:1-733:7 (leading: Newline)
-8768: Lt              "<" at 733:7-733:8
-8769: Ident           "Array" at 733:8-733:13
-8770: Lt              "<" at 733:13-733:14
-8771: Ident           "T" at 733:14-733:15
-8772: Shr             ">>" at 733:15-733:17
-8773: LBrace          "{" at 733:18-733:19 (leading: Space)
-8774: At              "@" at 734:5-734:6 (leading: Newline, Space)
-8775: Ident           "intrinsic" at 734:6-734:15
-8776: KwFn            "fn" at 734:16-734:18 (leading: Space)
-8777: Ident           "__add" at 734:19-734:24 (leading: Space)
-8778: LParen          "(" at 734:24-734:25
-8779: Ident           "self" at 734:25-734:29
-8780: Colon           ":" at 734:29-734:30
-8781: Amp             "&" at 734:31-734:32 (leading: Space)
-8782: Ident           "Array" at 734:32-734:37
-8783: Lt              "<" at 734:37-734:38
-8784: Ident           "T" at 734:38-734:39
-8785: Gt              ">" at 734:39-734:40
-8786: Comma           "," at 734:40-734:41
-8787: Ident           "other" at 734:42-734:47 (leading: Space)
-8788: Colon           ":" at 734:47-734:48
-8789: Amp             "&" at 734:49-734:50 (leading: Space)
-8790: Ident           "Array" at 734:50-734:55
-8791: Lt              "<" at 734:55-734:56
-8792: Ident           "T" at 734:56-734:57
-8793: Gt              ">" at 734:57-734:58
-8794: RParen          ")" at 734:58-734:59
-8795: Arrow           "->" at 734:60-734:62 (leading: Space)
-8796: Ident           "Array" at 734:63-734:68 (leading: Space)
-8797: Lt              "<" at 734:68-734:69
-8798: Ident           "T" at 734:69-734:70
-8799: Gt              ">" at 734:70-734:71
-8800: Semicolon       ";" at 734:71-734:72
-8801: At              "@" at 735:5-735:6 (leading: Newline, Space)
-8802: Ident           "intrinsic" at 735:6-735:15
-8803: KwFn            "fn" at 735:16-735:18 (leading: Space)
-8804: Ident           "__index" at 735:19-735:26 (leading: Space)
-8805: LParen          "(" at 735:26-735:27
-8806: Ident           "self" at 735:27-735:31
-8807: Colon           ":" at 735:31-735:32
-8808: Amp             "&" at 735:33-735:34 (leading: Space)
-8809: Ident           "Array" at 735:34-735:39
-8810: Lt              "<" at 735:39-735:40
-8811: Ident           "T" at 735:40-735:41
-8812: Gt              ">" at 735:41-735:42
-8813: Comma           "," at 735:42-735:43
-8814: Ident           "index" at 735:44-735:49 (leading: Space)
-8815: Colon           ":" at 735:49-735:50
-8816: Ident           "int" at 735:51-735:54 (leading: Space)
-8817: RParen          ")" at 735:54-735:55
-8818: Arrow           "->" at 735:56-735:58 (leading: Space)
-8819: Amp             "&" at 735:59-735:60 (leading: Space)
-8820: Ident           "T" at 735:60-735:61
-8821: Semicolon       ";" at 735:61-735:62
-8822: At              "@" at 736:5-736:6 (leading: Newline, Space)
-8823: Ident           "intrinsic" at 736:6-736:15
-8824: At              "@" at 736:16-736:17 (leading: Space)
-8825: Ident           "overload" at 736:17-736:25
-8826: KwFn            "fn" at 736:26-736:28 (leading: Space)
-8827: Ident           "__index" at 736:29-736:36 (leading: Space)
-8828: LParen          "(" at 736:36-736:37
-8829: Ident           "self" at 736:37-736:41
-8830: Colon           ":" at 736:41-736:42
-8831: Amp             "&" at 736:43-736:44 (leading: Space)
-8832: Ident           "Array" at 736:44-736:49
-8833: Lt              "<" at 736:49-736:50
-8834: Ident           "T" at 736:50-736:51
-8835: Gt              ">" at 736:51-736:52
-8836: Comma           "," at 736:52-736:53
-8837: Ident           "index" at 736:54-736:59 (leading: Space)
-8838: Colon           ":" at 736:59-736:60
-8839: Ident           "Range" at 736:61-736:66 (leading: Space)
-8840: Lt              "<" at 736:66-736:67
-8841: Ident           "int" at 736:67-736:70
-8842: Gt              ">" at 736:70-736:71
-8843: RParen          ")" at 736:71-736:72
-8844: Arrow           "->" at 736:73-736:75 (leading: Space)
-8845: Ident           "Array" at 736:76-736:81 (leading: Space)
-8846: Lt              "<" at 736:81-736:82
-8847: Ident           "T" at 736:82-736:83
-8848: Gt              ">" at 736:83-736:84
-8849: Semicolon       ";" at 736:84-736:85
-8850: At              "@" at 737:5-737:6 (leading: Newline, Space)
-8851: Ident           "intrinsic" at 737:6-737:15
-8852: KwFn            "fn" at 737:16-737:18 (leading: Space)
-8853: Ident           "__index_set" at 737:19-737:30 (leading: Space)
-8854: LParen          "(" at 737:30-737:31
-8855: Ident           "self" at 737:31-737:35
-8856: Colon           ":" at 737:35-737:36
-8857: Amp             "&" at 737:37-737:38 (leading: Space)
-8858: KwMut           "mut" at 737:38-737:41
-8859: Ident           "Array" at 737:42-737:47 (leading: Space)
-8860: Lt              "<" at 737:47-737:48
-8861: Ident           "T" at 737:48-737:49
-8862: Gt              ">" at 737:49-737:50
-8863: Comma           "," at 737:50-737:51
-8864: Ident           "index" at 737:52-737:57 (leading: Space)
-8865: Colon           ":" at 737:57-737:58
-8866: Ident           "int" at 737:59-737:62 (leading: Space)
-8867: Comma           "," at 737:62-737:63
-8868: Ident           "value" at 737:64-737:69 (leading: Space)
-8869: Colon           ":" at 737:69-737:70
-8870: Ident           "T" at 737:71-737:72 (leading: Space)
-8871: RParen          ")" at 737:72-737:73
-8872: Arrow           "->" at 737:74-737:76 (leading: Space)
-8873: NothingLit      "nothing" at 737:77-737:84 (leading: Space)
-8874: Semicolon       ";" at 737:84-737:85
-8875: At              "@" at 738:5-738:6 (leading: Newline, Space)
-8876: Ident           "intrinsic" at 738:6-738:15
-8877: KwFn            "fn" at 738:16-738:18 (leading: Space)
-8878: Ident           "__range" at 738:19-738:26 (leading: Space)
-8879: LParen          "(" at 738:26-738:27
-8880: Ident           "self" at 738:27-738:31
-8881: Colon           ":" at 738:31-738:32
-8882: Amp             "&" at 738:33-738:34 (leading: Space)
-8883: Ident           "Array" at 738:34-738:39
-8884: Lt              "<" at 738:39-738:40
-8885: Ident           "T" at 738:40-738:41
-8886: Gt              ">" at 738:41-738:42
-8887: RParen          ")" at 738:42-738:43
-8888: Arrow           "->" at 738:44-738:46 (leading: Space)
-8889: Ident           "Range" at 738:47-738:52 (leading: Space)
-8890: Lt              "<" at 738:52-738:53
-8891: Ident           "T" at 738:53-738:54
-8892: Gt              ">" at 738:54-738:55
-8893: Semicolon       ";" at 738:55-738:56
-8894: At              "@" at 739:5-739:6 (leading: Newline, Space)
-8895: Ident           "intrinsic" at 739:6-739:15
-8896: KwFn            "fn" at 739:16-739:18 (leading: Space)
-8897: Ident           "__len" at 739:19-739:24 (leading: Space)
-8898: LParen          "(" at 739:24-739:25
-8899: Ident           "self" at 739:25-739:29
-8900: Colon           ":" at 739:29-739:30
-8901: Amp             "&" at 739:31-739:32 (leading: Space)
-8902: Ident           "Array" at 739:32-739:37
-8903: Lt              "<" at 739:37-739:38
-8904: Ident           "T" at 739:38-739:39
-8905: Gt              ">" at 739:39-739:40
-8906: RParen          ")" at 739:40-739:41
-8907: Arrow           "->" at 739:42-739:44 (leading: Space)
-8908: Ident           "uint" at 739:45-739:49 (leading: Space)
-8909: Semicolon       ";" at 739:49-739:50
-8910: RBrace          "}" at 740:1-740:2 (leading: Newline)
-8911: KwExtern        "extern" at 742:1-742:7 (leading: Newline)
-8912: Lt              "<" at 742:7-742:8
-8913: Ident           "ArrayFixed" at 742:8-742:18
-8914: Lt              "<" at 742:18-742:19
-8915: Ident           "T" at 742:19-742:20
-8916: Comma           "," at 742:20-742:21
-8917: Ident           "N" at 742:22-742:23 (leading: Space)
-8918: Shr             ">>" at 742:23-742:25
-8919: LBrace          "{" at 742:26-742:27 (leading: Space)
-8920: At              "@" at 743:5-743:6 (leading: Newline, Space)
-8921: Ident           "intrinsic" at 743:6-743:15
-8922: KwFn            "fn" at 743:16-743:18 (leading: Space)
-8923: Ident           "__add" at 743:19-743:24 (leading: Space)
-8924: LParen          "(" at 743:24-743:25
-8925: Ident           "self" at 743:25-743:29
-8926: Colon           ":" at 743:29-743:30
-8927: Amp             "&" at 743:31-743:32 (leading: Space)
-8928: Ident           "ArrayFixed" at 743:32-743:42
-8929: Lt              "<" at 743:42-743:43
-8930: Ident           "T" at 743:43-743:44
-8931: Comma           "," at 743:44-743:45
-8932: Ident           "N" at 743:46-743:47 (leading: Space)
-8933: Gt              ">" at 743:47-743:48
-8934: Comma           "," at 743:48-743:49
-8935: Ident           "other" at 743:50-743:55 (leading: Space)
-8936: Colon           ":" at 743:55-743:56
-8937: Amp             "&" at 743:57-743:58 (leading: Space)
-8938: Ident           "ArrayFixed" at 743:58-743:68
-8939: Lt              "<" at 743:68-743:69
-8940: Ident           "T" at 743:69-743:70
-8941: Comma           "," at 743:70-743:71
-8942: Ident           "N" at 743:72-743:73 (leading: Space)
-8943: Gt              ">" at 743:73-743:74
-8944: RParen          ")" at 743:74-743:75
-8945: Arrow           "->" at 743:76-743:78 (leading: Space)
-8946: Ident           "ArrayFixed" at 743:79-743:89 (leading: Space)
-8947: Lt              "<" at 743:89-743:90
-8948: Ident           "T" at 743:90-743:91
-8949: Comma           "," at 743:91-743:92
-8950: Ident           "N" at 743:93-743:94 (leading: Space)
-8951: Gt              ">" at 743:94-743:95
-8952: Semicolon       ";" at 743:95-743:96
-8953: At              "@" at 744:5-744:6 (leading: Newline, Space)
-8954: Ident           "intrinsic" at 744:6-744:15
-8955: KwFn            "fn" at 744:16-744:18 (leading: Space)
-8956: Ident           "__index" at 744:19-744:26 (leading: Space)
-8957: LParen          "(" at 744:26-744:27
-8958: Ident           "self" at 744:27-744:31
-8959: Colon           ":" at 744:31-744:32
-8960: Amp             "&" at 744:33-744:34 (leading: Space)
-8961: Ident           "ArrayFixed" at 744:34-744:44
-8962: Lt              "<" at 744:44-744:45
-8963: Ident           "T" at 744:45-744:46
-8964: Comma           "," at 744:46-744:47
-8965: Ident           "N" at 744:48-744:49 (leading: Space)
-8966: Gt              ">" at 744:49-744:50
-8967: Comma           "," at 744:50-744:51
-8968: Ident           "index" at 744:52-744:57 (leading: Space)
-8969: Colon           ":" at 744:57-744:58
-8970: Ident           "int" at 744:59-744:62 (leading: Space)
-8971: RParen          ")" at 744:62-744:63
-8972: Arrow           "->" at 744:64-744:66 (leading: Space)
-8973: Amp             "&" at 744:67-744:68 (leading: Space)
-8974: Ident           "T" at 744:68-744:69
-8975: Semicolon       ";" at 744:69-744:70
-8976: At              "@" at 745:5-745:6 (leading: Newline, Space)
-8977: Ident           "intrinsic" at 745:6-745:15
-8978: At              "@" at 745:16-745:17 (leading: Space)
-8979: Ident           "overload" at 745:17-745:25
-8980: KwFn            "fn" at 745:26-745:28 (leading: Space)
-8981: Ident           "__index" at 745:29-745:36 (leading: Space)
-8982: LParen          "(" at 745:36-745:37
-8983: Ident           "self" at 745:37-745:41
-8984: Colon           ":" at 745:41-745:42
-8985: Amp             "&" at 745:43-745:44 (leading: Space)
-8986: Ident           "ArrayFixed" at 745:44-745:54
-8987: Lt              "<" at 745:54-745:55
-8988: Ident           "T" at 745:55-745:56
-8989: Comma           "," at 745:56-745:57
-8990: Ident           "N" at 745:58-745:59 (leading: Space)
-8991: Gt              ">" at 745:59-745:60
-8992: Comma           "," at 745:60-745:61
-8993: Ident           "index" at 745:62-745:67 (leading: Space)
-8994: Colon           ":" at 745:67-745:68
-8995: Ident           "Range" at 745:69-745:74 (leading: Space)
-8996: Lt              "<" at 745:74-745:75
-8997: Ident           "int" at 745:75-745:78
-8998: Gt              ">" at 745:78-745:79
-8999: RParen          ")" at 745:79-745:80
-9000: Arrow           "->" at 745:81-745:83 (leading: Space)
-9001: Ident           "Array" at 745:84-745:89 (leading: Space)
-9002: Lt              "<" at 745:89-745:90
-9003: Ident           "T" at 745:90-745:91
-9004: Gt              ">" at 745:91-745:92
-9005: Semicolon       ";" at 745:92-745:93
-9006: At              "@" at 746:5-746:6 (leading: Newline, Space)
-9007: Ident           "intrinsic" at 746:6-746:15
-9008: KwFn            "fn" at 746:16-746:18 (leading: Space)
-9009: Ident           "__index_set" at 746:19-746:30 (leading: Space)
-9010: LParen          "(" at 746:30-746:31
-9011: Ident           "self" at 746:31-746:35
-9012: Colon           ":" at 746:35-746:36
-9013: Amp             "&" at 746:37-746:38 (leading: Space)
-9014: KwMut           "mut" at 746:38-746:41
-9015: Ident           "ArrayFixed" at 746:42-746:52 (leading: Space)
-9016: Lt              "<" at 746:52-746:53
-9017: Ident           "T" at 746:53-746:54
-9018: Comma           "," at 746:54-746:55
-9019: Ident           "N" at 746:56-746:57 (leading: Space)
-9020: Gt              ">" at 746:57-746:58
-9021: Comma           "," at 746:58-746:59
-9022: Ident           "index" at 746:60-746:65 (leading: Space)
-9023: Colon           ":" at 746:65-746:66
-9024: Ident           "int" at 746:67-746:70 (leading: Space)
-9025: Comma           "," at 746:70-746:71
-9026: Ident           "value" at 746:72-746:77 (leading: Space)
-9027: Colon           ":" at 746:77-746:78
-9028: Ident           "T" at 746:79-746:80 (leading: Space)
-9029: RParen          ")" at 746:80-746:81
-9030: Arrow           "->" at 746:82-746:84 (leading: Space)
-9031: NothingLit      "nothing" at 746:85-746:92 (leading: Space)
-9032: Semicolon       ";" at 746:92-746:93
-9033: At              "@" at 747:5-747:6 (leading: Newline, Space)
-9034: Ident           "intrinsic" at 747:6-747:15
-9035: KwFn            "fn" at 747:16-747:18 (leading: Space)
-9036: Ident           "__range" at 747:19-747:26 (leading: Space)
-9037: LParen          "(" at 747:26-747:27
-9038: Ident           "self" at 747:27-747:31
-9039: Colon           ":" at 747:31-747:32
-9040: Amp             "&" at 747:33-747:34 (leading: Space)
-9041: Ident           "ArrayFixed" at 747:34-747:44
-9042: Lt              "<" at 747:44-747:45
-9043: Ident           "T" at 747:45-747:46
-9044: Comma           "," at 747:46-747:47
-9045: Ident           "N" at 747:48-747:49 (leading: Space)
-9046: Gt              ">" at 747:49-747:50
-9047: RParen          ")" at 747:50-747:51
-9048: Arrow           "->" at 747:52-747:54 (leading: Space)
-9049: Ident           "Range" at 747:55-747:60 (leading: Space)
-9050: Lt              "<" at 747:60-747:61
-9051: Ident           "T" at 747:61-747:62
-9052: Gt              ">" at 747:62-747:63
-9053: Semicolon       ";" at 747:63-747:64
-9054: At              "@" at 748:5-748:6 (leading: Newline, Space)
-9055: Ident           "intrinsic" at 748:6-748:15
-9056: KwFn            "fn" at 748:16-748:18 (leading: Space)
-9057: Ident           "__len" at 748:19-748:24 (leading: Space)
-9058: LParen          "(" at 748:24-748:25
-9059: Ident           "self" at 748:25-748:29
-9060: Colon           ":" at 748:29-748:30
-9061: Amp             "&" at 748:31-748:32 (leading: Space)
-9062: Ident           "ArrayFixed" at 748:32-748:42
-9063: Lt              "<" at 748:42-748:43
-9064: Ident           "T" at 748:43-748:44
-9065: Comma           "," at 748:44-748:45
-9066: Ident           "N" at 748:46-748:47 (leading: Space)
-9067: Gt              ">" at 748:47-748:48
-9068: RParen          ")" at 748:48-748:49
-9069: Arrow           "->" at 748:50-748:52 (leading: Space)
-9070: Ident           "uint" at 748:53-748:57 (leading: Space)
-9071: Semicolon       ";" at 748:57-748:58
-9072: RBrace          "}" at 749:1-749:2 (leading: Newline)
-9073: At              "@" at 751:1-751:2 (leading: Newline)
-9074: Ident           "intrinsic" at 751:2-751:11
-9075: KwPub           "pub" at 752:1-752:4 (leading: Newline)
-9076: KwFn            "fn" at 752:5-752:7 (leading: Space)
-9077: Ident           "default" at 752:8-752:15 (leading: Space)
-9078: Lt              "<" at 752:15-752:16
-9079: Ident           "T" at 752:16-752:17
-9080: Gt              ">" at 752:17-752:18
-9081: LParen          "(" at 752:18-752:19
-9082: RParen          ")" at 752:19-752:20
-9083: Arrow           "->" at 752:21-752:23 (leading: Space)
-9084: Ident           "T" at 752:24-752:25 (leading: Space)
-9085: Semicolon       ";" at 752:25-752:26
-9086: At              "@" at 754:1-754:2 (leading: Newline)
-9087: Ident           "intrinsic" at 754:2-754:11
-9088: KwPub           "pub" at 755:1-755:4 (leading: Newline)
-9089: KwFn            "fn" at 755:5-755:7 (leading: Space)
-9090: Ident           "size_of" at 755:8-755:15 (leading: Space)
-9091: Lt              "<" at 755:15-755:16
-9092: Ident           "T" at 755:16-755:17
-9093: Gt              ">" at 755:17-755:18
-9094: LParen          "(" at 755:18-755:19
-9095: RParen          ")" at 755:19-755:20
-9096: Arrow           "->" at 755:21-755:23 (leading: Space)
-9097: Ident           "uint" at 755:24-755:28 (leading: Space)
-9098: Semicolon       ";" at 755:28-755:29
-9099: At              "@" at 757:1-757:2 (leading: Newline)
-9100: Ident           "intrinsic" at 757:2-757:11
-9101: KwPub           "pub" at 758:1-758:4 (leading: Newline)
-9102: KwFn            "fn" at 758:5-758:7 (leading: Space)
-9103: Ident           "align_of" at 758:8-758:16 (leading: Space)
-9104: Lt              "<" at 758:16-758:17
-9105: Ident           "T" at 758:17-758:18
-9106: Gt              ">" at 758:18-758:19
-9107: LParen          "(" at 758:19-758:20
-9108: RParen          ")" at 758:20-758:21
-9109: Arrow           "->" at 758:22-758:24 (leading: Space)
-9110: Ident           "uint" at 758:25-758:29 (leading: Space)
-9111: Semicolon       ";" at 758:29-758:30
-9112: KwPub           "pub" at 760:1-760:4 (leading: Newline)
-9113: KwContract      "contract" at 760:5-760:13 (leading: Space)
-9114: Ident           "ErrorLike" at 760:14-760:23 (leading: Space)
-9115: LBrace          "{" at 760:23-760:24
-9116: KwField         "field" at 761:5-761:10 (leading: Newline, Space)
-9117: Ident           "message" at 761:11-761:18 (leading: Space)
-9118: Colon           ":" at 761:18-761:19
-9119: Ident           "string" at 761:20-761:26 (leading: Space)
-9120: Semicolon       ";" at 761:26-761:27
-9121: KwField         "field" at 762:5-762:10 (leading: Newline, Space)
-9122: Ident           "code" at 762:11-762:15 (leading: Space)
-9123: Colon           ":" at 762:15-762:16
-9124: Ident           "uint" at 762:17-762:21 (leading: Space)
-9125: Semicolon       ";" at 762:21-762:22
-9126: RBrace          "}" at 763:1-763:2 (leading: Newline)
-9127: At              "@" at 765:1-765:2 (leading: Newline)
-9128: Ident           "intrinsic" at 765:2-765:11
-9129: KwPub           "pub" at 766:1-766:4 (leading: Newline)
-9130: KwFn            "fn" at 766:5-766:7 (leading: Space)
-9131: Ident           "exit" at 766:8-766:12 (leading: Space)
-9132: Lt              "<" at 766:12-766:13
-9133: Ident           "E" at 766:13-766:14
-9134: Colon           ":" at 766:14-766:15
-9135: Ident           "ErrorLike" at 766:16-766:25 (leading: Space)
-9136: Gt              ">" at 766:25-766:26
-9137: LParen          "(" at 766:26-766:27
-9138: Ident           "e" at 766:27-766:28
-9139: Colon           ":" at 766:28-766:29
-9140: Ident           "E" at 766:30-766:31 (leading: Space)
-9141: RParen          ")" at 766:31-766:32
-9142: Arrow           "->" at 766:33-766:35 (leading: Space)
-9143: NothingLit      "nothing" at 766:36-766:43 (leading: Space)
-9144: Semicolon       ";" at 766:43-766:44
-9145: At              "@" at 768:1-768:2 (leading: Newline)
-9146: Ident           "intrinsic" at 768:2-768:11
-9147: KwPub           "pub" at 769:1-769:4 (leading: Newline)
-9148: KwFn            "fn" at 769:5-769:7 (leading: Space)
-9149: Ident           "rt_panic" at 769:8-769:16 (leading: Space)
-9150: LParen          "(" at 769:16-769:17
-9151: Ident           "ptr" at 769:17-769:20
-9152: Colon           ":" at 769:20-769:21
-9153: Star            "*" at 769:22-769:23 (leading: Space)
-9154: Ident           "byte" at 769:23-769:27
-9155: Comma           "," at 769:27-769:28
-9156: Ident           "length" at 769:29-769:35 (leading: Space)
-9157: Colon           ":" at 769:35-769:36
-9158: Ident           "uint" at 769:37-769:41 (leading: Space)
-9159: RParen          ")" at 769:41-769:42
-9160: Arrow           "->" at 769:43-769:45 (leading: Space)
-9161: NothingLit      "nothing" at 769:46-769:53 (leading: Space)
-9162: Semicolon       ";" at 769:53-769:54
-9163: KwPub           "pub" at 771:1-771:4 (leading: Newline)
-9164: KwFn            "fn" at 771:5-771:7 (leading: Space)
-9165: Ident           "panic" at 771:8-771:13 (leading: Space)
-9166: LParen          "(" at 771:13-771:14
-9167: Ident           "msg" at 771:14-771:17
-9168: Colon           ":" at 771:17-771:18
-9169: Ident           "string" at 771:19-771:25 (leading: Space)
-9170: RParen          ")" at 771:25-771:26
-9171: Arrow           "->" at 771:27-771:29 (leading: Space)
-9172: NothingLit      "nothing" at 771:30-771:37 (leading: Space)
-9173: LBrace          "{" at 771:38-771:39 (leading: Space)
-9174: KwLet           "let" at 772:5-772:8 (leading: Newline, Space)
-9175: Ident           "ptr" at 772:9-772:12 (leading: Space)
-9176: Assign          "=" at 772:13-772:14 (leading: Space)
-9177: Ident           "rt_string_ptr" at 772:15-772:28 (leading: Space)
-9178: LParen          "(" at 772:28-772:29
-9179: Amp             "&" at 772:29-772:30
-9180: Ident           "msg" at 772:30-772:33
-9181: RParen          ")" at 772:33-772:34
-9182: Semicolon       ";" at 772:34-772:35
-9183: KwLet           "let" at 773:5-773:8 (leading: Newline, Space)
-9184: Ident           "length" at 773:9-773:15 (leading: Space)
-9185: Assign          "=" at 773:16-773:17 (leading: Space)
-9186: Ident           "rt_string_len_bytes" at 773:18-773:37 (leading: Space)
-9187: LParen          "(" at 773:37-773:38
-9188: Amp             "&" at 773:38-773:39
-9189: Ident           "msg" at 773:39-773:42
-9190: RParen          ")" at 773:42-773:43
-9191: Semicolon       ";" at 773:43-773:44
-9192: Ident           "rt_panic" at 774:5-774:13 (leading: Newline, Space)
-9193: LParen          "(" at 774:13-774:14
-9194: Ident           "ptr" at 774:14-774:17
-9195: Comma           "," at 774:17-774:18
-9196: Ident           "length" at 774:19-774:25 (leading: Space)
-9197: RParen          ")" at 774:25-774:26
-9198: Semicolon       ";" at 774:26-774:27
-9199: RBrace          "}" at 775:1-775:2 (leading: Newline)
-9200: At              "@" at 777:1-777:2 (leading: Newline)
-9201: Ident           "intrinsic" at 777:2-777:11
-9202: KwPub           "pub" at 778:1-778:4 (leading: Newline)
-9203: KwType          "type" at 778:5-778:9 (leading: Space)
-9204: Ident           "RwLock" at 778:10-778:16 (leading: Space)
-9205: Assign          "=" at 778:17-778:18 (leading: Space)
-9206: LBrace          "{" at 778:19-778:20 (leading: Space)
-9207: Ident           "__opaque" at 779:5-779:13 (leading: Newline, Space)
-9208: Colon           ":" at 779:13-779:14
-9209: Star            "*" at 779:15-779:16 (leading: Space)
-9210: Ident           "byte" at 779:16-779:20
-9211: Comma           "," at 779:20-779:21
-9212: RBrace          "}" at 780:1-780:2 (leading: Newline)
-9213: Semicolon       ";" at 780:2-780:3
-9214: KwExtern        "extern" at 782:1-782:7 (leading: Newline)
-9215: Lt              "<" at 782:7-782:8
-9216: Ident           "RwLock" at 782:8-782:14
-9217: Gt              ">" at 782:14-782:15
-9218: LBrace          "{" at 782:16-782:17 (leading: Space)
-9219: At              "@" at 783:5-783:6 (leading: Newline, Space)
-9220: Ident           "intrinsic" at 783:6-783:15
-9221: KwPub           "pub" at 783:16-783:19 (leading: Space)
-9222: KwFn            "fn" at 783:20-783:22 (leading: Space)
-9223: Ident           "new" at 783:23-783:26 (leading: Space)
-9224: LParen          "(" at 783:26-783:27
-9225: RParen          ")" at 783:27-783:28
-9226: Arrow           "->" at 783:29-783:31 (leading: Space)
-9227: Ident           "RwLock" at 783:32-783:38 (leading: Space)
-9228: Semicolon       ";" at 783:38-783:39
-9229: At              "@" at 784:5-784:6 (leading: Newline, Space)
-9230: Ident           "intrinsic" at 784:6-784:15
-9231: KwPub           "pub" at 784:16-784:19 (leading: Space)
-9232: KwFn            "fn" at 784:20-784:22 (leading: Space)
-9233: Ident           "read_lock" at 784:23-784:32 (leading: Space)
-9234: LParen          "(" at 784:32-784:33
-9235: Ident           "self" at 784:33-784:37
-9236: Colon           ":" at 784:37-784:38
-9237: Amp             "&" at 784:39-784:40 (leading: Space)
-9238: KwMut           "mut" at 784:40-784:43
-9239: Ident           "RwLock" at 784:44-784:50 (leading: Space)
-9240: RParen          ")" at 784:50-784:51
-9241: Arrow           "->" at 784:52-784:54 (leading: Space)
-9242: NothingLit      "nothing" at 784:55-784:62 (leading: Space)
-9243: Semicolon       ";" at 784:62-784:63
-9244: At              "@" at 785:5-785:6 (leading: Newline, Space)
-9245: Ident           "intrinsic" at 785:6-785:15
-9246: KwPub           "pub" at 785:16-785:19 (leading: Space)
-9247: KwFn            "fn" at 785:20-785:22 (leading: Space)
-9248: Ident           "read_unlock" at 785:23-785:34 (leading: Space)
-9249: LParen          "(" at 785:34-785:35
-9250: Ident           "self" at 785:35-785:39
-9251: Colon           ":" at 785:39-785:40
-9252: Amp             "&" at 785:41-785:42 (leading: Space)
-9253: KwMut           "mut" at 785:42-785:45
-9254: Ident           "RwLock" at 785:46-785:52 (leading: Space)
-9255: RParen          ")" at 785:52-785:53
-9256: Arrow           "->" at 785:54-785:56 (leading: Space)
-9257: NothingLit      "nothing" at 785:57-785:64 (leading: Space)
-9258: Semicolon       ";" at 785:64-785:65
-9259: At              "@" at 786:5-786:6 (leading: Newline, Space)
-9260: Ident           "intrinsic" at 786:6-786:15
-9261: KwPub           "pub" at 786:16-786:19 (leading: Space)
-9262: KwFn            "fn" at 786:20-786:22 (leading: Space)
-9263: Ident           "write_lock" at 786:23-786:33 (leading: Space)
-9264: LParen          "(" at 786:33-786:34
-9265: Ident           "self" at 786:34-786:38
-9266: Colon           ":" at 786:38-786:39
-9267: Amp             "&" at 786:40-786:41 (leading: Space)
-9268: KwMut           "mut" at 786:41-786:44
-9269: Ident           "RwLock" at 786:45-786:51 (leading: Space)
-9270: RParen          ")" at 786:51-786:52
-9271: Arrow           "->" at 786:53-786:55 (leading: Space)
-9272: NothingLit      "nothing" at 786:56-786:63 (leading: Space)
-9273: Semicolon       ";" at 786:63-786:64
-9274: At              "@" at 787:5-787:6 (leading: Newline, Space)
-9275: Ident           "intrinsic" at 787:6-787:15
-9276: KwPub           "pub" at 787:16-787:19 (leading: Space)
-9277: KwFn            "fn" at 787:20-787:22 (leading: Space)
-9278: Ident           "write_unlock" at 787:23-787:35 (leading: Space)
-9279: LParen          "(" at 787:35-787:36
-9280: Ident           "self" at 787:36-787:40
-9281: Colon           ":" at 787:40-787:41
-9282: Amp             "&" at 787:42-787:43 (leading: Space)
-9283: KwMut           "mut" at 787:43-787:46
-9284: Ident           "RwLock" at 787:47-787:53 (leading: Space)
-9285: RParen          ")" at 787:53-787:54
-9286: Arrow           "->" at 787:55-787:57 (leading: Space)
-9287: NothingLit      "nothing" at 787:58-787:65 (leading: Space)
-9288: Semicolon       ";" at 787:65-787:66
-9289: At              "@" at 788:5-788:6 (leading: Newline, Space)
-9290: Ident           "intrinsic" at 788:6-788:15
-9291: KwPub           "pub" at 788:16-788:19 (leading: Space)
-9292: KwFn            "fn" at 788:20-788:22 (leading: Space)
-9293: Ident           "try_read_lock" at 788:23-788:36 (leading: Space)
-9294: LParen          "(" at 788:36-788:37
-9295: Ident           "self" at 788:37-788:41
-9296: Colon           ":" at 788:41-788:42
-9297: Amp             "&" at 788:43-788:44 (leading: Space)
-9298: KwMut           "mut" at 788:44-788:47
-9299: Ident           "RwLock" at 788:48-788:54 (leading: Space)
-9300: RParen          ")" at 788:54-788:55
-9301: Arrow           "->" at 788:56-788:58 (leading: Space)
-9302: Ident           "bool" at 788:59-788:63 (leading: Space)
-9303: Semicolon       ";" at 788:63-788:64
-9304: At              "@" at 789:5-789:6 (leading: Newline, Space)
-9305: Ident           "intrinsic" at 789:6-789:15
-9306: KwPub           "pub" at 789:16-789:19 (leading: Space)
-9307: KwFn            "fn" at 789:20-789:22 (leading: Space)
-9308: Ident           "try_write_lock" at 789:23-789:37 (leading: Space)
-9309: LParen          "(" at 789:37-789:38
-9310: Ident           "self" at 789:38-789:42
-9311: Colon           ":" at 789:42-789:43
-9312: Amp             "&" at 789:44-789:45 (leading: Space)
-9313: KwMut           "mut" at 789:45-789:48
-9314: Ident           "RwLock" at 789:49-789:55 (leading: Space)
-9315: RParen          ")" at 789:55-789:56
-9316: Arrow           "->" at 789:57-789:59 (leading: Space)
-9317: Ident           "bool" at 789:60-789:64 (leading: Space)
-9318: Semicolon       ";" at 789:64-789:65
-9319: RBrace          "}" at 790:1-790:2 (leading: Newline)
-9320: At              "@" at 798:1-798:2 (leading: Newline, LineComment, Newline, LineComment, Newline, LineComment, Newline, LineComment, Newline, LineComment, Newline)
-9321: Ident           "intrinsic" at 798:2-798:11
-9322: KwPub           "pub" at 799:1-799:4 (leading: Newline)
-9323: KwFn            "fn" at 799:5-799:7 (leading: Space)
-9324: Ident           "atomic_load" at 799:8-799:19 (leading: Space)
-9325: LParen          "(" at 799:19-799:20
-9326: Ident           "ptr" at 799:20-799:23
-9327: Colon           ":" at 799:23-799:24
-9328: Amp             "&" at 799:25-799:26 (leading: Space)
-9329: Ident           "int" at 799:26-799:29
-9330: RParen          ")" at 799:29-799:30
-9331: Arrow           "->" at 799:31-799:33 (leading: Space)
-9332: Ident           "int" at 799:34-799:37 (leading: Space)
-9333: Semicolon       ";" at 799:37-799:38
-9334: At              "@" at 801:1-801:2 (leading: Newline)
-9335: Ident           "intrinsic" at 801:2-801:11
-9336: At              "@" at 802:1-802:2 (leading: Newline)
-9337: Ident           "overload" at 802:2-802:10
-9338: KwPub           "pub" at 803:1-803:4 (leading: Newline)
-9339: KwFn            "fn" at 803:5-803:7 (leading: Space)
-9340: Ident           "atomic_load" at 803:8-803:19 (leading: Space)
-9341: LParen          "(" at 803:19-803:20
-9342: Ident           "ptr" at 803:20-803:23
-9343: Colon           ":" at 803:23-803:24
-9344: Amp             "&" at 803:25-803:26 (leading: Space)
-9345: Ident           "uint" at 803:26-803:30
-9346: RParen          ")" at 803:30-803:31
-9347: Arrow           "->" at 803:32-803:34 (leading: Space)
-9348: Ident           "uint" at 803:35-803:39 (leading: Space)
-9349: Semicolon       ";" at 803:39-803:40
-9350: At              "@" at 805:1-805:2 (leading: Newline)
-9351: Ident           "intrinsic" at 805:2-805:11
-9352: At              "@" at 806:1-806:2 (leading: Newline)
-9353: Ident           "overload" at 806:2-806:10
-9354: KwPub           "pub" at 807:1-807:4 (leading: Newline)
-9355: KwFn            "fn" at 807:5-807:7 (leading: Space)
-9356: Ident           "atomic_load" at 807:8-807:19 (leading: Space)
-9357: LParen          "(" at 807:19-807:20
-9358: Ident           "ptr" at 807:20-807:23
-9359: Colon           ":" at 807:23-807:24
-9360: Amp             "&" at 807:25-807:26 (leading: Space)
-9361: Ident           "bool" at 807:26-807:30
-9362: RParen          ")" at 807:30-807:31
-9363: Arrow           "->" at 807:32-807:34 (leading: Space)
-9364: Ident           "bool" at 807:35-807:39 (leading: Space)
-9365: Semicolon       ";" at 807:39-807:40
-9366: At              "@" at 810:1-810:2 (leading: Newline, LineComment, Newline)
-9367: Ident           "intrinsic" at 810:2-810:11
-9368: KwPub           "pub" at 811:1-811:4 (leading: Newline)
-9369: KwFn            "fn" at 811:5-811:7 (leading: Space)
-9370: Ident           "atomic_store" at 811:8-811:20 (leading: Space)
-9371: LParen          "(" at 811:20-811:21
-9372: Ident           "ptr" at 811:21-811:24
-9373: Colon           ":" at 811:24-811:25
-9374: Amp             "&" at 811:26-811:27 (leading: Space)
-9375: KwMut           "mut" at 811:27-811:30
-9376: Ident           "int" at 811:31-811:34 (leading: Space)
-9377: Comma           "," at 811:34-811:35
-9378: Ident           "value" at 811:36-811:41 (leading: Space)
-9379: Colon           ":" at 811:41-811:42
-9380: Ident           "int" at 811:43-811:46 (leading: Space)
-9381: RParen          ")" at 811:46-811:47
-9382: Arrow           "->" at 811:48-811:50 (leading: Space)
-9383: NothingLit      "nothing" at 811:51-811:58 (leading: Space)
-9384: Semicolon       ";" at 811:58-811:59
-9385: At              "@" at 813:1-813:2 (leading: Newline)
-9386: Ident           "intrinsic" at 813:2-813:11
-9387: At              "@" at 814:1-814:2 (leading: Newline)
-9388: Ident           "overload" at 814:2-814:10
-9389: KwPub           "pub" at 815:1-815:4 (leading: Newline)
-9390: KwFn            "fn" at 815:5-815:7 (leading: Space)
-9391: Ident           "atomic_store" at 815:8-815:20 (leading: Space)
-9392: LParen          "(" at 815:20-815:21
-9393: Ident           "ptr" at 815:21-815:24
-9394: Colon           ":" at 815:24-815:25
-9395: Amp             "&" at 815:26-815:27 (leading: Space)
-9396: KwMut           "mut" at 815:27-815:30
-9397: Ident           "uint" at 815:31-815:35 (leading: Space)
-9398: Comma           "," at 815:35-815:36
-9399: Ident           "value" at 815:37-815:42 (leading: Space)
-9400: Colon           ":" at 815:42-815:43
-9401: Ident           "uint" at 815:44-815:48 (leading: Space)
-9402: RParen          ")" at 815:48-815:49
-9403: Arrow           "->" at 815:50-815:52 (leading: Space)
-9404: NothingLit      "nothing" at 815:53-815:60 (leading: Space)
-9405: Semicolon       ";" at 815:60-815:61
-9406: At              "@" at 817:1-817:2 (leading: Newline)
-9407: Ident           "intrinsic" at 817:2-817:11
-9408: At              "@" at 818:1-818:2 (leading: Newline)
-9409: Ident           "overload" at 818:2-818:10
-9410: KwPub           "pub" at 819:1-819:4 (leading: Newline)
-9411: KwFn            "fn" at 819:5-819:7 (leading: Space)
-9412: Ident           "atomic_store" at 819:8-819:20 (leading: Space)
-9413: LParen          "(" at 819:20-819:21
-9414: Ident           "ptr" at 819:21-819:24
-9415: Colon           ":" at 819:24-819:25
-9416: Amp             "&" at 819:26-819:27 (leading: Space)
-9417: KwMut           "mut" at 819:27-819:30
-9418: Ident           "bool" at 819:31-819:35 (leading: Space)
-9419: Comma           "," at 819:35-819:36
-9420: Ident           "value" at 819:37-819:42 (leading: Space)
-9421: Colon           ":" at 819:42-819:43
-9422: Ident           "bool" at 819:44-819:48 (leading: Space)
-9423: RParen          ")" at 819:48-819:49
-9424: Arrow           "->" at 819:50-819:52 (leading: Space)
-9425: NothingLit      "nothing" at 819:53-819:60 (leading: Space)
-9426: Semicolon       ";" at 819:60-819:61
-9427: At              "@" at 822:1-822:2 (leading: Newline, LineComment, Newline)
-9428: Ident           "intrinsic" at 822:2-822:11
-9429: KwPub           "pub" at 823:1-823:4 (leading: Newline)
-9430: KwFn            "fn" at 823:5-823:7 (leading: Space)
-9431: Ident           "atomic_exchange" at 823:8-823:23 (leading: Space)
-9432: LParen          "(" at 823:23-823:24
-9433: Ident           "ptr" at 823:24-823:27
-9434: Colon           ":" at 823:27-823:28
-9435: Amp             "&" at 823:29-823:30 (leading: Space)
-9436: KwMut           "mut" at 823:30-823:33
-9437: Ident           "int" at 823:34-823:37 (leading: Space)
-9438: Comma           "," at 823:37-823:38
-9439: Ident           "new_val" at 823:39-823:46 (leading: Space)
-9440: Colon           ":" at 823:46-823:47
-9441: Ident           "int" at 823:48-823:51 (leading: Space)
-9442: RParen          ")" at 823:51-823:52
-9443: Arrow           "->" at 823:53-823:55 (leading: Space)
-9444: Ident           "int" at 823:56-823:59 (leading: Space)
-9445: Semicolon       ";" at 823:59-823:60
-9446: At              "@" at 825:1-825:2 (leading: Newline)
-9447: Ident           "intrinsic" at 825:2-825:11
-9448: At              "@" at 826:1-826:2 (leading: Newline)
-9449: Ident           "overload" at 826:2-826:10
-9450: KwPub           "pub" at 827:1-827:4 (leading: Newline)
-9451: KwFn            "fn" at 827:5-827:7 (leading: Space)
-9452: Ident           "atomic_exchange" at 827:8-827:23 (leading: Space)
-9453: LParen          "(" at 827:23-827:24
-9454: Ident           "ptr" at 827:24-827:27
-9455: Colon           ":" at 827:27-827:28
-9456: Amp             "&" at 827:29-827:30 (leading: Space)
-9457: KwMut           "mut" at 827:30-827:33
-9458: Ident           "uint" at 827:34-827:38 (leading: Space)
-9459: Comma           "," at 827:38-827:39
-9460: Ident           "new_val" at 827:40-827:47 (leading: Space)
-9461: Colon           ":" at 827:47-827:48
-9462: Ident           "uint" at 827:49-827:53 (leading: Space)
-9463: RParen          ")" at 827:53-827:54
-9464: Arrow           "->" at 827:55-827:57 (leading: Space)
-9465: Ident           "uint" at 827:58-827:62 (leading: Space)
-9466: Semicolon       ";" at 827:62-827:63
-9467: At              "@" at 829:1-829:2 (leading: Newline)
-9468: Ident           "intrinsic" at 829:2-829:11
-9469: At              "@" at 830:1-830:2 (leading: Newline)
-9470: Ident           "overload" at 830:2-830:10
-9471: KwPub           "pub" at 831:1-831:4 (leading: Newline)
-9472: KwFn            "fn" at 831:5-831:7 (leading: Space)
-9473: Ident           "atomic_exchange" at 831:8-831:23 (leading: Space)
-9474: LParen          "(" at 831:23-831:24
-9475: Ident           "ptr" at 831:24-831:27
-9476: Colon           ":" at 831:27-831:28
-9477: Amp             "&" at 831:29-831:30 (leading: Space)
-9478: KwMut           "mut" at 831:30-831:33
-9479: Ident           "bool" at 831:34-831:38 (leading: Space)
-9480: Comma           "," at 831:38-831:39
-9481: Ident           "new_val" at 831:40-831:47 (leading: Space)
-9482: Colon           ":" at 831:47-831:48
-9483: Ident           "bool" at 831:49-831:53 (leading: Space)
-9484: RParen          ")" at 831:53-831:54
-9485: Arrow           "->" at 831:55-831:57 (leading: Space)
-9486: Ident           "bool" at 831:58-831:62 (leading: Space)
-9487: Semicolon       ";" at 831:62-831:63
-9488: At              "@" at 835:1-835:2 (leading: Newline, LineComment, Newline, LineComment, Newline)
-9489: Ident           "intrinsic" at 835:2-835:11
-9490: KwPub           "pub" at 836:1-836:4 (leading: Newline)
-9491: KwFn            "fn" at 836:5-836:7 (leading: Space)
-9492: Ident           "atomic_compare_exchange" at 836:8-836:31 (leading: Space)
-9493: LParen          "(" at 836:31-836:32
-9494: Ident           "ptr" at 836:32-836:35
-9495: Colon           ":" at 836:35-836:36
-9496: Amp             "&" at 836:37-836:38 (leading: Space)
-9497: KwMut           "mut" at 836:38-836:41
-9498: Ident           "int" at 836:42-836:45 (leading: Space)
-9499: Comma           "," at 836:45-836:46
-9500: Ident           "expected" at 836:47-836:55 (leading: Space)
-9501: Colon           ":" at 836:55-836:56
-9502: Ident           "int" at 836:57-836:60 (leading: Space)
-9503: Comma           "," at 836:60-836:61
-9504: Ident           "desired" at 836:62-836:69 (leading: Space)
-9505: Colon           ":" at 836:69-836:70
-9506: Ident           "int" at 836:71-836:74 (leading: Space)
-9507: RParen          ")" at 836:74-836:75
-9508: Arrow           "->" at 836:76-836:78 (leading: Space)
-9509: Ident           "bool" at 836:79-836:83 (leading: Space)
-9510: Semicolon       ";" at 836:83-836:84
-9511: At              "@" at 838:1-838:2 (leading: Newline)
-9512: Ident           "intrinsic" at 838:2-838:11
-9513: At              "@" at 839:1-839:2 (leading: Newline)
-9514: Ident           "overload" at 839:2-839:10
-9515: KwPub           "pub" at 840:1-840:4 (leading: Newline)
-9516: KwFn            "fn" at 840:5-840:7 (leading: Space)
-9517: Ident           "atomic_compare_exchange" at 840:8-840:31 (leading: Space)
-9518: LParen          "(" at 840:31-840:32
-9519: Ident           "ptr" at 840:32-840:35
-9520: Colon           ":" at 840:35-840:36
-9521: Amp             "&" at 840:37-840:38 (leading: Space)
-9522: KwMut           "mut" at 840:38-840:41
-9523: Ident           "uint" at 840:42-840:46 (leading: Space)
-9524: Comma           "," at 840:46-840:47
-9525: Ident           "expected" at 840:48-840:56 (leading: Space)
-9526: Colon           ":" at 840:56-840:57
-9527: Ident           "uint" at 840:58-840:62 (leading: Space)
-9528: Comma           "," at 840:62-840:63
-9529: Ident           "desired" at 840:64-840:71 (leading: Space)
-9530: Colon           ":" at 840:71-840:72
-9531: Ident           "uint" at 840:73-840:77 (leading: Space)
-9532: RParen          ")" at 840:77-840:78
-9533: Arrow           "->" at 840:79-840:81 (leading: Space)
-9534: Ident           "bool" at 840:82-840:86 (leading: Space)
-9535: Semicolon       ";" at 840:86-840:87
-9536: At              "@" at 842:1-842:2 (leading: Newline)
-9537: Ident           "intrinsic" at 842:2-842:11
-9538: At              "@" at 843:1-843:2 (leading: Newline)
-9539: Ident           "overload" at 843:2-843:10
-9540: KwPub           "pub" at 844:1-844:4 (leading: Newline)
-9541: KwFn            "fn" at 844:5-844:7 (leading: Space)
-9542: Ident           "atomic_compare_exchange" at 844:8-844:31 (leading: Space)
-9543: LParen          "(" at 844:31-844:32
-9544: Ident           "ptr" at 844:32-844:35
-9545: Colon           ":" at 844:35-844:36
-9546: Amp             "&" at 844:37-844:38 (leading: Space)
-9547: KwMut           "mut" at 844:38-844:41
-9548: Ident           "bool" at 844:42-844:46 (leading: Space)
-9549: Comma           "," at 844:46-844:47
-9550: Ident           "expected" at 844:48-844:56 (leading: Space)
-9551: Colon           ":" at 844:56-844:57
-9552: Ident           "bool" at 844:58-844:62 (leading: Space)
-9553: Comma           "," at 844:62-844:63
-9554: Ident           "desired" at 844:64-844:71 (leading: Space)
-9555: Colon           ":" at 844:71-844:72
-9556: Ident           "bool" at 844:73-844:77 (leading: Space)
-9557: RParen          ")" at 844:77-844:78
-9558: Arrow           "->" at 844:79-844:81 (leading: Space)
-9559: Ident           "bool" at 844:82-844:86 (leading: Space)
-9560: Semicolon       ";" at 844:86-844:87
-9561: At              "@" at 847:1-847:2 (leading: Newline, LineComment, Newline)
-9562: Ident           "intrinsic" at 847:2-847:11
-9563: KwPub           "pub" at 848:1-848:4 (leading: Newline)
-9564: KwFn            "fn" at 848:5-848:7 (leading: Space)
-9565: Ident           "atomic_fetch_add" at 848:8-848:24 (leading: Space)
-9566: LParen          "(" at 848:24-848:25
-9567: Ident           "ptr" at 848:25-848:28
-9568: Colon           ":" at 848:28-848:29
-9569: Amp             "&" at 848:30-848:31 (leading: Space)
-9570: KwMut           "mut" at 848:31-848:34
-9571: Ident           "int" at 848:35-848:38 (leading: Space)
-9572: Comma           "," at 848:38-848:39
-9573: Ident           "delta" at 848:40-848:45 (leading: Space)
-9574: Colon           ":" at 848:45-848:46
-9575: Ident           "int" at 848:47-848:50 (leading: Space)
-9576: RParen          ")" at 848:50-848:51
-9577: Arrow           "->" at 848:52-848:54 (leading: Space)
-9578: Ident           "int" at 848:55-848:58 (leading: Space)
-9579: Semicolon       ";" at 848:58-848:59
-9580: At              "@" at 850:1-850:2 (leading: Newline)
-9581: Ident           "intrinsic" at 850:2-850:11
-9582: At              "@" at 851:1-851:2 (leading: Newline)
-9583: Ident           "overload" at 851:2-851:10
-9584: KwPub           "pub" at 852:1-852:4 (leading: Newline)
-9585: KwFn            "fn" at 852:5-852:7 (leading: Space)
-9586: Ident           "atomic_fetch_add" at 852:8-852:24 (leading: Space)
-9587: LParen          "(" at 852:24-852:25
-9588: Ident           "ptr" at 852:25-852:28
-9589: Colon           ":" at 852:28-852:29
-9590: Amp             "&" at 852:30-852:31 (leading: Space)
-9591: KwMut           "mut" at 852:31-852:34
-9592: Ident           "uint" at 852:35-852:39 (leading: Space)
-9593: Comma           "," at 852:39-852:40
-9594: Ident           "delta" at 852:41-852:46 (leading: Space)
-9595: Colon           ":" at 852:46-852:47
-9596: Ident           "uint" at 852:48-852:52 (leading: Space)
-9597: RParen          ")" at 852:52-852:53
-9598: Arrow           "->" at 852:54-852:56 (leading: Space)
-9599: Ident           "uint" at 852:57-852:61 (leading: Space)
-9600: Semicolon       ";" at 852:61-852:62
-9601: At              "@" at 855:1-855:2 (leading: Newline, LineComment, Newline)
-9602: Ident           "intrinsic" at 855:2-855:11
-9603: KwPub           "pub" at 856:1-856:4 (leading: Newline)
-9604: KwFn            "fn" at 856:5-856:7 (leading: Space)
-9605: Ident           "atomic_fetch_sub" at 856:8-856:24 (leading: Space)
-9606: LParen          "(" at 856:24-856:25
-9607: Ident           "ptr" at 856:25-856:28
-9608: Colon           ":" at 856:28-856:29
-9609: Amp             "&" at 856:30-856:31 (leading: Space)
-9610: KwMut           "mut" at 856:31-856:34
-9611: Ident           "int" at 856:35-856:38 (leading: Space)
-9612: Comma           "," at 856:38-856:39
-9613: Ident           "delta" at 856:40-856:45 (leading: Space)
-9614: Colon           ":" at 856:45-856:46
-9615: Ident           "int" at 856:47-856:50 (leading: Space)
-9616: RParen          ")" at 856:50-856:51
-9617: Arrow           "->" at 856:52-856:54 (leading: Space)
-9618: Ident           "int" at 856:55-856:58 (leading: Space)
-9619: Semicolon       ";" at 856:58-856:59
-9620: At              "@" at 858:1-858:2 (leading: Newline)
-9621: Ident           "intrinsic" at 858:2-858:11
-9622: At              "@" at 859:1-859:2 (leading: Newline)
-9623: Ident           "overload" at 859:2-859:10
-9624: KwPub           "pub" at 860:1-860:4 (leading: Newline)
-9625: KwFn            "fn" at 860:5-860:7 (leading: Space)
-9626: Ident           "atomic_fetch_sub" at 860:8-860:24 (leading: Space)
-9627: LParen          "(" at 860:24-860:25
-9628: Ident           "ptr" at 860:25-860:28
-9629: Colon           ":" at 860:28-860:29
-9630: Amp             "&" at 860:30-860:31 (leading: Space)
-9631: KwMut           "mut" at 860:31-860:34
-9632: Ident           "uint" at 860:35-860:39 (leading: Space)
-9633: Comma           "," at 860:39-860:40
-9634: Ident           "delta" at 860:41-860:46 (leading: Space)
-9635: Colon           ":" at 860:46-860:47
-9636: Ident           "uint" at 860:48-860:52 (leading: Space)
-9637: RParen          ")" at 860:52-860:53
-9638: Arrow           "->" at 860:54-860:56 (leading: Space)
-9639: Ident           "uint" at 860:57-860:61 (leading: Space)
-9640: Semicolon       ";" at 860:61-860:62
-9641: At              "@" at 865:1-865:2 (leading: Newline, LineComment, Newline, LineComment, Newline)
-9642: Ident           "intrinsic" at 865:2-865:11
-9643: KwPub           "pub" at 866:1-866:4 (leading: Newline)
-9644: KwFn            "fn" at 866:5-866:7 (leading: Space)
-9645: Ident           "rt_argv" at 866:8-866:15 (leading: Space)
-9646: LParen          "(" at 866:15-866:16
-9647: RParen          ")" at 866:16-866:17
-9648: Arrow           "->" at 866:18-866:20 (leading: Space)
-9649: Ident           "string" at 866:21-866:27 (leading: Space)
-9650: LBracket        "[" at 866:27-866:28
-9651: RBracket        "]" at 866:28-866:29
-9652: Semicolon       ";" at 866:29-866:30
-9653: At              "@" at 869:1-869:2 (leading: Newline, LineComment, Newline)
-9654: Ident           "intrinsic" at 869:2-869:11
-9655: KwPub           "pub" at 870:1-870:4 (leading: Newline)
-9656: KwFn            "fn" at 870:5-870:7 (leading: Space)
-9657: Ident           "rt_stdin_read_all" at 870:8-870:25 (leading: Space)
-9658: LParen          "(" at 870:25-870:26
-9659: RParen          ")" at 870:26-870:27
-9660: Arrow           "->" at 870:28-870:30 (leading: Space)
-9661: Ident           "string" at 870:31-870:37 (leading: Space)
-9662: Semicolon       ";" at 870:37-870:38
-9663: At              "@" at 873:1-873:2 (leading: Newline, LineComment, Newline)
-9664: Ident           "intrinsic" at 873:2-873:11
-9665: KwPub           "pub" at 874:1-874:4 (leading: Newline)
-9666: KwFn            "fn" at 874:5-874:7 (leading: Space)
-9667: Ident           "rt_exit" at 874:8-874:15 (leading: Space)
-9668: LParen          "(" at 874:15-874:16
-9669: Ident           "code" at 874:16-874:20
-9670: Colon           ":" at 874:20-874:21
-9671: Ident           "int" at 874:22-874:25 (leading: Space)
-9672: RParen          ")" at 874:25-874:26
-9673: Arrow           "->" at 874:27-874:29 (leading: Space)
-9674: NothingLit      "nothing" at 874:30-874:37 (leading: Space)
-9675: Semicolon       ";" at 874:37-874:38
-9676: EOF             at 875:1-875:1
+1310: At              "@" at 132:1-132:2 (leading: Newline)
+1311: Ident           "intrinsic" at 132:2-132:11
+1312: KwFn            "fn" at 132:12-132:14 (leading: Space)
+1313: Ident           "rt_array_append_raw_bytes" at 132:15-132:40 (leading: Space)
+1314: LParen          "(" at 132:40-132:41
+1315: Ident           "a" at 132:41-132:42
+1316: Colon           ":" at 132:42-132:43
+1317: Amp             "&" at 132:44-132:45 (leading: Space)
+1318: KwMut           "mut" at 132:45-132:48
+1319: Ident           "byte" at 132:49-132:53 (leading: Space)
+1320: LBracket        "[" at 132:53-132:54
+1321: RBracket        "]" at 132:54-132:55
+1322: Comma           "," at 132:55-132:56
+1323: Ident           "ptr" at 132:57-132:60 (leading: Space)
+1324: Colon           ":" at 132:60-132:61
+1325: Star            "*" at 132:62-132:63 (leading: Space)
+1326: Ident           "byte" at 132:63-132:67
+1327: Comma           "," at 132:67-132:68
+1328: Ident           "length" at 132:69-132:75 (leading: Space)
+1329: Colon           ":" at 132:75-132:76
+1330: Ident           "uint64" at 132:77-132:83 (leading: Space)
+1331: RParen          ")" at 132:83-132:84
+1332: Arrow           "->" at 132:85-132:87 (leading: Space)
+1333: NothingLit      "nothing" at 132:88-132:95 (leading: Space)
+1334: Semicolon       ";" at 132:95-132:96
+1335: At              "@" at 135:1-135:2 (leading: Newline, LineComment, Newline)
+1336: Ident           "intrinsic" at 135:2-135:11
+1337: KwFn            "fn" at 135:12-135:14 (leading: Space)
+1338: Ident           "rt_map_new" at 135:15-135:25 (leading: Space)
+1339: Lt              "<" at 135:25-135:26
+1340: Ident           "K" at 135:26-135:27
+1341: Comma           "," at 135:27-135:28
+1342: Ident           "V" at 135:29-135:30 (leading: Space)
+1343: Gt              ">" at 135:30-135:31
+1344: LParen          "(" at 135:31-135:32
+1345: RParen          ")" at 135:32-135:33
+1346: Arrow           "->" at 135:34-135:36 (leading: Space)
+1347: Ident           "Map" at 135:37-135:40 (leading: Space)
+1348: Lt              "<" at 135:40-135:41
+1349: Ident           "K" at 135:41-135:42
+1350: Comma           "," at 135:42-135:43
+1351: Ident           "V" at 135:44-135:45 (leading: Space)
+1352: Gt              ">" at 135:45-135:46
+1353: Semicolon       ";" at 135:46-135:47
+1354: At              "@" at 136:1-136:2 (leading: Newline)
+1355: Ident           "intrinsic" at 136:2-136:11
+1356: KwFn            "fn" at 136:12-136:14 (leading: Space)
+1357: Ident           "rt_map_len" at 136:15-136:25 (leading: Space)
+1358: Lt              "<" at 136:25-136:26
+1359: Ident           "K" at 136:26-136:27
+1360: Comma           "," at 136:27-136:28
+1361: Ident           "V" at 136:29-136:30 (leading: Space)
+1362: Gt              ">" at 136:30-136:31
+1363: LParen          "(" at 136:31-136:32
+1364: Ident           "m" at 136:32-136:33
+1365: Colon           ":" at 136:33-136:34
+1366: Amp             "&" at 136:35-136:36 (leading: Space)
+1367: Ident           "Map" at 136:36-136:39
+1368: Lt              "<" at 136:39-136:40
+1369: Ident           "K" at 136:40-136:41
+1370: Comma           "," at 136:41-136:42
+1371: Ident           "V" at 136:43-136:44 (leading: Space)
+1372: Gt              ">" at 136:44-136:45
+1373: RParen          ")" at 136:45-136:46
+1374: Arrow           "->" at 136:47-136:49 (leading: Space)
+1375: Ident           "uint" at 136:50-136:54 (leading: Space)
+1376: Semicolon       ";" at 136:54-136:55
+1377: At              "@" at 137:1-137:2 (leading: Newline)
+1378: Ident           "intrinsic" at 137:2-137:11
+1379: KwFn            "fn" at 137:12-137:14 (leading: Space)
+1380: Ident           "rt_map_contains" at 137:15-137:30 (leading: Space)
+1381: Lt              "<" at 137:30-137:31
+1382: Ident           "K" at 137:31-137:32
+1383: Comma           "," at 137:32-137:33
+1384: Ident           "V" at 137:34-137:35 (leading: Space)
+1385: Gt              ">" at 137:35-137:36
+1386: LParen          "(" at 137:36-137:37
+1387: Ident           "m" at 137:37-137:38
+1388: Colon           ":" at 137:38-137:39
+1389: Amp             "&" at 137:40-137:41 (leading: Space)
+1390: Ident           "Map" at 137:41-137:44
+1391: Lt              "<" at 137:44-137:45
+1392: Ident           "K" at 137:45-137:46
+1393: Comma           "," at 137:46-137:47
+1394: Ident           "V" at 137:48-137:49 (leading: Space)
+1395: Gt              ">" at 137:49-137:50
+1396: Comma           "," at 137:50-137:51
+1397: Ident           "key" at 137:52-137:55 (leading: Space)
+1398: Colon           ":" at 137:55-137:56
+1399: Amp             "&" at 137:57-137:58 (leading: Space)
+1400: Ident           "K" at 137:58-137:59
+1401: RParen          ")" at 137:59-137:60
+1402: Arrow           "->" at 137:61-137:63 (leading: Space)
+1403: Ident           "bool" at 137:64-137:68 (leading: Space)
+1404: Semicolon       ";" at 137:68-137:69
+1405: At              "@" at 138:1-138:2 (leading: Newline)
+1406: Ident           "intrinsic" at 138:2-138:11
+1407: KwFn            "fn" at 138:12-138:14 (leading: Space)
+1408: Ident           "rt_map_get_ref" at 138:15-138:29 (leading: Space)
+1409: Lt              "<" at 138:29-138:30
+1410: Ident           "K" at 138:30-138:31
+1411: Comma           "," at 138:31-138:32
+1412: Ident           "V" at 138:33-138:34 (leading: Space)
+1413: Gt              ">" at 138:34-138:35
+1414: LParen          "(" at 138:35-138:36
+1415: Ident           "m" at 138:36-138:37
+1416: Colon           ":" at 138:37-138:38
+1417: Amp             "&" at 138:39-138:40 (leading: Space)
+1418: Ident           "Map" at 138:40-138:43
+1419: Lt              "<" at 138:43-138:44
+1420: Ident           "K" at 138:44-138:45
+1421: Comma           "," at 138:45-138:46
+1422: Ident           "V" at 138:47-138:48 (leading: Space)
+1423: Gt              ">" at 138:48-138:49
+1424: Comma           "," at 138:49-138:50
+1425: Ident           "key" at 138:51-138:54 (leading: Space)
+1426: Colon           ":" at 138:54-138:55
+1427: Amp             "&" at 138:56-138:57 (leading: Space)
+1428: Ident           "K" at 138:57-138:58
+1429: RParen          ")" at 138:58-138:59
+1430: Arrow           "->" at 138:60-138:62 (leading: Space)
+1431: Ident           "Option" at 138:63-138:69 (leading: Space)
+1432: Lt              "<" at 138:69-138:70
+1433: Amp             "&" at 138:70-138:71
+1434: Ident           "V" at 138:71-138:72
+1435: Gt              ">" at 138:72-138:73
+1436: Semicolon       ";" at 138:73-138:74
+1437: At              "@" at 139:1-139:2 (leading: Newline)
+1438: Ident           "intrinsic" at 139:2-139:11
+1439: KwFn            "fn" at 139:12-139:14 (leading: Space)
+1440: Ident           "rt_map_get_mut" at 139:15-139:29 (leading: Space)
+1441: Lt              "<" at 139:29-139:30
+1442: Ident           "K" at 139:30-139:31
+1443: Comma           "," at 139:31-139:32
+1444: Ident           "V" at 139:33-139:34 (leading: Space)
+1445: Gt              ">" at 139:34-139:35
+1446: LParen          "(" at 139:35-139:36
+1447: Ident           "m" at 139:36-139:37
+1448: Colon           ":" at 139:37-139:38
+1449: Amp             "&" at 139:39-139:40 (leading: Space)
+1450: KwMut           "mut" at 139:40-139:43
+1451: Ident           "Map" at 139:44-139:47 (leading: Space)
+1452: Lt              "<" at 139:47-139:48
+1453: Ident           "K" at 139:48-139:49
+1454: Comma           "," at 139:49-139:50
+1455: Ident           "V" at 139:51-139:52 (leading: Space)
+1456: Gt              ">" at 139:52-139:53
+1457: Comma           "," at 139:53-139:54
+1458: Ident           "key" at 139:55-139:58 (leading: Space)
+1459: Colon           ":" at 139:58-139:59
+1460: Amp             "&" at 139:60-139:61 (leading: Space)
+1461: Ident           "K" at 139:61-139:62
+1462: RParen          ")" at 139:62-139:63
+1463: Arrow           "->" at 139:64-139:66 (leading: Space)
+1464: Ident           "Option" at 139:67-139:73 (leading: Space)
+1465: Lt              "<" at 139:73-139:74
+1466: Amp             "&" at 139:74-139:75
+1467: KwMut           "mut" at 139:75-139:78
+1468: Ident           "V" at 139:79-139:80 (leading: Space)
+1469: Gt              ">" at 139:80-139:81
+1470: Semicolon       ";" at 139:81-139:82
+1471: At              "@" at 140:1-140:2 (leading: Newline)
+1472: Ident           "intrinsic" at 140:2-140:11
+1473: KwFn            "fn" at 140:12-140:14 (leading: Space)
+1474: Ident           "rt_map_insert" at 140:15-140:28 (leading: Space)
+1475: Lt              "<" at 140:28-140:29
+1476: Ident           "K" at 140:29-140:30
+1477: Comma           "," at 140:30-140:31
+1478: Ident           "V" at 140:32-140:33 (leading: Space)
+1479: Gt              ">" at 140:33-140:34
+1480: LParen          "(" at 140:34-140:35
+1481: Ident           "m" at 140:35-140:36
+1482: Colon           ":" at 140:36-140:37
+1483: Amp             "&" at 140:38-140:39 (leading: Space)
+1484: KwMut           "mut" at 140:39-140:42
+1485: Ident           "Map" at 140:43-140:46 (leading: Space)
+1486: Lt              "<" at 140:46-140:47
+1487: Ident           "K" at 140:47-140:48
+1488: Comma           "," at 140:48-140:49
+1489: Ident           "V" at 140:50-140:51 (leading: Space)
+1490: Gt              ">" at 140:51-140:52
+1491: Comma           "," at 140:52-140:53
+1492: Ident           "key" at 140:54-140:57 (leading: Space)
+1493: Colon           ":" at 140:57-140:58
+1494: Ident           "K" at 140:59-140:60 (leading: Space)
+1495: Comma           "," at 140:60-140:61
+1496: Ident           "value" at 140:62-140:67 (leading: Space)
+1497: Colon           ":" at 140:67-140:68
+1498: Ident           "V" at 140:69-140:70 (leading: Space)
+1499: RParen          ")" at 140:70-140:71
+1500: Arrow           "->" at 140:72-140:74 (leading: Space)
+1501: Ident           "Option" at 140:75-140:81 (leading: Space)
+1502: Lt              "<" at 140:81-140:82
+1503: Ident           "V" at 140:82-140:83
+1504: Gt              ">" at 140:83-140:84
+1505: Semicolon       ";" at 140:84-140:85
+1506: At              "@" at 141:1-141:2 (leading: Newline)
+1507: Ident           "intrinsic" at 141:2-141:11
+1508: KwFn            "fn" at 141:12-141:14 (leading: Space)
+1509: Ident           "rt_map_remove" at 141:15-141:28 (leading: Space)
+1510: Lt              "<" at 141:28-141:29
+1511: Ident           "K" at 141:29-141:30
+1512: Comma           "," at 141:30-141:31
+1513: Ident           "V" at 141:32-141:33 (leading: Space)
+1514: Gt              ">" at 141:33-141:34
+1515: LParen          "(" at 141:34-141:35
+1516: Ident           "m" at 141:35-141:36
+1517: Colon           ":" at 141:36-141:37
+1518: Amp             "&" at 141:38-141:39 (leading: Space)
+1519: KwMut           "mut" at 141:39-141:42
+1520: Ident           "Map" at 141:43-141:46 (leading: Space)
+1521: Lt              "<" at 141:46-141:47
+1522: Ident           "K" at 141:47-141:48
+1523: Comma           "," at 141:48-141:49
+1524: Ident           "V" at 141:50-141:51 (leading: Space)
+1525: Gt              ">" at 141:51-141:52
+1526: Comma           "," at 141:52-141:53
+1527: Ident           "key" at 141:54-141:57 (leading: Space)
+1528: Colon           ":" at 141:57-141:58
+1529: Amp             "&" at 141:59-141:60 (leading: Space)
+1530: Ident           "K" at 141:60-141:61
+1531: RParen          ")" at 141:61-141:62
+1532: Arrow           "->" at 141:63-141:65 (leading: Space)
+1533: Ident           "Option" at 141:66-141:72 (leading: Space)
+1534: Lt              "<" at 141:72-141:73
+1535: Ident           "V" at 141:73-141:74
+1536: Gt              ">" at 141:74-141:75
+1537: Semicolon       ";" at 141:75-141:76
+1538: At              "@" at 142:1-142:2 (leading: Newline)
+1539: Ident           "intrinsic" at 142:2-142:11
+1540: KwFn            "fn" at 142:12-142:14 (leading: Space)
+1541: Ident           "rt_map_keys" at 142:15-142:26 (leading: Space)
+1542: Lt              "<" at 142:26-142:27
+1543: Ident           "K" at 142:27-142:28
+1544: Comma           "," at 142:28-142:29
+1545: Ident           "V" at 142:30-142:31 (leading: Space)
+1546: Gt              ">" at 142:31-142:32
+1547: LParen          "(" at 142:32-142:33
+1548: Ident           "m" at 142:33-142:34
+1549: Colon           ":" at 142:34-142:35
+1550: Amp             "&" at 142:36-142:37 (leading: Space)
+1551: Ident           "Map" at 142:37-142:40
+1552: Lt              "<" at 142:40-142:41
+1553: Ident           "K" at 142:41-142:42
+1554: Comma           "," at 142:42-142:43
+1555: Ident           "V" at 142:44-142:45 (leading: Space)
+1556: Gt              ">" at 142:45-142:46
+1557: RParen          ")" at 142:46-142:47
+1558: Arrow           "->" at 142:48-142:50 (leading: Space)
+1559: Ident           "K" at 142:51-142:52 (leading: Space)
+1560: LBracket        "[" at 142:52-142:53
+1561: RBracket        "]" at 142:53-142:54
+1562: Semicolon       ";" at 142:54-142:55
+1563: At              "@" at 145:1-145:2 (leading: Newline, LineComment, Newline)
+1564: Ident           "intrinsic" at 145:2-145:11
+1565: KwPub           "pub" at 146:1-146:4 (leading: Newline)
+1566: KwFn            "fn" at 146:5-146:7 (leading: Space)
+1567: Ident           "readline" at 146:8-146:16 (leading: Space)
+1568: LParen          "(" at 146:16-146:17
+1569: RParen          ")" at 146:17-146:18
+1570: Arrow           "->" at 146:19-146:21 (leading: Space)
+1571: Ident           "string" at 146:22-146:28 (leading: Space)
+1572: Semicolon       ";" at 146:28-146:29
+1573: At              "@" at 148:1-148:2 (leading: Newline)
+1574: Ident           "intrinsic" at 148:2-148:11
+1575: KwPub           "pub" at 149:1-149:4 (leading: Newline)
+1576: KwType          "type" at 149:5-149:9 (leading: Space)
+1577: Ident           "Range" at 149:10-149:15 (leading: Space)
+1578: Lt              "<" at 149:15-149:16
+1579: Ident           "T" at 149:16-149:17
+1580: Gt              ">" at 149:17-149:18
+1581: Assign          "=" at 149:19-149:20 (leading: Space)
+1582: LBrace          "{" at 149:21-149:22 (leading: Space)
+1583: Ident           "__state" at 150:5-150:12 (leading: Newline, Space)
+1584: Colon           ":" at 150:12-150:13
+1585: Star            "*" at 150:14-150:15 (leading: Space)
+1586: Ident           "byte" at 150:15-150:19
+1587: Comma           "," at 150:19-150:20
+1588: RBrace          "}" at 151:1-151:2 (leading: Newline)
+1589: Semicolon       ";" at 151:2-151:3
+1590: At              "@" at 154:1-154:2 (leading: Newline, LineComment, Newline)
+1591: Ident           "intrinsic" at 154:2-154:11
+1592: KwPub           "pub" at 154:12-154:15 (leading: Space)
+1593: KwFn            "fn" at 154:16-154:18 (leading: Space)
+1594: Ident           "rt_range_int_new" at 154:19-154:35 (leading: Space)
+1595: LParen          "(" at 154:35-154:36
+1596: Ident           "start" at 154:36-154:41
+1597: Colon           ":" at 154:41-154:42
+1598: Ident           "int" at 154:43-154:46 (leading: Space)
+1599: Comma           "," at 154:46-154:47
+1600: Ident           "end" at 154:48-154:51 (leading: Space)
+1601: Colon           ":" at 154:51-154:52
+1602: Ident           "int" at 154:53-154:56 (leading: Space)
+1603: Comma           "," at 154:56-154:57
+1604: Ident           "inclusive" at 154:58-154:67 (leading: Space)
+1605: Colon           ":" at 154:67-154:68
+1606: Ident           "bool" at 154:69-154:73 (leading: Space)
+1607: RParen          ")" at 154:73-154:74
+1608: Arrow           "->" at 154:75-154:77 (leading: Space)
+1609: Ident           "Range" at 154:78-154:83 (leading: Space)
+1610: Lt              "<" at 154:83-154:84
+1611: Ident           "int" at 154:84-154:87
+1612: Gt              ">" at 154:87-154:88
+1613: Semicolon       ";" at 154:88-154:89
+1614: At              "@" at 155:1-155:2 (leading: Newline)
+1615: Ident           "intrinsic" at 155:2-155:11
+1616: KwPub           "pub" at 155:12-155:15 (leading: Space)
+1617: KwFn            "fn" at 155:16-155:18 (leading: Space)
+1618: Ident           "rt_range_int_from_start" at 155:19-155:42 (leading: Space)
+1619: LParen          "(" at 155:42-155:43
+1620: Ident           "start" at 155:43-155:48
+1621: Colon           ":" at 155:48-155:49
+1622: Ident           "int" at 155:50-155:53 (leading: Space)
+1623: Comma           "," at 155:53-155:54
+1624: Ident           "inclusive" at 155:55-155:64 (leading: Space)
+1625: Colon           ":" at 155:64-155:65
+1626: Ident           "bool" at 155:66-155:70 (leading: Space)
+1627: RParen          ")" at 155:70-155:71
+1628: Arrow           "->" at 155:72-155:74 (leading: Space)
+1629: Ident           "Range" at 155:75-155:80 (leading: Space)
+1630: Lt              "<" at 155:80-155:81
+1631: Ident           "int" at 155:81-155:84
+1632: Gt              ">" at 155:84-155:85
+1633: Semicolon       ";" at 155:85-155:86
+1634: At              "@" at 156:1-156:2 (leading: Newline)
+1635: Ident           "intrinsic" at 156:2-156:11
+1636: KwPub           "pub" at 156:12-156:15 (leading: Space)
+1637: KwFn            "fn" at 156:16-156:18 (leading: Space)
+1638: Ident           "rt_range_int_to_end" at 156:19-156:38 (leading: Space)
+1639: LParen          "(" at 156:38-156:39
+1640: Ident           "end" at 156:39-156:42
+1641: Colon           ":" at 156:42-156:43
+1642: Ident           "int" at 156:44-156:47 (leading: Space)
+1643: Comma           "," at 156:47-156:48
+1644: Ident           "inclusive" at 156:49-156:58 (leading: Space)
+1645: Colon           ":" at 156:58-156:59
+1646: Ident           "bool" at 156:60-156:64 (leading: Space)
+1647: RParen          ")" at 156:64-156:65
+1648: Arrow           "->" at 156:66-156:68 (leading: Space)
+1649: Ident           "Range" at 156:69-156:74 (leading: Space)
+1650: Lt              "<" at 156:74-156:75
+1651: Ident           "int" at 156:75-156:78
+1652: Gt              ">" at 156:78-156:79
+1653: Semicolon       ";" at 156:79-156:80
+1654: At              "@" at 157:1-157:2 (leading: Newline)
+1655: Ident           "intrinsic" at 157:2-157:11
+1656: KwPub           "pub" at 157:12-157:15 (leading: Space)
+1657: KwFn            "fn" at 157:16-157:18 (leading: Space)
+1658: Ident           "rt_range_int_full" at 157:19-157:36 (leading: Space)
+1659: LParen          "(" at 157:36-157:37
+1660: Ident           "inclusive" at 157:37-157:46
+1661: Colon           ":" at 157:46-157:47
+1662: Ident           "bool" at 157:48-157:52 (leading: Space)
+1663: RParen          ")" at 157:52-157:53
+1664: Arrow           "->" at 157:54-157:56 (leading: Space)
+1665: Ident           "Range" at 157:57-157:62 (leading: Space)
+1666: Lt              "<" at 157:62-157:63
+1667: Ident           "int" at 157:63-157:66
+1668: Gt              ">" at 157:66-157:67
+1669: Semicolon       ";" at 157:67-157:68
+1670: KwExtern        "extern" at 159:1-159:7 (leading: Newline)
+1671: Lt              "<" at 159:7-159:8
+1672: Ident           "Range" at 159:8-159:13
+1673: Lt              "<" at 159:13-159:14
+1674: Ident           "T" at 159:14-159:15
+1675: Shr             ">>" at 159:15-159:17
+1676: LBrace          "{" at 159:18-159:19 (leading: Space)
+1677: At              "@" at 160:5-160:6 (leading: Newline, Space)
+1678: Ident           "intrinsic" at 160:6-160:15
+1679: KwPub           "pub" at 160:16-160:19 (leading: Space)
+1680: KwFn            "fn" at 160:20-160:22 (leading: Space)
+1681: Ident           "next" at 160:23-160:27 (leading: Space)
+1682: LParen          "(" at 160:27-160:28
+1683: Ident           "self" at 160:28-160:32
+1684: Colon           ":" at 160:32-160:33
+1685: Amp             "&" at 160:34-160:35 (leading: Space)
+1686: KwMut           "mut" at 160:35-160:38
+1687: Ident           "Range" at 160:39-160:44 (leading: Space)
+1688: Lt              "<" at 160:44-160:45
+1689: Ident           "T" at 160:45-160:46
+1690: Gt              ">" at 160:46-160:47
+1691: RParen          ")" at 160:47-160:48
+1692: Arrow           "->" at 160:49-160:51 (leading: Space)
+1693: Ident           "Option" at 160:52-160:58 (leading: Space)
+1694: Lt              "<" at 160:58-160:59
+1695: Ident           "T" at 160:59-160:60
+1696: Gt              ">" at 160:60-160:61
+1697: Semicolon       ";" at 160:61-160:62
+1698: RBrace          "}" at 161:1-161:2 (leading: Newline)
+1699: KwPub           "pub" at 163:1-163:4 (leading: Newline)
+1700: KwType          "type" at 163:5-163:9 (leading: Space)
+1701: Ident           "HeapStats" at 163:10-163:19 (leading: Space)
+1702: Assign          "=" at 163:20-163:21 (leading: Space)
+1703: LBrace          "{" at 163:22-163:23 (leading: Space)
+1704: Ident           "alloc_count" at 164:5-164:16 (leading: Newline, Space)
+1705: Colon           ":" at 164:16-164:17
+1706: Ident           "uint" at 164:18-164:22 (leading: Space)
+1707: Comma           "," at 164:22-164:23
+1708: Ident           "free_count" at 165:5-165:15 (leading: Newline, Space)
+1709: Colon           ":" at 165:15-165:16
+1710: Ident           "uint" at 165:17-165:21 (leading: Space)
+1711: Comma           "," at 165:21-165:22
+1712: Ident           "live_blocks" at 166:5-166:16 (leading: Newline, Space)
+1713: Colon           ":" at 166:16-166:17
+1714: Ident           "uint" at 166:18-166:22 (leading: Space)
+1715: Comma           "," at 166:22-166:23
+1716: Ident           "live_bytes" at 167:5-167:15 (leading: Newline, Space)
+1717: Colon           ":" at 167:15-167:16
+1718: Ident           "uint" at 167:17-167:21 (leading: Space)
+1719: Comma           "," at 167:21-167:22
+1720: Ident           "rc_increments" at 168:5-168:18 (leading: Newline, Space)
+1721: Colon           ":" at 168:18-168:19
+1722: Ident           "uint" at 168:20-168:24 (leading: Space)
+1723: Comma           "," at 168:24-168:25
+1724: Ident           "rc_decrements" at 169:5-169:18 (leading: Newline, Space)
+1725: Colon           ":" at 169:18-169:19
+1726: Ident           "uint" at 169:20-169:24 (leading: Space)
+1727: Comma           "," at 169:24-169:25
+1728: RBrace          "}" at 170:1-170:2 (leading: Newline)
+1729: Semicolon       ";" at 170:2-170:3
+1730: At              "@" at 176:1-176:2 (leading: Newline, LineComment, Newline, LineComment, Newline, LineComment, Newline, LineComment, Newline)
+1731: Ident           "intrinsic" at 176:2-176:11
+1732: KwPub           "pub" at 176:12-176:15 (leading: Space)
+1733: KwFn            "fn" at 176:16-176:18 (leading: Space)
+1734: Ident           "rt_heap_stats" at 176:19-176:32 (leading: Space)
+1735: LParen          "(" at 176:32-176:33
+1736: RParen          ")" at 176:33-176:34
+1737: Arrow           "->" at 176:35-176:37 (leading: Space)
+1738: Ident           "HeapStats" at 176:38-176:47 (leading: Space)
+1739: Semicolon       ";" at 176:47-176:48
+1740: At              "@" at 178:1-178:2 (leading: Newline, LineComment, Newline)
+1741: Ident           "intrinsic" at 178:2-178:11
+1742: KwPub           "pub" at 178:12-178:15 (leading: Space)
+1743: KwFn            "fn" at 178:16-178:18 (leading: Space)
+1744: Ident           "rt_heap_dump" at 178:19-178:31 (leading: Space)
+1745: LParen          "(" at 178:31-178:32
+1746: RParen          ")" at 178:32-178:33
+1747: Arrow           "->" at 178:34-178:36 (leading: Space)
+1748: Ident           "string" at 178:37-178:43 (leading: Space)
+1749: Semicolon       ";" at 178:43-178:44
+1750: At              "@" at 180:1-180:2 (leading: Newline, LineComment, Newline)
+1751: Ident           "intrinsic" at 180:2-180:11
+1752: KwPub           "pub" at 180:12-180:15 (leading: Space)
+1753: KwFn            "fn" at 180:16-180:18 (leading: Space)
+1754: Ident           "rt_worker_count" at 180:19-180:34 (leading: Space)
+1755: LParen          "(" at 180:34-180:35
+1756: RParen          ")" at 180:35-180:36
+1757: Arrow           "->" at 180:37-180:39 (leading: Space)
+1758: Ident           "uint" at 180:40-180:44 (leading: Space)
+1759: Semicolon       ";" at 180:44-180:45
+1760: KwPub           "pub" at 182:1-182:4 (leading: Newline)
+1761: KwType          "type" at 182:5-182:9 (leading: Space)
+1762: Ident           "Task" at 182:10-182:14 (leading: Space)
+1763: Lt              "<" at 182:14-182:15
+1764: Ident           "T" at 182:15-182:16
+1765: Gt              ">" at 182:16-182:17
+1766: Assign          "=" at 182:18-182:19 (leading: Space)
+1767: LBrace          "{" at 182:20-182:21 (leading: Space)
+1768: Ident           "__opaque" at 183:5-183:13 (leading: Newline, Space)
+1769: Colon           ":" at 183:13-183:14
+1770: Ident           "int" at 183:15-183:18 (leading: Space)
+1771: Comma           "," at 183:18-183:19
+1772: RBrace          "}" at 184:1-184:2 (leading: Newline)
+1773: Semicolon       ";" at 184:2-184:3
+1774: KwPub           "pub" at 186:1-186:4 (leading: Newline)
+1775: KwTag           "tag" at 186:5-186:8 (leading: Space)
+1776: Ident           "Cancelled" at 186:9-186:18 (leading: Space)
+1777: LParen          "(" at 186:18-186:19
+1778: RParen          ")" at 186:19-186:20
+1779: Semicolon       ";" at 186:20-186:21
+1780: KwPub           "pub" at 187:1-187:4 (leading: Newline)
+1781: KwType          "type" at 187:5-187:9 (leading: Space)
+1782: Ident           "TaskResult" at 187:10-187:20 (leading: Space)
+1783: Lt              "<" at 187:20-187:21
+1784: Ident           "T" at 187:21-187:22
+1785: Gt              ">" at 187:22-187:23
+1786: Assign          "=" at 187:24-187:25 (leading: Space)
+1787: Ident           "Success" at 187:26-187:33 (leading: Space)
+1788: LParen          "(" at 187:33-187:34
+1789: Ident           "T" at 187:34-187:35
+1790: RParen          ")" at 187:35-187:36
+1791: Pipe            "|" at 187:37-187:38 (leading: Space)
+1792: Ident           "Cancelled" at 187:39-187:48 (leading: Space)
+1793: Semicolon       ";" at 187:48-187:49
+1794: At              "@" at 189:1-189:2 (leading: Newline)
+1795: Ident           "intrinsic" at 189:2-189:11
+1796: KwFn            "fn" at 189:12-189:14 (leading: Space)
+1797: Ident           "rt_scope_enter" at 189:15-189:29 (leading: Space)
+1798: LParen          "(" at 189:29-189:30
+1799: Ident           "failfast" at 189:30-189:38
+1800: Colon           ":" at 189:38-189:39
+1801: Ident           "bool" at 189:40-189:44 (leading: Space)
+1802: RParen          ")" at 189:44-189:45
+1803: Arrow           "->" at 189:46-189:48 (leading: Space)
+1804: Ident           "uint" at 189:49-189:53 (leading: Space)
+1805: Semicolon       ";" at 189:53-189:54
+1806: At              "@" at 190:1-190:2 (leading: Newline)
+1807: Ident           "intrinsic" at 190:2-190:11
+1808: KwFn            "fn" at 190:12-190:14 (leading: Space)
+1809: Ident           "rt_scope_register_child" at 190:15-190:38 (leading: Space)
+1810: Lt              "<" at 190:38-190:39
+1811: Ident           "T" at 190:39-190:40
+1812: Gt              ">" at 190:40-190:41
+1813: LParen          "(" at 190:41-190:42
+1814: Ident           "scope" at 190:42-190:47
+1815: Colon           ":" at 190:47-190:48
+1816: Ident           "uint" at 190:49-190:53 (leading: Space)
+1817: Comma           "," at 190:53-190:54
+1818: Ident           "child" at 190:55-190:60 (leading: Space)
+1819: Colon           ":" at 190:60-190:61
+1820: Ident           "Task" at 190:62-190:66 (leading: Space)
+1821: Lt              "<" at 190:66-190:67
+1822: Ident           "T" at 190:67-190:68
+1823: Gt              ">" at 190:68-190:69
+1824: RParen          ")" at 190:69-190:70
+1825: Arrow           "->" at 190:71-190:73 (leading: Space)
+1826: NothingLit      "nothing" at 190:74-190:81 (leading: Space)
+1827: Semicolon       ";" at 190:81-190:82
+1828: At              "@" at 191:1-191:2 (leading: Newline)
+1829: Ident           "intrinsic" at 191:2-191:11
+1830: KwFn            "fn" at 191:12-191:14 (leading: Space)
+1831: Ident           "rt_scope_cancel_all" at 191:15-191:34 (leading: Space)
+1832: LParen          "(" at 191:34-191:35
+1833: Ident           "scope" at 191:35-191:40
+1834: Colon           ":" at 191:40-191:41
+1835: Ident           "uint" at 191:42-191:46 (leading: Space)
+1836: RParen          ")" at 191:46-191:47
+1837: Arrow           "->" at 191:48-191:50 (leading: Space)
+1838: NothingLit      "nothing" at 191:51-191:58 (leading: Space)
+1839: Semicolon       ";" at 191:58-191:59
+1840: At              "@" at 192:1-192:2 (leading: Newline)
+1841: Ident           "intrinsic" at 192:2-192:11
+1842: KwFn            "fn" at 192:12-192:14 (leading: Space)
+1843: Ident           "rt_scope_join_all" at 192:15-192:32 (leading: Space)
+1844: LParen          "(" at 192:32-192:33
+1845: Ident           "scope" at 192:33-192:38
+1846: Colon           ":" at 192:38-192:39
+1847: Ident           "uint" at 192:40-192:44 (leading: Space)
+1848: RParen          ")" at 192:44-192:45
+1849: Arrow           "->" at 192:46-192:48 (leading: Space)
+1850: Ident           "bool" at 192:49-192:53 (leading: Space)
+1851: Semicolon       ";" at 192:53-192:54
+1852: At              "@" at 193:1-193:2 (leading: Newline)
+1853: Ident           "intrinsic" at 193:2-193:11
+1854: KwFn            "fn" at 193:12-193:14 (leading: Space)
+1855: Ident           "rt_scope_exit" at 193:15-193:28 (leading: Space)
+1856: LParen          "(" at 193:28-193:29
+1857: Ident           "scope" at 193:29-193:34
+1858: Colon           ":" at 193:34-193:35
+1859: Ident           "uint" at 193:36-193:40 (leading: Space)
+1860: RParen          ")" at 193:40-193:41
+1861: Arrow           "->" at 193:42-193:44 (leading: Space)
+1862: NothingLit      "nothing" at 193:45-193:52 (leading: Space)
+1863: Semicolon       ";" at 193:52-193:53
+1864: KwExtern        "extern" at 195:1-195:7 (leading: Newline)
+1865: Lt              "<" at 195:7-195:8
+1866: Ident           "Task" at 195:8-195:12
+1867: Lt              "<" at 195:12-195:13
+1868: Ident           "T" at 195:13-195:14
+1869: Shr             ">>" at 195:14-195:16
+1870: LBrace          "{" at 195:17-195:18 (leading: Space)
+1871: At              "@" at 196:5-196:6 (leading: Newline, Space)
+1872: Ident           "intrinsic" at 196:6-196:15
+1873: KwPub           "pub" at 196:16-196:19 (leading: Space)
+1874: KwFn            "fn" at 196:20-196:22 (leading: Space)
+1875: Ident           "clone" at 196:23-196:28 (leading: Space)
+1876: LParen          "(" at 196:28-196:29
+1877: Ident           "self" at 196:29-196:33
+1878: Colon           ":" at 196:33-196:34
+1879: Amp             "&" at 196:35-196:36 (leading: Space)
+1880: Ident           "Task" at 196:36-196:40
+1881: Lt              "<" at 196:40-196:41
+1882: Ident           "T" at 196:41-196:42
+1883: Gt              ">" at 196:42-196:43
+1884: RParen          ")" at 196:43-196:44
+1885: Arrow           "->" at 196:45-196:47 (leading: Space)
+1886: Ident           "Task" at 196:48-196:52 (leading: Space)
+1887: Lt              "<" at 196:52-196:53
+1888: Ident           "T" at 196:53-196:54
+1889: Gt              ">" at 196:54-196:55
+1890: Semicolon       ";" at 196:55-196:56
+1891: At              "@" at 197:5-197:6 (leading: Newline, Space)
+1892: Ident           "intrinsic" at 197:6-197:15
+1893: KwPub           "pub" at 197:16-197:19 (leading: Space)
+1894: KwFn            "fn" at 197:20-197:22 (leading: Space)
+1895: Ident           "cancel" at 197:23-197:29 (leading: Space)
+1896: LParen          "(" at 197:29-197:30
+1897: Ident           "self" at 197:30-197:34
+1898: Colon           ":" at 197:34-197:35
+1899: Amp             "&" at 197:36-197:37 (leading: Space)
+1900: Ident           "Task" at 197:37-197:41
+1901: Lt              "<" at 197:41-197:42
+1902: Ident           "T" at 197:42-197:43
+1903: Gt              ">" at 197:43-197:44
+1904: RParen          ")" at 197:44-197:45
+1905: Arrow           "->" at 197:46-197:48 (leading: Space)
+1906: NothingLit      "nothing" at 197:49-197:56 (leading: Space)
+1907: Semicolon       ";" at 197:56-197:57
+1908: At              "@" at 198:5-198:6 (leading: Newline, Space)
+1909: Ident           "intrinsic" at 198:6-198:15
+1910: KwPub           "pub" at 198:16-198:19 (leading: Space)
+1911: KwFn            "fn" at 198:20-198:22 (leading: Space)
+1912: Ident           "await" at 198:23-198:28 (leading: Space)
+1913: LParen          "(" at 198:28-198:29
+1914: Ident           "self" at 198:29-198:33
+1915: Colon           ":" at 198:33-198:34
+1916: KwOwn           "own" at 198:35-198:38 (leading: Space)
+1917: Ident           "Task" at 198:39-198:43 (leading: Space)
+1918: Lt              "<" at 198:43-198:44
+1919: Ident           "T" at 198:44-198:45
+1920: Gt              ">" at 198:45-198:46
+1921: RParen          ")" at 198:46-198:47
+1922: Arrow           "->" at 198:48-198:50 (leading: Space)
+1923: Ident           "TaskResult" at 198:51-198:61 (leading: Space)
+1924: Lt              "<" at 198:61-198:62
+1925: Ident           "T" at 198:62-198:63
+1926: Gt              ">" at 198:63-198:64
+1927: Semicolon       ";" at 198:64-198:65
+1928: RBrace          "}" at 199:1-199:2 (leading: Newline)
+1929: At              "@" at 203:1-203:2 (leading: Newline, LineComment, Newline, LineComment, Newline)
+1930: Ident           "intrinsic" at 203:2-203:11
+1931: KwPub           "pub" at 204:1-204:4 (leading: Newline)
+1932: KwFn            "fn" at 204:5-204:7 (leading: Space)
+1933: Ident           "checkpoint" at 204:8-204:18 (leading: Space)
+1934: LParen          "(" at 204:18-204:19
+1935: RParen          ")" at 204:19-204:20
+1936: Arrow           "->" at 204:21-204:23 (leading: Space)
+1937: Ident           "Task" at 204:24-204:28 (leading: Space)
+1938: Lt              "<" at 204:28-204:29
+1939: NothingLit      "nothing" at 204:29-204:36
+1940: Gt              ">" at 204:36-204:37
+1941: Semicolon       ";" at 204:37-204:38
+1942: At              "@" at 207:1-207:2 (leading: Newline, LineComment, Newline)
+1943: Ident           "intrinsic" at 207:2-207:11
+1944: KwPub           "pub" at 207:12-207:15 (leading: Space)
+1945: KwFn            "fn" at 207:16-207:18 (leading: Space)
+1946: Ident           "sleep" at 207:19-207:24 (leading: Space)
+1947: LParen          "(" at 207:24-207:25
+1948: Ident           "ms" at 207:25-207:27
+1949: Colon           ":" at 207:27-207:28
+1950: Ident           "uint" at 207:29-207:33 (leading: Space)
+1951: RParen          ")" at 207:33-207:34
+1952: Arrow           "->" at 207:35-207:37 (leading: Space)
+1953: Ident           "Task" at 207:38-207:42 (leading: Space)
+1954: Lt              "<" at 207:42-207:43
+1955: NothingLit      "nothing" at 207:43-207:50
+1956: Gt              ">" at 207:50-207:51
+1957: Semicolon       ";" at 207:51-207:52
+1958: At              "@" at 211:1-211:2 (leading: Newline, LineComment, Newline, LineComment, Newline)
+1959: Ident           "intrinsic" at 211:2-211:11
+1960: KwPub           "pub" at 211:12-211:15 (leading: Space)
+1961: KwFn            "fn" at 211:16-211:18 (leading: Space)
+1962: Ident           "timeout" at 211:19-211:26 (leading: Space)
+1963: Lt              "<" at 211:26-211:27
+1964: Ident           "T" at 211:27-211:28
+1965: Gt              ">" at 211:28-211:29
+1966: LParen          "(" at 211:29-211:30
+1967: Ident           "t" at 211:30-211:31
+1968: Colon           ":" at 211:31-211:32
+1969: Ident           "Task" at 211:33-211:37 (leading: Space)
+1970: Lt              "<" at 211:37-211:38
+1971: Ident           "T" at 211:38-211:39
+1972: Gt              ">" at 211:39-211:40
+1973: Comma           "," at 211:40-211:41
+1974: Ident           "ms" at 211:42-211:44 (leading: Space)
+1975: Colon           ":" at 211:44-211:45
+1976: Ident           "uint" at 211:46-211:50 (leading: Space)
+1977: RParen          ")" at 211:50-211:51
+1978: Arrow           "->" at 211:52-211:54 (leading: Space)
+1979: Ident           "TaskResult" at 211:55-211:65 (leading: Space)
+1980: Lt              "<" at 211:65-211:66
+1981: Ident           "T" at 211:66-211:67
+1982: Gt              ">" at 211:67-211:68
+1983: Semicolon       ";" at 211:68-211:69
+1984: At              "@" at 214:1-214:2 (leading: Newline, LineComment, Newline)
+1985: Ident           "copy" at 214:2-214:6
+1986: At              "@" at 215:1-215:2 (leading: Newline)
+1987: Ident           "intrinsic" at 215:2-215:11
+1988: KwPub           "pub" at 216:1-216:4 (leading: Newline)
+1989: KwType          "type" at 216:5-216:9 (leading: Space)
+1990: Ident           "Channel" at 216:10-216:17 (leading: Space)
+1991: Lt              "<" at 216:17-216:18
+1992: Ident           "T" at 216:18-216:19
+1993: Gt              ">" at 216:19-216:20
+1994: Assign          "=" at 216:21-216:22 (leading: Space)
+1995: LBrace          "{" at 216:23-216:24 (leading: Space)
+1996: Ident           "__opaque" at 217:5-217:13 (leading: Newline, Space)
+1997: Colon           ":" at 217:13-217:14
+1998: Star            "*" at 217:15-217:16 (leading: Space)
+1999: Ident           "byte" at 217:16-217:20
+2000: Comma           "," at 217:20-217:21
+2001: RBrace          "}" at 218:1-218:2 (leading: Newline)
+2002: Semicolon       ";" at 218:2-218:3
+2003: KwExtern        "extern" at 220:1-220:7 (leading: Newline)
+2004: Lt              "<" at 220:7-220:8
+2005: Ident           "Channel" at 220:8-220:15
+2006: Lt              "<" at 220:15-220:16
+2007: Ident           "T" at 220:16-220:17
+2008: Shr             ">>" at 220:17-220:19
+2009: LBrace          "{" at 220:20-220:21 (leading: Space)
+2010: At              "@" at 222:5-222:6 (leading: Newline, Space, LineComment, Newline, Space)
+2011: Ident           "intrinsic" at 222:6-222:15
+2012: KwPub           "pub" at 222:16-222:19 (leading: Space)
+2013: KwFn            "fn" at 222:20-222:22 (leading: Space)
+2014: Ident           "new" at 222:23-222:26 (leading: Space)
+2015: LParen          "(" at 222:26-222:27
+2016: Ident           "capacity" at 222:27-222:35
+2017: Colon           ":" at 222:35-222:36
+2018: Ident           "uint" at 222:37-222:41 (leading: Space)
+2019: RParen          ")" at 222:41-222:42
+2020: Arrow           "->" at 222:43-222:45 (leading: Space)
+2021: KwOwn           "own" at 222:46-222:49 (leading: Space)
+2022: Ident           "Channel" at 222:50-222:57 (leading: Space)
+2023: Lt              "<" at 222:57-222:58
+2024: Ident           "T" at 222:58-222:59
+2025: Gt              ">" at 222:59-222:60
+2026: Semicolon       ";" at 222:60-222:61
+2027: At              "@" at 224:5-224:6 (leading: Newline, Space, LineComment, Newline, Space)
+2028: Ident           "intrinsic" at 224:6-224:15
+2029: KwPub           "pub" at 224:16-224:19 (leading: Space)
+2030: KwFn            "fn" at 224:20-224:22 (leading: Space)
+2031: Ident           "send" at 224:23-224:27 (leading: Space)
+2032: LParen          "(" at 224:27-224:28
+2033: Ident           "self" at 224:28-224:32
+2034: Colon           ":" at 224:32-224:33
+2035: Amp             "&" at 224:34-224:35 (leading: Space)
+2036: Ident           "Channel" at 224:35-224:42
+2037: Lt              "<" at 224:42-224:43
+2038: Ident           "T" at 224:43-224:44
+2039: Gt              ">" at 224:44-224:45
+2040: Comma           "," at 224:45-224:46
+2041: Ident           "value" at 224:47-224:52 (leading: Space)
+2042: Colon           ":" at 224:52-224:53
+2043: KwOwn           "own" at 224:54-224:57 (leading: Space)
+2044: Ident           "T" at 224:58-224:59 (leading: Space)
+2045: RParen          ")" at 224:59-224:60
+2046: Arrow           "->" at 224:61-224:63 (leading: Space)
+2047: NothingLit      "nothing" at 224:64-224:71 (leading: Space)
+2048: Semicolon       ";" at 224:71-224:72
+2049: At              "@" at 226:5-226:6 (leading: Newline, Space, LineComment, Newline, Space)
+2050: Ident           "intrinsic" at 226:6-226:15
+2051: KwPub           "pub" at 226:16-226:19 (leading: Space)
+2052: KwFn            "fn" at 226:20-226:22 (leading: Space)
+2053: Ident           "recv" at 226:23-226:27 (leading: Space)
+2054: LParen          "(" at 226:27-226:28
+2055: Ident           "self" at 226:28-226:32
+2056: Colon           ":" at 226:32-226:33
+2057: Amp             "&" at 226:34-226:35 (leading: Space)
+2058: Ident           "Channel" at 226:35-226:42
+2059: Lt              "<" at 226:42-226:43
+2060: Ident           "T" at 226:43-226:44
+2061: Gt              ">" at 226:44-226:45
+2062: RParen          ")" at 226:45-226:46
+2063: Arrow           "->" at 226:47-226:49 (leading: Space)
+2064: Ident           "Option" at 226:50-226:56 (leading: Space)
+2065: Lt              "<" at 226:56-226:57
+2066: Ident           "T" at 226:57-226:58
+2067: Gt              ">" at 226:58-226:59
+2068: Semicolon       ";" at 226:59-226:60
+2069: At              "@" at 228:5-228:6 (leading: Newline, Space, LineComment, Newline, Space)
+2070: Ident           "intrinsic" at 228:6-228:15
+2071: KwPub           "pub" at 228:16-228:19 (leading: Space)
+2072: KwFn            "fn" at 228:20-228:22 (leading: Space)
+2073: Ident           "try_send" at 228:23-228:31 (leading: Space)
+2074: LParen          "(" at 228:31-228:32
+2075: Ident           "self" at 228:32-228:36
+2076: Colon           ":" at 228:36-228:37
+2077: Amp             "&" at 228:38-228:39 (leading: Space)
+2078: Ident           "Channel" at 228:39-228:46
+2079: Lt              "<" at 228:46-228:47
+2080: Ident           "T" at 228:47-228:48
+2081: Gt              ">" at 228:48-228:49
+2082: Comma           "," at 228:49-228:50
+2083: Ident           "value" at 228:51-228:56 (leading: Space)
+2084: Colon           ":" at 228:56-228:57
+2085: KwOwn           "own" at 228:58-228:61 (leading: Space)
+2086: Ident           "T" at 228:62-228:63 (leading: Space)
+2087: RParen          ")" at 228:63-228:64
+2088: Arrow           "->" at 228:65-228:67 (leading: Space)
+2089: Ident           "bool" at 228:68-228:72 (leading: Space)
+2090: Semicolon       ";" at 228:72-228:73
+2091: At              "@" at 230:5-230:6 (leading: Newline, Space, LineComment, Newline, Space)
+2092: Ident           "intrinsic" at 230:6-230:15
+2093: KwPub           "pub" at 230:16-230:19 (leading: Space)
+2094: KwFn            "fn" at 230:20-230:22 (leading: Space)
+2095: Ident           "try_recv" at 230:23-230:31 (leading: Space)
+2096: LParen          "(" at 230:31-230:32
+2097: Ident           "self" at 230:32-230:36
+2098: Colon           ":" at 230:36-230:37
+2099: Amp             "&" at 230:38-230:39 (leading: Space)
+2100: Ident           "Channel" at 230:39-230:46
+2101: Lt              "<" at 230:46-230:47
+2102: Ident           "T" at 230:47-230:48
+2103: Gt              ">" at 230:48-230:49
+2104: RParen          ")" at 230:49-230:50
+2105: Arrow           "->" at 230:51-230:53 (leading: Space)
+2106: Ident           "Option" at 230:54-230:60 (leading: Space)
+2107: Lt              "<" at 230:60-230:61
+2108: Ident           "T" at 230:61-230:62
+2109: Gt              ">" at 230:62-230:63
+2110: Semicolon       ";" at 230:63-230:64
+2111: At              "@" at 232:5-232:6 (leading: Newline, Space, LineComment, Newline, Space)
+2112: Ident           "intrinsic" at 232:6-232:15
+2113: KwPub           "pub" at 232:16-232:19 (leading: Space)
+2114: KwFn            "fn" at 232:20-232:22 (leading: Space)
+2115: Ident           "close" at 232:23-232:28 (leading: Space)
+2116: LParen          "(" at 232:28-232:29
+2117: Ident           "self" at 232:29-232:33
+2118: Colon           ":" at 232:33-232:34
+2119: Amp             "&" at 232:35-232:36 (leading: Space)
+2120: Ident           "Channel" at 232:36-232:43
+2121: Lt              "<" at 232:43-232:44
+2122: Ident           "T" at 232:44-232:45
+2123: Gt              ">" at 232:45-232:46
+2124: RParen          ")" at 232:46-232:47
+2125: Arrow           "->" at 232:48-232:50 (leading: Space)
+2126: NothingLit      "nothing" at 232:51-232:58 (leading: Space)
+2127: Semicolon       ";" at 232:58-232:59
+2128: RBrace          "}" at 233:1-233:2 (leading: Newline)
+2129: At              "@" at 235:1-235:2 (leading: Newline)
+2130: Ident           "intrinsic" at 235:2-235:11
+2131: KwFn            "fn" at 236:1-236:3 (leading: Newline)
+2132: Ident           "make_channel" at 236:4-236:16 (leading: Space)
+2133: Lt              "<" at 236:16-236:17
+2134: Ident           "T" at 236:17-236:18
+2135: Gt              ">" at 236:18-236:19
+2136: LParen          "(" at 236:19-236:20
+2137: Ident           "capacity" at 236:20-236:28
+2138: Colon           ":" at 236:28-236:29
+2139: Ident           "uint" at 236:30-236:34 (leading: Space)
+2140: RParen          ")" at 236:34-236:35
+2141: Arrow           "->" at 236:36-236:38 (leading: Space)
+2142: KwOwn           "own" at 236:39-236:42 (leading: Space)
+2143: Ident           "Channel" at 236:43-236:50 (leading: Space)
+2144: Lt              "<" at 236:50-236:51
+2145: Ident           "T" at 236:51-236:52
+2146: Gt              ">" at 236:52-236:53
+2147: Semicolon       ";" at 236:53-236:54
+2148: KwPub           "pub" at 238:1-238:4 (leading: Newline)
+2149: KwContract      "contract" at 238:5-238:13 (leading: Space)
+2150: Ident           "Bounded" at 238:14-238:21 (leading: Space)
+2151: Lt              "<" at 238:21-238:22
+2152: Ident           "T" at 238:22-238:23
+2153: Gt              ">" at 238:23-238:24
+2154: LBrace          "{" at 238:25-238:26 (leading: Space)
+2155: KwFn            "fn" at 239:5-239:7 (leading: Newline, Space)
+2156: Ident           "__min_value" at 239:8-239:19 (leading: Space)
+2157: LParen          "(" at 239:19-239:20
+2158: RParen          ")" at 239:20-239:21
+2159: Arrow           "->" at 239:22-239:24 (leading: Space)
+2160: Ident           "T" at 239:25-239:26 (leading: Space)
+2161: Semicolon       ";" at 239:26-239:27
+2162: KwFn            "fn" at 240:5-240:7 (leading: Newline, Space)
+2163: Ident           "__max_value" at 240:8-240:19 (leading: Space)
+2164: LParen          "(" at 240:19-240:20
+2165: RParen          ")" at 240:20-240:21
+2166: Arrow           "->" at 240:22-240:24 (leading: Space)
+2167: Ident           "T" at 240:25-240:26 (leading: Space)
+2168: Semicolon       ";" at 240:26-240:27
+2169: RBrace          "}" at 241:1-241:2 (leading: Newline)
+2170: KwPub           "pub" at 243:1-243:4 (leading: Newline)
+2171: KwContract      "contract" at 243:5-243:13 (leading: Space)
+2172: Ident           "HasLength" at 243:14-243:23 (leading: Space)
+2173: Lt              "<" at 243:23-243:24
+2174: Ident           "T" at 243:24-243:25
+2175: Gt              ">" at 243:25-243:26
+2176: LBrace          "{" at 243:27-243:28 (leading: Space)
+2177: KwFn            "fn" at 244:5-244:7 (leading: Newline, Space)
+2178: Ident           "__len" at 244:8-244:13 (leading: Space)
+2179: LParen          "(" at 244:13-244:14
+2180: Ident           "self" at 244:14-244:18
+2181: Colon           ":" at 244:18-244:19
+2182: Amp             "&" at 244:20-244:21 (leading: Space)
+2183: Ident           "T" at 244:21-244:22
+2184: RParen          ")" at 244:22-244:23
+2185: Arrow           "->" at 244:24-244:26 (leading: Space)
+2186: Ident           "uint" at 244:27-244:31 (leading: Space)
+2187: Semicolon       ";" at 244:31-244:32
+2188: RBrace          "}" at 245:1-245:2 (leading: Newline)
+2189: KwPub           "pub" at 247:1-247:4 (leading: Newline)
+2190: KwContract      "contract" at 247:5-247:13 (leading: Space)
+2191: Ident           "Printable" at 247:14-247:23 (leading: Space)
+2192: Lt              "<" at 247:23-247:24
+2193: Ident           "T" at 247:24-247:25
+2194: Gt              ">" at 247:25-247:26
+2195: LBrace          "{" at 247:27-247:28 (leading: Space)
+2196: KwFn            "fn" at 248:5-248:7 (leading: Newline, Space)
+2197: Ident           "__to" at 248:8-248:12 (leading: Space)
+2198: LParen          "(" at 248:12-248:13
+2199: Ident           "self" at 248:13-248:17
+2200: Colon           ":" at 248:17-248:18
+2201: Amp             "&" at 248:19-248:20 (leading: Space)
+2202: Ident           "T" at 248:20-248:21
+2203: Comma           "," at 248:21-248:22
+2204: Ident           "target" at 248:23-248:29 (leading: Space)
+2205: Colon           ":" at 248:29-248:30
+2206: Ident           "string" at 248:31-248:37 (leading: Space)
+2207: RParen          ")" at 248:37-248:38
+2208: Arrow           "->" at 248:39-248:41 (leading: Space)
+2209: Ident           "string" at 248:42-248:48 (leading: Space)
+2210: Semicolon       ";" at 248:48-248:49
+2211: RBrace          "}" at 249:1-249:2 (leading: Newline)
+2212: KwPub           "pub" at 251:1-251:4 (leading: Newline)
+2213: KwFn            "fn" at 251:5-251:7 (leading: Space)
+2214: Ident           "max_value" at 251:8-251:17 (leading: Space)
+2215: Lt              "<" at 251:17-251:18
+2216: Ident           "T" at 251:18-251:19
+2217: Colon           ":" at 251:19-251:20
+2218: Ident           "Bounded" at 251:21-251:28 (leading: Space)
+2219: Lt              "<" at 251:28-251:29
+2220: Ident           "T" at 251:29-251:30
+2221: Shr             ">>" at 251:30-251:32
+2222: LParen          "(" at 251:32-251:33
+2223: RParen          ")" at 251:33-251:34
+2224: Arrow           "->" at 251:35-251:37 (leading: Space)
+2225: Ident           "T" at 251:38-251:39 (leading: Space)
+2226: LBrace          "{" at 251:40-251:41 (leading: Space)
+2227: KwReturn        "return" at 252:5-252:11 (leading: Newline, Space)
+2228: Ident           "T" at 252:12-252:13 (leading: Space)
+2229: Dot             "." at 252:13-252:14
+2230: Ident           "__max_value" at 252:14-252:25
+2231: LParen          "(" at 252:25-252:26
+2232: RParen          ")" at 252:26-252:27
+2233: Semicolon       ";" at 252:27-252:28
+2234: RBrace          "}" at 253:1-253:2 (leading: Newline)
+2235: KwPub           "pub" at 255:1-255:4 (leading: Newline)
+2236: KwFn            "fn" at 255:5-255:7 (leading: Space)
+2237: Ident           "min_value" at 255:8-255:17 (leading: Space)
+2238: Lt              "<" at 255:17-255:18
+2239: Ident           "T" at 255:18-255:19
+2240: Colon           ":" at 255:19-255:20
+2241: Ident           "Bounded" at 255:21-255:28 (leading: Space)
+2242: Lt              "<" at 255:28-255:29
+2243: Ident           "T" at 255:29-255:30
+2244: Shr             ">>" at 255:30-255:32
+2245: LParen          "(" at 255:32-255:33
+2246: RParen          ")" at 255:33-255:34
+2247: Arrow           "->" at 255:35-255:37 (leading: Space)
+2248: Ident           "T" at 255:38-255:39 (leading: Space)
+2249: LBrace          "{" at 255:40-255:41 (leading: Space)
+2250: KwReturn        "return" at 256:5-256:11 (leading: Newline, Space)
+2251: Ident           "T" at 256:12-256:13 (leading: Space)
+2252: Dot             "." at 256:13-256:14
+2253: Ident           "__min_value" at 256:14-256:25
+2254: LParen          "(" at 256:25-256:26
+2255: RParen          ")" at 256:26-256:27
+2256: Semicolon       ";" at 256:27-256:28
+2257: RBrace          "}" at 257:1-257:2 (leading: Newline)
+2258: KwExtern        "extern" at 259:1-259:7 (leading: Newline)
+2259: Lt              "<" at 259:7-259:8
+2260: Ident           "int" at 259:8-259:11
+2261: Gt              ">" at 259:11-259:12
+2262: LBrace          "{" at 259:13-259:14 (leading: Space)
+2263: At              "@" at 260:5-260:6 (leading: Newline, Space)
+2264: Ident           "intrinsic" at 260:6-260:15
+2265: KwFn            "fn" at 260:16-260:18 (leading: Space)
+2266: Ident           "__add" at 260:19-260:24 (leading: Space)
+2267: LParen          "(" at 260:24-260:25
+2268: Ident           "self" at 260:25-260:29
+2269: Colon           ":" at 260:29-260:30
+2270: Ident           "int" at 260:31-260:34 (leading: Space)
+2271: Comma           "," at 260:34-260:35
+2272: Ident           "other" at 260:36-260:41 (leading: Space)
+2273: Colon           ":" at 260:41-260:42
+2274: Ident           "int" at 260:43-260:46 (leading: Space)
+2275: RParen          ")" at 260:46-260:47
+2276: Arrow           "->" at 260:48-260:50 (leading: Space)
+2277: Ident           "int" at 260:51-260:54 (leading: Space)
+2278: Semicolon       ";" at 260:54-260:55
+2279: At              "@" at 261:5-261:6 (leading: Newline, Space)
+2280: Ident           "intrinsic" at 261:6-261:15
+2281: KwFn            "fn" at 261:16-261:18 (leading: Space)
+2282: Ident           "__sub" at 261:19-261:24 (leading: Space)
+2283: LParen          "(" at 261:24-261:25
+2284: Ident           "self" at 261:25-261:29
+2285: Colon           ":" at 261:29-261:30
+2286: Ident           "int" at 261:31-261:34 (leading: Space)
+2287: Comma           "," at 261:34-261:35
+2288: Ident           "other" at 261:36-261:41 (leading: Space)
+2289: Colon           ":" at 261:41-261:42
+2290: Ident           "int" at 261:43-261:46 (leading: Space)
+2291: RParen          ")" at 261:46-261:47
+2292: Arrow           "->" at 261:48-261:50 (leading: Space)
+2293: Ident           "int" at 261:51-261:54 (leading: Space)
+2294: Semicolon       ";" at 261:54-261:55
+2295: At              "@" at 262:5-262:6 (leading: Newline, Space)
+2296: Ident           "intrinsic" at 262:6-262:15
+2297: KwFn            "fn" at 262:16-262:18 (leading: Space)
+2298: Ident           "__mul" at 262:19-262:24 (leading: Space)
+2299: LParen          "(" at 262:24-262:25
+2300: Ident           "self" at 262:25-262:29
+2301: Colon           ":" at 262:29-262:30
+2302: Ident           "int" at 262:31-262:34 (leading: Space)
+2303: Comma           "," at 262:34-262:35
+2304: Ident           "other" at 262:36-262:41 (leading: Space)
+2305: Colon           ":" at 262:41-262:42
+2306: Ident           "int" at 262:43-262:46 (leading: Space)
+2307: RParen          ")" at 262:46-262:47
+2308: Arrow           "->" at 262:48-262:50 (leading: Space)
+2309: Ident           "int" at 262:51-262:54 (leading: Space)
+2310: Semicolon       ";" at 262:54-262:55
+2311: At              "@" at 263:5-263:6 (leading: Newline, Space)
+2312: Ident           "intrinsic" at 263:6-263:15
+2313: KwFn            "fn" at 263:16-263:18 (leading: Space)
+2314: Ident           "__div" at 263:19-263:24 (leading: Space)
+2315: LParen          "(" at 263:24-263:25
+2316: Ident           "self" at 263:25-263:29
+2317: Colon           ":" at 263:29-263:30
+2318: Ident           "int" at 263:31-263:34 (leading: Space)
+2319: Comma           "," at 263:34-263:35
+2320: Ident           "other" at 263:36-263:41 (leading: Space)
+2321: Colon           ":" at 263:41-263:42
+2322: Ident           "int" at 263:43-263:46 (leading: Space)
+2323: RParen          ")" at 263:46-263:47
+2324: Arrow           "->" at 263:48-263:50 (leading: Space)
+2325: Ident           "int" at 263:51-263:54 (leading: Space)
+2326: Semicolon       ";" at 263:54-263:55
+2327: At              "@" at 264:5-264:6 (leading: Newline, Space)
+2328: Ident           "intrinsic" at 264:6-264:15
+2329: KwFn            "fn" at 264:16-264:18 (leading: Space)
+2330: Ident           "__mod" at 264:19-264:24 (leading: Space)
+2331: LParen          "(" at 264:24-264:25
+2332: Ident           "self" at 264:25-264:29
+2333: Colon           ":" at 264:29-264:30
+2334: Ident           "int" at 264:31-264:34 (leading: Space)
+2335: Comma           "," at 264:34-264:35
+2336: Ident           "other" at 264:36-264:41 (leading: Space)
+2337: Colon           ":" at 264:41-264:42
+2338: Ident           "int" at 264:43-264:46 (leading: Space)
+2339: RParen          ")" at 264:46-264:47
+2340: Arrow           "->" at 264:48-264:50 (leading: Space)
+2341: Ident           "int" at 264:51-264:54 (leading: Space)
+2342: Semicolon       ";" at 264:54-264:55
+2343: At              "@" at 265:5-265:6 (leading: Newline, Space)
+2344: Ident           "intrinsic" at 265:6-265:15
+2345: KwFn            "fn" at 265:16-265:18 (leading: Space)
+2346: Ident           "__bit_and" at 265:19-265:28 (leading: Space)
+2347: LParen          "(" at 265:28-265:29
+2348: Ident           "self" at 265:29-265:33
+2349: Colon           ":" at 265:33-265:34
+2350: Ident           "int" at 265:35-265:38 (leading: Space)
+2351: Comma           "," at 265:38-265:39
+2352: Ident           "other" at 265:40-265:45 (leading: Space)
+2353: Colon           ":" at 265:45-265:46
+2354: Ident           "int" at 265:47-265:50 (leading: Space)
+2355: RParen          ")" at 265:50-265:51
+2356: Arrow           "->" at 265:52-265:54 (leading: Space)
+2357: Ident           "int" at 265:55-265:58 (leading: Space)
+2358: Semicolon       ";" at 265:58-265:59
+2359: At              "@" at 266:5-266:6 (leading: Newline, Space)
+2360: Ident           "intrinsic" at 266:6-266:15
+2361: KwFn            "fn" at 266:16-266:18 (leading: Space)
+2362: Ident           "__bit_or" at 266:19-266:27 (leading: Space)
+2363: LParen          "(" at 266:27-266:28
+2364: Ident           "self" at 266:28-266:32
+2365: Colon           ":" at 266:32-266:33
+2366: Ident           "int" at 266:34-266:37 (leading: Space)
+2367: Comma           "," at 266:37-266:38
+2368: Ident           "other" at 266:39-266:44 (leading: Space)
+2369: Colon           ":" at 266:44-266:45
+2370: Ident           "int" at 266:46-266:49 (leading: Space)
+2371: RParen          ")" at 266:49-266:50
+2372: Arrow           "->" at 266:51-266:53 (leading: Space)
+2373: Ident           "int" at 266:54-266:57 (leading: Space)
+2374: Semicolon       ";" at 266:57-266:58
+2375: At              "@" at 267:5-267:6 (leading: Newline, Space)
+2376: Ident           "intrinsic" at 267:6-267:15
+2377: KwFn            "fn" at 267:16-267:18 (leading: Space)
+2378: Ident           "__bit_xor" at 267:19-267:28 (leading: Space)
+2379: LParen          "(" at 267:28-267:29
+2380: Ident           "self" at 267:29-267:33
+2381: Colon           ":" at 267:33-267:34
+2382: Ident           "int" at 267:35-267:38 (leading: Space)
+2383: Comma           "," at 267:38-267:39
+2384: Ident           "other" at 267:40-267:45 (leading: Space)
+2385: Colon           ":" at 267:45-267:46
+2386: Ident           "int" at 267:47-267:50 (leading: Space)
+2387: RParen          ")" at 267:50-267:51
+2388: Arrow           "->" at 267:52-267:54 (leading: Space)
+2389: Ident           "int" at 267:55-267:58 (leading: Space)
+2390: Semicolon       ";" at 267:58-267:59
+2391: At              "@" at 268:5-268:6 (leading: Newline, Space)
+2392: Ident           "intrinsic" at 268:6-268:15
+2393: KwFn            "fn" at 268:16-268:18 (leading: Space)
+2394: Ident           "__shl" at 268:19-268:24 (leading: Space)
+2395: LParen          "(" at 268:24-268:25
+2396: Ident           "self" at 268:25-268:29
+2397: Colon           ":" at 268:29-268:30
+2398: Ident           "int" at 268:31-268:34 (leading: Space)
+2399: Comma           "," at 268:34-268:35
+2400: Ident           "other" at 268:36-268:41 (leading: Space)
+2401: Colon           ":" at 268:41-268:42
+2402: Ident           "int" at 268:43-268:46 (leading: Space)
+2403: RParen          ")" at 268:46-268:47
+2404: Arrow           "->" at 268:48-268:50 (leading: Space)
+2405: Ident           "int" at 268:51-268:54 (leading: Space)
+2406: Semicolon       ";" at 268:54-268:55
+2407: At              "@" at 269:5-269:6 (leading: Newline, Space)
+2408: Ident           "intrinsic" at 269:6-269:15
+2409: KwFn            "fn" at 269:16-269:18 (leading: Space)
+2410: Ident           "__shr" at 269:19-269:24 (leading: Space)
+2411: LParen          "(" at 269:24-269:25
+2412: Ident           "self" at 269:25-269:29
+2413: Colon           ":" at 269:29-269:30
+2414: Ident           "int" at 269:31-269:34 (leading: Space)
+2415: Comma           "," at 269:34-269:35
+2416: Ident           "other" at 269:36-269:41 (leading: Space)
+2417: Colon           ":" at 269:41-269:42
+2418: Ident           "int" at 269:43-269:46 (leading: Space)
+2419: RParen          ")" at 269:46-269:47
+2420: Arrow           "->" at 269:48-269:50 (leading: Space)
+2421: Ident           "int" at 269:51-269:54 (leading: Space)
+2422: Semicolon       ";" at 269:54-269:55
+2423: At              "@" at 270:5-270:6 (leading: Newline, Space)
+2424: Ident           "intrinsic" at 270:6-270:15
+2425: KwFn            "fn" at 270:16-270:18 (leading: Space)
+2426: Ident           "__lt" at 270:19-270:23 (leading: Space)
+2427: LParen          "(" at 270:23-270:24
+2428: Ident           "self" at 270:24-270:28
+2429: Colon           ":" at 270:28-270:29
+2430: Ident           "int" at 270:30-270:33 (leading: Space)
+2431: Comma           "," at 270:33-270:34
+2432: Ident           "other" at 270:35-270:40 (leading: Space)
+2433: Colon           ":" at 270:40-270:41
+2434: Ident           "int" at 270:42-270:45 (leading: Space)
+2435: RParen          ")" at 270:45-270:46
+2436: Arrow           "->" at 270:47-270:49 (leading: Space)
+2437: Ident           "bool" at 270:50-270:54 (leading: Space)
+2438: Semicolon       ";" at 270:54-270:55
+2439: At              "@" at 271:5-271:6 (leading: Newline, Space)
+2440: Ident           "intrinsic" at 271:6-271:15
+2441: KwFn            "fn" at 271:16-271:18 (leading: Space)
+2442: Ident           "__le" at 271:19-271:23 (leading: Space)
+2443: LParen          "(" at 271:23-271:24
+2444: Ident           "self" at 271:24-271:28
+2445: Colon           ":" at 271:28-271:29
+2446: Ident           "int" at 271:30-271:33 (leading: Space)
+2447: Comma           "," at 271:33-271:34
+2448: Ident           "other" at 271:35-271:40 (leading: Space)
+2449: Colon           ":" at 271:40-271:41
+2450: Ident           "int" at 271:42-271:45 (leading: Space)
+2451: RParen          ")" at 271:45-271:46
+2452: Arrow           "->" at 271:47-271:49 (leading: Space)
+2453: Ident           "bool" at 271:50-271:54 (leading: Space)
+2454: Semicolon       ";" at 271:54-271:55
+2455: At              "@" at 272:5-272:6 (leading: Newline, Space)
+2456: Ident           "intrinsic" at 272:6-272:15
+2457: KwFn            "fn" at 272:16-272:18 (leading: Space)
+2458: Ident           "__eq" at 272:19-272:23 (leading: Space)
+2459: LParen          "(" at 272:23-272:24
+2460: Ident           "self" at 272:24-272:28
+2461: Colon           ":" at 272:28-272:29
+2462: Ident           "int" at 272:30-272:33 (leading: Space)
+2463: Comma           "," at 272:33-272:34
+2464: Ident           "other" at 272:35-272:40 (leading: Space)
+2465: Colon           ":" at 272:40-272:41
+2466: Ident           "int" at 272:42-272:45 (leading: Space)
+2467: RParen          ")" at 272:45-272:46
+2468: Arrow           "->" at 272:47-272:49 (leading: Space)
+2469: Ident           "bool" at 272:50-272:54 (leading: Space)
+2470: Semicolon       ";" at 272:54-272:55
+2471: At              "@" at 273:5-273:6 (leading: Newline, Space)
+2472: Ident           "intrinsic" at 273:6-273:15
+2473: KwFn            "fn" at 273:16-273:18 (leading: Space)
+2474: Ident           "__ne" at 273:19-273:23 (leading: Space)
+2475: LParen          "(" at 273:23-273:24
+2476: Ident           "self" at 273:24-273:28
+2477: Colon           ":" at 273:28-273:29
+2478: Ident           "int" at 273:30-273:33 (leading: Space)
+2479: Comma           "," at 273:33-273:34
+2480: Ident           "other" at 273:35-273:40 (leading: Space)
+2481: Colon           ":" at 273:40-273:41
+2482: Ident           "int" at 273:42-273:45 (leading: Space)
+2483: RParen          ")" at 273:45-273:46
+2484: Arrow           "->" at 273:47-273:49 (leading: Space)
+2485: Ident           "bool" at 273:50-273:54 (leading: Space)
+2486: Semicolon       ";" at 273:54-273:55
+2487: At              "@" at 274:5-274:6 (leading: Newline, Space)
+2488: Ident           "intrinsic" at 274:6-274:15
+2489: KwFn            "fn" at 274:16-274:18 (leading: Space)
+2490: Ident           "__ge" at 274:19-274:23 (leading: Space)
+2491: LParen          "(" at 274:23-274:24
+2492: Ident           "self" at 274:24-274:28
+2493: Colon           ":" at 274:28-274:29
+2494: Ident           "int" at 274:30-274:33 (leading: Space)
+2495: Comma           "," at 274:33-274:34
+2496: Ident           "other" at 274:35-274:40 (leading: Space)
+2497: Colon           ":" at 274:40-274:41
+2498: Ident           "int" at 274:42-274:45 (leading: Space)
+2499: RParen          ")" at 274:45-274:46
+2500: Arrow           "->" at 274:47-274:49 (leading: Space)
+2501: Ident           "bool" at 274:50-274:54 (leading: Space)
+2502: Semicolon       ";" at 274:54-274:55
+2503: At              "@" at 275:5-275:6 (leading: Newline, Space)
+2504: Ident           "intrinsic" at 275:6-275:15
+2505: KwFn            "fn" at 275:16-275:18 (leading: Space)
+2506: Ident           "__gt" at 275:19-275:23 (leading: Space)
+2507: LParen          "(" at 275:23-275:24
+2508: Ident           "self" at 275:24-275:28
+2509: Colon           ":" at 275:28-275:29
+2510: Ident           "int" at 275:30-275:33 (leading: Space)
+2511: Comma           "," at 275:33-275:34
+2512: Ident           "other" at 275:35-275:40 (leading: Space)
+2513: Colon           ":" at 275:40-275:41
+2514: Ident           "int" at 275:42-275:45 (leading: Space)
+2515: RParen          ")" at 275:45-275:46
+2516: Arrow           "->" at 275:47-275:49 (leading: Space)
+2517: Ident           "bool" at 275:50-275:54 (leading: Space)
+2518: Semicolon       ";" at 275:54-275:55
+2519: At              "@" at 276:5-276:6 (leading: Newline, Space)
+2520: Ident           "intrinsic" at 276:6-276:15
+2521: KwFn            "fn" at 276:16-276:18 (leading: Space)
+2522: Ident           "__pos" at 276:19-276:24 (leading: Space)
+2523: LParen          "(" at 276:24-276:25
+2524: Ident           "self" at 276:25-276:29
+2525: Colon           ":" at 276:29-276:30
+2526: Ident           "int" at 276:31-276:34 (leading: Space)
+2527: RParen          ")" at 276:34-276:35
+2528: Arrow           "->" at 276:36-276:38 (leading: Space)
+2529: Ident           "int" at 276:39-276:42 (leading: Space)
+2530: Semicolon       ";" at 276:42-276:43
+2531: At              "@" at 277:5-277:6 (leading: Newline, Space)
+2532: Ident           "intrinsic" at 277:6-277:15
+2533: KwFn            "fn" at 277:16-277:18 (leading: Space)
+2534: Ident           "__neg" at 277:19-277:24 (leading: Space)
+2535: LParen          "(" at 277:24-277:25
+2536: Ident           "self" at 277:25-277:29
+2537: Colon           ":" at 277:29-277:30
+2538: Ident           "int" at 277:31-277:34 (leading: Space)
+2539: RParen          ")" at 277:34-277:35
+2540: Arrow           "->" at 277:36-277:38 (leading: Space)
+2541: Ident           "int" at 277:39-277:42 (leading: Space)
+2542: Semicolon       ";" at 277:42-277:43
+2543: At              "@" at 278:5-278:6 (leading: Newline, Space)
+2544: Ident           "intrinsic" at 278:6-278:15
+2545: KwFn            "fn" at 278:16-278:18 (leading: Space)
+2546: Ident           "__abs" at 278:19-278:24 (leading: Space)
+2547: LParen          "(" at 278:24-278:25
+2548: Ident           "self" at 278:25-278:29
+2549: Colon           ":" at 278:29-278:30
+2550: Ident           "int" at 278:31-278:34 (leading: Space)
+2551: RParen          ")" at 278:34-278:35
+2552: Arrow           "->" at 278:36-278:38 (leading: Space)
+2553: Ident           "int" at 278:39-278:42 (leading: Space)
+2554: Semicolon       ";" at 278:42-278:43
+2555: At              "@" at 279:5-279:6 (leading: Newline, Space)
+2556: Ident           "intrinsic" at 279:6-279:15
+2557: KwFn            "fn" at 279:16-279:18 (leading: Space)
+2558: Ident           "__to" at 279:19-279:23 (leading: Space)
+2559: LParen          "(" at 279:23-279:24
+2560: Ident           "self" at 279:24-279:28
+2561: Colon           ":" at 279:28-279:29
+2562: Ident           "int" at 279:30-279:33 (leading: Space)
+2563: Comma           "," at 279:33-279:34
+2564: Ident           "target" at 279:35-279:41 (leading: Space)
+2565: Colon           ":" at 279:41-279:42
+2566: Ident           "string" at 279:43-279:49 (leading: Space)
+2567: RParen          ")" at 279:49-279:50
+2568: Arrow           "->" at 279:51-279:53 (leading: Space)
+2569: Ident           "string" at 279:54-279:60 (leading: Space)
+2570: Semicolon       ";" at 279:60-279:61
+2571: At              "@" at 280:5-280:6 (leading: Newline, Space)
+2572: Ident           "overload" at 280:6-280:14
+2573: KwPub           "pub" at 280:15-280:18 (leading: Space)
+2574: KwFn            "fn" at 280:19-280:21 (leading: Space)
+2575: Ident           "__to" at 280:22-280:26 (leading: Space)
+2576: LParen          "(" at 280:26-280:27
+2577: Ident           "self" at 280:27-280:31
+2578: Colon           ":" at 280:31-280:32
+2579: Amp             "&" at 280:33-280:34 (leading: Space)
+2580: Ident           "int" at 280:34-280:37
+2581: Comma           "," at 280:37-280:38
+2582: Underscore      "_" at 280:39-280:40 (leading: Space)
+2583: Colon           ":" at 280:40-280:41
+2584: Ident           "string" at 280:42-280:48 (leading: Space)
+2585: RParen          ")" at 280:48-280:49
+2586: Arrow           "->" at 280:50-280:52 (leading: Space)
+2587: Ident           "string" at 280:53-280:59 (leading: Space)
+2588: LBrace          "{" at 280:60-280:61 (leading: Space)
+2589: KwReturn        "return" at 281:9-281:15 (leading: Newline, Space)
+2590: LParen          "(" at 281:16-281:17 (leading: Space)
+2591: Star            "*" at 281:17-281:18
+2592: Ident           "self" at 281:18-281:22
+2593: RParen          ")" at 281:22-281:23
+2594: KwTo            "to" at 281:24-281:26 (leading: Space)
+2595: Ident           "string" at 281:27-281:33 (leading: Space)
+2596: Semicolon       ";" at 281:33-281:34
+2597: RBrace          "}" at 282:5-282:6 (leading: Newline, Space)
+2598: At              "@" at 283:5-283:6 (leading: Newline, Space)
+2599: Ident           "intrinsic" at 283:6-283:15
+2600: At              "@" at 283:16-283:17 (leading: Space)
+2601: Ident           "overload" at 283:17-283:25
+2602: KwFn            "fn" at 283:26-283:28 (leading: Space)
+2603: Ident           "__to" at 283:29-283:33 (leading: Space)
+2604: LParen          "(" at 283:33-283:34
+2605: Ident           "self" at 283:34-283:38
+2606: Colon           ":" at 283:38-283:39
+2607: Ident           "int" at 283:40-283:43 (leading: Space)
+2608: Comma           "," at 283:43-283:44
+2609: Ident           "target" at 283:45-283:51 (leading: Space)
+2610: Colon           ":" at 283:51-283:52
+2611: Ident           "float" at 283:53-283:58 (leading: Space)
+2612: RParen          ")" at 283:58-283:59
+2613: Arrow           "->" at 283:60-283:62 (leading: Space)
+2614: Ident           "float" at 283:63-283:68 (leading: Space)
+2615: Semicolon       ";" at 283:68-283:69
+2616: At              "@" at 284:5-284:6 (leading: Newline, Space)
+2617: Ident           "intrinsic" at 284:6-284:15
+2618: At              "@" at 284:16-284:17 (leading: Space)
+2619: Ident           "overload" at 284:17-284:25
+2620: KwFn            "fn" at 284:26-284:28 (leading: Space)
+2621: Ident           "__to" at 284:29-284:33 (leading: Space)
+2622: LParen          "(" at 284:33-284:34
+2623: Ident           "self" at 284:34-284:38
+2624: Colon           ":" at 284:38-284:39
+2625: Ident           "int" at 284:40-284:43 (leading: Space)
+2626: Comma           "," at 284:43-284:44
+2627: Ident           "target" at 284:45-284:51 (leading: Space)
+2628: Colon           ":" at 284:51-284:52
+2629: Ident           "uint" at 284:53-284:57 (leading: Space)
+2630: RParen          ")" at 284:57-284:58
+2631: Arrow           "->" at 284:59-284:61 (leading: Space)
+2632: Ident           "uint" at 284:62-284:66 (leading: Space)
+2633: Semicolon       ";" at 284:66-284:67
+2634: At              "@" at 285:5-285:6 (leading: Newline, Space)
+2635: Ident           "intrinsic" at 285:6-285:15
+2636: At              "@" at 285:16-285:17 (leading: Space)
+2637: Ident           "overload" at 285:17-285:25
+2638: KwFn            "fn" at 285:26-285:28 (leading: Space)
+2639: Ident           "__to" at 285:29-285:33 (leading: Space)
+2640: LParen          "(" at 285:33-285:34
+2641: Ident           "self" at 285:34-285:38
+2642: Colon           ":" at 285:38-285:39
+2643: Ident           "int" at 285:40-285:43 (leading: Space)
+2644: Comma           "," at 285:43-285:44
+2645: Ident           "target" at 285:45-285:51 (leading: Space)
+2646: Colon           ":" at 285:51-285:52
+2647: Ident           "int8" at 285:53-285:57 (leading: Space)
+2648: RParen          ")" at 285:57-285:58
+2649: Arrow           "->" at 285:59-285:61 (leading: Space)
+2650: Ident           "int8" at 285:62-285:66 (leading: Space)
+2651: Semicolon       ";" at 285:66-285:67
+2652: At              "@" at 286:5-286:6 (leading: Newline, Space)
+2653: Ident           "intrinsic" at 286:6-286:15
+2654: At              "@" at 286:16-286:17 (leading: Space)
+2655: Ident           "overload" at 286:17-286:25
+2656: KwFn            "fn" at 286:26-286:28 (leading: Space)
+2657: Ident           "__to" at 286:29-286:33 (leading: Space)
+2658: LParen          "(" at 286:33-286:34
+2659: Ident           "self" at 286:34-286:38
+2660: Colon           ":" at 286:38-286:39
+2661: Ident           "int" at 286:40-286:43 (leading: Space)
+2662: Comma           "," at 286:43-286:44
+2663: Ident           "target" at 286:45-286:51 (leading: Space)
+2664: Colon           ":" at 286:51-286:52
+2665: Ident           "int16" at 286:53-286:58 (leading: Space)
+2666: RParen          ")" at 286:58-286:59
+2667: Arrow           "->" at 286:60-286:62 (leading: Space)
+2668: Ident           "int16" at 286:63-286:68 (leading: Space)
+2669: Semicolon       ";" at 286:68-286:69
+2670: At              "@" at 287:5-287:6 (leading: Newline, Space)
+2671: Ident           "intrinsic" at 287:6-287:15
+2672: At              "@" at 287:16-287:17 (leading: Space)
+2673: Ident           "overload" at 287:17-287:25
+2674: KwFn            "fn" at 287:26-287:28 (leading: Space)
+2675: Ident           "__to" at 287:29-287:33 (leading: Space)
+2676: LParen          "(" at 287:33-287:34
+2677: Ident           "self" at 287:34-287:38
+2678: Colon           ":" at 287:38-287:39
+2679: Ident           "int" at 287:40-287:43 (leading: Space)
+2680: Comma           "," at 287:43-287:44
+2681: Ident           "target" at 287:45-287:51 (leading: Space)
+2682: Colon           ":" at 287:51-287:52
+2683: Ident           "int32" at 287:53-287:58 (leading: Space)
+2684: RParen          ")" at 287:58-287:59
+2685: Arrow           "->" at 287:60-287:62 (leading: Space)
+2686: Ident           "int32" at 287:63-287:68 (leading: Space)
+2687: Semicolon       ";" at 287:68-287:69
+2688: At              "@" at 288:5-288:6 (leading: Newline, Space)
+2689: Ident           "intrinsic" at 288:6-288:15
+2690: At              "@" at 288:16-288:17 (leading: Space)
+2691: Ident           "overload" at 288:17-288:25
+2692: KwFn            "fn" at 288:26-288:28 (leading: Space)
+2693: Ident           "__to" at 288:29-288:33 (leading: Space)
+2694: LParen          "(" at 288:33-288:34
+2695: Ident           "self" at 288:34-288:38
+2696: Colon           ":" at 288:38-288:39
+2697: Ident           "int" at 288:40-288:43 (leading: Space)
+2698: Comma           "," at 288:43-288:44
+2699: Ident           "target" at 288:45-288:51 (leading: Space)
+2700: Colon           ":" at 288:51-288:52
+2701: Ident           "int64" at 288:53-288:58 (leading: Space)
+2702: RParen          ")" at 288:58-288:59
+2703: Arrow           "->" at 288:60-288:62 (leading: Space)
+2704: Ident           "int64" at 288:63-288:68 (leading: Space)
+2705: Semicolon       ";" at 288:68-288:69
+2706: At              "@" at 289:5-289:6 (leading: Newline, Space)
+2707: Ident           "intrinsic" at 289:6-289:15
+2708: At              "@" at 289:16-289:17 (leading: Space)
+2709: Ident           "overload" at 289:17-289:25
+2710: KwFn            "fn" at 289:26-289:28 (leading: Space)
+2711: Ident           "__to" at 289:29-289:33 (leading: Space)
+2712: LParen          "(" at 289:33-289:34
+2713: Ident           "self" at 289:34-289:38
+2714: Colon           ":" at 289:38-289:39
+2715: Ident           "int" at 289:40-289:43 (leading: Space)
+2716: Comma           "," at 289:43-289:44
+2717: Ident           "target" at 289:45-289:51 (leading: Space)
+2718: Colon           ":" at 289:51-289:52
+2719: Ident           "uint8" at 289:53-289:58 (leading: Space)
+2720: RParen          ")" at 289:58-289:59
+2721: Arrow           "->" at 289:60-289:62 (leading: Space)
+2722: Ident           "uint8" at 289:63-289:68 (leading: Space)
+2723: Semicolon       ";" at 289:68-289:69
+2724: At              "@" at 290:5-290:6 (leading: Newline, Space)
+2725: Ident           "intrinsic" at 290:6-290:15
+2726: At              "@" at 290:16-290:17 (leading: Space)
+2727: Ident           "overload" at 290:17-290:25
+2728: KwFn            "fn" at 290:26-290:28 (leading: Space)
+2729: Ident           "__to" at 290:29-290:33 (leading: Space)
+2730: LParen          "(" at 290:33-290:34
+2731: Ident           "self" at 290:34-290:38
+2732: Colon           ":" at 290:38-290:39
+2733: Ident           "int" at 290:40-290:43 (leading: Space)
+2734: Comma           "," at 290:43-290:44
+2735: Ident           "target" at 290:45-290:51 (leading: Space)
+2736: Colon           ":" at 290:51-290:52
+2737: Ident           "uint16" at 290:53-290:59 (leading: Space)
+2738: RParen          ")" at 290:59-290:60
+2739: Arrow           "->" at 290:61-290:63 (leading: Space)
+2740: Ident           "uint16" at 290:64-290:70 (leading: Space)
+2741: Semicolon       ";" at 290:70-290:71
+2742: At              "@" at 291:5-291:6 (leading: Newline, Space)
+2743: Ident           "intrinsic" at 291:6-291:15
+2744: At              "@" at 291:16-291:17 (leading: Space)
+2745: Ident           "overload" at 291:17-291:25
+2746: KwFn            "fn" at 291:26-291:28 (leading: Space)
+2747: Ident           "__to" at 291:29-291:33 (leading: Space)
+2748: LParen          "(" at 291:33-291:34
+2749: Ident           "self" at 291:34-291:38
+2750: Colon           ":" at 291:38-291:39
+2751: Ident           "int" at 291:40-291:43 (leading: Space)
+2752: Comma           "," at 291:43-291:44
+2753: Ident           "target" at 291:45-291:51 (leading: Space)
+2754: Colon           ":" at 291:51-291:52
+2755: Ident           "uint32" at 291:53-291:59 (leading: Space)
+2756: RParen          ")" at 291:59-291:60
+2757: Arrow           "->" at 291:61-291:63 (leading: Space)
+2758: Ident           "uint32" at 291:64-291:70 (leading: Space)
+2759: Semicolon       ";" at 291:70-291:71
+2760: At              "@" at 292:5-292:6 (leading: Newline, Space)
+2761: Ident           "intrinsic" at 292:6-292:15
+2762: At              "@" at 292:16-292:17 (leading: Space)
+2763: Ident           "overload" at 292:17-292:25
+2764: KwFn            "fn" at 292:26-292:28 (leading: Space)
+2765: Ident           "__to" at 292:29-292:33 (leading: Space)
+2766: LParen          "(" at 292:33-292:34
+2767: Ident           "self" at 292:34-292:38
+2768: Colon           ":" at 292:38-292:39
+2769: Ident           "int" at 292:40-292:43 (leading: Space)
+2770: Comma           "," at 292:43-292:44
+2771: Ident           "target" at 292:45-292:51 (leading: Space)
+2772: Colon           ":" at 292:51-292:52
+2773: Ident           "uint64" at 292:53-292:59 (leading: Space)
+2774: RParen          ")" at 292:59-292:60
+2775: Arrow           "->" at 292:61-292:63 (leading: Space)
+2776: Ident           "uint64" at 292:64-292:70 (leading: Space)
+2777: Semicolon       ";" at 292:70-292:71
+2778: At              "@" at 293:5-293:6 (leading: Newline, Space)
+2779: Ident           "intrinsic" at 293:6-293:15
+2780: At              "@" at 293:16-293:17 (leading: Space)
+2781: Ident           "overload" at 293:17-293:25
+2782: KwFn            "fn" at 293:26-293:28 (leading: Space)
+2783: Ident           "__to" at 293:29-293:33 (leading: Space)
+2784: LParen          "(" at 293:33-293:34
+2785: Ident           "self" at 293:34-293:38
+2786: Colon           ":" at 293:38-293:39
+2787: Ident           "int" at 293:40-293:43 (leading: Space)
+2788: Comma           "," at 293:43-293:44
+2789: Ident           "target" at 293:45-293:51 (leading: Space)
+2790: Colon           ":" at 293:51-293:52
+2791: Ident           "float16" at 293:53-293:60 (leading: Space)
+2792: RParen          ")" at 293:60-293:61
+2793: Arrow           "->" at 293:62-293:64 (leading: Space)
+2794: Ident           "float16" at 293:65-293:72 (leading: Space)
+2795: Semicolon       ";" at 293:72-293:73
+2796: At              "@" at 294:5-294:6 (leading: Newline, Space)
+2797: Ident           "intrinsic" at 294:6-294:15
+2798: At              "@" at 294:16-294:17 (leading: Space)
+2799: Ident           "overload" at 294:17-294:25
+2800: KwFn            "fn" at 294:26-294:28 (leading: Space)
+2801: Ident           "__to" at 294:29-294:33 (leading: Space)
+2802: LParen          "(" at 294:33-294:34
+2803: Ident           "self" at 294:34-294:38
+2804: Colon           ":" at 294:38-294:39
+2805: Ident           "int" at 294:40-294:43 (leading: Space)
+2806: Comma           "," at 294:43-294:44
+2807: Ident           "target" at 294:45-294:51 (leading: Space)
+2808: Colon           ":" at 294:51-294:52
+2809: Ident           "float32" at 294:53-294:60 (leading: Space)
+2810: RParen          ")" at 294:60-294:61
+2811: Arrow           "->" at 294:62-294:64 (leading: Space)
+2812: Ident           "float32" at 294:65-294:72 (leading: Space)
+2813: Semicolon       ";" at 294:72-294:73
+2814: At              "@" at 295:5-295:6 (leading: Newline, Space)
+2815: Ident           "intrinsic" at 295:6-295:15
+2816: At              "@" at 295:16-295:17 (leading: Space)
+2817: Ident           "overload" at 295:17-295:25
+2818: KwFn            "fn" at 295:26-295:28 (leading: Space)
+2819: Ident           "__to" at 295:29-295:33 (leading: Space)
+2820: LParen          "(" at 295:33-295:34
+2821: Ident           "self" at 295:34-295:38
+2822: Colon           ":" at 295:38-295:39
+2823: Ident           "int" at 295:40-295:43 (leading: Space)
+2824: Comma           "," at 295:43-295:44
+2825: Ident           "target" at 295:45-295:51 (leading: Space)
+2826: Colon           ":" at 295:51-295:52
+2827: Ident           "float64" at 295:53-295:60 (leading: Space)
+2828: RParen          ")" at 295:60-295:61
+2829: Arrow           "->" at 295:62-295:64 (leading: Space)
+2830: Ident           "float64" at 295:65-295:72 (leading: Space)
+2831: Semicolon       ";" at 295:72-295:73
+2832: At              "@" at 297:5-297:6 (leading: Newline, Space, LineComment, Newline, Space)
+2833: Ident           "intrinsic" at 297:6-297:15
+2834: KwPub           "pub" at 297:16-297:19 (leading: Space)
+2835: KwFn            "fn" at 297:20-297:22 (leading: Space)
+2836: Ident           "from_str" at 297:23-297:31 (leading: Space)
+2837: LParen          "(" at 297:31-297:32
+2838: Ident           "s" at 297:32-297:33
+2839: Colon           ":" at 297:33-297:34
+2840: Amp             "&" at 297:35-297:36 (leading: Space)
+2841: Ident           "string" at 297:36-297:42
+2842: RParen          ")" at 297:42-297:43
+2843: Arrow           "->" at 297:44-297:46 (leading: Space)
+2844: Ident           "Erring" at 297:47-297:53 (leading: Space)
+2845: Lt              "<" at 297:53-297:54
+2846: Ident           "int" at 297:54-297:57
+2847: Comma           "," at 297:57-297:58
+2848: Ident           "Error" at 297:59-297:64 (leading: Space)
+2849: Gt              ">" at 297:64-297:65
+2850: Semicolon       ";" at 297:65-297:66
+2851: RBrace          "}" at 298:1-298:2 (leading: Newline)
+2852: KwExtern        "extern" at 300:1-300:7 (leading: Newline)
+2853: Lt              "<" at 300:7-300:8
+2854: Ident           "uint" at 300:8-300:12
+2855: Gt              ">" at 300:12-300:13
+2856: LBrace          "{" at 300:14-300:15 (leading: Space)
+2857: At              "@" at 301:5-301:6 (leading: Newline, Space)
+2858: Ident           "intrinsic" at 301:6-301:15
+2859: KwFn            "fn" at 301:16-301:18 (leading: Space)
+2860: Ident           "__add" at 301:19-301:24 (leading: Space)
+2861: LParen          "(" at 301:24-301:25
+2862: Ident           "self" at 301:25-301:29
+2863: Colon           ":" at 301:29-301:30
+2864: Ident           "uint" at 301:31-301:35 (leading: Space)
+2865: Comma           "," at 301:35-301:36
+2866: Ident           "other" at 301:37-301:42 (leading: Space)
+2867: Colon           ":" at 301:42-301:43
+2868: Ident           "uint" at 301:44-301:48 (leading: Space)
+2869: RParen          ")" at 301:48-301:49
+2870: Arrow           "->" at 301:50-301:52 (leading: Space)
+2871: Ident           "uint" at 301:53-301:57 (leading: Space)
+2872: Semicolon       ";" at 301:57-301:58
+2873: At              "@" at 302:5-302:6 (leading: Newline, Space)
+2874: Ident           "intrinsic" at 302:6-302:15
+2875: KwFn            "fn" at 302:16-302:18 (leading: Space)
+2876: Ident           "__sub" at 302:19-302:24 (leading: Space)
+2877: LParen          "(" at 302:24-302:25
+2878: Ident           "self" at 302:25-302:29
+2879: Colon           ":" at 302:29-302:30
+2880: Ident           "uint" at 302:31-302:35 (leading: Space)
+2881: Comma           "," at 302:35-302:36
+2882: Ident           "other" at 302:37-302:42 (leading: Space)
+2883: Colon           ":" at 302:42-302:43
+2884: Ident           "uint" at 302:44-302:48 (leading: Space)
+2885: RParen          ")" at 302:48-302:49
+2886: Arrow           "->" at 302:50-302:52 (leading: Space)
+2887: Ident           "uint" at 302:53-302:57 (leading: Space)
+2888: Semicolon       ";" at 302:57-302:58
+2889: At              "@" at 303:5-303:6 (leading: Newline, Space)
+2890: Ident           "intrinsic" at 303:6-303:15
+2891: KwFn            "fn" at 303:16-303:18 (leading: Space)
+2892: Ident           "__mul" at 303:19-303:24 (leading: Space)
+2893: LParen          "(" at 303:24-303:25
+2894: Ident           "self" at 303:25-303:29
+2895: Colon           ":" at 303:29-303:30
+2896: Ident           "uint" at 303:31-303:35 (leading: Space)
+2897: Comma           "," at 303:35-303:36
+2898: Ident           "other" at 303:37-303:42 (leading: Space)
+2899: Colon           ":" at 303:42-303:43
+2900: Ident           "uint" at 303:44-303:48 (leading: Space)
+2901: RParen          ")" at 303:48-303:49
+2902: Arrow           "->" at 303:50-303:52 (leading: Space)
+2903: Ident           "uint" at 303:53-303:57 (leading: Space)
+2904: Semicolon       ";" at 303:57-303:58
+2905: At              "@" at 304:5-304:6 (leading: Newline, Space)
+2906: Ident           "intrinsic" at 304:6-304:15
+2907: KwFn            "fn" at 304:16-304:18 (leading: Space)
+2908: Ident           "__div" at 304:19-304:24 (leading: Space)
+2909: LParen          "(" at 304:24-304:25
+2910: Ident           "self" at 304:25-304:29
+2911: Colon           ":" at 304:29-304:30
+2912: Ident           "uint" at 304:31-304:35 (leading: Space)
+2913: Comma           "," at 304:35-304:36
+2914: Ident           "other" at 304:37-304:42 (leading: Space)
+2915: Colon           ":" at 304:42-304:43
+2916: Ident           "uint" at 304:44-304:48 (leading: Space)
+2917: RParen          ")" at 304:48-304:49
+2918: Arrow           "->" at 304:50-304:52 (leading: Space)
+2919: Ident           "uint" at 304:53-304:57 (leading: Space)
+2920: Semicolon       ";" at 304:57-304:58
+2921: At              "@" at 305:5-305:6 (leading: Newline, Space)
+2922: Ident           "intrinsic" at 305:6-305:15
+2923: KwFn            "fn" at 305:16-305:18 (leading: Space)
+2924: Ident           "__mod" at 305:19-305:24 (leading: Space)
+2925: LParen          "(" at 305:24-305:25
+2926: Ident           "self" at 305:25-305:29
+2927: Colon           ":" at 305:29-305:30
+2928: Ident           "uint" at 305:31-305:35 (leading: Space)
+2929: Comma           "," at 305:35-305:36
+2930: Ident           "other" at 305:37-305:42 (leading: Space)
+2931: Colon           ":" at 305:42-305:43
+2932: Ident           "uint" at 305:44-305:48 (leading: Space)
+2933: RParen          ")" at 305:48-305:49
+2934: Arrow           "->" at 305:50-305:52 (leading: Space)
+2935: Ident           "uint" at 305:53-305:57 (leading: Space)
+2936: Semicolon       ";" at 305:57-305:58
+2937: At              "@" at 306:5-306:6 (leading: Newline, Space)
+2938: Ident           "intrinsic" at 306:6-306:15
+2939: KwFn            "fn" at 306:16-306:18 (leading: Space)
+2940: Ident           "__bit_and" at 306:19-306:28 (leading: Space)
+2941: LParen          "(" at 306:28-306:29
+2942: Ident           "self" at 306:29-306:33
+2943: Colon           ":" at 306:33-306:34
+2944: Ident           "uint" at 306:35-306:39 (leading: Space)
+2945: Comma           "," at 306:39-306:40
+2946: Ident           "other" at 306:41-306:46 (leading: Space)
+2947: Colon           ":" at 306:46-306:47
+2948: Ident           "uint" at 306:48-306:52 (leading: Space)
+2949: RParen          ")" at 306:52-306:53
+2950: Arrow           "->" at 306:54-306:56 (leading: Space)
+2951: Ident           "uint" at 306:57-306:61 (leading: Space)
+2952: Semicolon       ";" at 306:61-306:62
+2953: At              "@" at 307:5-307:6 (leading: Newline, Space)
+2954: Ident           "intrinsic" at 307:6-307:15
+2955: KwFn            "fn" at 307:16-307:18 (leading: Space)
+2956: Ident           "__bit_or" at 307:19-307:27 (leading: Space)
+2957: LParen          "(" at 307:27-307:28
+2958: Ident           "self" at 307:28-307:32
+2959: Colon           ":" at 307:32-307:33
+2960: Ident           "uint" at 307:34-307:38 (leading: Space)
+2961: Comma           "," at 307:38-307:39
+2962: Ident           "other" at 307:40-307:45 (leading: Space)
+2963: Colon           ":" at 307:45-307:46
+2964: Ident           "uint" at 307:47-307:51 (leading: Space)
+2965: RParen          ")" at 307:51-307:52
+2966: Arrow           "->" at 307:53-307:55 (leading: Space)
+2967: Ident           "uint" at 307:56-307:60 (leading: Space)
+2968: Semicolon       ";" at 307:60-307:61
+2969: At              "@" at 308:5-308:6 (leading: Newline, Space)
+2970: Ident           "intrinsic" at 308:6-308:15
+2971: KwFn            "fn" at 308:16-308:18 (leading: Space)
+2972: Ident           "__bit_xor" at 308:19-308:28 (leading: Space)
+2973: LParen          "(" at 308:28-308:29
+2974: Ident           "self" at 308:29-308:33
+2975: Colon           ":" at 308:33-308:34
+2976: Ident           "uint" at 308:35-308:39 (leading: Space)
+2977: Comma           "," at 308:39-308:40
+2978: Ident           "other" at 308:41-308:46 (leading: Space)
+2979: Colon           ":" at 308:46-308:47
+2980: Ident           "uint" at 308:48-308:52 (leading: Space)
+2981: RParen          ")" at 308:52-308:53
+2982: Arrow           "->" at 308:54-308:56 (leading: Space)
+2983: Ident           "uint" at 308:57-308:61 (leading: Space)
+2984: Semicolon       ";" at 308:61-308:62
+2985: At              "@" at 309:5-309:6 (leading: Newline, Space)
+2986: Ident           "intrinsic" at 309:6-309:15
+2987: KwFn            "fn" at 309:16-309:18 (leading: Space)
+2988: Ident           "__shl" at 309:19-309:24 (leading: Space)
+2989: LParen          "(" at 309:24-309:25
+2990: Ident           "self" at 309:25-309:29
+2991: Colon           ":" at 309:29-309:30
+2992: Ident           "uint" at 309:31-309:35 (leading: Space)
+2993: Comma           "," at 309:35-309:36
+2994: Ident           "other" at 309:37-309:42 (leading: Space)
+2995: Colon           ":" at 309:42-309:43
+2996: Ident           "uint" at 309:44-309:48 (leading: Space)
+2997: RParen          ")" at 309:48-309:49
+2998: Arrow           "->" at 309:50-309:52 (leading: Space)
+2999: Ident           "uint" at 309:53-309:57 (leading: Space)
+3000: Semicolon       ";" at 309:57-309:58
+3001: At              "@" at 310:5-310:6 (leading: Newline, Space)
+3002: Ident           "intrinsic" at 310:6-310:15
+3003: KwFn            "fn" at 310:16-310:18 (leading: Space)
+3004: Ident           "__shr" at 310:19-310:24 (leading: Space)
+3005: LParen          "(" at 310:24-310:25
+3006: Ident           "self" at 310:25-310:29
+3007: Colon           ":" at 310:29-310:30
+3008: Ident           "uint" at 310:31-310:35 (leading: Space)
+3009: Comma           "," at 310:35-310:36
+3010: Ident           "other" at 310:37-310:42 (leading: Space)
+3011: Colon           ":" at 310:42-310:43
+3012: Ident           "uint" at 310:44-310:48 (leading: Space)
+3013: RParen          ")" at 310:48-310:49
+3014: Arrow           "->" at 310:50-310:52 (leading: Space)
+3015: Ident           "uint" at 310:53-310:57 (leading: Space)
+3016: Semicolon       ";" at 310:57-310:58
+3017: At              "@" at 311:5-311:6 (leading: Newline, Space)
+3018: Ident           "intrinsic" at 311:6-311:15
+3019: KwFn            "fn" at 311:16-311:18 (leading: Space)
+3020: Ident           "__lt" at 311:19-311:23 (leading: Space)
+3021: LParen          "(" at 311:23-311:24
+3022: Ident           "self" at 311:24-311:28
+3023: Colon           ":" at 311:28-311:29
+3024: Ident           "uint" at 311:30-311:34 (leading: Space)
+3025: Comma           "," at 311:34-311:35
+3026: Ident           "other" at 311:36-311:41 (leading: Space)
+3027: Colon           ":" at 311:41-311:42
+3028: Ident           "uint" at 311:43-311:47 (leading: Space)
+3029: RParen          ")" at 311:47-311:48
+3030: Arrow           "->" at 311:49-311:51 (leading: Space)
+3031: Ident           "bool" at 311:52-311:56 (leading: Space)
+3032: Semicolon       ";" at 311:56-311:57
+3033: At              "@" at 312:5-312:6 (leading: Newline, Space)
+3034: Ident           "intrinsic" at 312:6-312:15
+3035: KwFn            "fn" at 312:16-312:18 (leading: Space)
+3036: Ident           "__le" at 312:19-312:23 (leading: Space)
+3037: LParen          "(" at 312:23-312:24
+3038: Ident           "self" at 312:24-312:28
+3039: Colon           ":" at 312:28-312:29
+3040: Ident           "uint" at 312:30-312:34 (leading: Space)
+3041: Comma           "," at 312:34-312:35
+3042: Ident           "other" at 312:36-312:41 (leading: Space)
+3043: Colon           ":" at 312:41-312:42
+3044: Ident           "uint" at 312:43-312:47 (leading: Space)
+3045: RParen          ")" at 312:47-312:48
+3046: Arrow           "->" at 312:49-312:51 (leading: Space)
+3047: Ident           "bool" at 312:52-312:56 (leading: Space)
+3048: Semicolon       ";" at 312:56-312:57
+3049: At              "@" at 313:5-313:6 (leading: Newline, Space)
+3050: Ident           "intrinsic" at 313:6-313:15
+3051: KwFn            "fn" at 313:16-313:18 (leading: Space)
+3052: Ident           "__eq" at 313:19-313:23 (leading: Space)
+3053: LParen          "(" at 313:23-313:24
+3054: Ident           "self" at 313:24-313:28
+3055: Colon           ":" at 313:28-313:29
+3056: Ident           "uint" at 313:30-313:34 (leading: Space)
+3057: Comma           "," at 313:34-313:35
+3058: Ident           "other" at 313:36-313:41 (leading: Space)
+3059: Colon           ":" at 313:41-313:42
+3060: Ident           "uint" at 313:43-313:47 (leading: Space)
+3061: RParen          ")" at 313:47-313:48
+3062: Arrow           "->" at 313:49-313:51 (leading: Space)
+3063: Ident           "bool" at 313:52-313:56 (leading: Space)
+3064: Semicolon       ";" at 313:56-313:57
+3065: At              "@" at 314:5-314:6 (leading: Newline, Space)
+3066: Ident           "intrinsic" at 314:6-314:15
+3067: KwFn            "fn" at 314:16-314:18 (leading: Space)
+3068: Ident           "__ne" at 314:19-314:23 (leading: Space)
+3069: LParen          "(" at 314:23-314:24
+3070: Ident           "self" at 314:24-314:28
+3071: Colon           ":" at 314:28-314:29
+3072: Ident           "uint" at 314:30-314:34 (leading: Space)
+3073: Comma           "," at 314:34-314:35
+3074: Ident           "other" at 314:36-314:41 (leading: Space)
+3075: Colon           ":" at 314:41-314:42
+3076: Ident           "uint" at 314:43-314:47 (leading: Space)
+3077: RParen          ")" at 314:47-314:48
+3078: Arrow           "->" at 314:49-314:51 (leading: Space)
+3079: Ident           "bool" at 314:52-314:56 (leading: Space)
+3080: Semicolon       ";" at 314:56-314:57
+3081: At              "@" at 315:5-315:6 (leading: Newline, Space)
+3082: Ident           "intrinsic" at 315:6-315:15
+3083: KwFn            "fn" at 315:16-315:18 (leading: Space)
+3084: Ident           "__ge" at 315:19-315:23 (leading: Space)
+3085: LParen          "(" at 315:23-315:24
+3086: Ident           "self" at 315:24-315:28
+3087: Colon           ":" at 315:28-315:29
+3088: Ident           "uint" at 315:30-315:34 (leading: Space)
+3089: Comma           "," at 315:34-315:35
+3090: Ident           "other" at 315:36-315:41 (leading: Space)
+3091: Colon           ":" at 315:41-315:42
+3092: Ident           "uint" at 315:43-315:47 (leading: Space)
+3093: RParen          ")" at 315:47-315:48
+3094: Arrow           "->" at 315:49-315:51 (leading: Space)
+3095: Ident           "bool" at 315:52-315:56 (leading: Space)
+3096: Semicolon       ";" at 315:56-315:57
+3097: At              "@" at 316:5-316:6 (leading: Newline, Space)
+3098: Ident           "intrinsic" at 316:6-316:15
+3099: KwFn            "fn" at 316:16-316:18 (leading: Space)
+3100: Ident           "__gt" at 316:19-316:23 (leading: Space)
+3101: LParen          "(" at 316:23-316:24
+3102: Ident           "self" at 316:24-316:28
+3103: Colon           ":" at 316:28-316:29
+3104: Ident           "uint" at 316:30-316:34 (leading: Space)
+3105: Comma           "," at 316:34-316:35
+3106: Ident           "other" at 316:36-316:41 (leading: Space)
+3107: Colon           ":" at 316:41-316:42
+3108: Ident           "uint" at 316:43-316:47 (leading: Space)
+3109: RParen          ")" at 316:47-316:48
+3110: Arrow           "->" at 316:49-316:51 (leading: Space)
+3111: Ident           "bool" at 316:52-316:56 (leading: Space)
+3112: Semicolon       ";" at 316:56-316:57
+3113: At              "@" at 317:5-317:6 (leading: Newline, Space)
+3114: Ident           "intrinsic" at 317:6-317:15
+3115: KwFn            "fn" at 317:16-317:18 (leading: Space)
+3116: Ident           "__pos" at 317:19-317:24 (leading: Space)
+3117: LParen          "(" at 317:24-317:25
+3118: Ident           "self" at 317:25-317:29
+3119: Colon           ":" at 317:29-317:30
+3120: Ident           "uint" at 317:31-317:35 (leading: Space)
+3121: RParen          ")" at 317:35-317:36
+3122: Arrow           "->" at 317:37-317:39 (leading: Space)
+3123: Ident           "uint" at 317:40-317:44 (leading: Space)
+3124: Semicolon       ";" at 317:44-317:45
+3125: At              "@" at 318:5-318:6 (leading: Newline, Space)
+3126: Ident           "intrinsic" at 318:6-318:15
+3127: KwFn            "fn" at 318:16-318:18 (leading: Space)
+3128: Ident           "__abs" at 318:19-318:24 (leading: Space)
+3129: LParen          "(" at 318:24-318:25
+3130: Ident           "self" at 318:25-318:29
+3131: Colon           ":" at 318:29-318:30
+3132: Ident           "uint" at 318:31-318:35 (leading: Space)
+3133: RParen          ")" at 318:35-318:36
+3134: Arrow           "->" at 318:37-318:39 (leading: Space)
+3135: Ident           "uint" at 318:40-318:44 (leading: Space)
+3136: Semicolon       ";" at 318:44-318:45
+3137: At              "@" at 319:5-319:6 (leading: Newline, Space)
+3138: Ident           "intrinsic" at 319:6-319:15
+3139: KwFn            "fn" at 319:16-319:18 (leading: Space)
+3140: Ident           "__to" at 319:19-319:23 (leading: Space)
+3141: LParen          "(" at 319:23-319:24
+3142: Ident           "self" at 319:24-319:28
+3143: Colon           ":" at 319:28-319:29
+3144: Ident           "uint" at 319:30-319:34 (leading: Space)
+3145: Comma           "," at 319:34-319:35
+3146: Ident           "target" at 319:36-319:42 (leading: Space)
+3147: Colon           ":" at 319:42-319:43
+3148: Ident           "string" at 319:44-319:50 (leading: Space)
+3149: RParen          ")" at 319:50-319:51
+3150: Arrow           "->" at 319:52-319:54 (leading: Space)
+3151: Ident           "string" at 319:55-319:61 (leading: Space)
+3152: Semicolon       ";" at 319:61-319:62
+3153: At              "@" at 320:5-320:6 (leading: Newline, Space)
+3154: Ident           "overload" at 320:6-320:14
+3155: KwPub           "pub" at 320:15-320:18 (leading: Space)
+3156: KwFn            "fn" at 320:19-320:21 (leading: Space)
+3157: Ident           "__to" at 320:22-320:26 (leading: Space)
+3158: LParen          "(" at 320:26-320:27
+3159: Ident           "self" at 320:27-320:31
+3160: Colon           ":" at 320:31-320:32
+3161: Amp             "&" at 320:33-320:34 (leading: Space)
+3162: Ident           "uint" at 320:34-320:38
+3163: Comma           "," at 320:38-320:39
+3164: Underscore      "_" at 320:40-320:41 (leading: Space)
+3165: Colon           ":" at 320:41-320:42
+3166: Ident           "string" at 320:43-320:49 (leading: Space)
+3167: RParen          ")" at 320:49-320:50
+3168: Arrow           "->" at 320:51-320:53 (leading: Space)
+3169: Ident           "string" at 320:54-320:60 (leading: Space)
+3170: LBrace          "{" at 320:61-320:62 (leading: Space)
+3171: KwReturn        "return" at 321:9-321:15 (leading: Newline, Space)
+3172: LParen          "(" at 321:16-321:17 (leading: Space)
+3173: Star            "*" at 321:17-321:18
+3174: Ident           "self" at 321:18-321:22
+3175: RParen          ")" at 321:22-321:23
+3176: KwTo            "to" at 321:24-321:26 (leading: Space)
+3177: Ident           "string" at 321:27-321:33 (leading: Space)
+3178: Semicolon       ";" at 321:33-321:34
+3179: RBrace          "}" at 322:5-322:6 (leading: Newline, Space)
+3180: At              "@" at 323:5-323:6 (leading: Newline, Space)
+3181: Ident           "intrinsic" at 323:6-323:15
+3182: At              "@" at 323:16-323:17 (leading: Space)
+3183: Ident           "overload" at 323:17-323:25
+3184: KwFn            "fn" at 323:26-323:28 (leading: Space)
+3185: Ident           "__to" at 323:29-323:33 (leading: Space)
+3186: LParen          "(" at 323:33-323:34
+3187: Ident           "self" at 323:34-323:38
+3188: Colon           ":" at 323:38-323:39
+3189: Ident           "uint" at 323:40-323:44 (leading: Space)
+3190: Comma           "," at 323:44-323:45
+3191: Ident           "target" at 323:46-323:52 (leading: Space)
+3192: Colon           ":" at 323:52-323:53
+3193: Ident           "int" at 323:54-323:57 (leading: Space)
+3194: RParen          ")" at 323:57-323:58
+3195: Arrow           "->" at 323:59-323:61 (leading: Space)
+3196: Ident           "int" at 323:62-323:65 (leading: Space)
+3197: Semicolon       ";" at 323:65-323:66
+3198: At              "@" at 324:5-324:6 (leading: Newline, Space)
+3199: Ident           "intrinsic" at 324:6-324:15
+3200: At              "@" at 324:16-324:17 (leading: Space)
+3201: Ident           "overload" at 324:17-324:25
+3202: KwFn            "fn" at 324:26-324:28 (leading: Space)
+3203: Ident           "__to" at 324:29-324:33 (leading: Space)
+3204: LParen          "(" at 324:33-324:34
+3205: Ident           "self" at 324:34-324:38
+3206: Colon           ":" at 324:38-324:39
+3207: Ident           "uint" at 324:40-324:44 (leading: Space)
+3208: Comma           "," at 324:44-324:45
+3209: Ident           "target" at 324:46-324:52 (leading: Space)
+3210: Colon           ":" at 324:52-324:53
+3211: Ident           "float" at 324:54-324:59 (leading: Space)
+3212: RParen          ")" at 324:59-324:60
+3213: Arrow           "->" at 324:61-324:63 (leading: Space)
+3214: Ident           "float" at 324:64-324:69 (leading: Space)
+3215: Semicolon       ";" at 324:69-324:70
+3216: At              "@" at 325:5-325:6 (leading: Newline, Space)
+3217: Ident           "intrinsic" at 325:6-325:15
+3218: At              "@" at 325:16-325:17 (leading: Space)
+3219: Ident           "overload" at 325:17-325:25
+3220: KwFn            "fn" at 325:26-325:28 (leading: Space)
+3221: Ident           "__to" at 325:29-325:33 (leading: Space)
+3222: LParen          "(" at 325:33-325:34
+3223: Ident           "self" at 325:34-325:38
+3224: Colon           ":" at 325:38-325:39
+3225: Ident           "uint" at 325:40-325:44 (leading: Space)
+3226: Comma           "," at 325:44-325:45
+3227: Ident           "target" at 325:46-325:52 (leading: Space)
+3228: Colon           ":" at 325:52-325:53
+3229: Ident           "int8" at 325:54-325:58 (leading: Space)
+3230: RParen          ")" at 325:58-325:59
+3231: Arrow           "->" at 325:60-325:62 (leading: Space)
+3232: Ident           "int8" at 325:63-325:67 (leading: Space)
+3233: Semicolon       ";" at 325:67-325:68
+3234: At              "@" at 326:5-326:6 (leading: Newline, Space)
+3235: Ident           "intrinsic" at 326:6-326:15
+3236: At              "@" at 326:16-326:17 (leading: Space)
+3237: Ident           "overload" at 326:17-326:25
+3238: KwFn            "fn" at 326:26-326:28 (leading: Space)
+3239: Ident           "__to" at 326:29-326:33 (leading: Space)
+3240: LParen          "(" at 326:33-326:34
+3241: Ident           "self" at 326:34-326:38
+3242: Colon           ":" at 326:38-326:39
+3243: Ident           "uint" at 326:40-326:44 (leading: Space)
+3244: Comma           "," at 326:44-326:45
+3245: Ident           "target" at 326:46-326:52 (leading: Space)
+3246: Colon           ":" at 326:52-326:53
+3247: Ident           "int16" at 326:54-326:59 (leading: Space)
+3248: RParen          ")" at 326:59-326:60
+3249: Arrow           "->" at 326:61-326:63 (leading: Space)
+3250: Ident           "int16" at 326:64-326:69 (leading: Space)
+3251: Semicolon       ";" at 326:69-326:70
+3252: At              "@" at 327:5-327:6 (leading: Newline, Space)
+3253: Ident           "intrinsic" at 327:6-327:15
+3254: At              "@" at 327:16-327:17 (leading: Space)
+3255: Ident           "overload" at 327:17-327:25
+3256: KwFn            "fn" at 327:26-327:28 (leading: Space)
+3257: Ident           "__to" at 327:29-327:33 (leading: Space)
+3258: LParen          "(" at 327:33-327:34
+3259: Ident           "self" at 327:34-327:38
+3260: Colon           ":" at 327:38-327:39
+3261: Ident           "uint" at 327:40-327:44 (leading: Space)
+3262: Comma           "," at 327:44-327:45
+3263: Ident           "target" at 327:46-327:52 (leading: Space)
+3264: Colon           ":" at 327:52-327:53
+3265: Ident           "int32" at 327:54-327:59 (leading: Space)
+3266: RParen          ")" at 327:59-327:60
+3267: Arrow           "->" at 327:61-327:63 (leading: Space)
+3268: Ident           "int32" at 327:64-327:69 (leading: Space)
+3269: Semicolon       ";" at 327:69-327:70
+3270: At              "@" at 328:5-328:6 (leading: Newline, Space)
+3271: Ident           "intrinsic" at 328:6-328:15
+3272: At              "@" at 328:16-328:17 (leading: Space)
+3273: Ident           "overload" at 328:17-328:25
+3274: KwFn            "fn" at 328:26-328:28 (leading: Space)
+3275: Ident           "__to" at 328:29-328:33 (leading: Space)
+3276: LParen          "(" at 328:33-328:34
+3277: Ident           "self" at 328:34-328:38
+3278: Colon           ":" at 328:38-328:39
+3279: Ident           "uint" at 328:40-328:44 (leading: Space)
+3280: Comma           "," at 328:44-328:45
+3281: Ident           "target" at 328:46-328:52 (leading: Space)
+3282: Colon           ":" at 328:52-328:53
+3283: Ident           "int64" at 328:54-328:59 (leading: Space)
+3284: RParen          ")" at 328:59-328:60
+3285: Arrow           "->" at 328:61-328:63 (leading: Space)
+3286: Ident           "int64" at 328:64-328:69 (leading: Space)
+3287: Semicolon       ";" at 328:69-328:70
+3288: At              "@" at 329:5-329:6 (leading: Newline, Space)
+3289: Ident           "intrinsic" at 329:6-329:15
+3290: At              "@" at 329:16-329:17 (leading: Space)
+3291: Ident           "overload" at 329:17-329:25
+3292: KwFn            "fn" at 329:26-329:28 (leading: Space)
+3293: Ident           "__to" at 329:29-329:33 (leading: Space)
+3294: LParen          "(" at 329:33-329:34
+3295: Ident           "self" at 329:34-329:38
+3296: Colon           ":" at 329:38-329:39
+3297: Ident           "uint" at 329:40-329:44 (leading: Space)
+3298: Comma           "," at 329:44-329:45
+3299: Ident           "target" at 329:46-329:52 (leading: Space)
+3300: Colon           ":" at 329:52-329:53
+3301: Ident           "uint8" at 329:54-329:59 (leading: Space)
+3302: RParen          ")" at 329:59-329:60
+3303: Arrow           "->" at 329:61-329:63 (leading: Space)
+3304: Ident           "uint8" at 329:64-329:69 (leading: Space)
+3305: Semicolon       ";" at 329:69-329:70
+3306: At              "@" at 330:5-330:6 (leading: Newline, Space)
+3307: Ident           "intrinsic" at 330:6-330:15
+3308: At              "@" at 330:16-330:17 (leading: Space)
+3309: Ident           "overload" at 330:17-330:25
+3310: KwFn            "fn" at 330:26-330:28 (leading: Space)
+3311: Ident           "__to" at 330:29-330:33 (leading: Space)
+3312: LParen          "(" at 330:33-330:34
+3313: Ident           "self" at 330:34-330:38
+3314: Colon           ":" at 330:38-330:39
+3315: Ident           "uint" at 330:40-330:44 (leading: Space)
+3316: Comma           "," at 330:44-330:45
+3317: Ident           "target" at 330:46-330:52 (leading: Space)
+3318: Colon           ":" at 330:52-330:53
+3319: Ident           "uint16" at 330:54-330:60 (leading: Space)
+3320: RParen          ")" at 330:60-330:61
+3321: Arrow           "->" at 330:62-330:64 (leading: Space)
+3322: Ident           "uint16" at 330:65-330:71 (leading: Space)
+3323: Semicolon       ";" at 330:71-330:72
+3324: At              "@" at 331:5-331:6 (leading: Newline, Space)
+3325: Ident           "intrinsic" at 331:6-331:15
+3326: At              "@" at 331:16-331:17 (leading: Space)
+3327: Ident           "overload" at 331:17-331:25
+3328: KwFn            "fn" at 331:26-331:28 (leading: Space)
+3329: Ident           "__to" at 331:29-331:33 (leading: Space)
+3330: LParen          "(" at 331:33-331:34
+3331: Ident           "self" at 331:34-331:38
+3332: Colon           ":" at 331:38-331:39
+3333: Ident           "uint" at 331:40-331:44 (leading: Space)
+3334: Comma           "," at 331:44-331:45
+3335: Ident           "target" at 331:46-331:52 (leading: Space)
+3336: Colon           ":" at 331:52-331:53
+3337: Ident           "uint32" at 331:54-331:60 (leading: Space)
+3338: RParen          ")" at 331:60-331:61
+3339: Arrow           "->" at 331:62-331:64 (leading: Space)
+3340: Ident           "uint32" at 331:65-331:71 (leading: Space)
+3341: Semicolon       ";" at 331:71-331:72
+3342: At              "@" at 332:5-332:6 (leading: Newline, Space)
+3343: Ident           "intrinsic" at 332:6-332:15
+3344: At              "@" at 332:16-332:17 (leading: Space)
+3345: Ident           "overload" at 332:17-332:25
+3346: KwFn            "fn" at 332:26-332:28 (leading: Space)
+3347: Ident           "__to" at 332:29-332:33 (leading: Space)
+3348: LParen          "(" at 332:33-332:34
+3349: Ident           "self" at 332:34-332:38
+3350: Colon           ":" at 332:38-332:39
+3351: Ident           "uint" at 332:40-332:44 (leading: Space)
+3352: Comma           "," at 332:44-332:45
+3353: Ident           "target" at 332:46-332:52 (leading: Space)
+3354: Colon           ":" at 332:52-332:53
+3355: Ident           "uint64" at 332:54-332:60 (leading: Space)
+3356: RParen          ")" at 332:60-332:61
+3357: Arrow           "->" at 332:62-332:64 (leading: Space)
+3358: Ident           "uint64" at 332:65-332:71 (leading: Space)
+3359: Semicolon       ";" at 332:71-332:72
+3360: At              "@" at 333:5-333:6 (leading: Newline, Space)
+3361: Ident           "intrinsic" at 333:6-333:15
+3362: At              "@" at 333:16-333:17 (leading: Space)
+3363: Ident           "overload" at 333:17-333:25
+3364: KwFn            "fn" at 333:26-333:28 (leading: Space)
+3365: Ident           "__to" at 333:29-333:33 (leading: Space)
+3366: LParen          "(" at 333:33-333:34
+3367: Ident           "self" at 333:34-333:38
+3368: Colon           ":" at 333:38-333:39
+3369: Ident           "uint" at 333:40-333:44 (leading: Space)
+3370: Comma           "," at 333:44-333:45
+3371: Ident           "target" at 333:46-333:52 (leading: Space)
+3372: Colon           ":" at 333:52-333:53
+3373: Ident           "float16" at 333:54-333:61 (leading: Space)
+3374: RParen          ")" at 333:61-333:62
+3375: Arrow           "->" at 333:63-333:65 (leading: Space)
+3376: Ident           "float16" at 333:66-333:73 (leading: Space)
+3377: Semicolon       ";" at 333:73-333:74
+3378: At              "@" at 334:5-334:6 (leading: Newline, Space)
+3379: Ident           "intrinsic" at 334:6-334:15
+3380: At              "@" at 334:16-334:17 (leading: Space)
+3381: Ident           "overload" at 334:17-334:25
+3382: KwFn            "fn" at 334:26-334:28 (leading: Space)
+3383: Ident           "__to" at 334:29-334:33 (leading: Space)
+3384: LParen          "(" at 334:33-334:34
+3385: Ident           "self" at 334:34-334:38
+3386: Colon           ":" at 334:38-334:39
+3387: Ident           "uint" at 334:40-334:44 (leading: Space)
+3388: Comma           "," at 334:44-334:45
+3389: Ident           "target" at 334:46-334:52 (leading: Space)
+3390: Colon           ":" at 334:52-334:53
+3391: Ident           "float32" at 334:54-334:61 (leading: Space)
+3392: RParen          ")" at 334:61-334:62
+3393: Arrow           "->" at 334:63-334:65 (leading: Space)
+3394: Ident           "float32" at 334:66-334:73 (leading: Space)
+3395: Semicolon       ";" at 334:73-334:74
+3396: At              "@" at 335:5-335:6 (leading: Newline, Space)
+3397: Ident           "intrinsic" at 335:6-335:15
+3398: At              "@" at 335:16-335:17 (leading: Space)
+3399: Ident           "overload" at 335:17-335:25
+3400: KwFn            "fn" at 335:26-335:28 (leading: Space)
+3401: Ident           "__to" at 335:29-335:33 (leading: Space)
+3402: LParen          "(" at 335:33-335:34
+3403: Ident           "self" at 335:34-335:38
+3404: Colon           ":" at 335:38-335:39
+3405: Ident           "uint" at 335:40-335:44 (leading: Space)
+3406: Comma           "," at 335:44-335:45
+3407: Ident           "target" at 335:46-335:52 (leading: Space)
+3408: Colon           ":" at 335:52-335:53
+3409: Ident           "float64" at 335:54-335:61 (leading: Space)
+3410: RParen          ")" at 335:61-335:62
+3411: Arrow           "->" at 335:63-335:65 (leading: Space)
+3412: Ident           "float64" at 335:66-335:73 (leading: Space)
+3413: Semicolon       ";" at 335:73-335:74
+3414: At              "@" at 337:5-337:6 (leading: Newline, Space, LineComment, Newline, Space)
+3415: Ident           "intrinsic" at 337:6-337:15
+3416: KwPub           "pub" at 337:16-337:19 (leading: Space)
+3417: KwFn            "fn" at 337:20-337:22 (leading: Space)
+3418: Ident           "from_str" at 337:23-337:31 (leading: Space)
+3419: LParen          "(" at 337:31-337:32
+3420: Ident           "s" at 337:32-337:33
+3421: Colon           ":" at 337:33-337:34
+3422: Amp             "&" at 337:35-337:36 (leading: Space)
+3423: Ident           "string" at 337:36-337:42
+3424: RParen          ")" at 337:42-337:43
+3425: Arrow           "->" at 337:44-337:46 (leading: Space)
+3426: Ident           "Erring" at 337:47-337:53 (leading: Space)
+3427: Lt              "<" at 337:53-337:54
+3428: Ident           "uint" at 337:54-337:58
+3429: Comma           "," at 337:58-337:59
+3430: Ident           "Error" at 337:60-337:65 (leading: Space)
+3431: Gt              ">" at 337:65-337:66
+3432: Semicolon       ";" at 337:66-337:67
+3433: RBrace          "}" at 338:1-338:2 (leading: Newline)
+3434: KwExtern        "extern" at 340:1-340:7 (leading: Newline)
+3435: Lt              "<" at 340:7-340:8
+3436: Ident           "int8" at 340:8-340:12
+3437: Gt              ">" at 340:12-340:13
+3438: LBrace          "{" at 340:14-340:15 (leading: Space)
+3439: KwPub           "pub" at 341:5-341:8 (leading: Newline, Space)
+3440: KwFn            "fn" at 341:9-341:11 (leading: Space)
+3441: Ident           "__min_value" at 341:12-341:23 (leading: Space)
+3442: LParen          "(" at 341:23-341:24
+3443: RParen          ")" at 341:24-341:25
+3444: Arrow           "->" at 341:26-341:28 (leading: Space)
+3445: Ident           "int8" at 341:29-341:33 (leading: Space)
+3446: LBrace          "{" at 341:34-341:35 (leading: Space)
+3447: KwReturn        "return" at 341:36-341:42 (leading: Space)
+3448: LParen          "(" at 341:43-341:44 (leading: Space)
+3449: Minus           "-" at 341:44-341:45
+3450: IntLit          "128" at 341:45-341:48
+3451: RParen          ")" at 341:48-341:49
+3452: Colon           ":" at 341:49-341:50
+3453: Ident           "int8" at 341:50-341:54
+3454: Semicolon       ";" at 341:54-341:55
+3455: RBrace          "}" at 341:56-341:57 (leading: Space)
+3456: KwPub           "pub" at 342:5-342:8 (leading: Newline, Space)
+3457: KwFn            "fn" at 342:9-342:11 (leading: Space)
+3458: Ident           "__max_value" at 342:12-342:23 (leading: Space)
+3459: LParen          "(" at 342:23-342:24
+3460: RParen          ")" at 342:24-342:25
+3461: Arrow           "->" at 342:26-342:28 (leading: Space)
+3462: Ident           "int8" at 342:29-342:33 (leading: Space)
+3463: LBrace          "{" at 342:34-342:35 (leading: Space)
+3464: KwReturn        "return" at 342:36-342:42 (leading: Space)
+3465: LParen          "(" at 342:43-342:44 (leading: Space)
+3466: IntLit          "127" at 342:44-342:47
+3467: RParen          ")" at 342:47-342:48
+3468: Colon           ":" at 342:48-342:49
+3469: Ident           "int8" at 342:49-342:53
+3470: Semicolon       ";" at 342:53-342:54
+3471: RBrace          "}" at 342:55-342:56 (leading: Space)
+3472: At              "@" at 343:5-343:6 (leading: Newline, Space)
+3473: Ident           "intrinsic" at 343:6-343:15
+3474: KwFn            "fn" at 343:16-343:18 (leading: Space)
+3475: Ident           "__add" at 343:19-343:24 (leading: Space)
+3476: LParen          "(" at 343:24-343:25
+3477: Ident           "self" at 343:25-343:29
+3478: Colon           ":" at 343:29-343:30
+3479: Ident           "int8" at 343:31-343:35 (leading: Space)
+3480: Comma           "," at 343:35-343:36
+3481: Ident           "other" at 343:37-343:42 (leading: Space)
+3482: Colon           ":" at 343:42-343:43
+3483: Ident           "int8" at 343:44-343:48 (leading: Space)
+3484: RParen          ")" at 343:48-343:49
+3485: Arrow           "->" at 343:50-343:52 (leading: Space)
+3486: Ident           "int8" at 343:53-343:57 (leading: Space)
+3487: Semicolon       ";" at 343:57-343:58
+3488: At              "@" at 344:5-344:6 (leading: Newline, Space)
+3489: Ident           "intrinsic" at 344:6-344:15
+3490: KwFn            "fn" at 344:16-344:18 (leading: Space)
+3491: Ident           "__sub" at 344:19-344:24 (leading: Space)
+3492: LParen          "(" at 344:24-344:25
+3493: Ident           "self" at 344:25-344:29
+3494: Colon           ":" at 344:29-344:30
+3495: Ident           "int8" at 344:31-344:35 (leading: Space)
+3496: Comma           "," at 344:35-344:36
+3497: Ident           "other" at 344:37-344:42 (leading: Space)
+3498: Colon           ":" at 344:42-344:43
+3499: Ident           "int8" at 344:44-344:48 (leading: Space)
+3500: RParen          ")" at 344:48-344:49
+3501: Arrow           "->" at 344:50-344:52 (leading: Space)
+3502: Ident           "int8" at 344:53-344:57 (leading: Space)
+3503: Semicolon       ";" at 344:57-344:58
+3504: At              "@" at 345:5-345:6 (leading: Newline, Space)
+3505: Ident           "intrinsic" at 345:6-345:15
+3506: KwFn            "fn" at 345:16-345:18 (leading: Space)
+3507: Ident           "__mul" at 345:19-345:24 (leading: Space)
+3508: LParen          "(" at 345:24-345:25
+3509: Ident           "self" at 345:25-345:29
+3510: Colon           ":" at 345:29-345:30
+3511: Ident           "int8" at 345:31-345:35 (leading: Space)
+3512: Comma           "," at 345:35-345:36
+3513: Ident           "other" at 345:37-345:42 (leading: Space)
+3514: Colon           ":" at 345:42-345:43
+3515: Ident           "int8" at 345:44-345:48 (leading: Space)
+3516: RParen          ")" at 345:48-345:49
+3517: Arrow           "->" at 345:50-345:52 (leading: Space)
+3518: Ident           "int8" at 345:53-345:57 (leading: Space)
+3519: Semicolon       ";" at 345:57-345:58
+3520: At              "@" at 346:5-346:6 (leading: Newline, Space)
+3521: Ident           "intrinsic" at 346:6-346:15
+3522: KwFn            "fn" at 346:16-346:18 (leading: Space)
+3523: Ident           "__div" at 346:19-346:24 (leading: Space)
+3524: LParen          "(" at 346:24-346:25
+3525: Ident           "self" at 346:25-346:29
+3526: Colon           ":" at 346:29-346:30
+3527: Ident           "int8" at 346:31-346:35 (leading: Space)
+3528: Comma           "," at 346:35-346:36
+3529: Ident           "other" at 346:37-346:42 (leading: Space)
+3530: Colon           ":" at 346:42-346:43
+3531: Ident           "int8" at 346:44-346:48 (leading: Space)
+3532: RParen          ")" at 346:48-346:49
+3533: Arrow           "->" at 346:50-346:52 (leading: Space)
+3534: Ident           "int8" at 346:53-346:57 (leading: Space)
+3535: Semicolon       ";" at 346:57-346:58
+3536: At              "@" at 347:5-347:6 (leading: Newline, Space)
+3537: Ident           "intrinsic" at 347:6-347:15
+3538: KwFn            "fn" at 347:16-347:18 (leading: Space)
+3539: Ident           "__mod" at 347:19-347:24 (leading: Space)
+3540: LParen          "(" at 347:24-347:25
+3541: Ident           "self" at 347:25-347:29
+3542: Colon           ":" at 347:29-347:30
+3543: Ident           "int8" at 347:31-347:35 (leading: Space)
+3544: Comma           "," at 347:35-347:36
+3545: Ident           "other" at 347:37-347:42 (leading: Space)
+3546: Colon           ":" at 347:42-347:43
+3547: Ident           "int8" at 347:44-347:48 (leading: Space)
+3548: RParen          ")" at 347:48-347:49
+3549: Arrow           "->" at 347:50-347:52 (leading: Space)
+3550: Ident           "int8" at 347:53-347:57 (leading: Space)
+3551: Semicolon       ";" at 347:57-347:58
+3552: At              "@" at 348:5-348:6 (leading: Newline, Space)
+3553: Ident           "intrinsic" at 348:6-348:15
+3554: KwFn            "fn" at 348:16-348:18 (leading: Space)
+3555: Ident           "__bit_and" at 348:19-348:28 (leading: Space)
+3556: LParen          "(" at 348:28-348:29
+3557: Ident           "self" at 348:29-348:33
+3558: Colon           ":" at 348:33-348:34
+3559: Ident           "int8" at 348:35-348:39 (leading: Space)
+3560: Comma           "," at 348:39-348:40
+3561: Ident           "other" at 348:41-348:46 (leading: Space)
+3562: Colon           ":" at 348:46-348:47
+3563: Ident           "int8" at 348:48-348:52 (leading: Space)
+3564: RParen          ")" at 348:52-348:53
+3565: Arrow           "->" at 348:54-348:56 (leading: Space)
+3566: Ident           "int8" at 348:57-348:61 (leading: Space)
+3567: Semicolon       ";" at 348:61-348:62
+3568: At              "@" at 349:5-349:6 (leading: Newline, Space)
+3569: Ident           "intrinsic" at 349:6-349:15
+3570: KwFn            "fn" at 349:16-349:18 (leading: Space)
+3571: Ident           "__bit_or" at 349:19-349:27 (leading: Space)
+3572: LParen          "(" at 349:27-349:28
+3573: Ident           "self" at 349:28-349:32
+3574: Colon           ":" at 349:32-349:33
+3575: Ident           "int8" at 349:34-349:38 (leading: Space)
+3576: Comma           "," at 349:38-349:39
+3577: Ident           "other" at 349:40-349:45 (leading: Space)
+3578: Colon           ":" at 349:45-349:46
+3579: Ident           "int8" at 349:47-349:51 (leading: Space)
+3580: RParen          ")" at 349:51-349:52
+3581: Arrow           "->" at 349:53-349:55 (leading: Space)
+3582: Ident           "int8" at 349:56-349:60 (leading: Space)
+3583: Semicolon       ";" at 349:60-349:61
+3584: At              "@" at 350:5-350:6 (leading: Newline, Space)
+3585: Ident           "intrinsic" at 350:6-350:15
+3586: KwFn            "fn" at 350:16-350:18 (leading: Space)
+3587: Ident           "__bit_xor" at 350:19-350:28 (leading: Space)
+3588: LParen          "(" at 350:28-350:29
+3589: Ident           "self" at 350:29-350:33
+3590: Colon           ":" at 350:33-350:34
+3591: Ident           "int8" at 350:35-350:39 (leading: Space)
+3592: Comma           "," at 350:39-350:40
+3593: Ident           "other" at 350:41-350:46 (leading: Space)
+3594: Colon           ":" at 350:46-350:47
+3595: Ident           "int8" at 350:48-350:52 (leading: Space)
+3596: RParen          ")" at 350:52-350:53
+3597: Arrow           "->" at 350:54-350:56 (leading: Space)
+3598: Ident           "int8" at 350:57-350:61 (leading: Space)
+3599: Semicolon       ";" at 350:61-350:62
+3600: At              "@" at 351:5-351:6 (leading: Newline, Space)
+3601: Ident           "intrinsic" at 351:6-351:15
+3602: KwFn            "fn" at 351:16-351:18 (leading: Space)
+3603: Ident           "__shl" at 351:19-351:24 (leading: Space)
+3604: LParen          "(" at 351:24-351:25
+3605: Ident           "self" at 351:25-351:29
+3606: Colon           ":" at 351:29-351:30
+3607: Ident           "int8" at 351:31-351:35 (leading: Space)
+3608: Comma           "," at 351:35-351:36
+3609: Ident           "other" at 351:37-351:42 (leading: Space)
+3610: Colon           ":" at 351:42-351:43
+3611: Ident           "int8" at 351:44-351:48 (leading: Space)
+3612: RParen          ")" at 351:48-351:49
+3613: Arrow           "->" at 351:50-351:52 (leading: Space)
+3614: Ident           "int8" at 351:53-351:57 (leading: Space)
+3615: Semicolon       ";" at 351:57-351:58
+3616: At              "@" at 352:5-352:6 (leading: Newline, Space)
+3617: Ident           "intrinsic" at 352:6-352:15
+3618: KwFn            "fn" at 352:16-352:18 (leading: Space)
+3619: Ident           "__shr" at 352:19-352:24 (leading: Space)
+3620: LParen          "(" at 352:24-352:25
+3621: Ident           "self" at 352:25-352:29
+3622: Colon           ":" at 352:29-352:30
+3623: Ident           "int8" at 352:31-352:35 (leading: Space)
+3624: Comma           "," at 352:35-352:36
+3625: Ident           "other" at 352:37-352:42 (leading: Space)
+3626: Colon           ":" at 352:42-352:43
+3627: Ident           "int8" at 352:44-352:48 (leading: Space)
+3628: RParen          ")" at 352:48-352:49
+3629: Arrow           "->" at 352:50-352:52 (leading: Space)
+3630: Ident           "int8" at 352:53-352:57 (leading: Space)
+3631: Semicolon       ";" at 352:57-352:58
+3632: At              "@" at 353:5-353:6 (leading: Newline, Space)
+3633: Ident           "intrinsic" at 353:6-353:15
+3634: KwFn            "fn" at 353:16-353:18 (leading: Space)
+3635: Ident           "__lt" at 353:19-353:23 (leading: Space)
+3636: LParen          "(" at 353:23-353:24
+3637: Ident           "self" at 353:24-353:28
+3638: Colon           ":" at 353:28-353:29
+3639: Ident           "int8" at 353:30-353:34 (leading: Space)
+3640: Comma           "," at 353:34-353:35
+3641: Ident           "other" at 353:36-353:41 (leading: Space)
+3642: Colon           ":" at 353:41-353:42
+3643: Ident           "int8" at 353:43-353:47 (leading: Space)
+3644: RParen          ")" at 353:47-353:48
+3645: Arrow           "->" at 353:49-353:51 (leading: Space)
+3646: Ident           "bool" at 353:52-353:56 (leading: Space)
+3647: Semicolon       ";" at 353:56-353:57
+3648: At              "@" at 354:5-354:6 (leading: Newline, Space)
+3649: Ident           "intrinsic" at 354:6-354:15
+3650: KwFn            "fn" at 354:16-354:18 (leading: Space)
+3651: Ident           "__le" at 354:19-354:23 (leading: Space)
+3652: LParen          "(" at 354:23-354:24
+3653: Ident           "self" at 354:24-354:28
+3654: Colon           ":" at 354:28-354:29
+3655: Ident           "int8" at 354:30-354:34 (leading: Space)
+3656: Comma           "," at 354:34-354:35
+3657: Ident           "other" at 354:36-354:41 (leading: Space)
+3658: Colon           ":" at 354:41-354:42
+3659: Ident           "int8" at 354:43-354:47 (leading: Space)
+3660: RParen          ")" at 354:47-354:48
+3661: Arrow           "->" at 354:49-354:51 (leading: Space)
+3662: Ident           "bool" at 354:52-354:56 (leading: Space)
+3663: Semicolon       ";" at 354:56-354:57
+3664: At              "@" at 355:5-355:6 (leading: Newline, Space)
+3665: Ident           "intrinsic" at 355:6-355:15
+3666: KwFn            "fn" at 355:16-355:18 (leading: Space)
+3667: Ident           "__eq" at 355:19-355:23 (leading: Space)
+3668: LParen          "(" at 355:23-355:24
+3669: Ident           "self" at 355:24-355:28
+3670: Colon           ":" at 355:28-355:29
+3671: Ident           "int8" at 355:30-355:34 (leading: Space)
+3672: Comma           "," at 355:34-355:35
+3673: Ident           "other" at 355:36-355:41 (leading: Space)
+3674: Colon           ":" at 355:41-355:42
+3675: Ident           "int8" at 355:43-355:47 (leading: Space)
+3676: RParen          ")" at 355:47-355:48
+3677: Arrow           "->" at 355:49-355:51 (leading: Space)
+3678: Ident           "bool" at 355:52-355:56 (leading: Space)
+3679: Semicolon       ";" at 355:56-355:57
+3680: At              "@" at 356:5-356:6 (leading: Newline, Space)
+3681: Ident           "intrinsic" at 356:6-356:15
+3682: KwFn            "fn" at 356:16-356:18 (leading: Space)
+3683: Ident           "__ne" at 356:19-356:23 (leading: Space)
+3684: LParen          "(" at 356:23-356:24
+3685: Ident           "self" at 356:24-356:28
+3686: Colon           ":" at 356:28-356:29
+3687: Ident           "int8" at 356:30-356:34 (leading: Space)
+3688: Comma           "," at 356:34-356:35
+3689: Ident           "other" at 356:36-356:41 (leading: Space)
+3690: Colon           ":" at 356:41-356:42
+3691: Ident           "int8" at 356:43-356:47 (leading: Space)
+3692: RParen          ")" at 356:47-356:48
+3693: Arrow           "->" at 356:49-356:51 (leading: Space)
+3694: Ident           "bool" at 356:52-356:56 (leading: Space)
+3695: Semicolon       ";" at 356:56-356:57
+3696: At              "@" at 357:5-357:6 (leading: Newline, Space)
+3697: Ident           "intrinsic" at 357:6-357:15
+3698: KwFn            "fn" at 357:16-357:18 (leading: Space)
+3699: Ident           "__ge" at 357:19-357:23 (leading: Space)
+3700: LParen          "(" at 357:23-357:24
+3701: Ident           "self" at 357:24-357:28
+3702: Colon           ":" at 357:28-357:29
+3703: Ident           "int8" at 357:30-357:34 (leading: Space)
+3704: Comma           "," at 357:34-357:35
+3705: Ident           "other" at 357:36-357:41 (leading: Space)
+3706: Colon           ":" at 357:41-357:42
+3707: Ident           "int8" at 357:43-357:47 (leading: Space)
+3708: RParen          ")" at 357:47-357:48
+3709: Arrow           "->" at 357:49-357:51 (leading: Space)
+3710: Ident           "bool" at 357:52-357:56 (leading: Space)
+3711: Semicolon       ";" at 357:56-357:57
+3712: At              "@" at 358:5-358:6 (leading: Newline, Space)
+3713: Ident           "intrinsic" at 358:6-358:15
+3714: KwFn            "fn" at 358:16-358:18 (leading: Space)
+3715: Ident           "__gt" at 358:19-358:23 (leading: Space)
+3716: LParen          "(" at 358:23-358:24
+3717: Ident           "self" at 358:24-358:28
+3718: Colon           ":" at 358:28-358:29
+3719: Ident           "int8" at 358:30-358:34 (leading: Space)
+3720: Comma           "," at 358:34-358:35
+3721: Ident           "other" at 358:36-358:41 (leading: Space)
+3722: Colon           ":" at 358:41-358:42
+3723: Ident           "int8" at 358:43-358:47 (leading: Space)
+3724: RParen          ")" at 358:47-358:48
+3725: Arrow           "->" at 358:49-358:51 (leading: Space)
+3726: Ident           "bool" at 358:52-358:56 (leading: Space)
+3727: Semicolon       ";" at 358:56-358:57
+3728: At              "@" at 359:5-359:6 (leading: Newline, Space)
+3729: Ident           "intrinsic" at 359:6-359:15
+3730: KwFn            "fn" at 359:16-359:18 (leading: Space)
+3731: Ident           "__pos" at 359:19-359:24 (leading: Space)
+3732: LParen          "(" at 359:24-359:25
+3733: Ident           "self" at 359:25-359:29
+3734: Colon           ":" at 359:29-359:30
+3735: Ident           "int8" at 359:31-359:35 (leading: Space)
+3736: RParen          ")" at 359:35-359:36
+3737: Arrow           "->" at 359:37-359:39 (leading: Space)
+3738: Ident           "int8" at 359:40-359:44 (leading: Space)
+3739: Semicolon       ";" at 359:44-359:45
+3740: At              "@" at 360:5-360:6 (leading: Newline, Space)
+3741: Ident           "intrinsic" at 360:6-360:15
+3742: KwFn            "fn" at 360:16-360:18 (leading: Space)
+3743: Ident           "__neg" at 360:19-360:24 (leading: Space)
+3744: LParen          "(" at 360:24-360:25
+3745: Ident           "self" at 360:25-360:29
+3746: Colon           ":" at 360:29-360:30
+3747: Ident           "int8" at 360:31-360:35 (leading: Space)
+3748: RParen          ")" at 360:35-360:36
+3749: Arrow           "->" at 360:37-360:39 (leading: Space)
+3750: Ident           "int8" at 360:40-360:44 (leading: Space)
+3751: Semicolon       ";" at 360:44-360:45
+3752: At              "@" at 361:5-361:6 (leading: Newline, Space)
+3753: Ident           "intrinsic" at 361:6-361:15
+3754: KwFn            "fn" at 361:16-361:18 (leading: Space)
+3755: Ident           "__abs" at 361:19-361:24 (leading: Space)
+3756: LParen          "(" at 361:24-361:25
+3757: Ident           "self" at 361:25-361:29
+3758: Colon           ":" at 361:29-361:30
+3759: Ident           "int8" at 361:31-361:35 (leading: Space)
+3760: RParen          ")" at 361:35-361:36
+3761: Arrow           "->" at 361:37-361:39 (leading: Space)
+3762: Ident           "int8" at 361:40-361:44 (leading: Space)
+3763: Semicolon       ";" at 361:44-361:45
+3764: At              "@" at 362:5-362:6 (leading: Newline, Space)
+3765: Ident           "intrinsic" at 362:6-362:15
+3766: KwFn            "fn" at 362:16-362:18 (leading: Space)
+3767: Ident           "__to" at 362:19-362:23 (leading: Space)
+3768: LParen          "(" at 362:23-362:24
+3769: Ident           "self" at 362:24-362:28
+3770: Colon           ":" at 362:28-362:29
+3771: Ident           "int8" at 362:30-362:34 (leading: Space)
+3772: Comma           "," at 362:34-362:35
+3773: Ident           "target" at 362:36-362:42 (leading: Space)
+3774: Colon           ":" at 362:42-362:43
+3775: Ident           "int" at 362:44-362:47 (leading: Space)
+3776: RParen          ")" at 362:47-362:48
+3777: Arrow           "->" at 362:49-362:51 (leading: Space)
+3778: Ident           "int" at 362:52-362:55 (leading: Space)
+3779: Semicolon       ";" at 362:55-362:56
+3780: At              "@" at 363:5-363:6 (leading: Newline, Space)
+3781: Ident           "intrinsic" at 363:6-363:15
+3782: At              "@" at 363:16-363:17 (leading: Space)
+3783: Ident           "overload" at 363:17-363:25
+3784: KwFn            "fn" at 363:26-363:28 (leading: Space)
+3785: Ident           "__to" at 363:29-363:33 (leading: Space)
+3786: LParen          "(" at 363:33-363:34
+3787: Ident           "self" at 363:34-363:38
+3788: Colon           ":" at 363:38-363:39
+3789: Ident           "int8" at 363:40-363:44 (leading: Space)
+3790: Comma           "," at 363:44-363:45
+3791: Ident           "target" at 363:46-363:52 (leading: Space)
+3792: Colon           ":" at 363:52-363:53
+3793: Ident           "int16" at 363:54-363:59 (leading: Space)
+3794: RParen          ")" at 363:59-363:60
+3795: Arrow           "->" at 363:61-363:63 (leading: Space)
+3796: Ident           "int16" at 363:64-363:69 (leading: Space)
+3797: Semicolon       ";" at 363:69-363:70
+3798: At              "@" at 364:5-364:6 (leading: Newline, Space)
+3799: Ident           "intrinsic" at 364:6-364:15
+3800: At              "@" at 364:16-364:17 (leading: Space)
+3801: Ident           "overload" at 364:17-364:25
+3802: KwFn            "fn" at 364:26-364:28 (leading: Space)
+3803: Ident           "__to" at 364:29-364:33 (leading: Space)
+3804: LParen          "(" at 364:33-364:34
+3805: Ident           "self" at 364:34-364:38
+3806: Colon           ":" at 364:38-364:39
+3807: Ident           "int8" at 364:40-364:44 (leading: Space)
+3808: Comma           "," at 364:44-364:45
+3809: Ident           "target" at 364:46-364:52 (leading: Space)
+3810: Colon           ":" at 364:52-364:53
+3811: Ident           "int32" at 364:54-364:59 (leading: Space)
+3812: RParen          ")" at 364:59-364:60
+3813: Arrow           "->" at 364:61-364:63 (leading: Space)
+3814: Ident           "int32" at 364:64-364:69 (leading: Space)
+3815: Semicolon       ";" at 364:69-364:70
+3816: At              "@" at 365:5-365:6 (leading: Newline, Space)
+3817: Ident           "intrinsic" at 365:6-365:15
+3818: At              "@" at 365:16-365:17 (leading: Space)
+3819: Ident           "overload" at 365:17-365:25
+3820: KwFn            "fn" at 365:26-365:28 (leading: Space)
+3821: Ident           "__to" at 365:29-365:33 (leading: Space)
+3822: LParen          "(" at 365:33-365:34
+3823: Ident           "self" at 365:34-365:38
+3824: Colon           ":" at 365:38-365:39
+3825: Ident           "int8" at 365:40-365:44 (leading: Space)
+3826: Comma           "," at 365:44-365:45
+3827: Ident           "target" at 365:46-365:52 (leading: Space)
+3828: Colon           ":" at 365:52-365:53
+3829: Ident           "int64" at 365:54-365:59 (leading: Space)
+3830: RParen          ")" at 365:59-365:60
+3831: Arrow           "->" at 365:61-365:63 (leading: Space)
+3832: Ident           "int64" at 365:64-365:69 (leading: Space)
+3833: Semicolon       ";" at 365:69-365:70
+3834: At              "@" at 366:5-366:6 (leading: Newline, Space)
+3835: Ident           "intrinsic" at 366:6-366:15
+3836: KwPub           "pub" at 366:16-366:19 (leading: Space)
+3837: KwFn            "fn" at 366:20-366:22 (leading: Space)
+3838: Ident           "from_str" at 366:23-366:31 (leading: Space)
+3839: LParen          "(" at 366:31-366:32
+3840: Ident           "s" at 366:32-366:33
+3841: Colon           ":" at 366:33-366:34
+3842: Amp             "&" at 366:35-366:36 (leading: Space)
+3843: Ident           "string" at 366:36-366:42
+3844: RParen          ")" at 366:42-366:43
+3845: Arrow           "->" at 366:44-366:46 (leading: Space)
+3846: Ident           "Erring" at 366:47-366:53 (leading: Space)
+3847: Lt              "<" at 366:53-366:54
+3848: Ident           "int8" at 366:54-366:58
+3849: Comma           "," at 366:58-366:59
+3850: Ident           "Error" at 366:60-366:65 (leading: Space)
+3851: Gt              ">" at 366:65-366:66
+3852: Semicolon       ";" at 366:66-366:67
+3853: RBrace          "}" at 367:1-367:2 (leading: Newline)
+3854: KwExtern        "extern" at 369:1-369:7 (leading: Newline)
+3855: Lt              "<" at 369:7-369:8
+3856: Ident           "int16" at 369:8-369:13
+3857: Gt              ">" at 369:13-369:14
+3858: LBrace          "{" at 369:15-369:16 (leading: Space)
+3859: KwPub           "pub" at 370:5-370:8 (leading: Newline, Space)
+3860: KwFn            "fn" at 370:9-370:11 (leading: Space)
+3861: Ident           "__min_value" at 370:12-370:23 (leading: Space)
+3862: LParen          "(" at 370:23-370:24
+3863: RParen          ")" at 370:24-370:25
+3864: Arrow           "->" at 370:26-370:28 (leading: Space)
+3865: Ident           "int16" at 370:29-370:34 (leading: Space)
+3866: LBrace          "{" at 370:35-370:36 (leading: Space)
+3867: KwReturn        "return" at 370:37-370:43 (leading: Space)
+3868: LParen          "(" at 370:44-370:45 (leading: Space)
+3869: Minus           "-" at 370:45-370:46
+3870: IntLit          "32_768" at 370:46-370:52
+3871: RParen          ")" at 370:52-370:53
+3872: Colon           ":" at 370:53-370:54
+3873: Ident           "int16" at 370:54-370:59
+3874: Semicolon       ";" at 370:59-370:60
+3875: RBrace          "}" at 370:61-370:62 (leading: Space)
+3876: KwPub           "pub" at 371:5-371:8 (leading: Newline, Space)
+3877: KwFn            "fn" at 371:9-371:11 (leading: Space)
+3878: Ident           "__max_value" at 371:12-371:23 (leading: Space)
+3879: LParen          "(" at 371:23-371:24
+3880: RParen          ")" at 371:24-371:25
+3881: Arrow           "->" at 371:26-371:28 (leading: Space)
+3882: Ident           "int16" at 371:29-371:34 (leading: Space)
+3883: LBrace          "{" at 371:35-371:36 (leading: Space)
+3884: KwReturn        "return" at 371:37-371:43 (leading: Space)
+3885: LParen          "(" at 371:44-371:45 (leading: Space)
+3886: IntLit          "32_767" at 371:45-371:51
+3887: RParen          ")" at 371:51-371:52
+3888: Colon           ":" at 371:52-371:53
+3889: Ident           "int16" at 371:53-371:58
+3890: Semicolon       ";" at 371:58-371:59
+3891: RBrace          "}" at 371:60-371:61 (leading: Space)
+3892: At              "@" at 372:5-372:6 (leading: Newline, Space)
+3893: Ident           "intrinsic" at 372:6-372:15
+3894: KwFn            "fn" at 372:16-372:18 (leading: Space)
+3895: Ident           "__add" at 372:19-372:24 (leading: Space)
+3896: LParen          "(" at 372:24-372:25
+3897: Ident           "self" at 372:25-372:29
+3898: Colon           ":" at 372:29-372:30
+3899: Ident           "int16" at 372:31-372:36 (leading: Space)
+3900: Comma           "," at 372:36-372:37
+3901: Ident           "other" at 372:38-372:43 (leading: Space)
+3902: Colon           ":" at 372:43-372:44
+3903: Ident           "int16" at 372:45-372:50 (leading: Space)
+3904: RParen          ")" at 372:50-372:51
+3905: Arrow           "->" at 372:52-372:54 (leading: Space)
+3906: Ident           "int16" at 372:55-372:60 (leading: Space)
+3907: Semicolon       ";" at 372:60-372:61
+3908: At              "@" at 373:5-373:6 (leading: Newline, Space)
+3909: Ident           "intrinsic" at 373:6-373:15
+3910: KwFn            "fn" at 373:16-373:18 (leading: Space)
+3911: Ident           "__sub" at 373:19-373:24 (leading: Space)
+3912: LParen          "(" at 373:24-373:25
+3913: Ident           "self" at 373:25-373:29
+3914: Colon           ":" at 373:29-373:30
+3915: Ident           "int16" at 373:31-373:36 (leading: Space)
+3916: Comma           "," at 373:36-373:37
+3917: Ident           "other" at 373:38-373:43 (leading: Space)
+3918: Colon           ":" at 373:43-373:44
+3919: Ident           "int16" at 373:45-373:50 (leading: Space)
+3920: RParen          ")" at 373:50-373:51
+3921: Arrow           "->" at 373:52-373:54 (leading: Space)
+3922: Ident           "int16" at 373:55-373:60 (leading: Space)
+3923: Semicolon       ";" at 373:60-373:61
+3924: At              "@" at 374:5-374:6 (leading: Newline, Space)
+3925: Ident           "intrinsic" at 374:6-374:15
+3926: KwFn            "fn" at 374:16-374:18 (leading: Space)
+3927: Ident           "__mul" at 374:19-374:24 (leading: Space)
+3928: LParen          "(" at 374:24-374:25
+3929: Ident           "self" at 374:25-374:29
+3930: Colon           ":" at 374:29-374:30
+3931: Ident           "int16" at 374:31-374:36 (leading: Space)
+3932: Comma           "," at 374:36-374:37
+3933: Ident           "other" at 374:38-374:43 (leading: Space)
+3934: Colon           ":" at 374:43-374:44
+3935: Ident           "int16" at 374:45-374:50 (leading: Space)
+3936: RParen          ")" at 374:50-374:51
+3937: Arrow           "->" at 374:52-374:54 (leading: Space)
+3938: Ident           "int16" at 374:55-374:60 (leading: Space)
+3939: Semicolon       ";" at 374:60-374:61
+3940: At              "@" at 375:5-375:6 (leading: Newline, Space)
+3941: Ident           "intrinsic" at 375:6-375:15
+3942: KwFn            "fn" at 375:16-375:18 (leading: Space)
+3943: Ident           "__div" at 375:19-375:24 (leading: Space)
+3944: LParen          "(" at 375:24-375:25
+3945: Ident           "self" at 375:25-375:29
+3946: Colon           ":" at 375:29-375:30
+3947: Ident           "int16" at 375:31-375:36 (leading: Space)
+3948: Comma           "," at 375:36-375:37
+3949: Ident           "other" at 375:38-375:43 (leading: Space)
+3950: Colon           ":" at 375:43-375:44
+3951: Ident           "int16" at 375:45-375:50 (leading: Space)
+3952: RParen          ")" at 375:50-375:51
+3953: Arrow           "->" at 375:52-375:54 (leading: Space)
+3954: Ident           "int16" at 375:55-375:60 (leading: Space)
+3955: Semicolon       ";" at 375:60-375:61
+3956: At              "@" at 376:5-376:6 (leading: Newline, Space)
+3957: Ident           "intrinsic" at 376:6-376:15
+3958: KwFn            "fn" at 376:16-376:18 (leading: Space)
+3959: Ident           "__mod" at 376:19-376:24 (leading: Space)
+3960: LParen          "(" at 376:24-376:25
+3961: Ident           "self" at 376:25-376:29
+3962: Colon           ":" at 376:29-376:30
+3963: Ident           "int16" at 376:31-376:36 (leading: Space)
+3964: Comma           "," at 376:36-376:37
+3965: Ident           "other" at 376:38-376:43 (leading: Space)
+3966: Colon           ":" at 376:43-376:44
+3967: Ident           "int16" at 376:45-376:50 (leading: Space)
+3968: RParen          ")" at 376:50-376:51
+3969: Arrow           "->" at 376:52-376:54 (leading: Space)
+3970: Ident           "int16" at 376:55-376:60 (leading: Space)
+3971: Semicolon       ";" at 376:60-376:61
+3972: At              "@" at 377:5-377:6 (leading: Newline, Space)
+3973: Ident           "intrinsic" at 377:6-377:15
+3974: KwFn            "fn" at 377:16-377:18 (leading: Space)
+3975: Ident           "__bit_and" at 377:19-377:28 (leading: Space)
+3976: LParen          "(" at 377:28-377:29
+3977: Ident           "self" at 377:29-377:33
+3978: Colon           ":" at 377:33-377:34
+3979: Ident           "int16" at 377:35-377:40 (leading: Space)
+3980: Comma           "," at 377:40-377:41
+3981: Ident           "other" at 377:42-377:47 (leading: Space)
+3982: Colon           ":" at 377:47-377:48
+3983: Ident           "int16" at 377:49-377:54 (leading: Space)
+3984: RParen          ")" at 377:54-377:55
+3985: Arrow           "->" at 377:56-377:58 (leading: Space)
+3986: Ident           "int16" at 377:59-377:64 (leading: Space)
+3987: Semicolon       ";" at 377:64-377:65
+3988: At              "@" at 378:5-378:6 (leading: Newline, Space)
+3989: Ident           "intrinsic" at 378:6-378:15
+3990: KwFn            "fn" at 378:16-378:18 (leading: Space)
+3991: Ident           "__bit_or" at 378:19-378:27 (leading: Space)
+3992: LParen          "(" at 378:27-378:28
+3993: Ident           "self" at 378:28-378:32
+3994: Colon           ":" at 378:32-378:33
+3995: Ident           "int16" at 378:34-378:39 (leading: Space)
+3996: Comma           "," at 378:39-378:40
+3997: Ident           "other" at 378:41-378:46 (leading: Space)
+3998: Colon           ":" at 378:46-378:47
+3999: Ident           "int16" at 378:48-378:53 (leading: Space)
+4000: RParen          ")" at 378:53-378:54
+4001: Arrow           "->" at 378:55-378:57 (leading: Space)
+4002: Ident           "int16" at 378:58-378:63 (leading: Space)
+4003: Semicolon       ";" at 378:63-378:64
+4004: At              "@" at 379:5-379:6 (leading: Newline, Space)
+4005: Ident           "intrinsic" at 379:6-379:15
+4006: KwFn            "fn" at 379:16-379:18 (leading: Space)
+4007: Ident           "__bit_xor" at 379:19-379:28 (leading: Space)
+4008: LParen          "(" at 379:28-379:29
+4009: Ident           "self" at 379:29-379:33
+4010: Colon           ":" at 379:33-379:34
+4011: Ident           "int16" at 379:35-379:40 (leading: Space)
+4012: Comma           "," at 379:40-379:41
+4013: Ident           "other" at 379:42-379:47 (leading: Space)
+4014: Colon           ":" at 379:47-379:48
+4015: Ident           "int16" at 379:49-379:54 (leading: Space)
+4016: RParen          ")" at 379:54-379:55
+4017: Arrow           "->" at 379:56-379:58 (leading: Space)
+4018: Ident           "int16" at 379:59-379:64 (leading: Space)
+4019: Semicolon       ";" at 379:64-379:65
+4020: At              "@" at 380:5-380:6 (leading: Newline, Space)
+4021: Ident           "intrinsic" at 380:6-380:15
+4022: KwFn            "fn" at 380:16-380:18 (leading: Space)
+4023: Ident           "__shl" at 380:19-380:24 (leading: Space)
+4024: LParen          "(" at 380:24-380:25
+4025: Ident           "self" at 380:25-380:29
+4026: Colon           ":" at 380:29-380:30
+4027: Ident           "int16" at 380:31-380:36 (leading: Space)
+4028: Comma           "," at 380:36-380:37
+4029: Ident           "other" at 380:38-380:43 (leading: Space)
+4030: Colon           ":" at 380:43-380:44
+4031: Ident           "int16" at 380:45-380:50 (leading: Space)
+4032: RParen          ")" at 380:50-380:51
+4033: Arrow           "->" at 380:52-380:54 (leading: Space)
+4034: Ident           "int16" at 380:55-380:60 (leading: Space)
+4035: Semicolon       ";" at 380:60-380:61
+4036: At              "@" at 381:5-381:6 (leading: Newline, Space)
+4037: Ident           "intrinsic" at 381:6-381:15
+4038: KwFn            "fn" at 381:16-381:18 (leading: Space)
+4039: Ident           "__shr" at 381:19-381:24 (leading: Space)
+4040: LParen          "(" at 381:24-381:25
+4041: Ident           "self" at 381:25-381:29
+4042: Colon           ":" at 381:29-381:30
+4043: Ident           "int16" at 381:31-381:36 (leading: Space)
+4044: Comma           "," at 381:36-381:37
+4045: Ident           "other" at 381:38-381:43 (leading: Space)
+4046: Colon           ":" at 381:43-381:44
+4047: Ident           "int16" at 381:45-381:50 (leading: Space)
+4048: RParen          ")" at 381:50-381:51
+4049: Arrow           "->" at 381:52-381:54 (leading: Space)
+4050: Ident           "int16" at 381:55-381:60 (leading: Space)
+4051: Semicolon       ";" at 381:60-381:61
+4052: At              "@" at 382:5-382:6 (leading: Newline, Space)
+4053: Ident           "intrinsic" at 382:6-382:15
+4054: KwFn            "fn" at 382:16-382:18 (leading: Space)
+4055: Ident           "__lt" at 382:19-382:23 (leading: Space)
+4056: LParen          "(" at 382:23-382:24
+4057: Ident           "self" at 382:24-382:28
+4058: Colon           ":" at 382:28-382:29
+4059: Ident           "int16" at 382:30-382:35 (leading: Space)
+4060: Comma           "," at 382:35-382:36
+4061: Ident           "other" at 382:37-382:42 (leading: Space)
+4062: Colon           ":" at 382:42-382:43
+4063: Ident           "int16" at 382:44-382:49 (leading: Space)
+4064: RParen          ")" at 382:49-382:50
+4065: Arrow           "->" at 382:51-382:53 (leading: Space)
+4066: Ident           "bool" at 382:54-382:58 (leading: Space)
+4067: Semicolon       ";" at 382:58-382:59
+4068: At              "@" at 383:5-383:6 (leading: Newline, Space)
+4069: Ident           "intrinsic" at 383:6-383:15
+4070: KwFn            "fn" at 383:16-383:18 (leading: Space)
+4071: Ident           "__le" at 383:19-383:23 (leading: Space)
+4072: LParen          "(" at 383:23-383:24
+4073: Ident           "self" at 383:24-383:28
+4074: Colon           ":" at 383:28-383:29
+4075: Ident           "int16" at 383:30-383:35 (leading: Space)
+4076: Comma           "," at 383:35-383:36
+4077: Ident           "other" at 383:37-383:42 (leading: Space)
+4078: Colon           ":" at 383:42-383:43
+4079: Ident           "int16" at 383:44-383:49 (leading: Space)
+4080: RParen          ")" at 383:49-383:50
+4081: Arrow           "->" at 383:51-383:53 (leading: Space)
+4082: Ident           "bool" at 383:54-383:58 (leading: Space)
+4083: Semicolon       ";" at 383:58-383:59
+4084: At              "@" at 384:5-384:6 (leading: Newline, Space)
+4085: Ident           "intrinsic" at 384:6-384:15
+4086: KwFn            "fn" at 384:16-384:18 (leading: Space)
+4087: Ident           "__eq" at 384:19-384:23 (leading: Space)
+4088: LParen          "(" at 384:23-384:24
+4089: Ident           "self" at 384:24-384:28
+4090: Colon           ":" at 384:28-384:29
+4091: Ident           "int16" at 384:30-384:35 (leading: Space)
+4092: Comma           "," at 384:35-384:36
+4093: Ident           "other" at 384:37-384:42 (leading: Space)
+4094: Colon           ":" at 384:42-384:43
+4095: Ident           "int16" at 384:44-384:49 (leading: Space)
+4096: RParen          ")" at 384:49-384:50
+4097: Arrow           "->" at 384:51-384:53 (leading: Space)
+4098: Ident           "bool" at 384:54-384:58 (leading: Space)
+4099: Semicolon       ";" at 384:58-384:59
+4100: At              "@" at 385:5-385:6 (leading: Newline, Space)
+4101: Ident           "intrinsic" at 385:6-385:15
+4102: KwFn            "fn" at 385:16-385:18 (leading: Space)
+4103: Ident           "__ne" at 385:19-385:23 (leading: Space)
+4104: LParen          "(" at 385:23-385:24
+4105: Ident           "self" at 385:24-385:28
+4106: Colon           ":" at 385:28-385:29
+4107: Ident           "int16" at 385:30-385:35 (leading: Space)
+4108: Comma           "," at 385:35-385:36
+4109: Ident           "other" at 385:37-385:42 (leading: Space)
+4110: Colon           ":" at 385:42-385:43
+4111: Ident           "int16" at 385:44-385:49 (leading: Space)
+4112: RParen          ")" at 385:49-385:50
+4113: Arrow           "->" at 385:51-385:53 (leading: Space)
+4114: Ident           "bool" at 385:54-385:58 (leading: Space)
+4115: Semicolon       ";" at 385:58-385:59
+4116: At              "@" at 386:5-386:6 (leading: Newline, Space)
+4117: Ident           "intrinsic" at 386:6-386:15
+4118: KwFn            "fn" at 386:16-386:18 (leading: Space)
+4119: Ident           "__ge" at 386:19-386:23 (leading: Space)
+4120: LParen          "(" at 386:23-386:24
+4121: Ident           "self" at 386:24-386:28
+4122: Colon           ":" at 386:28-386:29
+4123: Ident           "int16" at 386:30-386:35 (leading: Space)
+4124: Comma           "," at 386:35-386:36
+4125: Ident           "other" at 386:37-386:42 (leading: Space)
+4126: Colon           ":" at 386:42-386:43
+4127: Ident           "int16" at 386:44-386:49 (leading: Space)
+4128: RParen          ")" at 386:49-386:50
+4129: Arrow           "->" at 386:51-386:53 (leading: Space)
+4130: Ident           "bool" at 386:54-386:58 (leading: Space)
+4131: Semicolon       ";" at 386:58-386:59
+4132: At              "@" at 387:5-387:6 (leading: Newline, Space)
+4133: Ident           "intrinsic" at 387:6-387:15
+4134: KwFn            "fn" at 387:16-387:18 (leading: Space)
+4135: Ident           "__gt" at 387:19-387:23 (leading: Space)
+4136: LParen          "(" at 387:23-387:24
+4137: Ident           "self" at 387:24-387:28
+4138: Colon           ":" at 387:28-387:29
+4139: Ident           "int16" at 387:30-387:35 (leading: Space)
+4140: Comma           "," at 387:35-387:36
+4141: Ident           "other" at 387:37-387:42 (leading: Space)
+4142: Colon           ":" at 387:42-387:43
+4143: Ident           "int16" at 387:44-387:49 (leading: Space)
+4144: RParen          ")" at 387:49-387:50
+4145: Arrow           "->" at 387:51-387:53 (leading: Space)
+4146: Ident           "bool" at 387:54-387:58 (leading: Space)
+4147: Semicolon       ";" at 387:58-387:59
+4148: At              "@" at 388:5-388:6 (leading: Newline, Space)
+4149: Ident           "intrinsic" at 388:6-388:15
+4150: KwFn            "fn" at 388:16-388:18 (leading: Space)
+4151: Ident           "__pos" at 388:19-388:24 (leading: Space)
+4152: LParen          "(" at 388:24-388:25
+4153: Ident           "self" at 388:25-388:29
+4154: Colon           ":" at 388:29-388:30
+4155: Ident           "int16" at 388:31-388:36 (leading: Space)
+4156: RParen          ")" at 388:36-388:37
+4157: Arrow           "->" at 388:38-388:40 (leading: Space)
+4158: Ident           "int16" at 388:41-388:46 (leading: Space)
+4159: Semicolon       ";" at 388:46-388:47
+4160: At              "@" at 389:5-389:6 (leading: Newline, Space)
+4161: Ident           "intrinsic" at 389:6-389:15
+4162: KwFn            "fn" at 389:16-389:18 (leading: Space)
+4163: Ident           "__neg" at 389:19-389:24 (leading: Space)
+4164: LParen          "(" at 389:24-389:25
+4165: Ident           "self" at 389:25-389:29
+4166: Colon           ":" at 389:29-389:30
+4167: Ident           "int16" at 389:31-389:36 (leading: Space)
+4168: RParen          ")" at 389:36-389:37
+4169: Arrow           "->" at 389:38-389:40 (leading: Space)
+4170: Ident           "int16" at 389:41-389:46 (leading: Space)
+4171: Semicolon       ";" at 389:46-389:47
+4172: At              "@" at 390:5-390:6 (leading: Newline, Space)
+4173: Ident           "intrinsic" at 390:6-390:15
+4174: KwFn            "fn" at 390:16-390:18 (leading: Space)
+4175: Ident           "__abs" at 390:19-390:24 (leading: Space)
+4176: LParen          "(" at 390:24-390:25
+4177: Ident           "self" at 390:25-390:29
+4178: Colon           ":" at 390:29-390:30
+4179: Ident           "int16" at 390:31-390:36 (leading: Space)
+4180: RParen          ")" at 390:36-390:37
+4181: Arrow           "->" at 390:38-390:40 (leading: Space)
+4182: Ident           "int16" at 390:41-390:46 (leading: Space)
+4183: Semicolon       ";" at 390:46-390:47
+4184: At              "@" at 391:5-391:6 (leading: Newline, Space)
+4185: Ident           "intrinsic" at 391:6-391:15
+4186: KwFn            "fn" at 391:16-391:18 (leading: Space)
+4187: Ident           "__to" at 391:19-391:23 (leading: Space)
+4188: LParen          "(" at 391:23-391:24
+4189: Ident           "self" at 391:24-391:28
+4190: Colon           ":" at 391:28-391:29
+4191: Ident           "int16" at 391:30-391:35 (leading: Space)
+4192: Comma           "," at 391:35-391:36
+4193: Ident           "target" at 391:37-391:43 (leading: Space)
+4194: Colon           ":" at 391:43-391:44
+4195: Ident           "int" at 391:45-391:48 (leading: Space)
+4196: RParen          ")" at 391:48-391:49
+4197: Arrow           "->" at 391:50-391:52 (leading: Space)
+4198: Ident           "int" at 391:53-391:56 (leading: Space)
+4199: Semicolon       ";" at 391:56-391:57
+4200: At              "@" at 392:5-392:6 (leading: Newline, Space)
+4201: Ident           "intrinsic" at 392:6-392:15
+4202: At              "@" at 392:16-392:17 (leading: Space)
+4203: Ident           "overload" at 392:17-392:25
+4204: KwFn            "fn" at 392:26-392:28 (leading: Space)
+4205: Ident           "__to" at 392:29-392:33 (leading: Space)
+4206: LParen          "(" at 392:33-392:34
+4207: Ident           "self" at 392:34-392:38
+4208: Colon           ":" at 392:38-392:39
+4209: Ident           "int16" at 392:40-392:45 (leading: Space)
+4210: Comma           "," at 392:45-392:46
+4211: Ident           "target" at 392:47-392:53 (leading: Space)
+4212: Colon           ":" at 392:53-392:54
+4213: Ident           "int8" at 392:55-392:59 (leading: Space)
+4214: RParen          ")" at 392:59-392:60
+4215: Arrow           "->" at 392:61-392:63 (leading: Space)
+4216: Ident           "int8" at 392:64-392:68 (leading: Space)
+4217: Semicolon       ";" at 392:68-392:69
+4218: At              "@" at 393:5-393:6 (leading: Newline, Space)
+4219: Ident           "intrinsic" at 393:6-393:15
+4220: At              "@" at 393:16-393:17 (leading: Space)
+4221: Ident           "overload" at 393:17-393:25
+4222: KwFn            "fn" at 393:26-393:28 (leading: Space)
+4223: Ident           "__to" at 393:29-393:33 (leading: Space)
+4224: LParen          "(" at 393:33-393:34
+4225: Ident           "self" at 393:34-393:38
+4226: Colon           ":" at 393:38-393:39
+4227: Ident           "int16" at 393:40-393:45 (leading: Space)
+4228: Comma           "," at 393:45-393:46
+4229: Ident           "target" at 393:47-393:53 (leading: Space)
+4230: Colon           ":" at 393:53-393:54
+4231: Ident           "int32" at 393:55-393:60 (leading: Space)
+4232: RParen          ")" at 393:60-393:61
+4233: Arrow           "->" at 393:62-393:64 (leading: Space)
+4234: Ident           "int32" at 393:65-393:70 (leading: Space)
+4235: Semicolon       ";" at 393:70-393:71
+4236: At              "@" at 394:5-394:6 (leading: Newline, Space)
+4237: Ident           "intrinsic" at 394:6-394:15
+4238: At              "@" at 394:16-394:17 (leading: Space)
+4239: Ident           "overload" at 394:17-394:25
+4240: KwFn            "fn" at 394:26-394:28 (leading: Space)
+4241: Ident           "__to" at 394:29-394:33 (leading: Space)
+4242: LParen          "(" at 394:33-394:34
+4243: Ident           "self" at 394:34-394:38
+4244: Colon           ":" at 394:38-394:39
+4245: Ident           "int16" at 394:40-394:45 (leading: Space)
+4246: Comma           "," at 394:45-394:46
+4247: Ident           "target" at 394:47-394:53 (leading: Space)
+4248: Colon           ":" at 394:53-394:54
+4249: Ident           "int64" at 394:55-394:60 (leading: Space)
+4250: RParen          ")" at 394:60-394:61
+4251: Arrow           "->" at 394:62-394:64 (leading: Space)
+4252: Ident           "int64" at 394:65-394:70 (leading: Space)
+4253: Semicolon       ";" at 394:70-394:71
+4254: At              "@" at 395:5-395:6 (leading: Newline, Space)
+4255: Ident           "intrinsic" at 395:6-395:15
+4256: KwPub           "pub" at 395:16-395:19 (leading: Space)
+4257: KwFn            "fn" at 395:20-395:22 (leading: Space)
+4258: Ident           "from_str" at 395:23-395:31 (leading: Space)
+4259: LParen          "(" at 395:31-395:32
+4260: Ident           "s" at 395:32-395:33
+4261: Colon           ":" at 395:33-395:34
+4262: Amp             "&" at 395:35-395:36 (leading: Space)
+4263: Ident           "string" at 395:36-395:42
+4264: RParen          ")" at 395:42-395:43
+4265: Arrow           "->" at 395:44-395:46 (leading: Space)
+4266: Ident           "Erring" at 395:47-395:53 (leading: Space)
+4267: Lt              "<" at 395:53-395:54
+4268: Ident           "int16" at 395:54-395:59
+4269: Comma           "," at 395:59-395:60
+4270: Ident           "Error" at 395:61-395:66 (leading: Space)
+4271: Gt              ">" at 395:66-395:67
+4272: Semicolon       ";" at 395:67-395:68
+4273: RBrace          "}" at 396:1-396:2 (leading: Newline)
+4274: KwExtern        "extern" at 398:1-398:7 (leading: Newline)
+4275: Lt              "<" at 398:7-398:8
+4276: Ident           "int32" at 398:8-398:13
+4277: Gt              ">" at 398:13-398:14
+4278: LBrace          "{" at 398:15-398:16 (leading: Space)
+4279: KwPub           "pub" at 399:5-399:8 (leading: Newline, Space)
+4280: KwFn            "fn" at 399:9-399:11 (leading: Space)
+4281: Ident           "__min_value" at 399:12-399:23 (leading: Space)
+4282: LParen          "(" at 399:23-399:24
+4283: RParen          ")" at 399:24-399:25
+4284: Arrow           "->" at 399:26-399:28 (leading: Space)
+4285: Ident           "int32" at 399:29-399:34 (leading: Space)
+4286: LBrace          "{" at 399:35-399:36 (leading: Space)
+4287: KwReturn        "return" at 399:37-399:43 (leading: Space)
+4288: LParen          "(" at 399:44-399:45 (leading: Space)
+4289: Minus           "-" at 399:45-399:46
+4290: IntLit          "2_147_483_648" at 399:46-399:59
+4291: RParen          ")" at 399:59-399:60
+4292: Colon           ":" at 399:60-399:61
+4293: Ident           "int32" at 399:61-399:66
+4294: Semicolon       ";" at 399:66-399:67
+4295: RBrace          "}" at 399:68-399:69 (leading: Space)
+4296: KwPub           "pub" at 400:5-400:8 (leading: Newline, Space)
+4297: KwFn            "fn" at 400:9-400:11 (leading: Space)
+4298: Ident           "__max_value" at 400:12-400:23 (leading: Space)
+4299: LParen          "(" at 400:23-400:24
+4300: RParen          ")" at 400:24-400:25
+4301: Arrow           "->" at 400:26-400:28 (leading: Space)
+4302: Ident           "int32" at 400:29-400:34 (leading: Space)
+4303: LBrace          "{" at 400:35-400:36 (leading: Space)
+4304: KwReturn        "return" at 400:37-400:43 (leading: Space)
+4305: LParen          "(" at 400:44-400:45 (leading: Space)
+4306: IntLit          "2_147_483_647" at 400:45-400:58
+4307: RParen          ")" at 400:58-400:59
+4308: Colon           ":" at 400:59-400:60
+4309: Ident           "int32" at 400:60-400:65
+4310: Semicolon       ";" at 400:65-400:66
+4311: RBrace          "}" at 400:67-400:68 (leading: Space)
+4312: At              "@" at 401:5-401:6 (leading: Newline, Space)
+4313: Ident           "intrinsic" at 401:6-401:15
+4314: KwFn            "fn" at 401:16-401:18 (leading: Space)
+4315: Ident           "__add" at 401:19-401:24 (leading: Space)
+4316: LParen          "(" at 401:24-401:25
+4317: Ident           "self" at 401:25-401:29
+4318: Colon           ":" at 401:29-401:30
+4319: Ident           "int32" at 401:31-401:36 (leading: Space)
+4320: Comma           "," at 401:36-401:37
+4321: Ident           "other" at 401:38-401:43 (leading: Space)
+4322: Colon           ":" at 401:43-401:44
+4323: Ident           "int32" at 401:45-401:50 (leading: Space)
+4324: RParen          ")" at 401:50-401:51
+4325: Arrow           "->" at 401:52-401:54 (leading: Space)
+4326: Ident           "int32" at 401:55-401:60 (leading: Space)
+4327: Semicolon       ";" at 401:60-401:61
+4328: At              "@" at 402:5-402:6 (leading: Newline, Space)
+4329: Ident           "intrinsic" at 402:6-402:15
+4330: KwFn            "fn" at 402:16-402:18 (leading: Space)
+4331: Ident           "__sub" at 402:19-402:24 (leading: Space)
+4332: LParen          "(" at 402:24-402:25
+4333: Ident           "self" at 402:25-402:29
+4334: Colon           ":" at 402:29-402:30
+4335: Ident           "int32" at 402:31-402:36 (leading: Space)
+4336: Comma           "," at 402:36-402:37
+4337: Ident           "other" at 402:38-402:43 (leading: Space)
+4338: Colon           ":" at 402:43-402:44
+4339: Ident           "int32" at 402:45-402:50 (leading: Space)
+4340: RParen          ")" at 402:50-402:51
+4341: Arrow           "->" at 402:52-402:54 (leading: Space)
+4342: Ident           "int32" at 402:55-402:60 (leading: Space)
+4343: Semicolon       ";" at 402:60-402:61
+4344: At              "@" at 403:5-403:6 (leading: Newline, Space)
+4345: Ident           "intrinsic" at 403:6-403:15
+4346: KwFn            "fn" at 403:16-403:18 (leading: Space)
+4347: Ident           "__mul" at 403:19-403:24 (leading: Space)
+4348: LParen          "(" at 403:24-403:25
+4349: Ident           "self" at 403:25-403:29
+4350: Colon           ":" at 403:29-403:30
+4351: Ident           "int32" at 403:31-403:36 (leading: Space)
+4352: Comma           "," at 403:36-403:37
+4353: Ident           "other" at 403:38-403:43 (leading: Space)
+4354: Colon           ":" at 403:43-403:44
+4355: Ident           "int32" at 403:45-403:50 (leading: Space)
+4356: RParen          ")" at 403:50-403:51
+4357: Arrow           "->" at 403:52-403:54 (leading: Space)
+4358: Ident           "int32" at 403:55-403:60 (leading: Space)
+4359: Semicolon       ";" at 403:60-403:61
+4360: At              "@" at 404:5-404:6 (leading: Newline, Space)
+4361: Ident           "intrinsic" at 404:6-404:15
+4362: KwFn            "fn" at 404:16-404:18 (leading: Space)
+4363: Ident           "__div" at 404:19-404:24 (leading: Space)
+4364: LParen          "(" at 404:24-404:25
+4365: Ident           "self" at 404:25-404:29
+4366: Colon           ":" at 404:29-404:30
+4367: Ident           "int32" at 404:31-404:36 (leading: Space)
+4368: Comma           "," at 404:36-404:37
+4369: Ident           "other" at 404:38-404:43 (leading: Space)
+4370: Colon           ":" at 404:43-404:44
+4371: Ident           "int32" at 404:45-404:50 (leading: Space)
+4372: RParen          ")" at 404:50-404:51
+4373: Arrow           "->" at 404:52-404:54 (leading: Space)
+4374: Ident           "int32" at 404:55-404:60 (leading: Space)
+4375: Semicolon       ";" at 404:60-404:61
+4376: At              "@" at 405:5-405:6 (leading: Newline, Space)
+4377: Ident           "intrinsic" at 405:6-405:15
+4378: KwFn            "fn" at 405:16-405:18 (leading: Space)
+4379: Ident           "__mod" at 405:19-405:24 (leading: Space)
+4380: LParen          "(" at 405:24-405:25
+4381: Ident           "self" at 405:25-405:29
+4382: Colon           ":" at 405:29-405:30
+4383: Ident           "int32" at 405:31-405:36 (leading: Space)
+4384: Comma           "," at 405:36-405:37
+4385: Ident           "other" at 405:38-405:43 (leading: Space)
+4386: Colon           ":" at 405:43-405:44
+4387: Ident           "int32" at 405:45-405:50 (leading: Space)
+4388: RParen          ")" at 405:50-405:51
+4389: Arrow           "->" at 405:52-405:54 (leading: Space)
+4390: Ident           "int32" at 405:55-405:60 (leading: Space)
+4391: Semicolon       ";" at 405:60-405:61
+4392: At              "@" at 406:5-406:6 (leading: Newline, Space)
+4393: Ident           "intrinsic" at 406:6-406:15
+4394: KwFn            "fn" at 406:16-406:18 (leading: Space)
+4395: Ident           "__bit_and" at 406:19-406:28 (leading: Space)
+4396: LParen          "(" at 406:28-406:29
+4397: Ident           "self" at 406:29-406:33
+4398: Colon           ":" at 406:33-406:34
+4399: Ident           "int32" at 406:35-406:40 (leading: Space)
+4400: Comma           "," at 406:40-406:41
+4401: Ident           "other" at 406:42-406:47 (leading: Space)
+4402: Colon           ":" at 406:47-406:48
+4403: Ident           "int32" at 406:49-406:54 (leading: Space)
+4404: RParen          ")" at 406:54-406:55
+4405: Arrow           "->" at 406:56-406:58 (leading: Space)
+4406: Ident           "int32" at 406:59-406:64 (leading: Space)
+4407: Semicolon       ";" at 406:64-406:65
+4408: At              "@" at 407:5-407:6 (leading: Newline, Space)
+4409: Ident           "intrinsic" at 407:6-407:15
+4410: KwFn            "fn" at 407:16-407:18 (leading: Space)
+4411: Ident           "__bit_or" at 407:19-407:27 (leading: Space)
+4412: LParen          "(" at 407:27-407:28
+4413: Ident           "self" at 407:28-407:32
+4414: Colon           ":" at 407:32-407:33
+4415: Ident           "int32" at 407:34-407:39 (leading: Space)
+4416: Comma           "," at 407:39-407:40
+4417: Ident           "other" at 407:41-407:46 (leading: Space)
+4418: Colon           ":" at 407:46-407:47
+4419: Ident           "int32" at 407:48-407:53 (leading: Space)
+4420: RParen          ")" at 407:53-407:54
+4421: Arrow           "->" at 407:55-407:57 (leading: Space)
+4422: Ident           "int32" at 407:58-407:63 (leading: Space)
+4423: Semicolon       ";" at 407:63-407:64
+4424: At              "@" at 408:5-408:6 (leading: Newline, Space)
+4425: Ident           "intrinsic" at 408:6-408:15
+4426: KwFn            "fn" at 408:16-408:18 (leading: Space)
+4427: Ident           "__bit_xor" at 408:19-408:28 (leading: Space)
+4428: LParen          "(" at 408:28-408:29
+4429: Ident           "self" at 408:29-408:33
+4430: Colon           ":" at 408:33-408:34
+4431: Ident           "int32" at 408:35-408:40 (leading: Space)
+4432: Comma           "," at 408:40-408:41
+4433: Ident           "other" at 408:42-408:47 (leading: Space)
+4434: Colon           ":" at 408:47-408:48
+4435: Ident           "int32" at 408:49-408:54 (leading: Space)
+4436: RParen          ")" at 408:54-408:55
+4437: Arrow           "->" at 408:56-408:58 (leading: Space)
+4438: Ident           "int32" at 408:59-408:64 (leading: Space)
+4439: Semicolon       ";" at 408:64-408:65
+4440: At              "@" at 409:5-409:6 (leading: Newline, Space)
+4441: Ident           "intrinsic" at 409:6-409:15
+4442: KwFn            "fn" at 409:16-409:18 (leading: Space)
+4443: Ident           "__shl" at 409:19-409:24 (leading: Space)
+4444: LParen          "(" at 409:24-409:25
+4445: Ident           "self" at 409:25-409:29
+4446: Colon           ":" at 409:29-409:30
+4447: Ident           "int32" at 409:31-409:36 (leading: Space)
+4448: Comma           "," at 409:36-409:37
+4449: Ident           "other" at 409:38-409:43 (leading: Space)
+4450: Colon           ":" at 409:43-409:44
+4451: Ident           "int32" at 409:45-409:50 (leading: Space)
+4452: RParen          ")" at 409:50-409:51
+4453: Arrow           "->" at 409:52-409:54 (leading: Space)
+4454: Ident           "int32" at 409:55-409:60 (leading: Space)
+4455: Semicolon       ";" at 409:60-409:61
+4456: At              "@" at 410:5-410:6 (leading: Newline, Space)
+4457: Ident           "intrinsic" at 410:6-410:15
+4458: KwFn            "fn" at 410:16-410:18 (leading: Space)
+4459: Ident           "__shr" at 410:19-410:24 (leading: Space)
+4460: LParen          "(" at 410:24-410:25
+4461: Ident           "self" at 410:25-410:29
+4462: Colon           ":" at 410:29-410:30
+4463: Ident           "int32" at 410:31-410:36 (leading: Space)
+4464: Comma           "," at 410:36-410:37
+4465: Ident           "other" at 410:38-410:43 (leading: Space)
+4466: Colon           ":" at 410:43-410:44
+4467: Ident           "int32" at 410:45-410:50 (leading: Space)
+4468: RParen          ")" at 410:50-410:51
+4469: Arrow           "->" at 410:52-410:54 (leading: Space)
+4470: Ident           "int32" at 410:55-410:60 (leading: Space)
+4471: Semicolon       ";" at 410:60-410:61
+4472: At              "@" at 411:5-411:6 (leading: Newline, Space)
+4473: Ident           "intrinsic" at 411:6-411:15
+4474: KwFn            "fn" at 411:16-411:18 (leading: Space)
+4475: Ident           "__lt" at 411:19-411:23 (leading: Space)
+4476: LParen          "(" at 411:23-411:24
+4477: Ident           "self" at 411:24-411:28
+4478: Colon           ":" at 411:28-411:29
+4479: Ident           "int32" at 411:30-411:35 (leading: Space)
+4480: Comma           "," at 411:35-411:36
+4481: Ident           "other" at 411:37-411:42 (leading: Space)
+4482: Colon           ":" at 411:42-411:43
+4483: Ident           "int32" at 411:44-411:49 (leading: Space)
+4484: RParen          ")" at 411:49-411:50
+4485: Arrow           "->" at 411:51-411:53 (leading: Space)
+4486: Ident           "bool" at 411:54-411:58 (leading: Space)
+4487: Semicolon       ";" at 411:58-411:59
+4488: At              "@" at 412:5-412:6 (leading: Newline, Space)
+4489: Ident           "intrinsic" at 412:6-412:15
+4490: KwFn            "fn" at 412:16-412:18 (leading: Space)
+4491: Ident           "__le" at 412:19-412:23 (leading: Space)
+4492: LParen          "(" at 412:23-412:24
+4493: Ident           "self" at 412:24-412:28
+4494: Colon           ":" at 412:28-412:29
+4495: Ident           "int32" at 412:30-412:35 (leading: Space)
+4496: Comma           "," at 412:35-412:36
+4497: Ident           "other" at 412:37-412:42 (leading: Space)
+4498: Colon           ":" at 412:42-412:43
+4499: Ident           "int32" at 412:44-412:49 (leading: Space)
+4500: RParen          ")" at 412:49-412:50
+4501: Arrow           "->" at 412:51-412:53 (leading: Space)
+4502: Ident           "bool" at 412:54-412:58 (leading: Space)
+4503: Semicolon       ";" at 412:58-412:59
+4504: At              "@" at 413:5-413:6 (leading: Newline, Space)
+4505: Ident           "intrinsic" at 413:6-413:15
+4506: KwFn            "fn" at 413:16-413:18 (leading: Space)
+4507: Ident           "__eq" at 413:19-413:23 (leading: Space)
+4508: LParen          "(" at 413:23-413:24
+4509: Ident           "self" at 413:24-413:28
+4510: Colon           ":" at 413:28-413:29
+4511: Ident           "int32" at 413:30-413:35 (leading: Space)
+4512: Comma           "," at 413:35-413:36
+4513: Ident           "other" at 413:37-413:42 (leading: Space)
+4514: Colon           ":" at 413:42-413:43
+4515: Ident           "int32" at 413:44-413:49 (leading: Space)
+4516: RParen          ")" at 413:49-413:50
+4517: Arrow           "->" at 413:51-413:53 (leading: Space)
+4518: Ident           "bool" at 413:54-413:58 (leading: Space)
+4519: Semicolon       ";" at 413:58-413:59
+4520: At              "@" at 414:5-414:6 (leading: Newline, Space)
+4521: Ident           "intrinsic" at 414:6-414:15
+4522: KwFn            "fn" at 414:16-414:18 (leading: Space)
+4523: Ident           "__ne" at 414:19-414:23 (leading: Space)
+4524: LParen          "(" at 414:23-414:24
+4525: Ident           "self" at 414:24-414:28
+4526: Colon           ":" at 414:28-414:29
+4527: Ident           "int32" at 414:30-414:35 (leading: Space)
+4528: Comma           "," at 414:35-414:36
+4529: Ident           "other" at 414:37-414:42 (leading: Space)
+4530: Colon           ":" at 414:42-414:43
+4531: Ident           "int32" at 414:44-414:49 (leading: Space)
+4532: RParen          ")" at 414:49-414:50
+4533: Arrow           "->" at 414:51-414:53 (leading: Space)
+4534: Ident           "bool" at 414:54-414:58 (leading: Space)
+4535: Semicolon       ";" at 414:58-414:59
+4536: At              "@" at 415:5-415:6 (leading: Newline, Space)
+4537: Ident           "intrinsic" at 415:6-415:15
+4538: KwFn            "fn" at 415:16-415:18 (leading: Space)
+4539: Ident           "__ge" at 415:19-415:23 (leading: Space)
+4540: LParen          "(" at 415:23-415:24
+4541: Ident           "self" at 415:24-415:28
+4542: Colon           ":" at 415:28-415:29
+4543: Ident           "int32" at 415:30-415:35 (leading: Space)
+4544: Comma           "," at 415:35-415:36
+4545: Ident           "other" at 415:37-415:42 (leading: Space)
+4546: Colon           ":" at 415:42-415:43
+4547: Ident           "int32" at 415:44-415:49 (leading: Space)
+4548: RParen          ")" at 415:49-415:50
+4549: Arrow           "->" at 415:51-415:53 (leading: Space)
+4550: Ident           "bool" at 415:54-415:58 (leading: Space)
+4551: Semicolon       ";" at 415:58-415:59
+4552: At              "@" at 416:5-416:6 (leading: Newline, Space)
+4553: Ident           "intrinsic" at 416:6-416:15
+4554: KwFn            "fn" at 416:16-416:18 (leading: Space)
+4555: Ident           "__gt" at 416:19-416:23 (leading: Space)
+4556: LParen          "(" at 416:23-416:24
+4557: Ident           "self" at 416:24-416:28
+4558: Colon           ":" at 416:28-416:29
+4559: Ident           "int32" at 416:30-416:35 (leading: Space)
+4560: Comma           "," at 416:35-416:36
+4561: Ident           "other" at 416:37-416:42 (leading: Space)
+4562: Colon           ":" at 416:42-416:43
+4563: Ident           "int32" at 416:44-416:49 (leading: Space)
+4564: RParen          ")" at 416:49-416:50
+4565: Arrow           "->" at 416:51-416:53 (leading: Space)
+4566: Ident           "bool" at 416:54-416:58 (leading: Space)
+4567: Semicolon       ";" at 416:58-416:59
+4568: At              "@" at 417:5-417:6 (leading: Newline, Space)
+4569: Ident           "intrinsic" at 417:6-417:15
+4570: KwFn            "fn" at 417:16-417:18 (leading: Space)
+4571: Ident           "__pos" at 417:19-417:24 (leading: Space)
+4572: LParen          "(" at 417:24-417:25
+4573: Ident           "self" at 417:25-417:29
+4574: Colon           ":" at 417:29-417:30
+4575: Ident           "int32" at 417:31-417:36 (leading: Space)
+4576: RParen          ")" at 417:36-417:37
+4577: Arrow           "->" at 417:38-417:40 (leading: Space)
+4578: Ident           "int32" at 417:41-417:46 (leading: Space)
+4579: Semicolon       ";" at 417:46-417:47
+4580: At              "@" at 418:5-418:6 (leading: Newline, Space)
+4581: Ident           "intrinsic" at 418:6-418:15
+4582: KwFn            "fn" at 418:16-418:18 (leading: Space)
+4583: Ident           "__neg" at 418:19-418:24 (leading: Space)
+4584: LParen          "(" at 418:24-418:25
+4585: Ident           "self" at 418:25-418:29
+4586: Colon           ":" at 418:29-418:30
+4587: Ident           "int32" at 418:31-418:36 (leading: Space)
+4588: RParen          ")" at 418:36-418:37
+4589: Arrow           "->" at 418:38-418:40 (leading: Space)
+4590: Ident           "int32" at 418:41-418:46 (leading: Space)
+4591: Semicolon       ";" at 418:46-418:47
+4592: At              "@" at 419:5-419:6 (leading: Newline, Space)
+4593: Ident           "intrinsic" at 419:6-419:15
+4594: KwFn            "fn" at 419:16-419:18 (leading: Space)
+4595: Ident           "__abs" at 419:19-419:24 (leading: Space)
+4596: LParen          "(" at 419:24-419:25
+4597: Ident           "self" at 419:25-419:29
+4598: Colon           ":" at 419:29-419:30
+4599: Ident           "int32" at 419:31-419:36 (leading: Space)
+4600: RParen          ")" at 419:36-419:37
+4601: Arrow           "->" at 419:38-419:40 (leading: Space)
+4602: Ident           "int32" at 419:41-419:46 (leading: Space)
+4603: Semicolon       ";" at 419:46-419:47
+4604: At              "@" at 420:5-420:6 (leading: Newline, Space)
+4605: Ident           "intrinsic" at 420:6-420:15
+4606: KwFn            "fn" at 420:16-420:18 (leading: Space)
+4607: Ident           "__to" at 420:19-420:23 (leading: Space)
+4608: LParen          "(" at 420:23-420:24
+4609: Ident           "self" at 420:24-420:28
+4610: Colon           ":" at 420:28-420:29
+4611: Ident           "int32" at 420:30-420:35 (leading: Space)
+4612: Comma           "," at 420:35-420:36
+4613: Ident           "target" at 420:37-420:43 (leading: Space)
+4614: Colon           ":" at 420:43-420:44
+4615: Ident           "int" at 420:45-420:48 (leading: Space)
+4616: RParen          ")" at 420:48-420:49
+4617: Arrow           "->" at 420:50-420:52 (leading: Space)
+4618: Ident           "int" at 420:53-420:56 (leading: Space)
+4619: Semicolon       ";" at 420:56-420:57
+4620: At              "@" at 421:5-421:6 (leading: Newline, Space)
+4621: Ident           "intrinsic" at 421:6-421:15
+4622: At              "@" at 421:16-421:17 (leading: Space)
+4623: Ident           "overload" at 421:17-421:25
+4624: KwFn            "fn" at 421:26-421:28 (leading: Space)
+4625: Ident           "__to" at 421:29-421:33 (leading: Space)
+4626: LParen          "(" at 421:33-421:34
+4627: Ident           "self" at 421:34-421:38
+4628: Colon           ":" at 421:38-421:39
+4629: Ident           "int32" at 421:40-421:45 (leading: Space)
+4630: Comma           "," at 421:45-421:46
+4631: Ident           "target" at 421:47-421:53 (leading: Space)
+4632: Colon           ":" at 421:53-421:54
+4633: Ident           "int8" at 421:55-421:59 (leading: Space)
+4634: RParen          ")" at 421:59-421:60
+4635: Arrow           "->" at 421:61-421:63 (leading: Space)
+4636: Ident           "int8" at 421:64-421:68 (leading: Space)
+4637: Semicolon       ";" at 421:68-421:69
+4638: At              "@" at 422:5-422:6 (leading: Newline, Space)
+4639: Ident           "intrinsic" at 422:6-422:15
+4640: At              "@" at 422:16-422:17 (leading: Space)
+4641: Ident           "overload" at 422:17-422:25
+4642: KwFn            "fn" at 422:26-422:28 (leading: Space)
+4643: Ident           "__to" at 422:29-422:33 (leading: Space)
+4644: LParen          "(" at 422:33-422:34
+4645: Ident           "self" at 422:34-422:38
+4646: Colon           ":" at 422:38-422:39
+4647: Ident           "int32" at 422:40-422:45 (leading: Space)
+4648: Comma           "," at 422:45-422:46
+4649: Ident           "target" at 422:47-422:53 (leading: Space)
+4650: Colon           ":" at 422:53-422:54
+4651: Ident           "int16" at 422:55-422:60 (leading: Space)
+4652: RParen          ")" at 422:60-422:61
+4653: Arrow           "->" at 422:62-422:64 (leading: Space)
+4654: Ident           "int16" at 422:65-422:70 (leading: Space)
+4655: Semicolon       ";" at 422:70-422:71
+4656: At              "@" at 423:5-423:6 (leading: Newline, Space)
+4657: Ident           "intrinsic" at 423:6-423:15
+4658: At              "@" at 423:16-423:17 (leading: Space)
+4659: Ident           "overload" at 423:17-423:25
+4660: KwFn            "fn" at 423:26-423:28 (leading: Space)
+4661: Ident           "__to" at 423:29-423:33 (leading: Space)
+4662: LParen          "(" at 423:33-423:34
+4663: Ident           "self" at 423:34-423:38
+4664: Colon           ":" at 423:38-423:39
+4665: Ident           "int32" at 423:40-423:45 (leading: Space)
+4666: Comma           "," at 423:45-423:46
+4667: Ident           "target" at 423:47-423:53 (leading: Space)
+4668: Colon           ":" at 423:53-423:54
+4669: Ident           "int64" at 423:55-423:60 (leading: Space)
+4670: RParen          ")" at 423:60-423:61
+4671: Arrow           "->" at 423:62-423:64 (leading: Space)
+4672: Ident           "int64" at 423:65-423:70 (leading: Space)
+4673: Semicolon       ";" at 423:70-423:71
+4674: At              "@" at 424:5-424:6 (leading: Newline, Space)
+4675: Ident           "intrinsic" at 424:6-424:15
+4676: KwPub           "pub" at 424:16-424:19 (leading: Space)
+4677: KwFn            "fn" at 424:20-424:22 (leading: Space)
+4678: Ident           "from_str" at 424:23-424:31 (leading: Space)
+4679: LParen          "(" at 424:31-424:32
+4680: Ident           "s" at 424:32-424:33
+4681: Colon           ":" at 424:33-424:34
+4682: Amp             "&" at 424:35-424:36 (leading: Space)
+4683: Ident           "string" at 424:36-424:42
+4684: RParen          ")" at 424:42-424:43
+4685: Arrow           "->" at 424:44-424:46 (leading: Space)
+4686: Ident           "Erring" at 424:47-424:53 (leading: Space)
+4687: Lt              "<" at 424:53-424:54
+4688: Ident           "int32" at 424:54-424:59
+4689: Comma           "," at 424:59-424:60
+4690: Ident           "Error" at 424:61-424:66 (leading: Space)
+4691: Gt              ">" at 424:66-424:67
+4692: Semicolon       ";" at 424:67-424:68
+4693: RBrace          "}" at 425:1-425:2 (leading: Newline)
+4694: KwExtern        "extern" at 427:1-427:7 (leading: Newline)
+4695: Lt              "<" at 427:7-427:8
+4696: Ident           "int64" at 427:8-427:13
+4697: Gt              ">" at 427:13-427:14
+4698: LBrace          "{" at 427:15-427:16 (leading: Space)
+4699: KwPub           "pub" at 428:5-428:8 (leading: Newline, Space)
+4700: KwFn            "fn" at 428:9-428:11 (leading: Space)
+4701: Ident           "__min_value" at 428:12-428:23 (leading: Space)
+4702: LParen          "(" at 428:23-428:24
+4703: RParen          ")" at 428:24-428:25
+4704: Arrow           "->" at 428:26-428:28 (leading: Space)
+4705: Ident           "int64" at 428:29-428:34 (leading: Space)
+4706: LBrace          "{" at 428:35-428:36 (leading: Space)
+4707: KwReturn        "return" at 428:37-428:43 (leading: Space)
+4708: LParen          "(" at 428:44-428:45 (leading: Space)
+4709: Minus           "-" at 428:45-428:46
+4710: IntLit          "9_223_372_036_854_775_808" at 428:46-428:71
+4711: RParen          ")" at 428:71-428:72
+4712: Colon           ":" at 428:72-428:73
+4713: Ident           "int64" at 428:73-428:78
+4714: Semicolon       ";" at 428:78-428:79
+4715: RBrace          "}" at 428:80-428:81 (leading: Space)
+4716: KwPub           "pub" at 429:5-429:8 (leading: Newline, Space)
+4717: KwFn            "fn" at 429:9-429:11 (leading: Space)
+4718: Ident           "__max_value" at 429:12-429:23 (leading: Space)
+4719: LParen          "(" at 429:23-429:24
+4720: RParen          ")" at 429:24-429:25
+4721: Arrow           "->" at 429:26-429:28 (leading: Space)
+4722: Ident           "int64" at 429:29-429:34 (leading: Space)
+4723: LBrace          "{" at 429:35-429:36 (leading: Space)
+4724: KwReturn        "return" at 429:37-429:43 (leading: Space)
+4725: LParen          "(" at 429:44-429:45 (leading: Space)
+4726: IntLit          "9_223_372_036_854_775_807" at 429:45-429:70
+4727: RParen          ")" at 429:70-429:71
+4728: Colon           ":" at 429:71-429:72
+4729: Ident           "int64" at 429:72-429:77
+4730: Semicolon       ";" at 429:77-429:78
+4731: RBrace          "}" at 429:79-429:80 (leading: Space)
+4732: At              "@" at 430:5-430:6 (leading: Newline, Space)
+4733: Ident           "intrinsic" at 430:6-430:15
+4734: KwFn            "fn" at 430:16-430:18 (leading: Space)
+4735: Ident           "__add" at 430:19-430:24 (leading: Space)
+4736: LParen          "(" at 430:24-430:25
+4737: Ident           "self" at 430:25-430:29
+4738: Colon           ":" at 430:29-430:30
+4739: Ident           "int64" at 430:31-430:36 (leading: Space)
+4740: Comma           "," at 430:36-430:37
+4741: Ident           "other" at 430:38-430:43 (leading: Space)
+4742: Colon           ":" at 430:43-430:44
+4743: Ident           "int64" at 430:45-430:50 (leading: Space)
+4744: RParen          ")" at 430:50-430:51
+4745: Arrow           "->" at 430:52-430:54 (leading: Space)
+4746: Ident           "int64" at 430:55-430:60 (leading: Space)
+4747: Semicolon       ";" at 430:60-430:61
+4748: At              "@" at 431:5-431:6 (leading: Newline, Space)
+4749: Ident           "intrinsic" at 431:6-431:15
+4750: KwFn            "fn" at 431:16-431:18 (leading: Space)
+4751: Ident           "__sub" at 431:19-431:24 (leading: Space)
+4752: LParen          "(" at 431:24-431:25
+4753: Ident           "self" at 431:25-431:29
+4754: Colon           ":" at 431:29-431:30
+4755: Ident           "int64" at 431:31-431:36 (leading: Space)
+4756: Comma           "," at 431:36-431:37
+4757: Ident           "other" at 431:38-431:43 (leading: Space)
+4758: Colon           ":" at 431:43-431:44
+4759: Ident           "int64" at 431:45-431:50 (leading: Space)
+4760: RParen          ")" at 431:50-431:51
+4761: Arrow           "->" at 431:52-431:54 (leading: Space)
+4762: Ident           "int64" at 431:55-431:60 (leading: Space)
+4763: Semicolon       ";" at 431:60-431:61
+4764: At              "@" at 432:5-432:6 (leading: Newline, Space)
+4765: Ident           "intrinsic" at 432:6-432:15
+4766: KwFn            "fn" at 432:16-432:18 (leading: Space)
+4767: Ident           "__mul" at 432:19-432:24 (leading: Space)
+4768: LParen          "(" at 432:24-432:25
+4769: Ident           "self" at 432:25-432:29
+4770: Colon           ":" at 432:29-432:30
+4771: Ident           "int64" at 432:31-432:36 (leading: Space)
+4772: Comma           "," at 432:36-432:37
+4773: Ident           "other" at 432:38-432:43 (leading: Space)
+4774: Colon           ":" at 432:43-432:44
+4775: Ident           "int64" at 432:45-432:50 (leading: Space)
+4776: RParen          ")" at 432:50-432:51
+4777: Arrow           "->" at 432:52-432:54 (leading: Space)
+4778: Ident           "int64" at 432:55-432:60 (leading: Space)
+4779: Semicolon       ";" at 432:60-432:61
+4780: At              "@" at 433:5-433:6 (leading: Newline, Space)
+4781: Ident           "intrinsic" at 433:6-433:15
+4782: KwFn            "fn" at 433:16-433:18 (leading: Space)
+4783: Ident           "__div" at 433:19-433:24 (leading: Space)
+4784: LParen          "(" at 433:24-433:25
+4785: Ident           "self" at 433:25-433:29
+4786: Colon           ":" at 433:29-433:30
+4787: Ident           "int64" at 433:31-433:36 (leading: Space)
+4788: Comma           "," at 433:36-433:37
+4789: Ident           "other" at 433:38-433:43 (leading: Space)
+4790: Colon           ":" at 433:43-433:44
+4791: Ident           "int64" at 433:45-433:50 (leading: Space)
+4792: RParen          ")" at 433:50-433:51
+4793: Arrow           "->" at 433:52-433:54 (leading: Space)
+4794: Ident           "int64" at 433:55-433:60 (leading: Space)
+4795: Semicolon       ";" at 433:60-433:61
+4796: At              "@" at 434:5-434:6 (leading: Newline, Space)
+4797: Ident           "intrinsic" at 434:6-434:15
+4798: KwFn            "fn" at 434:16-434:18 (leading: Space)
+4799: Ident           "__mod" at 434:19-434:24 (leading: Space)
+4800: LParen          "(" at 434:24-434:25
+4801: Ident           "self" at 434:25-434:29
+4802: Colon           ":" at 434:29-434:30
+4803: Ident           "int64" at 434:31-434:36 (leading: Space)
+4804: Comma           "," at 434:36-434:37
+4805: Ident           "other" at 434:38-434:43 (leading: Space)
+4806: Colon           ":" at 434:43-434:44
+4807: Ident           "int64" at 434:45-434:50 (leading: Space)
+4808: RParen          ")" at 434:50-434:51
+4809: Arrow           "->" at 434:52-434:54 (leading: Space)
+4810: Ident           "int64" at 434:55-434:60 (leading: Space)
+4811: Semicolon       ";" at 434:60-434:61
+4812: At              "@" at 435:5-435:6 (leading: Newline, Space)
+4813: Ident           "intrinsic" at 435:6-435:15
+4814: KwFn            "fn" at 435:16-435:18 (leading: Space)
+4815: Ident           "__bit_and" at 435:19-435:28 (leading: Space)
+4816: LParen          "(" at 435:28-435:29
+4817: Ident           "self" at 435:29-435:33
+4818: Colon           ":" at 435:33-435:34
+4819: Ident           "int64" at 435:35-435:40 (leading: Space)
+4820: Comma           "," at 435:40-435:41
+4821: Ident           "other" at 435:42-435:47 (leading: Space)
+4822: Colon           ":" at 435:47-435:48
+4823: Ident           "int64" at 435:49-435:54 (leading: Space)
+4824: RParen          ")" at 435:54-435:55
+4825: Arrow           "->" at 435:56-435:58 (leading: Space)
+4826: Ident           "int64" at 435:59-435:64 (leading: Space)
+4827: Semicolon       ";" at 435:64-435:65
+4828: At              "@" at 436:5-436:6 (leading: Newline, Space)
+4829: Ident           "intrinsic" at 436:6-436:15
+4830: KwFn            "fn" at 436:16-436:18 (leading: Space)
+4831: Ident           "__bit_or" at 436:19-436:27 (leading: Space)
+4832: LParen          "(" at 436:27-436:28
+4833: Ident           "self" at 436:28-436:32
+4834: Colon           ":" at 436:32-436:33
+4835: Ident           "int64" at 436:34-436:39 (leading: Space)
+4836: Comma           "," at 436:39-436:40
+4837: Ident           "other" at 436:41-436:46 (leading: Space)
+4838: Colon           ":" at 436:46-436:47
+4839: Ident           "int64" at 436:48-436:53 (leading: Space)
+4840: RParen          ")" at 436:53-436:54
+4841: Arrow           "->" at 436:55-436:57 (leading: Space)
+4842: Ident           "int64" at 436:58-436:63 (leading: Space)
+4843: Semicolon       ";" at 436:63-436:64
+4844: At              "@" at 437:5-437:6 (leading: Newline, Space)
+4845: Ident           "intrinsic" at 437:6-437:15
+4846: KwFn            "fn" at 437:16-437:18 (leading: Space)
+4847: Ident           "__bit_xor" at 437:19-437:28 (leading: Space)
+4848: LParen          "(" at 437:28-437:29
+4849: Ident           "self" at 437:29-437:33
+4850: Colon           ":" at 437:33-437:34
+4851: Ident           "int64" at 437:35-437:40 (leading: Space)
+4852: Comma           "," at 437:40-437:41
+4853: Ident           "other" at 437:42-437:47 (leading: Space)
+4854: Colon           ":" at 437:47-437:48
+4855: Ident           "int64" at 437:49-437:54 (leading: Space)
+4856: RParen          ")" at 437:54-437:55
+4857: Arrow           "->" at 437:56-437:58 (leading: Space)
+4858: Ident           "int64" at 437:59-437:64 (leading: Space)
+4859: Semicolon       ";" at 437:64-437:65
+4860: At              "@" at 438:5-438:6 (leading: Newline, Space)
+4861: Ident           "intrinsic" at 438:6-438:15
+4862: KwFn            "fn" at 438:16-438:18 (leading: Space)
+4863: Ident           "__shl" at 438:19-438:24 (leading: Space)
+4864: LParen          "(" at 438:24-438:25
+4865: Ident           "self" at 438:25-438:29
+4866: Colon           ":" at 438:29-438:30
+4867: Ident           "int64" at 438:31-438:36 (leading: Space)
+4868: Comma           "," at 438:36-438:37
+4869: Ident           "other" at 438:38-438:43 (leading: Space)
+4870: Colon           ":" at 438:43-438:44
+4871: Ident           "int64" at 438:45-438:50 (leading: Space)
+4872: RParen          ")" at 438:50-438:51
+4873: Arrow           "->" at 438:52-438:54 (leading: Space)
+4874: Ident           "int64" at 438:55-438:60 (leading: Space)
+4875: Semicolon       ";" at 438:60-438:61
+4876: At              "@" at 439:5-439:6 (leading: Newline, Space)
+4877: Ident           "intrinsic" at 439:6-439:15
+4878: KwFn            "fn" at 439:16-439:18 (leading: Space)
+4879: Ident           "__shr" at 439:19-439:24 (leading: Space)
+4880: LParen          "(" at 439:24-439:25
+4881: Ident           "self" at 439:25-439:29
+4882: Colon           ":" at 439:29-439:30
+4883: Ident           "int64" at 439:31-439:36 (leading: Space)
+4884: Comma           "," at 439:36-439:37
+4885: Ident           "other" at 439:38-439:43 (leading: Space)
+4886: Colon           ":" at 439:43-439:44
+4887: Ident           "int64" at 439:45-439:50 (leading: Space)
+4888: RParen          ")" at 439:50-439:51
+4889: Arrow           "->" at 439:52-439:54 (leading: Space)
+4890: Ident           "int64" at 439:55-439:60 (leading: Space)
+4891: Semicolon       ";" at 439:60-439:61
+4892: At              "@" at 440:5-440:6 (leading: Newline, Space)
+4893: Ident           "intrinsic" at 440:6-440:15
+4894: KwFn            "fn" at 440:16-440:18 (leading: Space)
+4895: Ident           "__lt" at 440:19-440:23 (leading: Space)
+4896: LParen          "(" at 440:23-440:24
+4897: Ident           "self" at 440:24-440:28
+4898: Colon           ":" at 440:28-440:29
+4899: Ident           "int64" at 440:30-440:35 (leading: Space)
+4900: Comma           "," at 440:35-440:36
+4901: Ident           "other" at 440:37-440:42 (leading: Space)
+4902: Colon           ":" at 440:42-440:43
+4903: Ident           "int64" at 440:44-440:49 (leading: Space)
+4904: RParen          ")" at 440:49-440:50
+4905: Arrow           "->" at 440:51-440:53 (leading: Space)
+4906: Ident           "bool" at 440:54-440:58 (leading: Space)
+4907: Semicolon       ";" at 440:58-440:59
+4908: At              "@" at 441:5-441:6 (leading: Newline, Space)
+4909: Ident           "intrinsic" at 441:6-441:15
+4910: KwFn            "fn" at 441:16-441:18 (leading: Space)
+4911: Ident           "__le" at 441:19-441:23 (leading: Space)
+4912: LParen          "(" at 441:23-441:24
+4913: Ident           "self" at 441:24-441:28
+4914: Colon           ":" at 441:28-441:29
+4915: Ident           "int64" at 441:30-441:35 (leading: Space)
+4916: Comma           "," at 441:35-441:36
+4917: Ident           "other" at 441:37-441:42 (leading: Space)
+4918: Colon           ":" at 441:42-441:43
+4919: Ident           "int64" at 441:44-441:49 (leading: Space)
+4920: RParen          ")" at 441:49-441:50
+4921: Arrow           "->" at 441:51-441:53 (leading: Space)
+4922: Ident           "bool" at 441:54-441:58 (leading: Space)
+4923: Semicolon       ";" at 441:58-441:59
+4924: At              "@" at 442:5-442:6 (leading: Newline, Space)
+4925: Ident           "intrinsic" at 442:6-442:15
+4926: KwFn            "fn" at 442:16-442:18 (leading: Space)
+4927: Ident           "__eq" at 442:19-442:23 (leading: Space)
+4928: LParen          "(" at 442:23-442:24
+4929: Ident           "self" at 442:24-442:28
+4930: Colon           ":" at 442:28-442:29
+4931: Ident           "int64" at 442:30-442:35 (leading: Space)
+4932: Comma           "," at 442:35-442:36
+4933: Ident           "other" at 442:37-442:42 (leading: Space)
+4934: Colon           ":" at 442:42-442:43
+4935: Ident           "int64" at 442:44-442:49 (leading: Space)
+4936: RParen          ")" at 442:49-442:50
+4937: Arrow           "->" at 442:51-442:53 (leading: Space)
+4938: Ident           "bool" at 442:54-442:58 (leading: Space)
+4939: Semicolon       ";" at 442:58-442:59
+4940: At              "@" at 443:5-443:6 (leading: Newline, Space)
+4941: Ident           "intrinsic" at 443:6-443:15
+4942: KwFn            "fn" at 443:16-443:18 (leading: Space)
+4943: Ident           "__ne" at 443:19-443:23 (leading: Space)
+4944: LParen          "(" at 443:23-443:24
+4945: Ident           "self" at 443:24-443:28
+4946: Colon           ":" at 443:28-443:29
+4947: Ident           "int64" at 443:30-443:35 (leading: Space)
+4948: Comma           "," at 443:35-443:36
+4949: Ident           "other" at 443:37-443:42 (leading: Space)
+4950: Colon           ":" at 443:42-443:43
+4951: Ident           "int64" at 443:44-443:49 (leading: Space)
+4952: RParen          ")" at 443:49-443:50
+4953: Arrow           "->" at 443:51-443:53 (leading: Space)
+4954: Ident           "bool" at 443:54-443:58 (leading: Space)
+4955: Semicolon       ";" at 443:58-443:59
+4956: At              "@" at 444:5-444:6 (leading: Newline, Space)
+4957: Ident           "intrinsic" at 444:6-444:15
+4958: KwFn            "fn" at 444:16-444:18 (leading: Space)
+4959: Ident           "__ge" at 444:19-444:23 (leading: Space)
+4960: LParen          "(" at 444:23-444:24
+4961: Ident           "self" at 444:24-444:28
+4962: Colon           ":" at 444:28-444:29
+4963: Ident           "int64" at 444:30-444:35 (leading: Space)
+4964: Comma           "," at 444:35-444:36
+4965: Ident           "other" at 444:37-444:42 (leading: Space)
+4966: Colon           ":" at 444:42-444:43
+4967: Ident           "int64" at 444:44-444:49 (leading: Space)
+4968: RParen          ")" at 444:49-444:50
+4969: Arrow           "->" at 444:51-444:53 (leading: Space)
+4970: Ident           "bool" at 444:54-444:58 (leading: Space)
+4971: Semicolon       ";" at 444:58-444:59
+4972: At              "@" at 445:5-445:6 (leading: Newline, Space)
+4973: Ident           "intrinsic" at 445:6-445:15
+4974: KwFn            "fn" at 445:16-445:18 (leading: Space)
+4975: Ident           "__gt" at 445:19-445:23 (leading: Space)
+4976: LParen          "(" at 445:23-445:24
+4977: Ident           "self" at 445:24-445:28
+4978: Colon           ":" at 445:28-445:29
+4979: Ident           "int64" at 445:30-445:35 (leading: Space)
+4980: Comma           "," at 445:35-445:36
+4981: Ident           "other" at 445:37-445:42 (leading: Space)
+4982: Colon           ":" at 445:42-445:43
+4983: Ident           "int64" at 445:44-445:49 (leading: Space)
+4984: RParen          ")" at 445:49-445:50
+4985: Arrow           "->" at 445:51-445:53 (leading: Space)
+4986: Ident           "bool" at 445:54-445:58 (leading: Space)
+4987: Semicolon       ";" at 445:58-445:59
+4988: At              "@" at 446:5-446:6 (leading: Newline, Space)
+4989: Ident           "intrinsic" at 446:6-446:15
+4990: KwFn            "fn" at 446:16-446:18 (leading: Space)
+4991: Ident           "__pos" at 446:19-446:24 (leading: Space)
+4992: LParen          "(" at 446:24-446:25
+4993: Ident           "self" at 446:25-446:29
+4994: Colon           ":" at 446:29-446:30
+4995: Ident           "int64" at 446:31-446:36 (leading: Space)
+4996: RParen          ")" at 446:36-446:37
+4997: Arrow           "->" at 446:38-446:40 (leading: Space)
+4998: Ident           "int64" at 446:41-446:46 (leading: Space)
+4999: Semicolon       ";" at 446:46-446:47
+5000: At              "@" at 447:5-447:6 (leading: Newline, Space)
+5001: Ident           "intrinsic" at 447:6-447:15
+5002: KwFn            "fn" at 447:16-447:18 (leading: Space)
+5003: Ident           "__neg" at 447:19-447:24 (leading: Space)
+5004: LParen          "(" at 447:24-447:25
+5005: Ident           "self" at 447:25-447:29
+5006: Colon           ":" at 447:29-447:30
+5007: Ident           "int64" at 447:31-447:36 (leading: Space)
+5008: RParen          ")" at 447:36-447:37
+5009: Arrow           "->" at 447:38-447:40 (leading: Space)
+5010: Ident           "int64" at 447:41-447:46 (leading: Space)
+5011: Semicolon       ";" at 447:46-447:47
+5012: At              "@" at 448:5-448:6 (leading: Newline, Space)
+5013: Ident           "intrinsic" at 448:6-448:15
+5014: KwFn            "fn" at 448:16-448:18 (leading: Space)
+5015: Ident           "__abs" at 448:19-448:24 (leading: Space)
+5016: LParen          "(" at 448:24-448:25
+5017: Ident           "self" at 448:25-448:29
+5018: Colon           ":" at 448:29-448:30
+5019: Ident           "int64" at 448:31-448:36 (leading: Space)
+5020: RParen          ")" at 448:36-448:37
+5021: Arrow           "->" at 448:38-448:40 (leading: Space)
+5022: Ident           "int64" at 448:41-448:46 (leading: Space)
+5023: Semicolon       ";" at 448:46-448:47
+5024: At              "@" at 449:5-449:6 (leading: Newline, Space)
+5025: Ident           "intrinsic" at 449:6-449:15
+5026: KwFn            "fn" at 449:16-449:18 (leading: Space)
+5027: Ident           "__to" at 449:19-449:23 (leading: Space)
+5028: LParen          "(" at 449:23-449:24
+5029: Ident           "self" at 449:24-449:28
+5030: Colon           ":" at 449:28-449:29
+5031: Ident           "int64" at 449:30-449:35 (leading: Space)
+5032: Comma           "," at 449:35-449:36
+5033: Ident           "target" at 449:37-449:43 (leading: Space)
+5034: Colon           ":" at 449:43-449:44
+5035: Ident           "int" at 449:45-449:48 (leading: Space)
+5036: RParen          ")" at 449:48-449:49
+5037: Arrow           "->" at 449:50-449:52 (leading: Space)
+5038: Ident           "int" at 449:53-449:56 (leading: Space)
+5039: Semicolon       ";" at 449:56-449:57
+5040: At              "@" at 450:5-450:6 (leading: Newline, Space)
+5041: Ident           "intrinsic" at 450:6-450:15
+5042: At              "@" at 450:16-450:17 (leading: Space)
+5043: Ident           "overload" at 450:17-450:25
+5044: KwFn            "fn" at 450:26-450:28 (leading: Space)
+5045: Ident           "__to" at 450:29-450:33 (leading: Space)
+5046: LParen          "(" at 450:33-450:34
+5047: Ident           "self" at 450:34-450:38
+5048: Colon           ":" at 450:38-450:39
+5049: Ident           "int64" at 450:40-450:45 (leading: Space)
+5050: Comma           "," at 450:45-450:46
+5051: Ident           "target" at 450:47-450:53 (leading: Space)
+5052: Colon           ":" at 450:53-450:54
+5053: Ident           "int8" at 450:55-450:59 (leading: Space)
+5054: RParen          ")" at 450:59-450:60
+5055: Arrow           "->" at 450:61-450:63 (leading: Space)
+5056: Ident           "int8" at 450:64-450:68 (leading: Space)
+5057: Semicolon       ";" at 450:68-450:69
+5058: At              "@" at 451:5-451:6 (leading: Newline, Space)
+5059: Ident           "intrinsic" at 451:6-451:15
+5060: At              "@" at 451:16-451:17 (leading: Space)
+5061: Ident           "overload" at 451:17-451:25
+5062: KwFn            "fn" at 451:26-451:28 (leading: Space)
+5063: Ident           "__to" at 451:29-451:33 (leading: Space)
+5064: LParen          "(" at 451:33-451:34
+5065: Ident           "self" at 451:34-451:38
+5066: Colon           ":" at 451:38-451:39
+5067: Ident           "int64" at 451:40-451:45 (leading: Space)
+5068: Comma           "," at 451:45-451:46
+5069: Ident           "target" at 451:47-451:53 (leading: Space)
+5070: Colon           ":" at 451:53-451:54
+5071: Ident           "int16" at 451:55-451:60 (leading: Space)
+5072: RParen          ")" at 451:60-451:61
+5073: Arrow           "->" at 451:62-451:64 (leading: Space)
+5074: Ident           "int16" at 451:65-451:70 (leading: Space)
+5075: Semicolon       ";" at 451:70-451:71
+5076: At              "@" at 452:5-452:6 (leading: Newline, Space)
+5077: Ident           "intrinsic" at 452:6-452:15
+5078: At              "@" at 452:16-452:17 (leading: Space)
+5079: Ident           "overload" at 452:17-452:25
+5080: KwFn            "fn" at 452:26-452:28 (leading: Space)
+5081: Ident           "__to" at 452:29-452:33 (leading: Space)
+5082: LParen          "(" at 452:33-452:34
+5083: Ident           "self" at 452:34-452:38
+5084: Colon           ":" at 452:38-452:39
+5085: Ident           "int64" at 452:40-452:45 (leading: Space)
+5086: Comma           "," at 452:45-452:46
+5087: Ident           "target" at 452:47-452:53 (leading: Space)
+5088: Colon           ":" at 452:53-452:54
+5089: Ident           "int32" at 452:55-452:60 (leading: Space)
+5090: RParen          ")" at 452:60-452:61
+5091: Arrow           "->" at 452:62-452:64 (leading: Space)
+5092: Ident           "int32" at 452:65-452:70 (leading: Space)
+5093: Semicolon       ";" at 452:70-452:71
+5094: At              "@" at 453:5-453:6 (leading: Newline, Space)
+5095: Ident           "intrinsic" at 453:6-453:15
+5096: KwPub           "pub" at 453:16-453:19 (leading: Space)
+5097: KwFn            "fn" at 453:20-453:22 (leading: Space)
+5098: Ident           "from_str" at 453:23-453:31 (leading: Space)
+5099: LParen          "(" at 453:31-453:32
+5100: Ident           "s" at 453:32-453:33
+5101: Colon           ":" at 453:33-453:34
+5102: Amp             "&" at 453:35-453:36 (leading: Space)
+5103: Ident           "string" at 453:36-453:42
+5104: RParen          ")" at 453:42-453:43
+5105: Arrow           "->" at 453:44-453:46 (leading: Space)
+5106: Ident           "Erring" at 453:47-453:53 (leading: Space)
+5107: Lt              "<" at 453:53-453:54
+5108: Ident           "int64" at 453:54-453:59
+5109: Comma           "," at 453:59-453:60
+5110: Ident           "Error" at 453:61-453:66 (leading: Space)
+5111: Gt              ">" at 453:66-453:67
+5112: Semicolon       ";" at 453:67-453:68
+5113: RBrace          "}" at 454:1-454:2 (leading: Newline)
+5114: KwExtern        "extern" at 456:1-456:7 (leading: Newline)
+5115: Lt              "<" at 456:7-456:8
+5116: Ident           "uint8" at 456:8-456:13
+5117: Gt              ">" at 456:13-456:14
+5118: LBrace          "{" at 456:15-456:16 (leading: Space)
+5119: KwPub           "pub" at 457:5-457:8 (leading: Newline, Space)
+5120: KwFn            "fn" at 457:9-457:11 (leading: Space)
+5121: Ident           "__min_value" at 457:12-457:23 (leading: Space)
+5122: LParen          "(" at 457:23-457:24
+5123: RParen          ")" at 457:24-457:25
+5124: Arrow           "->" at 457:26-457:28 (leading: Space)
+5125: Ident           "uint8" at 457:29-457:34 (leading: Space)
+5126: LBrace          "{" at 457:35-457:36 (leading: Space)
+5127: KwReturn        "return" at 457:37-457:43 (leading: Space)
+5128: LParen          "(" at 457:44-457:45 (leading: Space)
+5129: IntLit          "0" at 457:45-457:46
+5130: RParen          ")" at 457:46-457:47
+5131: Colon           ":" at 457:47-457:48
+5132: Ident           "uint8" at 457:48-457:53
+5133: Semicolon       ";" at 457:53-457:54
+5134: RBrace          "}" at 457:55-457:56 (leading: Space)
+5135: KwPub           "pub" at 458:5-458:8 (leading: Newline, Space)
+5136: KwFn            "fn" at 458:9-458:11 (leading: Space)
+5137: Ident           "__max_value" at 458:12-458:23 (leading: Space)
+5138: LParen          "(" at 458:23-458:24
+5139: RParen          ")" at 458:24-458:25
+5140: Arrow           "->" at 458:26-458:28 (leading: Space)
+5141: Ident           "uint8" at 458:29-458:34 (leading: Space)
+5142: LBrace          "{" at 458:35-458:36 (leading: Space)
+5143: KwReturn        "return" at 458:37-458:43 (leading: Space)
+5144: LParen          "(" at 458:44-458:45 (leading: Space)
+5145: IntLit          "255" at 458:45-458:48
+5146: RParen          ")" at 458:48-458:49
+5147: Colon           ":" at 458:49-458:50
+5148: Ident           "uint8" at 458:50-458:55
+5149: Semicolon       ";" at 458:55-458:56
+5150: RBrace          "}" at 458:57-458:58 (leading: Space)
+5151: At              "@" at 459:5-459:6 (leading: Newline, Space)
+5152: Ident           "intrinsic" at 459:6-459:15
+5153: KwFn            "fn" at 459:16-459:18 (leading: Space)
+5154: Ident           "__add" at 459:19-459:24 (leading: Space)
+5155: LParen          "(" at 459:24-459:25
+5156: Ident           "self" at 459:25-459:29
+5157: Colon           ":" at 459:29-459:30
+5158: Ident           "uint8" at 459:31-459:36 (leading: Space)
+5159: Comma           "," at 459:36-459:37
+5160: Ident           "other" at 459:38-459:43 (leading: Space)
+5161: Colon           ":" at 459:43-459:44
+5162: Ident           "uint8" at 459:45-459:50 (leading: Space)
+5163: RParen          ")" at 459:50-459:51
+5164: Arrow           "->" at 459:52-459:54 (leading: Space)
+5165: Ident           "uint8" at 459:55-459:60 (leading: Space)
+5166: Semicolon       ";" at 459:60-459:61
+5167: At              "@" at 460:5-460:6 (leading: Newline, Space)
+5168: Ident           "intrinsic" at 460:6-460:15
+5169: KwFn            "fn" at 460:16-460:18 (leading: Space)
+5170: Ident           "__sub" at 460:19-460:24 (leading: Space)
+5171: LParen          "(" at 460:24-460:25
+5172: Ident           "self" at 460:25-460:29
+5173: Colon           ":" at 460:29-460:30
+5174: Ident           "uint8" at 460:31-460:36 (leading: Space)
+5175: Comma           "," at 460:36-460:37
+5176: Ident           "other" at 460:38-460:43 (leading: Space)
+5177: Colon           ":" at 460:43-460:44
+5178: Ident           "uint8" at 460:45-460:50 (leading: Space)
+5179: RParen          ")" at 460:50-460:51
+5180: Arrow           "->" at 460:52-460:54 (leading: Space)
+5181: Ident           "uint8" at 460:55-460:60 (leading: Space)
+5182: Semicolon       ";" at 460:60-460:61
+5183: At              "@" at 461:5-461:6 (leading: Newline, Space)
+5184: Ident           "intrinsic" at 461:6-461:15
+5185: KwFn            "fn" at 461:16-461:18 (leading: Space)
+5186: Ident           "__mul" at 461:19-461:24 (leading: Space)
+5187: LParen          "(" at 461:24-461:25
+5188: Ident           "self" at 461:25-461:29
+5189: Colon           ":" at 461:29-461:30
+5190: Ident           "uint8" at 461:31-461:36 (leading: Space)
+5191: Comma           "," at 461:36-461:37
+5192: Ident           "other" at 461:38-461:43 (leading: Space)
+5193: Colon           ":" at 461:43-461:44
+5194: Ident           "uint8" at 461:45-461:50 (leading: Space)
+5195: RParen          ")" at 461:50-461:51
+5196: Arrow           "->" at 461:52-461:54 (leading: Space)
+5197: Ident           "uint8" at 461:55-461:60 (leading: Space)
+5198: Semicolon       ";" at 461:60-461:61
+5199: At              "@" at 462:5-462:6 (leading: Newline, Space)
+5200: Ident           "intrinsic" at 462:6-462:15
+5201: KwFn            "fn" at 462:16-462:18 (leading: Space)
+5202: Ident           "__div" at 462:19-462:24 (leading: Space)
+5203: LParen          "(" at 462:24-462:25
+5204: Ident           "self" at 462:25-462:29
+5205: Colon           ":" at 462:29-462:30
+5206: Ident           "uint8" at 462:31-462:36 (leading: Space)
+5207: Comma           "," at 462:36-462:37
+5208: Ident           "other" at 462:38-462:43 (leading: Space)
+5209: Colon           ":" at 462:43-462:44
+5210: Ident           "uint8" at 462:45-462:50 (leading: Space)
+5211: RParen          ")" at 462:50-462:51
+5212: Arrow           "->" at 462:52-462:54 (leading: Space)
+5213: Ident           "uint8" at 462:55-462:60 (leading: Space)
+5214: Semicolon       ";" at 462:60-462:61
+5215: At              "@" at 463:5-463:6 (leading: Newline, Space)
+5216: Ident           "intrinsic" at 463:6-463:15
+5217: KwFn            "fn" at 463:16-463:18 (leading: Space)
+5218: Ident           "__mod" at 463:19-463:24 (leading: Space)
+5219: LParen          "(" at 463:24-463:25
+5220: Ident           "self" at 463:25-463:29
+5221: Colon           ":" at 463:29-463:30
+5222: Ident           "uint8" at 463:31-463:36 (leading: Space)
+5223: Comma           "," at 463:36-463:37
+5224: Ident           "other" at 463:38-463:43 (leading: Space)
+5225: Colon           ":" at 463:43-463:44
+5226: Ident           "uint8" at 463:45-463:50 (leading: Space)
+5227: RParen          ")" at 463:50-463:51
+5228: Arrow           "->" at 463:52-463:54 (leading: Space)
+5229: Ident           "uint8" at 463:55-463:60 (leading: Space)
+5230: Semicolon       ";" at 463:60-463:61
+5231: At              "@" at 464:5-464:6 (leading: Newline, Space)
+5232: Ident           "intrinsic" at 464:6-464:15
+5233: KwFn            "fn" at 464:16-464:18 (leading: Space)
+5234: Ident           "__bit_and" at 464:19-464:28 (leading: Space)
+5235: LParen          "(" at 464:28-464:29
+5236: Ident           "self" at 464:29-464:33
+5237: Colon           ":" at 464:33-464:34
+5238: Ident           "uint8" at 464:35-464:40 (leading: Space)
+5239: Comma           "," at 464:40-464:41
+5240: Ident           "other" at 464:42-464:47 (leading: Space)
+5241: Colon           ":" at 464:47-464:48
+5242: Ident           "uint8" at 464:49-464:54 (leading: Space)
+5243: RParen          ")" at 464:54-464:55
+5244: Arrow           "->" at 464:56-464:58 (leading: Space)
+5245: Ident           "uint8" at 464:59-464:64 (leading: Space)
+5246: Semicolon       ";" at 464:64-464:65
+5247: At              "@" at 465:5-465:6 (leading: Newline, Space)
+5248: Ident           "intrinsic" at 465:6-465:15
+5249: KwFn            "fn" at 465:16-465:18 (leading: Space)
+5250: Ident           "__bit_or" at 465:19-465:27 (leading: Space)
+5251: LParen          "(" at 465:27-465:28
+5252: Ident           "self" at 465:28-465:32
+5253: Colon           ":" at 465:32-465:33
+5254: Ident           "uint8" at 465:34-465:39 (leading: Space)
+5255: Comma           "," at 465:39-465:40
+5256: Ident           "other" at 465:41-465:46 (leading: Space)
+5257: Colon           ":" at 465:46-465:47
+5258: Ident           "uint8" at 465:48-465:53 (leading: Space)
+5259: RParen          ")" at 465:53-465:54
+5260: Arrow           "->" at 465:55-465:57 (leading: Space)
+5261: Ident           "uint8" at 465:58-465:63 (leading: Space)
+5262: Semicolon       ";" at 465:63-465:64
+5263: At              "@" at 466:5-466:6 (leading: Newline, Space)
+5264: Ident           "intrinsic" at 466:6-466:15
+5265: KwFn            "fn" at 466:16-466:18 (leading: Space)
+5266: Ident           "__bit_xor" at 466:19-466:28 (leading: Space)
+5267: LParen          "(" at 466:28-466:29
+5268: Ident           "self" at 466:29-466:33
+5269: Colon           ":" at 466:33-466:34
+5270: Ident           "uint8" at 466:35-466:40 (leading: Space)
+5271: Comma           "," at 466:40-466:41
+5272: Ident           "other" at 466:42-466:47 (leading: Space)
+5273: Colon           ":" at 466:47-466:48
+5274: Ident           "uint8" at 466:49-466:54 (leading: Space)
+5275: RParen          ")" at 466:54-466:55
+5276: Arrow           "->" at 466:56-466:58 (leading: Space)
+5277: Ident           "uint8" at 466:59-466:64 (leading: Space)
+5278: Semicolon       ";" at 466:64-466:65
+5279: At              "@" at 467:5-467:6 (leading: Newline, Space)
+5280: Ident           "intrinsic" at 467:6-467:15
+5281: KwFn            "fn" at 467:16-467:18 (leading: Space)
+5282: Ident           "__shl" at 467:19-467:24 (leading: Space)
+5283: LParen          "(" at 467:24-467:25
+5284: Ident           "self" at 467:25-467:29
+5285: Colon           ":" at 467:29-467:30
+5286: Ident           "uint8" at 467:31-467:36 (leading: Space)
+5287: Comma           "," at 467:36-467:37
+5288: Ident           "other" at 467:38-467:43 (leading: Space)
+5289: Colon           ":" at 467:43-467:44
+5290: Ident           "uint8" at 467:45-467:50 (leading: Space)
+5291: RParen          ")" at 467:50-467:51
+5292: Arrow           "->" at 467:52-467:54 (leading: Space)
+5293: Ident           "uint8" at 467:55-467:60 (leading: Space)
+5294: Semicolon       ";" at 467:60-467:61
+5295: At              "@" at 468:5-468:6 (leading: Newline, Space)
+5296: Ident           "intrinsic" at 468:6-468:15
+5297: KwFn            "fn" at 468:16-468:18 (leading: Space)
+5298: Ident           "__shr" at 468:19-468:24 (leading: Space)
+5299: LParen          "(" at 468:24-468:25
+5300: Ident           "self" at 468:25-468:29
+5301: Colon           ":" at 468:29-468:30
+5302: Ident           "uint8" at 468:31-468:36 (leading: Space)
+5303: Comma           "," at 468:36-468:37
+5304: Ident           "other" at 468:38-468:43 (leading: Space)
+5305: Colon           ":" at 468:43-468:44
+5306: Ident           "uint8" at 468:45-468:50 (leading: Space)
+5307: RParen          ")" at 468:50-468:51
+5308: Arrow           "->" at 468:52-468:54 (leading: Space)
+5309: Ident           "uint8" at 468:55-468:60 (leading: Space)
+5310: Semicolon       ";" at 468:60-468:61
+5311: At              "@" at 469:5-469:6 (leading: Newline, Space)
+5312: Ident           "intrinsic" at 469:6-469:15
+5313: KwFn            "fn" at 469:16-469:18 (leading: Space)
+5314: Ident           "__lt" at 469:19-469:23 (leading: Space)
+5315: LParen          "(" at 469:23-469:24
+5316: Ident           "self" at 469:24-469:28
+5317: Colon           ":" at 469:28-469:29
+5318: Ident           "uint8" at 469:30-469:35 (leading: Space)
+5319: Comma           "," at 469:35-469:36
+5320: Ident           "other" at 469:37-469:42 (leading: Space)
+5321: Colon           ":" at 469:42-469:43
+5322: Ident           "uint8" at 469:44-469:49 (leading: Space)
+5323: RParen          ")" at 469:49-469:50
+5324: Arrow           "->" at 469:51-469:53 (leading: Space)
+5325: Ident           "bool" at 469:54-469:58 (leading: Space)
+5326: Semicolon       ";" at 469:58-469:59
+5327: At              "@" at 470:5-470:6 (leading: Newline, Space)
+5328: Ident           "intrinsic" at 470:6-470:15
+5329: KwFn            "fn" at 470:16-470:18 (leading: Space)
+5330: Ident           "__le" at 470:19-470:23 (leading: Space)
+5331: LParen          "(" at 470:23-470:24
+5332: Ident           "self" at 470:24-470:28
+5333: Colon           ":" at 470:28-470:29
+5334: Ident           "uint8" at 470:30-470:35 (leading: Space)
+5335: Comma           "," at 470:35-470:36
+5336: Ident           "other" at 470:37-470:42 (leading: Space)
+5337: Colon           ":" at 470:42-470:43
+5338: Ident           "uint8" at 470:44-470:49 (leading: Space)
+5339: RParen          ")" at 470:49-470:50
+5340: Arrow           "->" at 470:51-470:53 (leading: Space)
+5341: Ident           "bool" at 470:54-470:58 (leading: Space)
+5342: Semicolon       ";" at 470:58-470:59
+5343: At              "@" at 471:5-471:6 (leading: Newline, Space)
+5344: Ident           "intrinsic" at 471:6-471:15
+5345: KwFn            "fn" at 471:16-471:18 (leading: Space)
+5346: Ident           "__eq" at 471:19-471:23 (leading: Space)
+5347: LParen          "(" at 471:23-471:24
+5348: Ident           "self" at 471:24-471:28
+5349: Colon           ":" at 471:28-471:29
+5350: Ident           "uint8" at 471:30-471:35 (leading: Space)
+5351: Comma           "," at 471:35-471:36
+5352: Ident           "other" at 471:37-471:42 (leading: Space)
+5353: Colon           ":" at 471:42-471:43
+5354: Ident           "uint8" at 471:44-471:49 (leading: Space)
+5355: RParen          ")" at 471:49-471:50
+5356: Arrow           "->" at 471:51-471:53 (leading: Space)
+5357: Ident           "bool" at 471:54-471:58 (leading: Space)
+5358: Semicolon       ";" at 471:58-471:59
+5359: At              "@" at 472:5-472:6 (leading: Newline, Space)
+5360: Ident           "intrinsic" at 472:6-472:15
+5361: KwFn            "fn" at 472:16-472:18 (leading: Space)
+5362: Ident           "__ne" at 472:19-472:23 (leading: Space)
+5363: LParen          "(" at 472:23-472:24
+5364: Ident           "self" at 472:24-472:28
+5365: Colon           ":" at 472:28-472:29
+5366: Ident           "uint8" at 472:30-472:35 (leading: Space)
+5367: Comma           "," at 472:35-472:36
+5368: Ident           "other" at 472:37-472:42 (leading: Space)
+5369: Colon           ":" at 472:42-472:43
+5370: Ident           "uint8" at 472:44-472:49 (leading: Space)
+5371: RParen          ")" at 472:49-472:50
+5372: Arrow           "->" at 472:51-472:53 (leading: Space)
+5373: Ident           "bool" at 472:54-472:58 (leading: Space)
+5374: Semicolon       ";" at 472:58-472:59
+5375: At              "@" at 473:5-473:6 (leading: Newline, Space)
+5376: Ident           "intrinsic" at 473:6-473:15
+5377: KwFn            "fn" at 473:16-473:18 (leading: Space)
+5378: Ident           "__ge" at 473:19-473:23 (leading: Space)
+5379: LParen          "(" at 473:23-473:24
+5380: Ident           "self" at 473:24-473:28
+5381: Colon           ":" at 473:28-473:29
+5382: Ident           "uint8" at 473:30-473:35 (leading: Space)
+5383: Comma           "," at 473:35-473:36
+5384: Ident           "other" at 473:37-473:42 (leading: Space)
+5385: Colon           ":" at 473:42-473:43
+5386: Ident           "uint8" at 473:44-473:49 (leading: Space)
+5387: RParen          ")" at 473:49-473:50
+5388: Arrow           "->" at 473:51-473:53 (leading: Space)
+5389: Ident           "bool" at 473:54-473:58 (leading: Space)
+5390: Semicolon       ";" at 473:58-473:59
+5391: At              "@" at 474:5-474:6 (leading: Newline, Space)
+5392: Ident           "intrinsic" at 474:6-474:15
+5393: KwFn            "fn" at 474:16-474:18 (leading: Space)
+5394: Ident           "__gt" at 474:19-474:23 (leading: Space)
+5395: LParen          "(" at 474:23-474:24
+5396: Ident           "self" at 474:24-474:28
+5397: Colon           ":" at 474:28-474:29
+5398: Ident           "uint8" at 474:30-474:35 (leading: Space)
+5399: Comma           "," at 474:35-474:36
+5400: Ident           "other" at 474:37-474:42 (leading: Space)
+5401: Colon           ":" at 474:42-474:43
+5402: Ident           "uint8" at 474:44-474:49 (leading: Space)
+5403: RParen          ")" at 474:49-474:50
+5404: Arrow           "->" at 474:51-474:53 (leading: Space)
+5405: Ident           "bool" at 474:54-474:58 (leading: Space)
+5406: Semicolon       ";" at 474:58-474:59
+5407: At              "@" at 475:5-475:6 (leading: Newline, Space)
+5408: Ident           "intrinsic" at 475:6-475:15
+5409: KwFn            "fn" at 475:16-475:18 (leading: Space)
+5410: Ident           "__pos" at 475:19-475:24 (leading: Space)
+5411: LParen          "(" at 475:24-475:25
+5412: Ident           "self" at 475:25-475:29
+5413: Colon           ":" at 475:29-475:30
+5414: Ident           "uint8" at 475:31-475:36 (leading: Space)
+5415: RParen          ")" at 475:36-475:37
+5416: Arrow           "->" at 475:38-475:40 (leading: Space)
+5417: Ident           "uint8" at 475:41-475:46 (leading: Space)
+5418: Semicolon       ";" at 475:46-475:47
+5419: At              "@" at 476:5-476:6 (leading: Newline, Space)
+5420: Ident           "intrinsic" at 476:6-476:15
+5421: KwFn            "fn" at 476:16-476:18 (leading: Space)
+5422: Ident           "__abs" at 476:19-476:24 (leading: Space)
+5423: LParen          "(" at 476:24-476:25
+5424: Ident           "self" at 476:25-476:29
+5425: Colon           ":" at 476:29-476:30
+5426: Ident           "uint8" at 476:31-476:36 (leading: Space)
+5427: RParen          ")" at 476:36-476:37
+5428: Arrow           "->" at 476:38-476:40 (leading: Space)
+5429: Ident           "uint8" at 476:41-476:46 (leading: Space)
+5430: Semicolon       ";" at 476:46-476:47
+5431: At              "@" at 477:5-477:6 (leading: Newline, Space)
+5432: Ident           "intrinsic" at 477:6-477:15
+5433: KwFn            "fn" at 477:16-477:18 (leading: Space)
+5434: Ident           "__to" at 477:19-477:23 (leading: Space)
+5435: LParen          "(" at 477:23-477:24
+5436: Ident           "self" at 477:24-477:28
+5437: Colon           ":" at 477:28-477:29
+5438: Ident           "uint8" at 477:30-477:35 (leading: Space)
+5439: Comma           "," at 477:35-477:36
+5440: Ident           "target" at 477:37-477:43 (leading: Space)
+5441: Colon           ":" at 477:43-477:44
+5442: Ident           "uint" at 477:45-477:49 (leading: Space)
+5443: RParen          ")" at 477:49-477:50
+5444: Arrow           "->" at 477:51-477:53 (leading: Space)
+5445: Ident           "uint" at 477:54-477:58 (leading: Space)
+5446: Semicolon       ";" at 477:58-477:59
+5447: At              "@" at 478:5-478:6 (leading: Newline, Space)
+5448: Ident           "intrinsic" at 478:6-478:15
+5449: At              "@" at 478:16-478:17 (leading: Space)
+5450: Ident           "overload" at 478:17-478:25
+5451: KwFn            "fn" at 478:26-478:28 (leading: Space)
+5452: Ident           "__to" at 478:29-478:33 (leading: Space)
+5453: LParen          "(" at 478:33-478:34
+5454: Ident           "self" at 478:34-478:38
+5455: Colon           ":" at 478:38-478:39
+5456: Ident           "uint8" at 478:40-478:45 (leading: Space)
+5457: Comma           "," at 478:45-478:46
+5458: Ident           "target" at 478:47-478:53 (leading: Space)
+5459: Colon           ":" at 478:53-478:54
+5460: Ident           "uint16" at 478:55-478:61 (leading: Space)
+5461: RParen          ")" at 478:61-478:62
+5462: Arrow           "->" at 478:63-478:65 (leading: Space)
+5463: Ident           "uint16" at 478:66-478:72 (leading: Space)
+5464: Semicolon       ";" at 478:72-478:73
+5465: At              "@" at 479:5-479:6 (leading: Newline, Space)
+5466: Ident           "intrinsic" at 479:6-479:15
+5467: At              "@" at 479:16-479:17 (leading: Space)
+5468: Ident           "overload" at 479:17-479:25
+5469: KwFn            "fn" at 479:26-479:28 (leading: Space)
+5470: Ident           "__to" at 479:29-479:33 (leading: Space)
+5471: LParen          "(" at 479:33-479:34
+5472: Ident           "self" at 479:34-479:38
+5473: Colon           ":" at 479:38-479:39
+5474: Ident           "uint8" at 479:40-479:45 (leading: Space)
+5475: Comma           "," at 479:45-479:46
+5476: Ident           "target" at 479:47-479:53 (leading: Space)
+5477: Colon           ":" at 479:53-479:54
+5478: Ident           "uint32" at 479:55-479:61 (leading: Space)
+5479: RParen          ")" at 479:61-479:62
+5480: Arrow           "->" at 479:63-479:65 (leading: Space)
+5481: Ident           "uint32" at 479:66-479:72 (leading: Space)
+5482: Semicolon       ";" at 479:72-479:73
+5483: At              "@" at 480:5-480:6 (leading: Newline, Space)
+5484: Ident           "intrinsic" at 480:6-480:15
+5485: At              "@" at 480:16-480:17 (leading: Space)
+5486: Ident           "overload" at 480:17-480:25
+5487: KwFn            "fn" at 480:26-480:28 (leading: Space)
+5488: Ident           "__to" at 480:29-480:33 (leading: Space)
+5489: LParen          "(" at 480:33-480:34
+5490: Ident           "self" at 480:34-480:38
+5491: Colon           ":" at 480:38-480:39
+5492: Ident           "uint8" at 480:40-480:45 (leading: Space)
+5493: Comma           "," at 480:45-480:46
+5494: Ident           "target" at 480:47-480:53 (leading: Space)
+5495: Colon           ":" at 480:53-480:54
+5496: Ident           "uint64" at 480:55-480:61 (leading: Space)
+5497: RParen          ")" at 480:61-480:62
+5498: Arrow           "->" at 480:63-480:65 (leading: Space)
+5499: Ident           "uint64" at 480:66-480:72 (leading: Space)
+5500: Semicolon       ";" at 480:72-480:73
+5501: At              "@" at 481:5-481:6 (leading: Newline, Space)
+5502: Ident           "intrinsic" at 481:6-481:15
+5503: KwPub           "pub" at 481:16-481:19 (leading: Space)
+5504: KwFn            "fn" at 481:20-481:22 (leading: Space)
+5505: Ident           "from_str" at 481:23-481:31 (leading: Space)
+5506: LParen          "(" at 481:31-481:32
+5507: Ident           "s" at 481:32-481:33
+5508: Colon           ":" at 481:33-481:34
+5509: Amp             "&" at 481:35-481:36 (leading: Space)
+5510: Ident           "string" at 481:36-481:42
+5511: RParen          ")" at 481:42-481:43
+5512: Arrow           "->" at 481:44-481:46 (leading: Space)
+5513: Ident           "Erring" at 481:47-481:53 (leading: Space)
+5514: Lt              "<" at 481:53-481:54
+5515: Ident           "uint8" at 481:54-481:59
+5516: Comma           "," at 481:59-481:60
+5517: Ident           "Error" at 481:61-481:66 (leading: Space)
+5518: Gt              ">" at 481:66-481:67
+5519: Semicolon       ";" at 481:67-481:68
+5520: RBrace          "}" at 482:1-482:2 (leading: Newline)
+5521: KwExtern        "extern" at 484:1-484:7 (leading: Newline)
+5522: Lt              "<" at 484:7-484:8
+5523: Ident           "uint16" at 484:8-484:14
+5524: Gt              ">" at 484:14-484:15
+5525: LBrace          "{" at 484:16-484:17 (leading: Space)
+5526: KwPub           "pub" at 485:5-485:8 (leading: Newline, Space)
+5527: KwFn            "fn" at 485:9-485:11 (leading: Space)
+5528: Ident           "__min_value" at 485:12-485:23 (leading: Space)
+5529: LParen          "(" at 485:23-485:24
+5530: RParen          ")" at 485:24-485:25
+5531: Arrow           "->" at 485:26-485:28 (leading: Space)
+5532: Ident           "uint16" at 485:29-485:35 (leading: Space)
+5533: LBrace          "{" at 485:36-485:37 (leading: Space)
+5534: KwReturn        "return" at 485:38-485:44 (leading: Space)
+5535: LParen          "(" at 485:45-485:46 (leading: Space)
+5536: IntLit          "0" at 485:46-485:47
+5537: RParen          ")" at 485:47-485:48
+5538: Colon           ":" at 485:48-485:49
+5539: Ident           "uint16" at 485:49-485:55
+5540: Semicolon       ";" at 485:55-485:56
+5541: RBrace          "}" at 485:57-485:58 (leading: Space)
+5542: KwPub           "pub" at 486:5-486:8 (leading: Newline, Space)
+5543: KwFn            "fn" at 486:9-486:11 (leading: Space)
+5544: Ident           "__max_value" at 486:12-486:23 (leading: Space)
+5545: LParen          "(" at 486:23-486:24
+5546: RParen          ")" at 486:24-486:25
+5547: Arrow           "->" at 486:26-486:28 (leading: Space)
+5548: Ident           "uint16" at 486:29-486:35 (leading: Space)
+5549: LBrace          "{" at 486:36-486:37 (leading: Space)
+5550: KwReturn        "return" at 486:38-486:44 (leading: Space)
+5551: LParen          "(" at 486:45-486:46 (leading: Space)
+5552: IntLit          "65_535" at 486:46-486:52
+5553: RParen          ")" at 486:52-486:53
+5554: Colon           ":" at 486:53-486:54
+5555: Ident           "uint16" at 486:54-486:60
+5556: Semicolon       ";" at 486:60-486:61
+5557: RBrace          "}" at 486:62-486:63 (leading: Space)
+5558: At              "@" at 487:5-487:6 (leading: Newline, Space)
+5559: Ident           "intrinsic" at 487:6-487:15
+5560: KwFn            "fn" at 487:16-487:18 (leading: Space)
+5561: Ident           "__add" at 487:19-487:24 (leading: Space)
+5562: LParen          "(" at 487:24-487:25
+5563: Ident           "self" at 487:25-487:29
+5564: Colon           ":" at 487:29-487:30
+5565: Ident           "uint16" at 487:31-487:37 (leading: Space)
+5566: Comma           "," at 487:37-487:38
+5567: Ident           "other" at 487:39-487:44 (leading: Space)
+5568: Colon           ":" at 487:44-487:45
+5569: Ident           "uint16" at 487:46-487:52 (leading: Space)
+5570: RParen          ")" at 487:52-487:53
+5571: Arrow           "->" at 487:54-487:56 (leading: Space)
+5572: Ident           "uint16" at 487:57-487:63 (leading: Space)
+5573: Semicolon       ";" at 487:63-487:64
+5574: At              "@" at 488:5-488:6 (leading: Newline, Space)
+5575: Ident           "intrinsic" at 488:6-488:15
+5576: KwFn            "fn" at 488:16-488:18 (leading: Space)
+5577: Ident           "__sub" at 488:19-488:24 (leading: Space)
+5578: LParen          "(" at 488:24-488:25
+5579: Ident           "self" at 488:25-488:29
+5580: Colon           ":" at 488:29-488:30
+5581: Ident           "uint16" at 488:31-488:37 (leading: Space)
+5582: Comma           "," at 488:37-488:38
+5583: Ident           "other" at 488:39-488:44 (leading: Space)
+5584: Colon           ":" at 488:44-488:45
+5585: Ident           "uint16" at 488:46-488:52 (leading: Space)
+5586: RParen          ")" at 488:52-488:53
+5587: Arrow           "->" at 488:54-488:56 (leading: Space)
+5588: Ident           "uint16" at 488:57-488:63 (leading: Space)
+5589: Semicolon       ";" at 488:63-488:64
+5590: At              "@" at 489:5-489:6 (leading: Newline, Space)
+5591: Ident           "intrinsic" at 489:6-489:15
+5592: KwFn            "fn" at 489:16-489:18 (leading: Space)
+5593: Ident           "__mul" at 489:19-489:24 (leading: Space)
+5594: LParen          "(" at 489:24-489:25
+5595: Ident           "self" at 489:25-489:29
+5596: Colon           ":" at 489:29-489:30
+5597: Ident           "uint16" at 489:31-489:37 (leading: Space)
+5598: Comma           "," at 489:37-489:38
+5599: Ident           "other" at 489:39-489:44 (leading: Space)
+5600: Colon           ":" at 489:44-489:45
+5601: Ident           "uint16" at 489:46-489:52 (leading: Space)
+5602: RParen          ")" at 489:52-489:53
+5603: Arrow           "->" at 489:54-489:56 (leading: Space)
+5604: Ident           "uint16" at 489:57-489:63 (leading: Space)
+5605: Semicolon       ";" at 489:63-489:64
+5606: At              "@" at 490:5-490:6 (leading: Newline, Space)
+5607: Ident           "intrinsic" at 490:6-490:15
+5608: KwFn            "fn" at 490:16-490:18 (leading: Space)
+5609: Ident           "__div" at 490:19-490:24 (leading: Space)
+5610: LParen          "(" at 490:24-490:25
+5611: Ident           "self" at 490:25-490:29
+5612: Colon           ":" at 490:29-490:30
+5613: Ident           "uint16" at 490:31-490:37 (leading: Space)
+5614: Comma           "," at 490:37-490:38
+5615: Ident           "other" at 490:39-490:44 (leading: Space)
+5616: Colon           ":" at 490:44-490:45
+5617: Ident           "uint16" at 490:46-490:52 (leading: Space)
+5618: RParen          ")" at 490:52-490:53
+5619: Arrow           "->" at 490:54-490:56 (leading: Space)
+5620: Ident           "uint16" at 490:57-490:63 (leading: Space)
+5621: Semicolon       ";" at 490:63-490:64
+5622: At              "@" at 491:5-491:6 (leading: Newline, Space)
+5623: Ident           "intrinsic" at 491:6-491:15
+5624: KwFn            "fn" at 491:16-491:18 (leading: Space)
+5625: Ident           "__mod" at 491:19-491:24 (leading: Space)
+5626: LParen          "(" at 491:24-491:25
+5627: Ident           "self" at 491:25-491:29
+5628: Colon           ":" at 491:29-491:30
+5629: Ident           "uint16" at 491:31-491:37 (leading: Space)
+5630: Comma           "," at 491:37-491:38
+5631: Ident           "other" at 491:39-491:44 (leading: Space)
+5632: Colon           ":" at 491:44-491:45
+5633: Ident           "uint16" at 491:46-491:52 (leading: Space)
+5634: RParen          ")" at 491:52-491:53
+5635: Arrow           "->" at 491:54-491:56 (leading: Space)
+5636: Ident           "uint16" at 491:57-491:63 (leading: Space)
+5637: Semicolon       ";" at 491:63-491:64
+5638: At              "@" at 492:5-492:6 (leading: Newline, Space)
+5639: Ident           "intrinsic" at 492:6-492:15
+5640: KwFn            "fn" at 492:16-492:18 (leading: Space)
+5641: Ident           "__bit_and" at 492:19-492:28 (leading: Space)
+5642: LParen          "(" at 492:28-492:29
+5643: Ident           "self" at 492:29-492:33
+5644: Colon           ":" at 492:33-492:34
+5645: Ident           "uint16" at 492:35-492:41 (leading: Space)
+5646: Comma           "," at 492:41-492:42
+5647: Ident           "other" at 492:43-492:48 (leading: Space)
+5648: Colon           ":" at 492:48-492:49
+5649: Ident           "uint16" at 492:50-492:56 (leading: Space)
+5650: RParen          ")" at 492:56-492:57
+5651: Arrow           "->" at 492:58-492:60 (leading: Space)
+5652: Ident           "uint16" at 492:61-492:67 (leading: Space)
+5653: Semicolon       ";" at 492:67-492:68
+5654: At              "@" at 493:5-493:6 (leading: Newline, Space)
+5655: Ident           "intrinsic" at 493:6-493:15
+5656: KwFn            "fn" at 493:16-493:18 (leading: Space)
+5657: Ident           "__bit_or" at 493:19-493:27 (leading: Space)
+5658: LParen          "(" at 493:27-493:28
+5659: Ident           "self" at 493:28-493:32
+5660: Colon           ":" at 493:32-493:33
+5661: Ident           "uint16" at 493:34-493:40 (leading: Space)
+5662: Comma           "," at 493:40-493:41
+5663: Ident           "other" at 493:42-493:47 (leading: Space)
+5664: Colon           ":" at 493:47-493:48
+5665: Ident           "uint16" at 493:49-493:55 (leading: Space)
+5666: RParen          ")" at 493:55-493:56
+5667: Arrow           "->" at 493:57-493:59 (leading: Space)
+5668: Ident           "uint16" at 493:60-493:66 (leading: Space)
+5669: Semicolon       ";" at 493:66-493:67
+5670: At              "@" at 494:5-494:6 (leading: Newline, Space)
+5671: Ident           "intrinsic" at 494:6-494:15
+5672: KwFn            "fn" at 494:16-494:18 (leading: Space)
+5673: Ident           "__bit_xor" at 494:19-494:28 (leading: Space)
+5674: LParen          "(" at 494:28-494:29
+5675: Ident           "self" at 494:29-494:33
+5676: Colon           ":" at 494:33-494:34
+5677: Ident           "uint16" at 494:35-494:41 (leading: Space)
+5678: Comma           "," at 494:41-494:42
+5679: Ident           "other" at 494:43-494:48 (leading: Space)
+5680: Colon           ":" at 494:48-494:49
+5681: Ident           "uint16" at 494:50-494:56 (leading: Space)
+5682: RParen          ")" at 494:56-494:57
+5683: Arrow           "->" at 494:58-494:60 (leading: Space)
+5684: Ident           "uint16" at 494:61-494:67 (leading: Space)
+5685: Semicolon       ";" at 494:67-494:68
+5686: At              "@" at 495:5-495:6 (leading: Newline, Space)
+5687: Ident           "intrinsic" at 495:6-495:15
+5688: KwFn            "fn" at 495:16-495:18 (leading: Space)
+5689: Ident           "__shl" at 495:19-495:24 (leading: Space)
+5690: LParen          "(" at 495:24-495:25
+5691: Ident           "self" at 495:25-495:29
+5692: Colon           ":" at 495:29-495:30
+5693: Ident           "uint16" at 495:31-495:37 (leading: Space)
+5694: Comma           "," at 495:37-495:38
+5695: Ident           "other" at 495:39-495:44 (leading: Space)
+5696: Colon           ":" at 495:44-495:45
+5697: Ident           "uint16" at 495:46-495:52 (leading: Space)
+5698: RParen          ")" at 495:52-495:53
+5699: Arrow           "->" at 495:54-495:56 (leading: Space)
+5700: Ident           "uint16" at 495:57-495:63 (leading: Space)
+5701: Semicolon       ";" at 495:63-495:64
+5702: At              "@" at 496:5-496:6 (leading: Newline, Space)
+5703: Ident           "intrinsic" at 496:6-496:15
+5704: KwFn            "fn" at 496:16-496:18 (leading: Space)
+5705: Ident           "__shr" at 496:19-496:24 (leading: Space)
+5706: LParen          "(" at 496:24-496:25
+5707: Ident           "self" at 496:25-496:29
+5708: Colon           ":" at 496:29-496:30
+5709: Ident           "uint16" at 496:31-496:37 (leading: Space)
+5710: Comma           "," at 496:37-496:38
+5711: Ident           "other" at 496:39-496:44 (leading: Space)
+5712: Colon           ":" at 496:44-496:45
+5713: Ident           "uint16" at 496:46-496:52 (leading: Space)
+5714: RParen          ")" at 496:52-496:53
+5715: Arrow           "->" at 496:54-496:56 (leading: Space)
+5716: Ident           "uint16" at 496:57-496:63 (leading: Space)
+5717: Semicolon       ";" at 496:63-496:64
+5718: At              "@" at 497:5-497:6 (leading: Newline, Space)
+5719: Ident           "intrinsic" at 497:6-497:15
+5720: KwFn            "fn" at 497:16-497:18 (leading: Space)
+5721: Ident           "__lt" at 497:19-497:23 (leading: Space)
+5722: LParen          "(" at 497:23-497:24
+5723: Ident           "self" at 497:24-497:28
+5724: Colon           ":" at 497:28-497:29
+5725: Ident           "uint16" at 497:30-497:36 (leading: Space)
+5726: Comma           "," at 497:36-497:37
+5727: Ident           "other" at 497:38-497:43 (leading: Space)
+5728: Colon           ":" at 497:43-497:44
+5729: Ident           "uint16" at 497:45-497:51 (leading: Space)
+5730: RParen          ")" at 497:51-497:52
+5731: Arrow           "->" at 497:53-497:55 (leading: Space)
+5732: Ident           "bool" at 497:56-497:60 (leading: Space)
+5733: Semicolon       ";" at 497:60-497:61
+5734: At              "@" at 498:5-498:6 (leading: Newline, Space)
+5735: Ident           "intrinsic" at 498:6-498:15
+5736: KwFn            "fn" at 498:16-498:18 (leading: Space)
+5737: Ident           "__le" at 498:19-498:23 (leading: Space)
+5738: LParen          "(" at 498:23-498:24
+5739: Ident           "self" at 498:24-498:28
+5740: Colon           ":" at 498:28-498:29
+5741: Ident           "uint16" at 498:30-498:36 (leading: Space)
+5742: Comma           "," at 498:36-498:37
+5743: Ident           "other" at 498:38-498:43 (leading: Space)
+5744: Colon           ":" at 498:43-498:44
+5745: Ident           "uint16" at 498:45-498:51 (leading: Space)
+5746: RParen          ")" at 498:51-498:52
+5747: Arrow           "->" at 498:53-498:55 (leading: Space)
+5748: Ident           "bool" at 498:56-498:60 (leading: Space)
+5749: Semicolon       ";" at 498:60-498:61
+5750: At              "@" at 499:5-499:6 (leading: Newline, Space)
+5751: Ident           "intrinsic" at 499:6-499:15
+5752: KwFn            "fn" at 499:16-499:18 (leading: Space)
+5753: Ident           "__eq" at 499:19-499:23 (leading: Space)
+5754: LParen          "(" at 499:23-499:24
+5755: Ident           "self" at 499:24-499:28
+5756: Colon           ":" at 499:28-499:29
+5757: Ident           "uint16" at 499:30-499:36 (leading: Space)
+5758: Comma           "," at 499:36-499:37
+5759: Ident           "other" at 499:38-499:43 (leading: Space)
+5760: Colon           ":" at 499:43-499:44
+5761: Ident           "uint16" at 499:45-499:51 (leading: Space)
+5762: RParen          ")" at 499:51-499:52
+5763: Arrow           "->" at 499:53-499:55 (leading: Space)
+5764: Ident           "bool" at 499:56-499:60 (leading: Space)
+5765: Semicolon       ";" at 499:60-499:61
+5766: At              "@" at 500:5-500:6 (leading: Newline, Space)
+5767: Ident           "intrinsic" at 500:6-500:15
+5768: KwFn            "fn" at 500:16-500:18 (leading: Space)
+5769: Ident           "__ne" at 500:19-500:23 (leading: Space)
+5770: LParen          "(" at 500:23-500:24
+5771: Ident           "self" at 500:24-500:28
+5772: Colon           ":" at 500:28-500:29
+5773: Ident           "uint16" at 500:30-500:36 (leading: Space)
+5774: Comma           "," at 500:36-500:37
+5775: Ident           "other" at 500:38-500:43 (leading: Space)
+5776: Colon           ":" at 500:43-500:44
+5777: Ident           "uint16" at 500:45-500:51 (leading: Space)
+5778: RParen          ")" at 500:51-500:52
+5779: Arrow           "->" at 500:53-500:55 (leading: Space)
+5780: Ident           "bool" at 500:56-500:60 (leading: Space)
+5781: Semicolon       ";" at 500:60-500:61
+5782: At              "@" at 501:5-501:6 (leading: Newline, Space)
+5783: Ident           "intrinsic" at 501:6-501:15
+5784: KwFn            "fn" at 501:16-501:18 (leading: Space)
+5785: Ident           "__ge" at 501:19-501:23 (leading: Space)
+5786: LParen          "(" at 501:23-501:24
+5787: Ident           "self" at 501:24-501:28
+5788: Colon           ":" at 501:28-501:29
+5789: Ident           "uint16" at 501:30-501:36 (leading: Space)
+5790: Comma           "," at 501:36-501:37
+5791: Ident           "other" at 501:38-501:43 (leading: Space)
+5792: Colon           ":" at 501:43-501:44
+5793: Ident           "uint16" at 501:45-501:51 (leading: Space)
+5794: RParen          ")" at 501:51-501:52
+5795: Arrow           "->" at 501:53-501:55 (leading: Space)
+5796: Ident           "bool" at 501:56-501:60 (leading: Space)
+5797: Semicolon       ";" at 501:60-501:61
+5798: At              "@" at 502:5-502:6 (leading: Newline, Space)
+5799: Ident           "intrinsic" at 502:6-502:15
+5800: KwFn            "fn" at 502:16-502:18 (leading: Space)
+5801: Ident           "__gt" at 502:19-502:23 (leading: Space)
+5802: LParen          "(" at 502:23-502:24
+5803: Ident           "self" at 502:24-502:28
+5804: Colon           ":" at 502:28-502:29
+5805: Ident           "uint16" at 502:30-502:36 (leading: Space)
+5806: Comma           "," at 502:36-502:37
+5807: Ident           "other" at 502:38-502:43 (leading: Space)
+5808: Colon           ":" at 502:43-502:44
+5809: Ident           "uint16" at 502:45-502:51 (leading: Space)
+5810: RParen          ")" at 502:51-502:52
+5811: Arrow           "->" at 502:53-502:55 (leading: Space)
+5812: Ident           "bool" at 502:56-502:60 (leading: Space)
+5813: Semicolon       ";" at 502:60-502:61
+5814: At              "@" at 503:5-503:6 (leading: Newline, Space)
+5815: Ident           "intrinsic" at 503:6-503:15
+5816: KwFn            "fn" at 503:16-503:18 (leading: Space)
+5817: Ident           "__pos" at 503:19-503:24 (leading: Space)
+5818: LParen          "(" at 503:24-503:25
+5819: Ident           "self" at 503:25-503:29
+5820: Colon           ":" at 503:29-503:30
+5821: Ident           "uint16" at 503:31-503:37 (leading: Space)
+5822: RParen          ")" at 503:37-503:38
+5823: Arrow           "->" at 503:39-503:41 (leading: Space)
+5824: Ident           "uint16" at 503:42-503:48 (leading: Space)
+5825: Semicolon       ";" at 503:48-503:49
+5826: At              "@" at 504:5-504:6 (leading: Newline, Space)
+5827: Ident           "intrinsic" at 504:6-504:15
+5828: KwFn            "fn" at 504:16-504:18 (leading: Space)
+5829: Ident           "__abs" at 504:19-504:24 (leading: Space)
+5830: LParen          "(" at 504:24-504:25
+5831: Ident           "self" at 504:25-504:29
+5832: Colon           ":" at 504:29-504:30
+5833: Ident           "uint16" at 504:31-504:37 (leading: Space)
+5834: RParen          ")" at 504:37-504:38
+5835: Arrow           "->" at 504:39-504:41 (leading: Space)
+5836: Ident           "uint16" at 504:42-504:48 (leading: Space)
+5837: Semicolon       ";" at 504:48-504:49
+5838: At              "@" at 505:5-505:6 (leading: Newline, Space)
+5839: Ident           "intrinsic" at 505:6-505:15
+5840: KwFn            "fn" at 505:16-505:18 (leading: Space)
+5841: Ident           "__to" at 505:19-505:23 (leading: Space)
+5842: LParen          "(" at 505:23-505:24
+5843: Ident           "self" at 505:24-505:28
+5844: Colon           ":" at 505:28-505:29
+5845: Ident           "uint16" at 505:30-505:36 (leading: Space)
+5846: Comma           "," at 505:36-505:37
+5847: Ident           "target" at 505:38-505:44 (leading: Space)
+5848: Colon           ":" at 505:44-505:45
+5849: Ident           "uint" at 505:46-505:50 (leading: Space)
+5850: RParen          ")" at 505:50-505:51
+5851: Arrow           "->" at 505:52-505:54 (leading: Space)
+5852: Ident           "uint" at 505:55-505:59 (leading: Space)
+5853: Semicolon       ";" at 505:59-505:60
+5854: At              "@" at 506:5-506:6 (leading: Newline, Space)
+5855: Ident           "intrinsic" at 506:6-506:15
+5856: At              "@" at 506:16-506:17 (leading: Space)
+5857: Ident           "overload" at 506:17-506:25
+5858: KwFn            "fn" at 506:26-506:28 (leading: Space)
+5859: Ident           "__to" at 506:29-506:33 (leading: Space)
+5860: LParen          "(" at 506:33-506:34
+5861: Ident           "self" at 506:34-506:38
+5862: Colon           ":" at 506:38-506:39
+5863: Ident           "uint16" at 506:40-506:46 (leading: Space)
+5864: Comma           "," at 506:46-506:47
+5865: Ident           "target" at 506:48-506:54 (leading: Space)
+5866: Colon           ":" at 506:54-506:55
+5867: Ident           "uint8" at 506:56-506:61 (leading: Space)
+5868: RParen          ")" at 506:61-506:62
+5869: Arrow           "->" at 506:63-506:65 (leading: Space)
+5870: Ident           "uint8" at 506:66-506:71 (leading: Space)
+5871: Semicolon       ";" at 506:71-506:72
+5872: At              "@" at 507:5-507:6 (leading: Newline, Space)
+5873: Ident           "intrinsic" at 507:6-507:15
+5874: At              "@" at 507:16-507:17 (leading: Space)
+5875: Ident           "overload" at 507:17-507:25
+5876: KwFn            "fn" at 507:26-507:28 (leading: Space)
+5877: Ident           "__to" at 507:29-507:33 (leading: Space)
+5878: LParen          "(" at 507:33-507:34
+5879: Ident           "self" at 507:34-507:38
+5880: Colon           ":" at 507:38-507:39
+5881: Ident           "uint16" at 507:40-507:46 (leading: Space)
+5882: Comma           "," at 507:46-507:47
+5883: Ident           "target" at 507:48-507:54 (leading: Space)
+5884: Colon           ":" at 507:54-507:55
+5885: Ident           "uint32" at 507:56-507:62 (leading: Space)
+5886: RParen          ")" at 507:62-507:63
+5887: Arrow           "->" at 507:64-507:66 (leading: Space)
+5888: Ident           "uint32" at 507:67-507:73 (leading: Space)
+5889: Semicolon       ";" at 507:73-507:74
+5890: At              "@" at 508:5-508:6 (leading: Newline, Space)
+5891: Ident           "intrinsic" at 508:6-508:15
+5892: At              "@" at 508:16-508:17 (leading: Space)
+5893: Ident           "overload" at 508:17-508:25
+5894: KwFn            "fn" at 508:26-508:28 (leading: Space)
+5895: Ident           "__to" at 508:29-508:33 (leading: Space)
+5896: LParen          "(" at 508:33-508:34
+5897: Ident           "self" at 508:34-508:38
+5898: Colon           ":" at 508:38-508:39
+5899: Ident           "uint16" at 508:40-508:46 (leading: Space)
+5900: Comma           "," at 508:46-508:47
+5901: Ident           "target" at 508:48-508:54 (leading: Space)
+5902: Colon           ":" at 508:54-508:55
+5903: Ident           "uint64" at 508:56-508:62 (leading: Space)
+5904: RParen          ")" at 508:62-508:63
+5905: Arrow           "->" at 508:64-508:66 (leading: Space)
+5906: Ident           "uint64" at 508:67-508:73 (leading: Space)
+5907: Semicolon       ";" at 508:73-508:74
+5908: At              "@" at 509:5-509:6 (leading: Newline, Space)
+5909: Ident           "intrinsic" at 509:6-509:15
+5910: KwPub           "pub" at 509:16-509:19 (leading: Space)
+5911: KwFn            "fn" at 509:20-509:22 (leading: Space)
+5912: Ident           "from_str" at 509:23-509:31 (leading: Space)
+5913: LParen          "(" at 509:31-509:32
+5914: Ident           "s" at 509:32-509:33
+5915: Colon           ":" at 509:33-509:34
+5916: Amp             "&" at 509:35-509:36 (leading: Space)
+5917: Ident           "string" at 509:36-509:42
+5918: RParen          ")" at 509:42-509:43
+5919: Arrow           "->" at 509:44-509:46 (leading: Space)
+5920: Ident           "Erring" at 509:47-509:53 (leading: Space)
+5921: Lt              "<" at 509:53-509:54
+5922: Ident           "uint16" at 509:54-509:60
+5923: Comma           "," at 509:60-509:61
+5924: Ident           "Error" at 509:62-509:67 (leading: Space)
+5925: Gt              ">" at 509:67-509:68
+5926: Semicolon       ";" at 509:68-509:69
+5927: RBrace          "}" at 510:1-510:2 (leading: Newline)
+5928: KwExtern        "extern" at 512:1-512:7 (leading: Newline)
+5929: Lt              "<" at 512:7-512:8
+5930: Ident           "uint32" at 512:8-512:14
+5931: Gt              ">" at 512:14-512:15
+5932: LBrace          "{" at 512:16-512:17 (leading: Space)
+5933: KwPub           "pub" at 513:5-513:8 (leading: Newline, Space)
+5934: KwFn            "fn" at 513:9-513:11 (leading: Space)
+5935: Ident           "__min_value" at 513:12-513:23 (leading: Space)
+5936: LParen          "(" at 513:23-513:24
+5937: RParen          ")" at 513:24-513:25
+5938: Arrow           "->" at 513:26-513:28 (leading: Space)
+5939: Ident           "uint32" at 513:29-513:35 (leading: Space)
+5940: LBrace          "{" at 513:36-513:37 (leading: Space)
+5941: KwReturn        "return" at 513:38-513:44 (leading: Space)
+5942: LParen          "(" at 513:45-513:46 (leading: Space)
+5943: IntLit          "0" at 513:46-513:47
+5944: RParen          ")" at 513:47-513:48
+5945: Colon           ":" at 513:48-513:49
+5946: Ident           "uint32" at 513:49-513:55
+5947: Semicolon       ";" at 513:55-513:56
+5948: RBrace          "}" at 513:57-513:58 (leading: Space)
+5949: KwPub           "pub" at 514:5-514:8 (leading: Newline, Space)
+5950: KwFn            "fn" at 514:9-514:11 (leading: Space)
+5951: Ident           "__max_value" at 514:12-514:23 (leading: Space)
+5952: LParen          "(" at 514:23-514:24
+5953: RParen          ")" at 514:24-514:25
+5954: Arrow           "->" at 514:26-514:28 (leading: Space)
+5955: Ident           "uint32" at 514:29-514:35 (leading: Space)
+5956: LBrace          "{" at 514:36-514:37 (leading: Space)
+5957: KwReturn        "return" at 514:38-514:44 (leading: Space)
+5958: LParen          "(" at 514:45-514:46 (leading: Space)
+5959: IntLit          "4_294_967_295" at 514:46-514:59
+5960: RParen          ")" at 514:59-514:60
+5961: Colon           ":" at 514:60-514:61
+5962: Ident           "uint32" at 514:61-514:67
+5963: Semicolon       ";" at 514:67-514:68
+5964: RBrace          "}" at 514:69-514:70 (leading: Space)
+5965: At              "@" at 515:5-515:6 (leading: Newline, Space)
+5966: Ident           "intrinsic" at 515:6-515:15
+5967: KwFn            "fn" at 515:16-515:18 (leading: Space)
+5968: Ident           "__add" at 515:19-515:24 (leading: Space)
+5969: LParen          "(" at 515:24-515:25
+5970: Ident           "self" at 515:25-515:29
+5971: Colon           ":" at 515:29-515:30
+5972: Ident           "uint32" at 515:31-515:37 (leading: Space)
+5973: Comma           "," at 515:37-515:38
+5974: Ident           "other" at 515:39-515:44 (leading: Space)
+5975: Colon           ":" at 515:44-515:45
+5976: Ident           "uint32" at 515:46-515:52 (leading: Space)
+5977: RParen          ")" at 515:52-515:53
+5978: Arrow           "->" at 515:54-515:56 (leading: Space)
+5979: Ident           "uint32" at 515:57-515:63 (leading: Space)
+5980: Semicolon       ";" at 515:63-515:64
+5981: At              "@" at 516:5-516:6 (leading: Newline, Space)
+5982: Ident           "intrinsic" at 516:6-516:15
+5983: KwFn            "fn" at 516:16-516:18 (leading: Space)
+5984: Ident           "__sub" at 516:19-516:24 (leading: Space)
+5985: LParen          "(" at 516:24-516:25
+5986: Ident           "self" at 516:25-516:29
+5987: Colon           ":" at 516:29-516:30
+5988: Ident           "uint32" at 516:31-516:37 (leading: Space)
+5989: Comma           "," at 516:37-516:38
+5990: Ident           "other" at 516:39-516:44 (leading: Space)
+5991: Colon           ":" at 516:44-516:45
+5992: Ident           "uint32" at 516:46-516:52 (leading: Space)
+5993: RParen          ")" at 516:52-516:53
+5994: Arrow           "->" at 516:54-516:56 (leading: Space)
+5995: Ident           "uint32" at 516:57-516:63 (leading: Space)
+5996: Semicolon       ";" at 516:63-516:64
+5997: At              "@" at 517:5-517:6 (leading: Newline, Space)
+5998: Ident           "intrinsic" at 517:6-517:15
+5999: KwFn            "fn" at 517:16-517:18 (leading: Space)
+6000: Ident           "__mul" at 517:19-517:24 (leading: Space)
+6001: LParen          "(" at 517:24-517:25
+6002: Ident           "self" at 517:25-517:29
+6003: Colon           ":" at 517:29-517:30
+6004: Ident           "uint32" at 517:31-517:37 (leading: Space)
+6005: Comma           "," at 517:37-517:38
+6006: Ident           "other" at 517:39-517:44 (leading: Space)
+6007: Colon           ":" at 517:44-517:45
+6008: Ident           "uint32" at 517:46-517:52 (leading: Space)
+6009: RParen          ")" at 517:52-517:53
+6010: Arrow           "->" at 517:54-517:56 (leading: Space)
+6011: Ident           "uint32" at 517:57-517:63 (leading: Space)
+6012: Semicolon       ";" at 517:63-517:64
+6013: At              "@" at 518:5-518:6 (leading: Newline, Space)
+6014: Ident           "intrinsic" at 518:6-518:15
+6015: KwFn            "fn" at 518:16-518:18 (leading: Space)
+6016: Ident           "__div" at 518:19-518:24 (leading: Space)
+6017: LParen          "(" at 518:24-518:25
+6018: Ident           "self" at 518:25-518:29
+6019: Colon           ":" at 518:29-518:30
+6020: Ident           "uint32" at 518:31-518:37 (leading: Space)
+6021: Comma           "," at 518:37-518:38
+6022: Ident           "other" at 518:39-518:44 (leading: Space)
+6023: Colon           ":" at 518:44-518:45
+6024: Ident           "uint32" at 518:46-518:52 (leading: Space)
+6025: RParen          ")" at 518:52-518:53
+6026: Arrow           "->" at 518:54-518:56 (leading: Space)
+6027: Ident           "uint32" at 518:57-518:63 (leading: Space)
+6028: Semicolon       ";" at 518:63-518:64
+6029: At              "@" at 519:5-519:6 (leading: Newline, Space)
+6030: Ident           "intrinsic" at 519:6-519:15
+6031: KwFn            "fn" at 519:16-519:18 (leading: Space)
+6032: Ident           "__mod" at 519:19-519:24 (leading: Space)
+6033: LParen          "(" at 519:24-519:25
+6034: Ident           "self" at 519:25-519:29
+6035: Colon           ":" at 519:29-519:30
+6036: Ident           "uint32" at 519:31-519:37 (leading: Space)
+6037: Comma           "," at 519:37-519:38
+6038: Ident           "other" at 519:39-519:44 (leading: Space)
+6039: Colon           ":" at 519:44-519:45
+6040: Ident           "uint32" at 519:46-519:52 (leading: Space)
+6041: RParen          ")" at 519:52-519:53
+6042: Arrow           "->" at 519:54-519:56 (leading: Space)
+6043: Ident           "uint32" at 519:57-519:63 (leading: Space)
+6044: Semicolon       ";" at 519:63-519:64
+6045: At              "@" at 520:5-520:6 (leading: Newline, Space)
+6046: Ident           "intrinsic" at 520:6-520:15
+6047: KwFn            "fn" at 520:16-520:18 (leading: Space)
+6048: Ident           "__bit_and" at 520:19-520:28 (leading: Space)
+6049: LParen          "(" at 520:28-520:29
+6050: Ident           "self" at 520:29-520:33
+6051: Colon           ":" at 520:33-520:34
+6052: Ident           "uint32" at 520:35-520:41 (leading: Space)
+6053: Comma           "," at 520:41-520:42
+6054: Ident           "other" at 520:43-520:48 (leading: Space)
+6055: Colon           ":" at 520:48-520:49
+6056: Ident           "uint32" at 520:50-520:56 (leading: Space)
+6057: RParen          ")" at 520:56-520:57
+6058: Arrow           "->" at 520:58-520:60 (leading: Space)
+6059: Ident           "uint32" at 520:61-520:67 (leading: Space)
+6060: Semicolon       ";" at 520:67-520:68
+6061: At              "@" at 521:5-521:6 (leading: Newline, Space)
+6062: Ident           "intrinsic" at 521:6-521:15
+6063: KwFn            "fn" at 521:16-521:18 (leading: Space)
+6064: Ident           "__bit_or" at 521:19-521:27 (leading: Space)
+6065: LParen          "(" at 521:27-521:28
+6066: Ident           "self" at 521:28-521:32
+6067: Colon           ":" at 521:32-521:33
+6068: Ident           "uint32" at 521:34-521:40 (leading: Space)
+6069: Comma           "," at 521:40-521:41
+6070: Ident           "other" at 521:42-521:47 (leading: Space)
+6071: Colon           ":" at 521:47-521:48
+6072: Ident           "uint32" at 521:49-521:55 (leading: Space)
+6073: RParen          ")" at 521:55-521:56
+6074: Arrow           "->" at 521:57-521:59 (leading: Space)
+6075: Ident           "uint32" at 521:60-521:66 (leading: Space)
+6076: Semicolon       ";" at 521:66-521:67
+6077: At              "@" at 522:5-522:6 (leading: Newline, Space)
+6078: Ident           "intrinsic" at 522:6-522:15
+6079: KwFn            "fn" at 522:16-522:18 (leading: Space)
+6080: Ident           "__bit_xor" at 522:19-522:28 (leading: Space)
+6081: LParen          "(" at 522:28-522:29
+6082: Ident           "self" at 522:29-522:33
+6083: Colon           ":" at 522:33-522:34
+6084: Ident           "uint32" at 522:35-522:41 (leading: Space)
+6085: Comma           "," at 522:41-522:42
+6086: Ident           "other" at 522:43-522:48 (leading: Space)
+6087: Colon           ":" at 522:48-522:49
+6088: Ident           "uint32" at 522:50-522:56 (leading: Space)
+6089: RParen          ")" at 522:56-522:57
+6090: Arrow           "->" at 522:58-522:60 (leading: Space)
+6091: Ident           "uint32" at 522:61-522:67 (leading: Space)
+6092: Semicolon       ";" at 522:67-522:68
+6093: At              "@" at 523:5-523:6 (leading: Newline, Space)
+6094: Ident           "intrinsic" at 523:6-523:15
+6095: KwFn            "fn" at 523:16-523:18 (leading: Space)
+6096: Ident           "__shl" at 523:19-523:24 (leading: Space)
+6097: LParen          "(" at 523:24-523:25
+6098: Ident           "self" at 523:25-523:29
+6099: Colon           ":" at 523:29-523:30
+6100: Ident           "uint32" at 523:31-523:37 (leading: Space)
+6101: Comma           "," at 523:37-523:38
+6102: Ident           "other" at 523:39-523:44 (leading: Space)
+6103: Colon           ":" at 523:44-523:45
+6104: Ident           "uint32" at 523:46-523:52 (leading: Space)
+6105: RParen          ")" at 523:52-523:53
+6106: Arrow           "->" at 523:54-523:56 (leading: Space)
+6107: Ident           "uint32" at 523:57-523:63 (leading: Space)
+6108: Semicolon       ";" at 523:63-523:64
+6109: At              "@" at 524:5-524:6 (leading: Newline, Space)
+6110: Ident           "intrinsic" at 524:6-524:15
+6111: KwFn            "fn" at 524:16-524:18 (leading: Space)
+6112: Ident           "__shr" at 524:19-524:24 (leading: Space)
+6113: LParen          "(" at 524:24-524:25
+6114: Ident           "self" at 524:25-524:29
+6115: Colon           ":" at 524:29-524:30
+6116: Ident           "uint32" at 524:31-524:37 (leading: Space)
+6117: Comma           "," at 524:37-524:38
+6118: Ident           "other" at 524:39-524:44 (leading: Space)
+6119: Colon           ":" at 524:44-524:45
+6120: Ident           "uint32" at 524:46-524:52 (leading: Space)
+6121: RParen          ")" at 524:52-524:53
+6122: Arrow           "->" at 524:54-524:56 (leading: Space)
+6123: Ident           "uint32" at 524:57-524:63 (leading: Space)
+6124: Semicolon       ";" at 524:63-524:64
+6125: At              "@" at 525:5-525:6 (leading: Newline, Space)
+6126: Ident           "intrinsic" at 525:6-525:15
+6127: KwFn            "fn" at 525:16-525:18 (leading: Space)
+6128: Ident           "__lt" at 525:19-525:23 (leading: Space)
+6129: LParen          "(" at 525:23-525:24
+6130: Ident           "self" at 525:24-525:28
+6131: Colon           ":" at 525:28-525:29
+6132: Ident           "uint32" at 525:30-525:36 (leading: Space)
+6133: Comma           "," at 525:36-525:37
+6134: Ident           "other" at 525:38-525:43 (leading: Space)
+6135: Colon           ":" at 525:43-525:44
+6136: Ident           "uint32" at 525:45-525:51 (leading: Space)
+6137: RParen          ")" at 525:51-525:52
+6138: Arrow           "->" at 525:53-525:55 (leading: Space)
+6139: Ident           "bool" at 525:56-525:60 (leading: Space)
+6140: Semicolon       ";" at 525:60-525:61
+6141: At              "@" at 526:5-526:6 (leading: Newline, Space)
+6142: Ident           "intrinsic" at 526:6-526:15
+6143: KwFn            "fn" at 526:16-526:18 (leading: Space)
+6144: Ident           "__le" at 526:19-526:23 (leading: Space)
+6145: LParen          "(" at 526:23-526:24
+6146: Ident           "self" at 526:24-526:28
+6147: Colon           ":" at 526:28-526:29
+6148: Ident           "uint32" at 526:30-526:36 (leading: Space)
+6149: Comma           "," at 526:36-526:37
+6150: Ident           "other" at 526:38-526:43 (leading: Space)
+6151: Colon           ":" at 526:43-526:44
+6152: Ident           "uint32" at 526:45-526:51 (leading: Space)
+6153: RParen          ")" at 526:51-526:52
+6154: Arrow           "->" at 526:53-526:55 (leading: Space)
+6155: Ident           "bool" at 526:56-526:60 (leading: Space)
+6156: Semicolon       ";" at 526:60-526:61
+6157: At              "@" at 527:5-527:6 (leading: Newline, Space)
+6158: Ident           "intrinsic" at 527:6-527:15
+6159: KwFn            "fn" at 527:16-527:18 (leading: Space)
+6160: Ident           "__eq" at 527:19-527:23 (leading: Space)
+6161: LParen          "(" at 527:23-527:24
+6162: Ident           "self" at 527:24-527:28
+6163: Colon           ":" at 527:28-527:29
+6164: Ident           "uint32" at 527:30-527:36 (leading: Space)
+6165: Comma           "," at 527:36-527:37
+6166: Ident           "other" at 527:38-527:43 (leading: Space)
+6167: Colon           ":" at 527:43-527:44
+6168: Ident           "uint32" at 527:45-527:51 (leading: Space)
+6169: RParen          ")" at 527:51-527:52
+6170: Arrow           "->" at 527:53-527:55 (leading: Space)
+6171: Ident           "bool" at 527:56-527:60 (leading: Space)
+6172: Semicolon       ";" at 527:60-527:61
+6173: At              "@" at 528:5-528:6 (leading: Newline, Space)
+6174: Ident           "intrinsic" at 528:6-528:15
+6175: KwFn            "fn" at 528:16-528:18 (leading: Space)
+6176: Ident           "__ne" at 528:19-528:23 (leading: Space)
+6177: LParen          "(" at 528:23-528:24
+6178: Ident           "self" at 528:24-528:28
+6179: Colon           ":" at 528:28-528:29
+6180: Ident           "uint32" at 528:30-528:36 (leading: Space)
+6181: Comma           "," at 528:36-528:37
+6182: Ident           "other" at 528:38-528:43 (leading: Space)
+6183: Colon           ":" at 528:43-528:44
+6184: Ident           "uint32" at 528:45-528:51 (leading: Space)
+6185: RParen          ")" at 528:51-528:52
+6186: Arrow           "->" at 528:53-528:55 (leading: Space)
+6187: Ident           "bool" at 528:56-528:60 (leading: Space)
+6188: Semicolon       ";" at 528:60-528:61
+6189: At              "@" at 529:5-529:6 (leading: Newline, Space)
+6190: Ident           "intrinsic" at 529:6-529:15
+6191: KwFn            "fn" at 529:16-529:18 (leading: Space)
+6192: Ident           "__ge" at 529:19-529:23 (leading: Space)
+6193: LParen          "(" at 529:23-529:24
+6194: Ident           "self" at 529:24-529:28
+6195: Colon           ":" at 529:28-529:29
+6196: Ident           "uint32" at 529:30-529:36 (leading: Space)
+6197: Comma           "," at 529:36-529:37
+6198: Ident           "other" at 529:38-529:43 (leading: Space)
+6199: Colon           ":" at 529:43-529:44
+6200: Ident           "uint32" at 529:45-529:51 (leading: Space)
+6201: RParen          ")" at 529:51-529:52
+6202: Arrow           "->" at 529:53-529:55 (leading: Space)
+6203: Ident           "bool" at 529:56-529:60 (leading: Space)
+6204: Semicolon       ";" at 529:60-529:61
+6205: At              "@" at 530:5-530:6 (leading: Newline, Space)
+6206: Ident           "intrinsic" at 530:6-530:15
+6207: KwFn            "fn" at 530:16-530:18 (leading: Space)
+6208: Ident           "__gt" at 530:19-530:23 (leading: Space)
+6209: LParen          "(" at 530:23-530:24
+6210: Ident           "self" at 530:24-530:28
+6211: Colon           ":" at 530:28-530:29
+6212: Ident           "uint32" at 530:30-530:36 (leading: Space)
+6213: Comma           "," at 530:36-530:37
+6214: Ident           "other" at 530:38-530:43 (leading: Space)
+6215: Colon           ":" at 530:43-530:44
+6216: Ident           "uint32" at 530:45-530:51 (leading: Space)
+6217: RParen          ")" at 530:51-530:52
+6218: Arrow           "->" at 530:53-530:55 (leading: Space)
+6219: Ident           "bool" at 530:56-530:60 (leading: Space)
+6220: Semicolon       ";" at 530:60-530:61
+6221: At              "@" at 531:5-531:6 (leading: Newline, Space)
+6222: Ident           "intrinsic" at 531:6-531:15
+6223: KwFn            "fn" at 531:16-531:18 (leading: Space)
+6224: Ident           "__pos" at 531:19-531:24 (leading: Space)
+6225: LParen          "(" at 531:24-531:25
+6226: Ident           "self" at 531:25-531:29
+6227: Colon           ":" at 531:29-531:30
+6228: Ident           "uint32" at 531:31-531:37 (leading: Space)
+6229: RParen          ")" at 531:37-531:38
+6230: Arrow           "->" at 531:39-531:41 (leading: Space)
+6231: Ident           "uint32" at 531:42-531:48 (leading: Space)
+6232: Semicolon       ";" at 531:48-531:49
+6233: At              "@" at 532:5-532:6 (leading: Newline, Space)
+6234: Ident           "intrinsic" at 532:6-532:15
+6235: KwFn            "fn" at 532:16-532:18 (leading: Space)
+6236: Ident           "__abs" at 532:19-532:24 (leading: Space)
+6237: LParen          "(" at 532:24-532:25
+6238: Ident           "self" at 532:25-532:29
+6239: Colon           ":" at 532:29-532:30
+6240: Ident           "uint32" at 532:31-532:37 (leading: Space)
+6241: RParen          ")" at 532:37-532:38
+6242: Arrow           "->" at 532:39-532:41 (leading: Space)
+6243: Ident           "uint32" at 532:42-532:48 (leading: Space)
+6244: Semicolon       ";" at 532:48-532:49
+6245: At              "@" at 533:5-533:6 (leading: Newline, Space)
+6246: Ident           "intrinsic" at 533:6-533:15
+6247: KwFn            "fn" at 533:16-533:18 (leading: Space)
+6248: Ident           "__to" at 533:19-533:23 (leading: Space)
+6249: LParen          "(" at 533:23-533:24
+6250: Ident           "self" at 533:24-533:28
+6251: Colon           ":" at 533:28-533:29
+6252: Ident           "uint32" at 533:30-533:36 (leading: Space)
+6253: Comma           "," at 533:36-533:37
+6254: Ident           "target" at 533:38-533:44 (leading: Space)
+6255: Colon           ":" at 533:44-533:45
+6256: Ident           "uint" at 533:46-533:50 (leading: Space)
+6257: RParen          ")" at 533:50-533:51
+6258: Arrow           "->" at 533:52-533:54 (leading: Space)
+6259: Ident           "uint" at 533:55-533:59 (leading: Space)
+6260: Semicolon       ";" at 533:59-533:60
+6261: At              "@" at 534:5-534:6 (leading: Newline, Space)
+6262: Ident           "intrinsic" at 534:6-534:15
+6263: At              "@" at 534:16-534:17 (leading: Space)
+6264: Ident           "overload" at 534:17-534:25
+6265: KwFn            "fn" at 534:26-534:28 (leading: Space)
+6266: Ident           "__to" at 534:29-534:33 (leading: Space)
+6267: LParen          "(" at 534:33-534:34
+6268: Ident           "self" at 534:34-534:38
+6269: Colon           ":" at 534:38-534:39
+6270: Ident           "uint32" at 534:40-534:46 (leading: Space)
+6271: Comma           "," at 534:46-534:47
+6272: Ident           "target" at 534:48-534:54 (leading: Space)
+6273: Colon           ":" at 534:54-534:55
+6274: Ident           "uint8" at 534:56-534:61 (leading: Space)
+6275: RParen          ")" at 534:61-534:62
+6276: Arrow           "->" at 534:63-534:65 (leading: Space)
+6277: Ident           "uint8" at 534:66-534:71 (leading: Space)
+6278: Semicolon       ";" at 534:71-534:72
+6279: At              "@" at 535:5-535:6 (leading: Newline, Space)
+6280: Ident           "intrinsic" at 535:6-535:15
+6281: At              "@" at 535:16-535:17 (leading: Space)
+6282: Ident           "overload" at 535:17-535:25
+6283: KwFn            "fn" at 535:26-535:28 (leading: Space)
+6284: Ident           "__to" at 535:29-535:33 (leading: Space)
+6285: LParen          "(" at 535:33-535:34
+6286: Ident           "self" at 535:34-535:38
+6287: Colon           ":" at 535:38-535:39
+6288: Ident           "uint32" at 535:40-535:46 (leading: Space)
+6289: Comma           "," at 535:46-535:47
+6290: Ident           "target" at 535:48-535:54 (leading: Space)
+6291: Colon           ":" at 535:54-535:55
+6292: Ident           "uint16" at 535:56-535:62 (leading: Space)
+6293: RParen          ")" at 535:62-535:63
+6294: Arrow           "->" at 535:64-535:66 (leading: Space)
+6295: Ident           "uint16" at 535:67-535:73 (leading: Space)
+6296: Semicolon       ";" at 535:73-535:74
+6297: At              "@" at 536:5-536:6 (leading: Newline, Space)
+6298: Ident           "intrinsic" at 536:6-536:15
+6299: At              "@" at 536:16-536:17 (leading: Space)
+6300: Ident           "overload" at 536:17-536:25
+6301: KwFn            "fn" at 536:26-536:28 (leading: Space)
+6302: Ident           "__to" at 536:29-536:33 (leading: Space)
+6303: LParen          "(" at 536:33-536:34
+6304: Ident           "self" at 536:34-536:38
+6305: Colon           ":" at 536:38-536:39
+6306: Ident           "uint32" at 536:40-536:46 (leading: Space)
+6307: Comma           "," at 536:46-536:47
+6308: Ident           "target" at 536:48-536:54 (leading: Space)
+6309: Colon           ":" at 536:54-536:55
+6310: Ident           "uint64" at 536:56-536:62 (leading: Space)
+6311: RParen          ")" at 536:62-536:63
+6312: Arrow           "->" at 536:64-536:66 (leading: Space)
+6313: Ident           "uint64" at 536:67-536:73 (leading: Space)
+6314: Semicolon       ";" at 536:73-536:74
+6315: At              "@" at 537:5-537:6 (leading: Newline, Space)
+6316: Ident           "intrinsic" at 537:6-537:15
+6317: KwPub           "pub" at 537:16-537:19 (leading: Space)
+6318: KwFn            "fn" at 537:20-537:22 (leading: Space)
+6319: Ident           "from_str" at 537:23-537:31 (leading: Space)
+6320: LParen          "(" at 537:31-537:32
+6321: Ident           "s" at 537:32-537:33
+6322: Colon           ":" at 537:33-537:34
+6323: Amp             "&" at 537:35-537:36 (leading: Space)
+6324: Ident           "string" at 537:36-537:42
+6325: RParen          ")" at 537:42-537:43
+6326: Arrow           "->" at 537:44-537:46 (leading: Space)
+6327: Ident           "Erring" at 537:47-537:53 (leading: Space)
+6328: Lt              "<" at 537:53-537:54
+6329: Ident           "uint32" at 537:54-537:60
+6330: Comma           "," at 537:60-537:61
+6331: Ident           "Error" at 537:62-537:67 (leading: Space)
+6332: Gt              ">" at 537:67-537:68
+6333: Semicolon       ";" at 537:68-537:69
+6334: RBrace          "}" at 538:1-538:2 (leading: Newline)
+6335: KwExtern        "extern" at 540:1-540:7 (leading: Newline)
+6336: Lt              "<" at 540:7-540:8
+6337: Ident           "uint64" at 540:8-540:14
+6338: Gt              ">" at 540:14-540:15
+6339: LBrace          "{" at 540:16-540:17 (leading: Space)
+6340: KwPub           "pub" at 541:5-541:8 (leading: Newline, Space)
+6341: KwFn            "fn" at 541:9-541:11 (leading: Space)
+6342: Ident           "__min_value" at 541:12-541:23 (leading: Space)
+6343: LParen          "(" at 541:23-541:24
+6344: RParen          ")" at 541:24-541:25
+6345: Arrow           "->" at 541:26-541:28 (leading: Space)
+6346: Ident           "uint64" at 541:29-541:35 (leading: Space)
+6347: LBrace          "{" at 541:36-541:37 (leading: Space)
+6348: KwReturn        "return" at 541:38-541:44 (leading: Space)
+6349: LParen          "(" at 541:45-541:46 (leading: Space)
+6350: IntLit          "0" at 541:46-541:47
+6351: RParen          ")" at 541:47-541:48
+6352: Colon           ":" at 541:48-541:49
+6353: Ident           "uint64" at 541:49-541:55
+6354: Semicolon       ";" at 541:55-541:56
+6355: RBrace          "}" at 541:57-541:58 (leading: Space)
+6356: KwPub           "pub" at 542:5-542:8 (leading: Newline, Space)
+6357: KwFn            "fn" at 542:9-542:11 (leading: Space)
+6358: Ident           "__max_value" at 542:12-542:23 (leading: Space)
+6359: LParen          "(" at 542:23-542:24
+6360: RParen          ")" at 542:24-542:25
+6361: Arrow           "->" at 542:26-542:28 (leading: Space)
+6362: Ident           "uint64" at 542:29-542:35 (leading: Space)
+6363: LBrace          "{" at 542:36-542:37 (leading: Space)
+6364: KwReturn        "return" at 542:38-542:44 (leading: Space)
+6365: LParen          "(" at 542:45-542:46 (leading: Space)
+6366: IntLit          "18_446_744_073_709_551_615" at 542:46-542:72
+6367: RParen          ")" at 542:72-542:73
+6368: Colon           ":" at 542:73-542:74
+6369: Ident           "uint64" at 542:74-542:80
+6370: Semicolon       ";" at 542:80-542:81
+6371: RBrace          "}" at 542:82-542:83 (leading: Space)
+6372: At              "@" at 543:5-543:6 (leading: Newline, Space)
+6373: Ident           "intrinsic" at 543:6-543:15
+6374: KwFn            "fn" at 543:16-543:18 (leading: Space)
+6375: Ident           "__add" at 543:19-543:24 (leading: Space)
+6376: LParen          "(" at 543:24-543:25
+6377: Ident           "self" at 543:25-543:29
+6378: Colon           ":" at 543:29-543:30
+6379: Ident           "uint64" at 543:31-543:37 (leading: Space)
+6380: Comma           "," at 543:37-543:38
+6381: Ident           "other" at 543:39-543:44 (leading: Space)
+6382: Colon           ":" at 543:44-543:45
+6383: Ident           "uint64" at 543:46-543:52 (leading: Space)
+6384: RParen          ")" at 543:52-543:53
+6385: Arrow           "->" at 543:54-543:56 (leading: Space)
+6386: Ident           "uint64" at 543:57-543:63 (leading: Space)
+6387: Semicolon       ";" at 543:63-543:64
+6388: At              "@" at 544:5-544:6 (leading: Newline, Space)
+6389: Ident           "intrinsic" at 544:6-544:15
+6390: KwFn            "fn" at 544:16-544:18 (leading: Space)
+6391: Ident           "__sub" at 544:19-544:24 (leading: Space)
+6392: LParen          "(" at 544:24-544:25
+6393: Ident           "self" at 544:25-544:29
+6394: Colon           ":" at 544:29-544:30
+6395: Ident           "uint64" at 544:31-544:37 (leading: Space)
+6396: Comma           "," at 544:37-544:38
+6397: Ident           "other" at 544:39-544:44 (leading: Space)
+6398: Colon           ":" at 544:44-544:45
+6399: Ident           "uint64" at 544:46-544:52 (leading: Space)
+6400: RParen          ")" at 544:52-544:53
+6401: Arrow           "->" at 544:54-544:56 (leading: Space)
+6402: Ident           "uint64" at 544:57-544:63 (leading: Space)
+6403: Semicolon       ";" at 544:63-544:64
+6404: At              "@" at 545:5-545:6 (leading: Newline, Space)
+6405: Ident           "intrinsic" at 545:6-545:15
+6406: KwFn            "fn" at 545:16-545:18 (leading: Space)
+6407: Ident           "__mul" at 545:19-545:24 (leading: Space)
+6408: LParen          "(" at 545:24-545:25
+6409: Ident           "self" at 545:25-545:29
+6410: Colon           ":" at 545:29-545:30
+6411: Ident           "uint64" at 545:31-545:37 (leading: Space)
+6412: Comma           "," at 545:37-545:38
+6413: Ident           "other" at 545:39-545:44 (leading: Space)
+6414: Colon           ":" at 545:44-545:45
+6415: Ident           "uint64" at 545:46-545:52 (leading: Space)
+6416: RParen          ")" at 545:52-545:53
+6417: Arrow           "->" at 545:54-545:56 (leading: Space)
+6418: Ident           "uint64" at 545:57-545:63 (leading: Space)
+6419: Semicolon       ";" at 545:63-545:64
+6420: At              "@" at 546:5-546:6 (leading: Newline, Space)
+6421: Ident           "intrinsic" at 546:6-546:15
+6422: KwFn            "fn" at 546:16-546:18 (leading: Space)
+6423: Ident           "__div" at 546:19-546:24 (leading: Space)
+6424: LParen          "(" at 546:24-546:25
+6425: Ident           "self" at 546:25-546:29
+6426: Colon           ":" at 546:29-546:30
+6427: Ident           "uint64" at 546:31-546:37 (leading: Space)
+6428: Comma           "," at 546:37-546:38
+6429: Ident           "other" at 546:39-546:44 (leading: Space)
+6430: Colon           ":" at 546:44-546:45
+6431: Ident           "uint64" at 546:46-546:52 (leading: Space)
+6432: RParen          ")" at 546:52-546:53
+6433: Arrow           "->" at 546:54-546:56 (leading: Space)
+6434: Ident           "uint64" at 546:57-546:63 (leading: Space)
+6435: Semicolon       ";" at 546:63-546:64
+6436: At              "@" at 547:5-547:6 (leading: Newline, Space)
+6437: Ident           "intrinsic" at 547:6-547:15
+6438: KwFn            "fn" at 547:16-547:18 (leading: Space)
+6439: Ident           "__mod" at 547:19-547:24 (leading: Space)
+6440: LParen          "(" at 547:24-547:25
+6441: Ident           "self" at 547:25-547:29
+6442: Colon           ":" at 547:29-547:30
+6443: Ident           "uint64" at 547:31-547:37 (leading: Space)
+6444: Comma           "," at 547:37-547:38
+6445: Ident           "other" at 547:39-547:44 (leading: Space)
+6446: Colon           ":" at 547:44-547:45
+6447: Ident           "uint64" at 547:46-547:52 (leading: Space)
+6448: RParen          ")" at 547:52-547:53
+6449: Arrow           "->" at 547:54-547:56 (leading: Space)
+6450: Ident           "uint64" at 547:57-547:63 (leading: Space)
+6451: Semicolon       ";" at 547:63-547:64
+6452: At              "@" at 548:5-548:6 (leading: Newline, Space)
+6453: Ident           "intrinsic" at 548:6-548:15
+6454: KwFn            "fn" at 548:16-548:18 (leading: Space)
+6455: Ident           "__bit_and" at 548:19-548:28 (leading: Space)
+6456: LParen          "(" at 548:28-548:29
+6457: Ident           "self" at 548:29-548:33
+6458: Colon           ":" at 548:33-548:34
+6459: Ident           "uint64" at 548:35-548:41 (leading: Space)
+6460: Comma           "," at 548:41-548:42
+6461: Ident           "other" at 548:43-548:48 (leading: Space)
+6462: Colon           ":" at 548:48-548:49
+6463: Ident           "uint64" at 548:50-548:56 (leading: Space)
+6464: RParen          ")" at 548:56-548:57
+6465: Arrow           "->" at 548:58-548:60 (leading: Space)
+6466: Ident           "uint64" at 548:61-548:67 (leading: Space)
+6467: Semicolon       ";" at 548:67-548:68
+6468: At              "@" at 549:5-549:6 (leading: Newline, Space)
+6469: Ident           "intrinsic" at 549:6-549:15
+6470: KwFn            "fn" at 549:16-549:18 (leading: Space)
+6471: Ident           "__bit_or" at 549:19-549:27 (leading: Space)
+6472: LParen          "(" at 549:27-549:28
+6473: Ident           "self" at 549:28-549:32
+6474: Colon           ":" at 549:32-549:33
+6475: Ident           "uint64" at 549:34-549:40 (leading: Space)
+6476: Comma           "," at 549:40-549:41
+6477: Ident           "other" at 549:42-549:47 (leading: Space)
+6478: Colon           ":" at 549:47-549:48
+6479: Ident           "uint64" at 549:49-549:55 (leading: Space)
+6480: RParen          ")" at 549:55-549:56
+6481: Arrow           "->" at 549:57-549:59 (leading: Space)
+6482: Ident           "uint64" at 549:60-549:66 (leading: Space)
+6483: Semicolon       ";" at 549:66-549:67
+6484: At              "@" at 550:5-550:6 (leading: Newline, Space)
+6485: Ident           "intrinsic" at 550:6-550:15
+6486: KwFn            "fn" at 550:16-550:18 (leading: Space)
+6487: Ident           "__bit_xor" at 550:19-550:28 (leading: Space)
+6488: LParen          "(" at 550:28-550:29
+6489: Ident           "self" at 550:29-550:33
+6490: Colon           ":" at 550:33-550:34
+6491: Ident           "uint64" at 550:35-550:41 (leading: Space)
+6492: Comma           "," at 550:41-550:42
+6493: Ident           "other" at 550:43-550:48 (leading: Space)
+6494: Colon           ":" at 550:48-550:49
+6495: Ident           "uint64" at 550:50-550:56 (leading: Space)
+6496: RParen          ")" at 550:56-550:57
+6497: Arrow           "->" at 550:58-550:60 (leading: Space)
+6498: Ident           "uint64" at 550:61-550:67 (leading: Space)
+6499: Semicolon       ";" at 550:67-550:68
+6500: At              "@" at 551:5-551:6 (leading: Newline, Space)
+6501: Ident           "intrinsic" at 551:6-551:15
+6502: KwFn            "fn" at 551:16-551:18 (leading: Space)
+6503: Ident           "__shl" at 551:19-551:24 (leading: Space)
+6504: LParen          "(" at 551:24-551:25
+6505: Ident           "self" at 551:25-551:29
+6506: Colon           ":" at 551:29-551:30
+6507: Ident           "uint64" at 551:31-551:37 (leading: Space)
+6508: Comma           "," at 551:37-551:38
+6509: Ident           "other" at 551:39-551:44 (leading: Space)
+6510: Colon           ":" at 551:44-551:45
+6511: Ident           "uint64" at 551:46-551:52 (leading: Space)
+6512: RParen          ")" at 551:52-551:53
+6513: Arrow           "->" at 551:54-551:56 (leading: Space)
+6514: Ident           "uint64" at 551:57-551:63 (leading: Space)
+6515: Semicolon       ";" at 551:63-551:64
+6516: At              "@" at 552:5-552:6 (leading: Newline, Space)
+6517: Ident           "intrinsic" at 552:6-552:15
+6518: KwFn            "fn" at 552:16-552:18 (leading: Space)
+6519: Ident           "__shr" at 552:19-552:24 (leading: Space)
+6520: LParen          "(" at 552:24-552:25
+6521: Ident           "self" at 552:25-552:29
+6522: Colon           ":" at 552:29-552:30
+6523: Ident           "uint64" at 552:31-552:37 (leading: Space)
+6524: Comma           "," at 552:37-552:38
+6525: Ident           "other" at 552:39-552:44 (leading: Space)
+6526: Colon           ":" at 552:44-552:45
+6527: Ident           "uint64" at 552:46-552:52 (leading: Space)
+6528: RParen          ")" at 552:52-552:53
+6529: Arrow           "->" at 552:54-552:56 (leading: Space)
+6530: Ident           "uint64" at 552:57-552:63 (leading: Space)
+6531: Semicolon       ";" at 552:63-552:64
+6532: At              "@" at 553:5-553:6 (leading: Newline, Space)
+6533: Ident           "intrinsic" at 553:6-553:15
+6534: KwFn            "fn" at 553:16-553:18 (leading: Space)
+6535: Ident           "__lt" at 553:19-553:23 (leading: Space)
+6536: LParen          "(" at 553:23-553:24
+6537: Ident           "self" at 553:24-553:28
+6538: Colon           ":" at 553:28-553:29
+6539: Ident           "uint64" at 553:30-553:36 (leading: Space)
+6540: Comma           "," at 553:36-553:37
+6541: Ident           "other" at 553:38-553:43 (leading: Space)
+6542: Colon           ":" at 553:43-553:44
+6543: Ident           "uint64" at 553:45-553:51 (leading: Space)
+6544: RParen          ")" at 553:51-553:52
+6545: Arrow           "->" at 553:53-553:55 (leading: Space)
+6546: Ident           "bool" at 553:56-553:60 (leading: Space)
+6547: Semicolon       ";" at 553:60-553:61
+6548: At              "@" at 554:5-554:6 (leading: Newline, Space)
+6549: Ident           "intrinsic" at 554:6-554:15
+6550: KwFn            "fn" at 554:16-554:18 (leading: Space)
+6551: Ident           "__le" at 554:19-554:23 (leading: Space)
+6552: LParen          "(" at 554:23-554:24
+6553: Ident           "self" at 554:24-554:28
+6554: Colon           ":" at 554:28-554:29
+6555: Ident           "uint64" at 554:30-554:36 (leading: Space)
+6556: Comma           "," at 554:36-554:37
+6557: Ident           "other" at 554:38-554:43 (leading: Space)
+6558: Colon           ":" at 554:43-554:44
+6559: Ident           "uint64" at 554:45-554:51 (leading: Space)
+6560: RParen          ")" at 554:51-554:52
+6561: Arrow           "->" at 554:53-554:55 (leading: Space)
+6562: Ident           "bool" at 554:56-554:60 (leading: Space)
+6563: Semicolon       ";" at 554:60-554:61
+6564: At              "@" at 555:5-555:6 (leading: Newline, Space)
+6565: Ident           "intrinsic" at 555:6-555:15
+6566: KwFn            "fn" at 555:16-555:18 (leading: Space)
+6567: Ident           "__eq" at 555:19-555:23 (leading: Space)
+6568: LParen          "(" at 555:23-555:24
+6569: Ident           "self" at 555:24-555:28
+6570: Colon           ":" at 555:28-555:29
+6571: Ident           "uint64" at 555:30-555:36 (leading: Space)
+6572: Comma           "," at 555:36-555:37
+6573: Ident           "other" at 555:38-555:43 (leading: Space)
+6574: Colon           ":" at 555:43-555:44
+6575: Ident           "uint64" at 555:45-555:51 (leading: Space)
+6576: RParen          ")" at 555:51-555:52
+6577: Arrow           "->" at 555:53-555:55 (leading: Space)
+6578: Ident           "bool" at 555:56-555:60 (leading: Space)
+6579: Semicolon       ";" at 555:60-555:61
+6580: At              "@" at 556:5-556:6 (leading: Newline, Space)
+6581: Ident           "intrinsic" at 556:6-556:15
+6582: KwFn            "fn" at 556:16-556:18 (leading: Space)
+6583: Ident           "__ne" at 556:19-556:23 (leading: Space)
+6584: LParen          "(" at 556:23-556:24
+6585: Ident           "self" at 556:24-556:28
+6586: Colon           ":" at 556:28-556:29
+6587: Ident           "uint64" at 556:30-556:36 (leading: Space)
+6588: Comma           "," at 556:36-556:37
+6589: Ident           "other" at 556:38-556:43 (leading: Space)
+6590: Colon           ":" at 556:43-556:44
+6591: Ident           "uint64" at 556:45-556:51 (leading: Space)
+6592: RParen          ")" at 556:51-556:52
+6593: Arrow           "->" at 556:53-556:55 (leading: Space)
+6594: Ident           "bool" at 556:56-556:60 (leading: Space)
+6595: Semicolon       ";" at 556:60-556:61
+6596: At              "@" at 557:5-557:6 (leading: Newline, Space)
+6597: Ident           "intrinsic" at 557:6-557:15
+6598: KwFn            "fn" at 557:16-557:18 (leading: Space)
+6599: Ident           "__ge" at 557:19-557:23 (leading: Space)
+6600: LParen          "(" at 557:23-557:24
+6601: Ident           "self" at 557:24-557:28
+6602: Colon           ":" at 557:28-557:29
+6603: Ident           "uint64" at 557:30-557:36 (leading: Space)
+6604: Comma           "," at 557:36-557:37
+6605: Ident           "other" at 557:38-557:43 (leading: Space)
+6606: Colon           ":" at 557:43-557:44
+6607: Ident           "uint64" at 557:45-557:51 (leading: Space)
+6608: RParen          ")" at 557:51-557:52
+6609: Arrow           "->" at 557:53-557:55 (leading: Space)
+6610: Ident           "bool" at 557:56-557:60 (leading: Space)
+6611: Semicolon       ";" at 557:60-557:61
+6612: At              "@" at 558:5-558:6 (leading: Newline, Space)
+6613: Ident           "intrinsic" at 558:6-558:15
+6614: KwFn            "fn" at 558:16-558:18 (leading: Space)
+6615: Ident           "__gt" at 558:19-558:23 (leading: Space)
+6616: LParen          "(" at 558:23-558:24
+6617: Ident           "self" at 558:24-558:28
+6618: Colon           ":" at 558:28-558:29
+6619: Ident           "uint64" at 558:30-558:36 (leading: Space)
+6620: Comma           "," at 558:36-558:37
+6621: Ident           "other" at 558:38-558:43 (leading: Space)
+6622: Colon           ":" at 558:43-558:44
+6623: Ident           "uint64" at 558:45-558:51 (leading: Space)
+6624: RParen          ")" at 558:51-558:52
+6625: Arrow           "->" at 558:53-558:55 (leading: Space)
+6626: Ident           "bool" at 558:56-558:60 (leading: Space)
+6627: Semicolon       ";" at 558:60-558:61
+6628: At              "@" at 559:5-559:6 (leading: Newline, Space)
+6629: Ident           "intrinsic" at 559:6-559:15
+6630: KwFn            "fn" at 559:16-559:18 (leading: Space)
+6631: Ident           "__pos" at 559:19-559:24 (leading: Space)
+6632: LParen          "(" at 559:24-559:25
+6633: Ident           "self" at 559:25-559:29
+6634: Colon           ":" at 559:29-559:30
+6635: Ident           "uint64" at 559:31-559:37 (leading: Space)
+6636: RParen          ")" at 559:37-559:38
+6637: Arrow           "->" at 559:39-559:41 (leading: Space)
+6638: Ident           "uint64" at 559:42-559:48 (leading: Space)
+6639: Semicolon       ";" at 559:48-559:49
+6640: At              "@" at 560:5-560:6 (leading: Newline, Space)
+6641: Ident           "intrinsic" at 560:6-560:15
+6642: KwFn            "fn" at 560:16-560:18 (leading: Space)
+6643: Ident           "__abs" at 560:19-560:24 (leading: Space)
+6644: LParen          "(" at 560:24-560:25
+6645: Ident           "self" at 560:25-560:29
+6646: Colon           ":" at 560:29-560:30
+6647: Ident           "uint64" at 560:31-560:37 (leading: Space)
+6648: RParen          ")" at 560:37-560:38
+6649: Arrow           "->" at 560:39-560:41 (leading: Space)
+6650: Ident           "uint64" at 560:42-560:48 (leading: Space)
+6651: Semicolon       ";" at 560:48-560:49
+6652: At              "@" at 561:5-561:6 (leading: Newline, Space)
+6653: Ident           "intrinsic" at 561:6-561:15
+6654: KwFn            "fn" at 561:16-561:18 (leading: Space)
+6655: Ident           "__to" at 561:19-561:23 (leading: Space)
+6656: LParen          "(" at 561:23-561:24
+6657: Ident           "self" at 561:24-561:28
+6658: Colon           ":" at 561:28-561:29
+6659: Ident           "uint64" at 561:30-561:36 (leading: Space)
+6660: Comma           "," at 561:36-561:37
+6661: Ident           "target" at 561:38-561:44 (leading: Space)
+6662: Colon           ":" at 561:44-561:45
+6663: Ident           "uint" at 561:46-561:50 (leading: Space)
+6664: RParen          ")" at 561:50-561:51
+6665: Arrow           "->" at 561:52-561:54 (leading: Space)
+6666: Ident           "uint" at 561:55-561:59 (leading: Space)
+6667: Semicolon       ";" at 561:59-561:60
+6668: At              "@" at 562:5-562:6 (leading: Newline, Space)
+6669: Ident           "intrinsic" at 562:6-562:15
+6670: At              "@" at 562:16-562:17 (leading: Space)
+6671: Ident           "overload" at 562:17-562:25
+6672: KwFn            "fn" at 562:26-562:28 (leading: Space)
+6673: Ident           "__to" at 562:29-562:33 (leading: Space)
+6674: LParen          "(" at 562:33-562:34
+6675: Ident           "self" at 562:34-562:38
+6676: Colon           ":" at 562:38-562:39
+6677: Ident           "uint64" at 562:40-562:46 (leading: Space)
+6678: Comma           "," at 562:46-562:47
+6679: Ident           "target" at 562:48-562:54 (leading: Space)
+6680: Colon           ":" at 562:54-562:55
+6681: Ident           "uint8" at 562:56-562:61 (leading: Space)
+6682: RParen          ")" at 562:61-562:62
+6683: Arrow           "->" at 562:63-562:65 (leading: Space)
+6684: Ident           "uint8" at 562:66-562:71 (leading: Space)
+6685: Semicolon       ";" at 562:71-562:72
+6686: At              "@" at 563:5-563:6 (leading: Newline, Space)
+6687: Ident           "intrinsic" at 563:6-563:15
+6688: At              "@" at 563:16-563:17 (leading: Space)
+6689: Ident           "overload" at 563:17-563:25
+6690: KwFn            "fn" at 563:26-563:28 (leading: Space)
+6691: Ident           "__to" at 563:29-563:33 (leading: Space)
+6692: LParen          "(" at 563:33-563:34
+6693: Ident           "self" at 563:34-563:38
+6694: Colon           ":" at 563:38-563:39
+6695: Ident           "uint64" at 563:40-563:46 (leading: Space)
+6696: Comma           "," at 563:46-563:47
+6697: Ident           "target" at 563:48-563:54 (leading: Space)
+6698: Colon           ":" at 563:54-563:55
+6699: Ident           "uint16" at 563:56-563:62 (leading: Space)
+6700: RParen          ")" at 563:62-563:63
+6701: Arrow           "->" at 563:64-563:66 (leading: Space)
+6702: Ident           "uint16" at 563:67-563:73 (leading: Space)
+6703: Semicolon       ";" at 563:73-563:74
+6704: At              "@" at 564:5-564:6 (leading: Newline, Space)
+6705: Ident           "intrinsic" at 564:6-564:15
+6706: At              "@" at 564:16-564:17 (leading: Space)
+6707: Ident           "overload" at 564:17-564:25
+6708: KwFn            "fn" at 564:26-564:28 (leading: Space)
+6709: Ident           "__to" at 564:29-564:33 (leading: Space)
+6710: LParen          "(" at 564:33-564:34
+6711: Ident           "self" at 564:34-564:38
+6712: Colon           ":" at 564:38-564:39
+6713: Ident           "uint64" at 564:40-564:46 (leading: Space)
+6714: Comma           "," at 564:46-564:47
+6715: Ident           "target" at 564:48-564:54 (leading: Space)
+6716: Colon           ":" at 564:54-564:55
+6717: Ident           "uint32" at 564:56-564:62 (leading: Space)
+6718: RParen          ")" at 564:62-564:63
+6719: Arrow           "->" at 564:64-564:66 (leading: Space)
+6720: Ident           "uint32" at 564:67-564:73 (leading: Space)
+6721: Semicolon       ";" at 564:73-564:74
+6722: At              "@" at 565:5-565:6 (leading: Newline, Space)
+6723: Ident           "intrinsic" at 565:6-565:15
+6724: KwPub           "pub" at 565:16-565:19 (leading: Space)
+6725: KwFn            "fn" at 565:20-565:22 (leading: Space)
+6726: Ident           "from_str" at 565:23-565:31 (leading: Space)
+6727: LParen          "(" at 565:31-565:32
+6728: Ident           "s" at 565:32-565:33
+6729: Colon           ":" at 565:33-565:34
+6730: Amp             "&" at 565:35-565:36 (leading: Space)
+6731: Ident           "string" at 565:36-565:42
+6732: RParen          ")" at 565:42-565:43
+6733: Arrow           "->" at 565:44-565:46 (leading: Space)
+6734: Ident           "Erring" at 565:47-565:53 (leading: Space)
+6735: Lt              "<" at 565:53-565:54
+6736: Ident           "uint64" at 565:54-565:60
+6737: Comma           "," at 565:60-565:61
+6738: Ident           "Error" at 565:62-565:67 (leading: Space)
+6739: Gt              ">" at 565:67-565:68
+6740: Semicolon       ";" at 565:68-565:69
+6741: RBrace          "}" at 566:1-566:2 (leading: Newline)
+6742: KwExtern        "extern" at 568:1-568:7 (leading: Newline)
+6743: Lt              "<" at 568:7-568:8
+6744: Ident           "float16" at 568:8-568:15
+6745: Gt              ">" at 568:15-568:16
+6746: LBrace          "{" at 568:17-568:18 (leading: Space)
+6747: KwPub           "pub" at 569:5-569:8 (leading: Newline, Space)
+6748: KwFn            "fn" at 569:9-569:11 (leading: Space)
+6749: Ident           "__min_value" at 569:12-569:23 (leading: Space)
+6750: LParen          "(" at 569:23-569:24
+6751: RParen          ")" at 569:24-569:25
+6752: Arrow           "->" at 569:26-569:28 (leading: Space)
+6753: Ident           "float16" at 569:29-569:36 (leading: Space)
+6754: LBrace          "{" at 569:37-569:38 (leading: Space)
+6755: KwReturn        "return" at 569:39-569:45 (leading: Space)
+6756: LParen          "(" at 569:46-569:47 (leading: Space)
+6757: Minus           "-" at 569:47-569:48
+6758: FloatLit        "65504.0" at 569:48-569:55
+6759: RParen          ")" at 569:55-569:56
+6760: Colon           ":" at 569:56-569:57
+6761: Ident           "float16" at 569:57-569:64
+6762: Semicolon       ";" at 569:64-569:65
+6763: RBrace          "}" at 569:66-569:67 (leading: Space)
+6764: KwPub           "pub" at 570:5-570:8 (leading: Newline, Space)
+6765: KwFn            "fn" at 570:9-570:11 (leading: Space)
+6766: Ident           "__max_value" at 570:12-570:23 (leading: Space)
+6767: LParen          "(" at 570:23-570:24
+6768: RParen          ")" at 570:24-570:25
+6769: Arrow           "->" at 570:26-570:28 (leading: Space)
+6770: Ident           "float16" at 570:29-570:36 (leading: Space)
+6771: LBrace          "{" at 570:37-570:38 (leading: Space)
+6772: KwReturn        "return" at 570:39-570:45 (leading: Space)
+6773: LParen          "(" at 570:46-570:47 (leading: Space)
+6774: FloatLit        "65504.0" at 570:47-570:54
+6775: RParen          ")" at 570:54-570:55
+6776: Colon           ":" at 570:55-570:56
+6777: Ident           "float16" at 570:56-570:63
+6778: Semicolon       ";" at 570:63-570:64
+6779: RBrace          "}" at 570:65-570:66 (leading: Space)
+6780: At              "@" at 571:5-571:6 (leading: Newline, Space)
+6781: Ident           "intrinsic" at 571:6-571:15
+6782: KwFn            "fn" at 571:16-571:18 (leading: Space)
+6783: Ident           "__add" at 571:19-571:24 (leading: Space)
+6784: LParen          "(" at 571:24-571:25
+6785: Ident           "self" at 571:25-571:29
+6786: Colon           ":" at 571:29-571:30
+6787: Ident           "float16" at 571:31-571:38 (leading: Space)
+6788: Comma           "," at 571:38-571:39
+6789: Ident           "other" at 571:40-571:45 (leading: Space)
+6790: Colon           ":" at 571:45-571:46
+6791: Ident           "float16" at 571:47-571:54 (leading: Space)
+6792: RParen          ")" at 571:54-571:55
+6793: Arrow           "->" at 571:56-571:58 (leading: Space)
+6794: Ident           "float16" at 571:59-571:66 (leading: Space)
+6795: Semicolon       ";" at 571:66-571:67
+6796: At              "@" at 572:5-572:6 (leading: Newline, Space)
+6797: Ident           "intrinsic" at 572:6-572:15
+6798: KwFn            "fn" at 572:16-572:18 (leading: Space)
+6799: Ident           "__sub" at 572:19-572:24 (leading: Space)
+6800: LParen          "(" at 572:24-572:25
+6801: Ident           "self" at 572:25-572:29
+6802: Colon           ":" at 572:29-572:30
+6803: Ident           "float16" at 572:31-572:38 (leading: Space)
+6804: Comma           "," at 572:38-572:39
+6805: Ident           "other" at 572:40-572:45 (leading: Space)
+6806: Colon           ":" at 572:45-572:46
+6807: Ident           "float16" at 572:47-572:54 (leading: Space)
+6808: RParen          ")" at 572:54-572:55
+6809: Arrow           "->" at 572:56-572:58 (leading: Space)
+6810: Ident           "float16" at 572:59-572:66 (leading: Space)
+6811: Semicolon       ";" at 572:66-572:67
+6812: At              "@" at 573:5-573:6 (leading: Newline, Space)
+6813: Ident           "intrinsic" at 573:6-573:15
+6814: KwFn            "fn" at 573:16-573:18 (leading: Space)
+6815: Ident           "__mul" at 573:19-573:24 (leading: Space)
+6816: LParen          "(" at 573:24-573:25
+6817: Ident           "self" at 573:25-573:29
+6818: Colon           ":" at 573:29-573:30
+6819: Ident           "float16" at 573:31-573:38 (leading: Space)
+6820: Comma           "," at 573:38-573:39
+6821: Ident           "other" at 573:40-573:45 (leading: Space)
+6822: Colon           ":" at 573:45-573:46
+6823: Ident           "float16" at 573:47-573:54 (leading: Space)
+6824: RParen          ")" at 573:54-573:55
+6825: Arrow           "->" at 573:56-573:58 (leading: Space)
+6826: Ident           "float16" at 573:59-573:66 (leading: Space)
+6827: Semicolon       ";" at 573:66-573:67
+6828: At              "@" at 574:5-574:6 (leading: Newline, Space)
+6829: Ident           "intrinsic" at 574:6-574:15
+6830: KwFn            "fn" at 574:16-574:18 (leading: Space)
+6831: Ident           "__div" at 574:19-574:24 (leading: Space)
+6832: LParen          "(" at 574:24-574:25
+6833: Ident           "self" at 574:25-574:29
+6834: Colon           ":" at 574:29-574:30
+6835: Ident           "float16" at 574:31-574:38 (leading: Space)
+6836: Comma           "," at 574:38-574:39
+6837: Ident           "other" at 574:40-574:45 (leading: Space)
+6838: Colon           ":" at 574:45-574:46
+6839: Ident           "float16" at 574:47-574:54 (leading: Space)
+6840: RParen          ")" at 574:54-574:55
+6841: Arrow           "->" at 574:56-574:58 (leading: Space)
+6842: Ident           "float16" at 574:59-574:66 (leading: Space)
+6843: Semicolon       ";" at 574:66-574:67
+6844: At              "@" at 575:5-575:6 (leading: Newline, Space)
+6845: Ident           "intrinsic" at 575:6-575:15
+6846: KwFn            "fn" at 575:16-575:18 (leading: Space)
+6847: Ident           "__mod" at 575:19-575:24 (leading: Space)
+6848: LParen          "(" at 575:24-575:25
+6849: Ident           "self" at 575:25-575:29
+6850: Colon           ":" at 575:29-575:30
+6851: Ident           "float16" at 575:31-575:38 (leading: Space)
+6852: Comma           "," at 575:38-575:39
+6853: Ident           "other" at 575:40-575:45 (leading: Space)
+6854: Colon           ":" at 575:45-575:46
+6855: Ident           "float16" at 575:47-575:54 (leading: Space)
+6856: RParen          ")" at 575:54-575:55
+6857: Arrow           "->" at 575:56-575:58 (leading: Space)
+6858: Ident           "float16" at 575:59-575:66 (leading: Space)
+6859: Semicolon       ";" at 575:66-575:67
+6860: At              "@" at 576:5-576:6 (leading: Newline, Space)
+6861: Ident           "intrinsic" at 576:6-576:15
+6862: KwFn            "fn" at 576:16-576:18 (leading: Space)
+6863: Ident           "__lt" at 576:19-576:23 (leading: Space)
+6864: LParen          "(" at 576:23-576:24
+6865: Ident           "self" at 576:24-576:28
+6866: Colon           ":" at 576:28-576:29
+6867: Ident           "float16" at 576:30-576:37 (leading: Space)
+6868: Comma           "," at 576:37-576:38
+6869: Ident           "other" at 576:39-576:44 (leading: Space)
+6870: Colon           ":" at 576:44-576:45
+6871: Ident           "float16" at 576:46-576:53 (leading: Space)
+6872: RParen          ")" at 576:53-576:54
+6873: Arrow           "->" at 576:55-576:57 (leading: Space)
+6874: Ident           "bool" at 576:58-576:62 (leading: Space)
+6875: Semicolon       ";" at 576:62-576:63
+6876: At              "@" at 577:5-577:6 (leading: Newline, Space)
+6877: Ident           "intrinsic" at 577:6-577:15
+6878: KwFn            "fn" at 577:16-577:18 (leading: Space)
+6879: Ident           "__le" at 577:19-577:23 (leading: Space)
+6880: LParen          "(" at 577:23-577:24
+6881: Ident           "self" at 577:24-577:28
+6882: Colon           ":" at 577:28-577:29
+6883: Ident           "float16" at 577:30-577:37 (leading: Space)
+6884: Comma           "," at 577:37-577:38
+6885: Ident           "other" at 577:39-577:44 (leading: Space)
+6886: Colon           ":" at 577:44-577:45
+6887: Ident           "float16" at 577:46-577:53 (leading: Space)
+6888: RParen          ")" at 577:53-577:54
+6889: Arrow           "->" at 577:55-577:57 (leading: Space)
+6890: Ident           "bool" at 577:58-577:62 (leading: Space)
+6891: Semicolon       ";" at 577:62-577:63
+6892: At              "@" at 578:5-578:6 (leading: Newline, Space)
+6893: Ident           "intrinsic" at 578:6-578:15
+6894: KwFn            "fn" at 578:16-578:18 (leading: Space)
+6895: Ident           "__eq" at 578:19-578:23 (leading: Space)
+6896: LParen          "(" at 578:23-578:24
+6897: Ident           "self" at 578:24-578:28
+6898: Colon           ":" at 578:28-578:29
+6899: Ident           "float16" at 578:30-578:37 (leading: Space)
+6900: Comma           "," at 578:37-578:38
+6901: Ident           "other" at 578:39-578:44 (leading: Space)
+6902: Colon           ":" at 578:44-578:45
+6903: Ident           "float16" at 578:46-578:53 (leading: Space)
+6904: RParen          ")" at 578:53-578:54
+6905: Arrow           "->" at 578:55-578:57 (leading: Space)
+6906: Ident           "bool" at 578:58-578:62 (leading: Space)
+6907: Semicolon       ";" at 578:62-578:63
+6908: At              "@" at 579:5-579:6 (leading: Newline, Space)
+6909: Ident           "intrinsic" at 579:6-579:15
+6910: KwFn            "fn" at 579:16-579:18 (leading: Space)
+6911: Ident           "__ne" at 579:19-579:23 (leading: Space)
+6912: LParen          "(" at 579:23-579:24
+6913: Ident           "self" at 579:24-579:28
+6914: Colon           ":" at 579:28-579:29
+6915: Ident           "float16" at 579:30-579:37 (leading: Space)
+6916: Comma           "," at 579:37-579:38
+6917: Ident           "other" at 579:39-579:44 (leading: Space)
+6918: Colon           ":" at 579:44-579:45
+6919: Ident           "float16" at 579:46-579:53 (leading: Space)
+6920: RParen          ")" at 579:53-579:54
+6921: Arrow           "->" at 579:55-579:57 (leading: Space)
+6922: Ident           "bool" at 579:58-579:62 (leading: Space)
+6923: Semicolon       ";" at 579:62-579:63
+6924: At              "@" at 580:5-580:6 (leading: Newline, Space)
+6925: Ident           "intrinsic" at 580:6-580:15
+6926: KwFn            "fn" at 580:16-580:18 (leading: Space)
+6927: Ident           "__ge" at 580:19-580:23 (leading: Space)
+6928: LParen          "(" at 580:23-580:24
+6929: Ident           "self" at 580:24-580:28
+6930: Colon           ":" at 580:28-580:29
+6931: Ident           "float16" at 580:30-580:37 (leading: Space)
+6932: Comma           "," at 580:37-580:38
+6933: Ident           "other" at 580:39-580:44 (leading: Space)
+6934: Colon           ":" at 580:44-580:45
+6935: Ident           "float16" at 580:46-580:53 (leading: Space)
+6936: RParen          ")" at 580:53-580:54
+6937: Arrow           "->" at 580:55-580:57 (leading: Space)
+6938: Ident           "bool" at 580:58-580:62 (leading: Space)
+6939: Semicolon       ";" at 580:62-580:63
+6940: At              "@" at 581:5-581:6 (leading: Newline, Space)
+6941: Ident           "intrinsic" at 581:6-581:15
+6942: KwFn            "fn" at 581:16-581:18 (leading: Space)
+6943: Ident           "__gt" at 581:19-581:23 (leading: Space)
+6944: LParen          "(" at 581:23-581:24
+6945: Ident           "self" at 581:24-581:28
+6946: Colon           ":" at 581:28-581:29
+6947: Ident           "float16" at 581:30-581:37 (leading: Space)
+6948: Comma           "," at 581:37-581:38
+6949: Ident           "other" at 581:39-581:44 (leading: Space)
+6950: Colon           ":" at 581:44-581:45
+6951: Ident           "float16" at 581:46-581:53 (leading: Space)
+6952: RParen          ")" at 581:53-581:54
+6953: Arrow           "->" at 581:55-581:57 (leading: Space)
+6954: Ident           "bool" at 581:58-581:62 (leading: Space)
+6955: Semicolon       ";" at 581:62-581:63
+6956: At              "@" at 582:5-582:6 (leading: Newline, Space)
+6957: Ident           "intrinsic" at 582:6-582:15
+6958: KwFn            "fn" at 582:16-582:18 (leading: Space)
+6959: Ident           "__pos" at 582:19-582:24 (leading: Space)
+6960: LParen          "(" at 582:24-582:25
+6961: Ident           "self" at 582:25-582:29
+6962: Colon           ":" at 582:29-582:30
+6963: Ident           "float16" at 582:31-582:38 (leading: Space)
+6964: RParen          ")" at 582:38-582:39
+6965: Arrow           "->" at 582:40-582:42 (leading: Space)
+6966: Ident           "float16" at 582:43-582:50 (leading: Space)
+6967: Semicolon       ";" at 582:50-582:51
+6968: At              "@" at 583:5-583:6 (leading: Newline, Space)
+6969: Ident           "intrinsic" at 583:6-583:15
+6970: KwFn            "fn" at 583:16-583:18 (leading: Space)
+6971: Ident           "__neg" at 583:19-583:24 (leading: Space)
+6972: LParen          "(" at 583:24-583:25
+6973: Ident           "self" at 583:25-583:29
+6974: Colon           ":" at 583:29-583:30
+6975: Ident           "float16" at 583:31-583:38 (leading: Space)
+6976: RParen          ")" at 583:38-583:39
+6977: Arrow           "->" at 583:40-583:42 (leading: Space)
+6978: Ident           "float16" at 583:43-583:50 (leading: Space)
+6979: Semicolon       ";" at 583:50-583:51
+6980: At              "@" at 584:5-584:6 (leading: Newline, Space)
+6981: Ident           "intrinsic" at 584:6-584:15
+6982: KwFn            "fn" at 584:16-584:18 (leading: Space)
+6983: Ident           "__abs" at 584:19-584:24 (leading: Space)
+6984: LParen          "(" at 584:24-584:25
+6985: Ident           "self" at 584:25-584:29
+6986: Colon           ":" at 584:29-584:30
+6987: Ident           "float16" at 584:31-584:38 (leading: Space)
+6988: RParen          ")" at 584:38-584:39
+6989: Arrow           "->" at 584:40-584:42 (leading: Space)
+6990: Ident           "float16" at 584:43-584:50 (leading: Space)
+6991: Semicolon       ";" at 584:50-584:51
+6992: At              "@" at 585:5-585:6 (leading: Newline, Space)
+6993: Ident           "intrinsic" at 585:6-585:15
+6994: KwFn            "fn" at 585:16-585:18 (leading: Space)
+6995: Ident           "__to" at 585:19-585:23 (leading: Space)
+6996: LParen          "(" at 585:23-585:24
+6997: Ident           "self" at 585:24-585:28
+6998: Colon           ":" at 585:28-585:29
+6999: Ident           "float16" at 585:30-585:37 (leading: Space)
+7000: Comma           "," at 585:37-585:38
+7001: Ident           "target" at 585:39-585:45 (leading: Space)
+7002: Colon           ":" at 585:45-585:46
+7003: Ident           "float" at 585:47-585:52 (leading: Space)
+7004: RParen          ")" at 585:52-585:53
+7005: Arrow           "->" at 585:54-585:56 (leading: Space)
+7006: Ident           "float" at 585:57-585:62 (leading: Space)
+7007: Semicolon       ";" at 585:62-585:63
+7008: At              "@" at 586:5-586:6 (leading: Newline, Space)
+7009: Ident           "intrinsic" at 586:6-586:15
+7010: At              "@" at 586:16-586:17 (leading: Space)
+7011: Ident           "overload" at 586:17-586:25
+7012: KwFn            "fn" at 586:26-586:28 (leading: Space)
+7013: Ident           "__to" at 586:29-586:33 (leading: Space)
+7014: LParen          "(" at 586:33-586:34
+7015: Ident           "self" at 586:34-586:38
+7016: Colon           ":" at 586:38-586:39
+7017: Ident           "float16" at 586:40-586:47 (leading: Space)
+7018: Comma           "," at 586:47-586:48
+7019: Ident           "target" at 586:49-586:55 (leading: Space)
+7020: Colon           ":" at 586:55-586:56
+7021: Ident           "float32" at 586:57-586:64 (leading: Space)
+7022: RParen          ")" at 586:64-586:65
+7023: Arrow           "->" at 586:66-586:68 (leading: Space)
+7024: Ident           "float32" at 586:69-586:76 (leading: Space)
+7025: Semicolon       ";" at 586:76-586:77
+7026: At              "@" at 587:5-587:6 (leading: Newline, Space)
+7027: Ident           "intrinsic" at 587:6-587:15
+7028: At              "@" at 587:16-587:17 (leading: Space)
+7029: Ident           "overload" at 587:17-587:25
+7030: KwFn            "fn" at 587:26-587:28 (leading: Space)
+7031: Ident           "__to" at 587:29-587:33 (leading: Space)
+7032: LParen          "(" at 587:33-587:34
+7033: Ident           "self" at 587:34-587:38
+7034: Colon           ":" at 587:38-587:39
+7035: Ident           "float16" at 587:40-587:47 (leading: Space)
+7036: Comma           "," at 587:47-587:48
+7037: Ident           "target" at 587:49-587:55 (leading: Space)
+7038: Colon           ":" at 587:55-587:56
+7039: Ident           "float64" at 587:57-587:64 (leading: Space)
+7040: RParen          ")" at 587:64-587:65
+7041: Arrow           "->" at 587:66-587:68 (leading: Space)
+7042: Ident           "float64" at 587:69-587:76 (leading: Space)
+7043: Semicolon       ";" at 587:76-587:77
+7044: At              "@" at 588:5-588:6 (leading: Newline, Space)
+7045: Ident           "intrinsic" at 588:6-588:15
+7046: KwPub           "pub" at 588:16-588:19 (leading: Space)
+7047: KwFn            "fn" at 588:20-588:22 (leading: Space)
+7048: Ident           "from_str" at 588:23-588:31 (leading: Space)
+7049: LParen          "(" at 588:31-588:32
+7050: Ident           "s" at 588:32-588:33
+7051: Colon           ":" at 588:33-588:34
+7052: Amp             "&" at 588:35-588:36 (leading: Space)
+7053: Ident           "string" at 588:36-588:42
+7054: RParen          ")" at 588:42-588:43
+7055: Arrow           "->" at 588:44-588:46 (leading: Space)
+7056: Ident           "Erring" at 588:47-588:53 (leading: Space)
+7057: Lt              "<" at 588:53-588:54
+7058: Ident           "float16" at 588:54-588:61
+7059: Comma           "," at 588:61-588:62
+7060: Ident           "Error" at 588:63-588:68 (leading: Space)
+7061: Gt              ">" at 588:68-588:69
+7062: Semicolon       ";" at 588:69-588:70
+7063: RBrace          "}" at 589:1-589:2 (leading: Newline)
+7064: KwExtern        "extern" at 591:1-591:7 (leading: Newline)
+7065: Lt              "<" at 591:7-591:8
+7066: Ident           "float32" at 591:8-591:15
+7067: Gt              ">" at 591:15-591:16
+7068: LBrace          "{" at 591:17-591:18 (leading: Space)
+7069: KwPub           "pub" at 592:5-592:8 (leading: Newline, Space)
+7070: KwFn            "fn" at 592:9-592:11 (leading: Space)
+7071: Ident           "__min_value" at 592:12-592:23 (leading: Space)
+7072: LParen          "(" at 592:23-592:24
+7073: RParen          ")" at 592:24-592:25
+7074: Arrow           "->" at 592:26-592:28 (leading: Space)
+7075: Ident           "float32" at 592:29-592:36 (leading: Space)
+7076: LBrace          "{" at 592:37-592:38 (leading: Space)
+7077: KwReturn        "return" at 592:39-592:45 (leading: Space)
+7078: LParen          "(" at 592:46-592:47 (leading: Space)
+7079: Minus           "-" at 592:47-592:48
+7080: FloatLit        "3.402_823_466_385_2886e+38" at 592:48-592:74
+7081: RParen          ")" at 592:74-592:75
+7082: Colon           ":" at 592:75-592:76
+7083: Ident           "float32" at 592:76-592:83
+7084: Semicolon       ";" at 592:83-592:84
+7085: RBrace          "}" at 592:85-592:86 (leading: Space)
+7086: KwPub           "pub" at 593:5-593:8 (leading: Newline, Space)
+7087: KwFn            "fn" at 593:9-593:11 (leading: Space)
+7088: Ident           "__max_value" at 593:12-593:23 (leading: Space)
+7089: LParen          "(" at 593:23-593:24
+7090: RParen          ")" at 593:24-593:25
+7091: Arrow           "->" at 593:26-593:28 (leading: Space)
+7092: Ident           "float32" at 593:29-593:36 (leading: Space)
+7093: LBrace          "{" at 593:37-593:38 (leading: Space)
+7094: KwReturn        "return" at 593:39-593:45 (leading: Space)
+7095: LParen          "(" at 593:46-593:47 (leading: Space)
+7096: FloatLit        "3.402_823_466_385_2886e+38" at 593:47-593:73
+7097: RParen          ")" at 593:73-593:74
+7098: Colon           ":" at 593:74-593:75
+7099: Ident           "float32" at 593:75-593:82
+7100: Semicolon       ";" at 593:82-593:83
+7101: RBrace          "}" at 593:84-593:85 (leading: Space)
+7102: At              "@" at 594:5-594:6 (leading: Newline, Space)
+7103: Ident           "intrinsic" at 594:6-594:15
+7104: KwFn            "fn" at 594:16-594:18 (leading: Space)
+7105: Ident           "__add" at 594:19-594:24 (leading: Space)
+7106: LParen          "(" at 594:24-594:25
+7107: Ident           "self" at 594:25-594:29
+7108: Colon           ":" at 594:29-594:30
+7109: Ident           "float32" at 594:31-594:38 (leading: Space)
+7110: Comma           "," at 594:38-594:39
+7111: Ident           "other" at 594:40-594:45 (leading: Space)
+7112: Colon           ":" at 594:45-594:46
+7113: Ident           "float32" at 594:47-594:54 (leading: Space)
+7114: RParen          ")" at 594:54-594:55
+7115: Arrow           "->" at 594:56-594:58 (leading: Space)
+7116: Ident           "float32" at 594:59-594:66 (leading: Space)
+7117: Semicolon       ";" at 594:66-594:67
+7118: At              "@" at 595:5-595:6 (leading: Newline, Space)
+7119: Ident           "intrinsic" at 595:6-595:15
+7120: KwFn            "fn" at 595:16-595:18 (leading: Space)
+7121: Ident           "__sub" at 595:19-595:24 (leading: Space)
+7122: LParen          "(" at 595:24-595:25
+7123: Ident           "self" at 595:25-595:29
+7124: Colon           ":" at 595:29-595:30
+7125: Ident           "float32" at 595:31-595:38 (leading: Space)
+7126: Comma           "," at 595:38-595:39
+7127: Ident           "other" at 595:40-595:45 (leading: Space)
+7128: Colon           ":" at 595:45-595:46
+7129: Ident           "float32" at 595:47-595:54 (leading: Space)
+7130: RParen          ")" at 595:54-595:55
+7131: Arrow           "->" at 595:56-595:58 (leading: Space)
+7132: Ident           "float32" at 595:59-595:66 (leading: Space)
+7133: Semicolon       ";" at 595:66-595:67
+7134: At              "@" at 596:5-596:6 (leading: Newline, Space)
+7135: Ident           "intrinsic" at 596:6-596:15
+7136: KwFn            "fn" at 596:16-596:18 (leading: Space)
+7137: Ident           "__mul" at 596:19-596:24 (leading: Space)
+7138: LParen          "(" at 596:24-596:25
+7139: Ident           "self" at 596:25-596:29
+7140: Colon           ":" at 596:29-596:30
+7141: Ident           "float32" at 596:31-596:38 (leading: Space)
+7142: Comma           "," at 596:38-596:39
+7143: Ident           "other" at 596:40-596:45 (leading: Space)
+7144: Colon           ":" at 596:45-596:46
+7145: Ident           "float32" at 596:47-596:54 (leading: Space)
+7146: RParen          ")" at 596:54-596:55
+7147: Arrow           "->" at 596:56-596:58 (leading: Space)
+7148: Ident           "float32" at 596:59-596:66 (leading: Space)
+7149: Semicolon       ";" at 596:66-596:67
+7150: At              "@" at 597:5-597:6 (leading: Newline, Space)
+7151: Ident           "intrinsic" at 597:6-597:15
+7152: KwFn            "fn" at 597:16-597:18 (leading: Space)
+7153: Ident           "__div" at 597:19-597:24 (leading: Space)
+7154: LParen          "(" at 597:24-597:25
+7155: Ident           "self" at 597:25-597:29
+7156: Colon           ":" at 597:29-597:30
+7157: Ident           "float32" at 597:31-597:38 (leading: Space)
+7158: Comma           "," at 597:38-597:39
+7159: Ident           "other" at 597:40-597:45 (leading: Space)
+7160: Colon           ":" at 597:45-597:46
+7161: Ident           "float32" at 597:47-597:54 (leading: Space)
+7162: RParen          ")" at 597:54-597:55
+7163: Arrow           "->" at 597:56-597:58 (leading: Space)
+7164: Ident           "float32" at 597:59-597:66 (leading: Space)
+7165: Semicolon       ";" at 597:66-597:67
+7166: At              "@" at 598:5-598:6 (leading: Newline, Space)
+7167: Ident           "intrinsic" at 598:6-598:15
+7168: KwFn            "fn" at 598:16-598:18 (leading: Space)
+7169: Ident           "__mod" at 598:19-598:24 (leading: Space)
+7170: LParen          "(" at 598:24-598:25
+7171: Ident           "self" at 598:25-598:29
+7172: Colon           ":" at 598:29-598:30
+7173: Ident           "float32" at 598:31-598:38 (leading: Space)
+7174: Comma           "," at 598:38-598:39
+7175: Ident           "other" at 598:40-598:45 (leading: Space)
+7176: Colon           ":" at 598:45-598:46
+7177: Ident           "float32" at 598:47-598:54 (leading: Space)
+7178: RParen          ")" at 598:54-598:55
+7179: Arrow           "->" at 598:56-598:58 (leading: Space)
+7180: Ident           "float32" at 598:59-598:66 (leading: Space)
+7181: Semicolon       ";" at 598:66-598:67
+7182: At              "@" at 599:5-599:6 (leading: Newline, Space)
+7183: Ident           "intrinsic" at 599:6-599:15
+7184: KwFn            "fn" at 599:16-599:18 (leading: Space)
+7185: Ident           "__lt" at 599:19-599:23 (leading: Space)
+7186: LParen          "(" at 599:23-599:24
+7187: Ident           "self" at 599:24-599:28
+7188: Colon           ":" at 599:28-599:29
+7189: Ident           "float32" at 599:30-599:37 (leading: Space)
+7190: Comma           "," at 599:37-599:38
+7191: Ident           "other" at 599:39-599:44 (leading: Space)
+7192: Colon           ":" at 599:44-599:45
+7193: Ident           "float32" at 599:46-599:53 (leading: Space)
+7194: RParen          ")" at 599:53-599:54
+7195: Arrow           "->" at 599:55-599:57 (leading: Space)
+7196: Ident           "bool" at 599:58-599:62 (leading: Space)
+7197: Semicolon       ";" at 599:62-599:63
+7198: At              "@" at 600:5-600:6 (leading: Newline, Space)
+7199: Ident           "intrinsic" at 600:6-600:15
+7200: KwFn            "fn" at 600:16-600:18 (leading: Space)
+7201: Ident           "__le" at 600:19-600:23 (leading: Space)
+7202: LParen          "(" at 600:23-600:24
+7203: Ident           "self" at 600:24-600:28
+7204: Colon           ":" at 600:28-600:29
+7205: Ident           "float32" at 600:30-600:37 (leading: Space)
+7206: Comma           "," at 600:37-600:38
+7207: Ident           "other" at 600:39-600:44 (leading: Space)
+7208: Colon           ":" at 600:44-600:45
+7209: Ident           "float32" at 600:46-600:53 (leading: Space)
+7210: RParen          ")" at 600:53-600:54
+7211: Arrow           "->" at 600:55-600:57 (leading: Space)
+7212: Ident           "bool" at 600:58-600:62 (leading: Space)
+7213: Semicolon       ";" at 600:62-600:63
+7214: At              "@" at 601:5-601:6 (leading: Newline, Space)
+7215: Ident           "intrinsic" at 601:6-601:15
+7216: KwFn            "fn" at 601:16-601:18 (leading: Space)
+7217: Ident           "__eq" at 601:19-601:23 (leading: Space)
+7218: LParen          "(" at 601:23-601:24
+7219: Ident           "self" at 601:24-601:28
+7220: Colon           ":" at 601:28-601:29
+7221: Ident           "float32" at 601:30-601:37 (leading: Space)
+7222: Comma           "," at 601:37-601:38
+7223: Ident           "other" at 601:39-601:44 (leading: Space)
+7224: Colon           ":" at 601:44-601:45
+7225: Ident           "float32" at 601:46-601:53 (leading: Space)
+7226: RParen          ")" at 601:53-601:54
+7227: Arrow           "->" at 601:55-601:57 (leading: Space)
+7228: Ident           "bool" at 601:58-601:62 (leading: Space)
+7229: Semicolon       ";" at 601:62-601:63
+7230: At              "@" at 602:5-602:6 (leading: Newline, Space)
+7231: Ident           "intrinsic" at 602:6-602:15
+7232: KwFn            "fn" at 602:16-602:18 (leading: Space)
+7233: Ident           "__ne" at 602:19-602:23 (leading: Space)
+7234: LParen          "(" at 602:23-602:24
+7235: Ident           "self" at 602:24-602:28
+7236: Colon           ":" at 602:28-602:29
+7237: Ident           "float32" at 602:30-602:37 (leading: Space)
+7238: Comma           "," at 602:37-602:38
+7239: Ident           "other" at 602:39-602:44 (leading: Space)
+7240: Colon           ":" at 602:44-602:45
+7241: Ident           "float32" at 602:46-602:53 (leading: Space)
+7242: RParen          ")" at 602:53-602:54
+7243: Arrow           "->" at 602:55-602:57 (leading: Space)
+7244: Ident           "bool" at 602:58-602:62 (leading: Space)
+7245: Semicolon       ";" at 602:62-602:63
+7246: At              "@" at 603:5-603:6 (leading: Newline, Space)
+7247: Ident           "intrinsic" at 603:6-603:15
+7248: KwFn            "fn" at 603:16-603:18 (leading: Space)
+7249: Ident           "__ge" at 603:19-603:23 (leading: Space)
+7250: LParen          "(" at 603:23-603:24
+7251: Ident           "self" at 603:24-603:28
+7252: Colon           ":" at 603:28-603:29
+7253: Ident           "float32" at 603:30-603:37 (leading: Space)
+7254: Comma           "," at 603:37-603:38
+7255: Ident           "other" at 603:39-603:44 (leading: Space)
+7256: Colon           ":" at 603:44-603:45
+7257: Ident           "float32" at 603:46-603:53 (leading: Space)
+7258: RParen          ")" at 603:53-603:54
+7259: Arrow           "->" at 603:55-603:57 (leading: Space)
+7260: Ident           "bool" at 603:58-603:62 (leading: Space)
+7261: Semicolon       ";" at 603:62-603:63
+7262: At              "@" at 604:5-604:6 (leading: Newline, Space)
+7263: Ident           "intrinsic" at 604:6-604:15
+7264: KwFn            "fn" at 604:16-604:18 (leading: Space)
+7265: Ident           "__gt" at 604:19-604:23 (leading: Space)
+7266: LParen          "(" at 604:23-604:24
+7267: Ident           "self" at 604:24-604:28
+7268: Colon           ":" at 604:28-604:29
+7269: Ident           "float32" at 604:30-604:37 (leading: Space)
+7270: Comma           "," at 604:37-604:38
+7271: Ident           "other" at 604:39-604:44 (leading: Space)
+7272: Colon           ":" at 604:44-604:45
+7273: Ident           "float32" at 604:46-604:53 (leading: Space)
+7274: RParen          ")" at 604:53-604:54
+7275: Arrow           "->" at 604:55-604:57 (leading: Space)
+7276: Ident           "bool" at 604:58-604:62 (leading: Space)
+7277: Semicolon       ";" at 604:62-604:63
+7278: At              "@" at 605:5-605:6 (leading: Newline, Space)
+7279: Ident           "intrinsic" at 605:6-605:15
+7280: KwFn            "fn" at 605:16-605:18 (leading: Space)
+7281: Ident           "__pos" at 605:19-605:24 (leading: Space)
+7282: LParen          "(" at 605:24-605:25
+7283: Ident           "self" at 605:25-605:29
+7284: Colon           ":" at 605:29-605:30
+7285: Ident           "float32" at 605:31-605:38 (leading: Space)
+7286: RParen          ")" at 605:38-605:39
+7287: Arrow           "->" at 605:40-605:42 (leading: Space)
+7288: Ident           "float32" at 605:43-605:50 (leading: Space)
+7289: Semicolon       ";" at 605:50-605:51
+7290: At              "@" at 606:5-606:6 (leading: Newline, Space)
+7291: Ident           "intrinsic" at 606:6-606:15
+7292: KwFn            "fn" at 606:16-606:18 (leading: Space)
+7293: Ident           "__neg" at 606:19-606:24 (leading: Space)
+7294: LParen          "(" at 606:24-606:25
+7295: Ident           "self" at 606:25-606:29
+7296: Colon           ":" at 606:29-606:30
+7297: Ident           "float32" at 606:31-606:38 (leading: Space)
+7298: RParen          ")" at 606:38-606:39
+7299: Arrow           "->" at 606:40-606:42 (leading: Space)
+7300: Ident           "float32" at 606:43-606:50 (leading: Space)
+7301: Semicolon       ";" at 606:50-606:51
+7302: At              "@" at 607:5-607:6 (leading: Newline, Space)
+7303: Ident           "intrinsic" at 607:6-607:15
+7304: KwFn            "fn" at 607:16-607:18 (leading: Space)
+7305: Ident           "__abs" at 607:19-607:24 (leading: Space)
+7306: LParen          "(" at 607:24-607:25
+7307: Ident           "self" at 607:25-607:29
+7308: Colon           ":" at 607:29-607:30
+7309: Ident           "float32" at 607:31-607:38 (leading: Space)
+7310: RParen          ")" at 607:38-607:39
+7311: Arrow           "->" at 607:40-607:42 (leading: Space)
+7312: Ident           "float32" at 607:43-607:50 (leading: Space)
+7313: Semicolon       ";" at 607:50-607:51
+7314: At              "@" at 608:5-608:6 (leading: Newline, Space)
+7315: Ident           "intrinsic" at 608:6-608:15
+7316: KwFn            "fn" at 608:16-608:18 (leading: Space)
+7317: Ident           "__to" at 608:19-608:23 (leading: Space)
+7318: LParen          "(" at 608:23-608:24
+7319: Ident           "self" at 608:24-608:28
+7320: Colon           ":" at 608:28-608:29
+7321: Ident           "float32" at 608:30-608:37 (leading: Space)
+7322: Comma           "," at 608:37-608:38
+7323: Ident           "target" at 608:39-608:45 (leading: Space)
+7324: Colon           ":" at 608:45-608:46
+7325: Ident           "float" at 608:47-608:52 (leading: Space)
+7326: RParen          ")" at 608:52-608:53
+7327: Arrow           "->" at 608:54-608:56 (leading: Space)
+7328: Ident           "float" at 608:57-608:62 (leading: Space)
+7329: Semicolon       ";" at 608:62-608:63
+7330: At              "@" at 609:5-609:6 (leading: Newline, Space)
+7331: Ident           "intrinsic" at 609:6-609:15
+7332: At              "@" at 609:16-609:17 (leading: Space)
+7333: Ident           "overload" at 609:17-609:25
+7334: KwFn            "fn" at 609:26-609:28 (leading: Space)
+7335: Ident           "__to" at 609:29-609:33 (leading: Space)
+7336: LParen          "(" at 609:33-609:34
+7337: Ident           "self" at 609:34-609:38
+7338: Colon           ":" at 609:38-609:39
+7339: Ident           "float32" at 609:40-609:47 (leading: Space)
+7340: Comma           "," at 609:47-609:48
+7341: Ident           "target" at 609:49-609:55 (leading: Space)
+7342: Colon           ":" at 609:55-609:56
+7343: Ident           "float16" at 609:57-609:64 (leading: Space)
+7344: RParen          ")" at 609:64-609:65
+7345: Arrow           "->" at 609:66-609:68 (leading: Space)
+7346: Ident           "float16" at 609:69-609:76 (leading: Space)
+7347: Semicolon       ";" at 609:76-609:77
+7348: At              "@" at 610:5-610:6 (leading: Newline, Space)
+7349: Ident           "intrinsic" at 610:6-610:15
+7350: At              "@" at 610:16-610:17 (leading: Space)
+7351: Ident           "overload" at 610:17-610:25
+7352: KwFn            "fn" at 610:26-610:28 (leading: Space)
+7353: Ident           "__to" at 610:29-610:33 (leading: Space)
+7354: LParen          "(" at 610:33-610:34
+7355: Ident           "self" at 610:34-610:38
+7356: Colon           ":" at 610:38-610:39
+7357: Ident           "float32" at 610:40-610:47 (leading: Space)
+7358: Comma           "," at 610:47-610:48
+7359: Ident           "target" at 610:49-610:55 (leading: Space)
+7360: Colon           ":" at 610:55-610:56
+7361: Ident           "float64" at 610:57-610:64 (leading: Space)
+7362: RParen          ")" at 610:64-610:65
+7363: Arrow           "->" at 610:66-610:68 (leading: Space)
+7364: Ident           "float64" at 610:69-610:76 (leading: Space)
+7365: Semicolon       ";" at 610:76-610:77
+7366: At              "@" at 611:5-611:6 (leading: Newline, Space)
+7367: Ident           "intrinsic" at 611:6-611:15
+7368: KwPub           "pub" at 611:16-611:19 (leading: Space)
+7369: KwFn            "fn" at 611:20-611:22 (leading: Space)
+7370: Ident           "from_str" at 611:23-611:31 (leading: Space)
+7371: LParen          "(" at 611:31-611:32
+7372: Ident           "s" at 611:32-611:33
+7373: Colon           ":" at 611:33-611:34
+7374: Amp             "&" at 611:35-611:36 (leading: Space)
+7375: Ident           "string" at 611:36-611:42
+7376: RParen          ")" at 611:42-611:43
+7377: Arrow           "->" at 611:44-611:46 (leading: Space)
+7378: Ident           "Erring" at 611:47-611:53 (leading: Space)
+7379: Lt              "<" at 611:53-611:54
+7380: Ident           "float32" at 611:54-611:61
+7381: Comma           "," at 611:61-611:62
+7382: Ident           "Error" at 611:63-611:68 (leading: Space)
+7383: Gt              ">" at 611:68-611:69
+7384: Semicolon       ";" at 611:69-611:70
+7385: RBrace          "}" at 612:1-612:2 (leading: Newline)
+7386: KwExtern        "extern" at 614:1-614:7 (leading: Newline)
+7387: Lt              "<" at 614:7-614:8
+7388: Ident           "float64" at 614:8-614:15
+7389: Gt              ">" at 614:15-614:16
+7390: LBrace          "{" at 614:17-614:18 (leading: Space)
+7391: KwPub           "pub" at 615:5-615:8 (leading: Newline, Space)
+7392: KwFn            "fn" at 615:9-615:11 (leading: Space)
+7393: Ident           "__min_value" at 615:12-615:23 (leading: Space)
+7394: LParen          "(" at 615:23-615:24
+7395: RParen          ")" at 615:24-615:25
+7396: Arrow           "->" at 615:26-615:28 (leading: Space)
+7397: Ident           "float64" at 615:29-615:36 (leading: Space)
+7398: LBrace          "{" at 615:37-615:38 (leading: Space)
+7399: KwReturn        "return" at 615:39-615:45 (leading: Space)
+7400: LParen          "(" at 615:46-615:47 (leading: Space)
+7401: Minus           "-" at 615:47-615:48
+7402: FloatLit        "1.797_693_134_862_3157e+308" at 615:48-615:75
+7403: RParen          ")" at 615:75-615:76
+7404: Colon           ":" at 615:76-615:77
+7405: Ident           "float64" at 615:77-615:84
+7406: Semicolon       ";" at 615:84-615:85
+7407: RBrace          "}" at 615:86-615:87 (leading: Space)
+7408: KwPub           "pub" at 616:5-616:8 (leading: Newline, Space)
+7409: KwFn            "fn" at 616:9-616:11 (leading: Space)
+7410: Ident           "__max_value" at 616:12-616:23 (leading: Space)
+7411: LParen          "(" at 616:23-616:24
+7412: RParen          ")" at 616:24-616:25
+7413: Arrow           "->" at 616:26-616:28 (leading: Space)
+7414: Ident           "float64" at 616:29-616:36 (leading: Space)
+7415: LBrace          "{" at 616:37-616:38 (leading: Space)
+7416: KwReturn        "return" at 616:39-616:45 (leading: Space)
+7417: LParen          "(" at 616:46-616:47 (leading: Space)
+7418: FloatLit        "1.797_693_134_862_3157e+308" at 616:47-616:74
+7419: RParen          ")" at 616:74-616:75
+7420: Colon           ":" at 616:75-616:76
+7421: Ident           "float64" at 616:76-616:83
+7422: Semicolon       ";" at 616:83-616:84
+7423: RBrace          "}" at 616:85-616:86 (leading: Space)
+7424: At              "@" at 617:5-617:6 (leading: Newline, Space)
+7425: Ident           "intrinsic" at 617:6-617:15
+7426: KwFn            "fn" at 617:16-617:18 (leading: Space)
+7427: Ident           "__add" at 617:19-617:24 (leading: Space)
+7428: LParen          "(" at 617:24-617:25
+7429: Ident           "self" at 617:25-617:29
+7430: Colon           ":" at 617:29-617:30
+7431: Ident           "float64" at 617:31-617:38 (leading: Space)
+7432: Comma           "," at 617:38-617:39
+7433: Ident           "other" at 617:40-617:45 (leading: Space)
+7434: Colon           ":" at 617:45-617:46
+7435: Ident           "float64" at 617:47-617:54 (leading: Space)
+7436: RParen          ")" at 617:54-617:55
+7437: Arrow           "->" at 617:56-617:58 (leading: Space)
+7438: Ident           "float64" at 617:59-617:66 (leading: Space)
+7439: Semicolon       ";" at 617:66-617:67
+7440: At              "@" at 618:5-618:6 (leading: Newline, Space)
+7441: Ident           "intrinsic" at 618:6-618:15
+7442: KwFn            "fn" at 618:16-618:18 (leading: Space)
+7443: Ident           "__sub" at 618:19-618:24 (leading: Space)
+7444: LParen          "(" at 618:24-618:25
+7445: Ident           "self" at 618:25-618:29
+7446: Colon           ":" at 618:29-618:30
+7447: Ident           "float64" at 618:31-618:38 (leading: Space)
+7448: Comma           "," at 618:38-618:39
+7449: Ident           "other" at 618:40-618:45 (leading: Space)
+7450: Colon           ":" at 618:45-618:46
+7451: Ident           "float64" at 618:47-618:54 (leading: Space)
+7452: RParen          ")" at 618:54-618:55
+7453: Arrow           "->" at 618:56-618:58 (leading: Space)
+7454: Ident           "float64" at 618:59-618:66 (leading: Space)
+7455: Semicolon       ";" at 618:66-618:67
+7456: At              "@" at 619:5-619:6 (leading: Newline, Space)
+7457: Ident           "intrinsic" at 619:6-619:15
+7458: KwFn            "fn" at 619:16-619:18 (leading: Space)
+7459: Ident           "__mul" at 619:19-619:24 (leading: Space)
+7460: LParen          "(" at 619:24-619:25
+7461: Ident           "self" at 619:25-619:29
+7462: Colon           ":" at 619:29-619:30
+7463: Ident           "float64" at 619:31-619:38 (leading: Space)
+7464: Comma           "," at 619:38-619:39
+7465: Ident           "other" at 619:40-619:45 (leading: Space)
+7466: Colon           ":" at 619:45-619:46
+7467: Ident           "float64" at 619:47-619:54 (leading: Space)
+7468: RParen          ")" at 619:54-619:55
+7469: Arrow           "->" at 619:56-619:58 (leading: Space)
+7470: Ident           "float64" at 619:59-619:66 (leading: Space)
+7471: Semicolon       ";" at 619:66-619:67
+7472: At              "@" at 620:5-620:6 (leading: Newline, Space)
+7473: Ident           "intrinsic" at 620:6-620:15
+7474: KwFn            "fn" at 620:16-620:18 (leading: Space)
+7475: Ident           "__div" at 620:19-620:24 (leading: Space)
+7476: LParen          "(" at 620:24-620:25
+7477: Ident           "self" at 620:25-620:29
+7478: Colon           ":" at 620:29-620:30
+7479: Ident           "float64" at 620:31-620:38 (leading: Space)
+7480: Comma           "," at 620:38-620:39
+7481: Ident           "other" at 620:40-620:45 (leading: Space)
+7482: Colon           ":" at 620:45-620:46
+7483: Ident           "float64" at 620:47-620:54 (leading: Space)
+7484: RParen          ")" at 620:54-620:55
+7485: Arrow           "->" at 620:56-620:58 (leading: Space)
+7486: Ident           "float64" at 620:59-620:66 (leading: Space)
+7487: Semicolon       ";" at 620:66-620:67
+7488: At              "@" at 621:5-621:6 (leading: Newline, Space)
+7489: Ident           "intrinsic" at 621:6-621:15
+7490: KwFn            "fn" at 621:16-621:18 (leading: Space)
+7491: Ident           "__mod" at 621:19-621:24 (leading: Space)
+7492: LParen          "(" at 621:24-621:25
+7493: Ident           "self" at 621:25-621:29
+7494: Colon           ":" at 621:29-621:30
+7495: Ident           "float64" at 621:31-621:38 (leading: Space)
+7496: Comma           "," at 621:38-621:39
+7497: Ident           "other" at 621:40-621:45 (leading: Space)
+7498: Colon           ":" at 621:45-621:46
+7499: Ident           "float64" at 621:47-621:54 (leading: Space)
+7500: RParen          ")" at 621:54-621:55
+7501: Arrow           "->" at 621:56-621:58 (leading: Space)
+7502: Ident           "float64" at 621:59-621:66 (leading: Space)
+7503: Semicolon       ";" at 621:66-621:67
+7504: At              "@" at 622:5-622:6 (leading: Newline, Space)
+7505: Ident           "intrinsic" at 622:6-622:15
+7506: KwFn            "fn" at 622:16-622:18 (leading: Space)
+7507: Ident           "__lt" at 622:19-622:23 (leading: Space)
+7508: LParen          "(" at 622:23-622:24
+7509: Ident           "self" at 622:24-622:28
+7510: Colon           ":" at 622:28-622:29
+7511: Ident           "float64" at 622:30-622:37 (leading: Space)
+7512: Comma           "," at 622:37-622:38
+7513: Ident           "other" at 622:39-622:44 (leading: Space)
+7514: Colon           ":" at 622:44-622:45
+7515: Ident           "float64" at 622:46-622:53 (leading: Space)
+7516: RParen          ")" at 622:53-622:54
+7517: Arrow           "->" at 622:55-622:57 (leading: Space)
+7518: Ident           "bool" at 622:58-622:62 (leading: Space)
+7519: Semicolon       ";" at 622:62-622:63
+7520: At              "@" at 623:5-623:6 (leading: Newline, Space)
+7521: Ident           "intrinsic" at 623:6-623:15
+7522: KwFn            "fn" at 623:16-623:18 (leading: Space)
+7523: Ident           "__le" at 623:19-623:23 (leading: Space)
+7524: LParen          "(" at 623:23-623:24
+7525: Ident           "self" at 623:24-623:28
+7526: Colon           ":" at 623:28-623:29
+7527: Ident           "float64" at 623:30-623:37 (leading: Space)
+7528: Comma           "," at 623:37-623:38
+7529: Ident           "other" at 623:39-623:44 (leading: Space)
+7530: Colon           ":" at 623:44-623:45
+7531: Ident           "float64" at 623:46-623:53 (leading: Space)
+7532: RParen          ")" at 623:53-623:54
+7533: Arrow           "->" at 623:55-623:57 (leading: Space)
+7534: Ident           "bool" at 623:58-623:62 (leading: Space)
+7535: Semicolon       ";" at 623:62-623:63
+7536: At              "@" at 624:5-624:6 (leading: Newline, Space)
+7537: Ident           "intrinsic" at 624:6-624:15
+7538: KwFn            "fn" at 624:16-624:18 (leading: Space)
+7539: Ident           "__eq" at 624:19-624:23 (leading: Space)
+7540: LParen          "(" at 624:23-624:24
+7541: Ident           "self" at 624:24-624:28
+7542: Colon           ":" at 624:28-624:29
+7543: Ident           "float64" at 624:30-624:37 (leading: Space)
+7544: Comma           "," at 624:37-624:38
+7545: Ident           "other" at 624:39-624:44 (leading: Space)
+7546: Colon           ":" at 624:44-624:45
+7547: Ident           "float64" at 624:46-624:53 (leading: Space)
+7548: RParen          ")" at 624:53-624:54
+7549: Arrow           "->" at 624:55-624:57 (leading: Space)
+7550: Ident           "bool" at 624:58-624:62 (leading: Space)
+7551: Semicolon       ";" at 624:62-624:63
+7552: At              "@" at 625:5-625:6 (leading: Newline, Space)
+7553: Ident           "intrinsic" at 625:6-625:15
+7554: KwFn            "fn" at 625:16-625:18 (leading: Space)
+7555: Ident           "__ne" at 625:19-625:23 (leading: Space)
+7556: LParen          "(" at 625:23-625:24
+7557: Ident           "self" at 625:24-625:28
+7558: Colon           ":" at 625:28-625:29
+7559: Ident           "float64" at 625:30-625:37 (leading: Space)
+7560: Comma           "," at 625:37-625:38
+7561: Ident           "other" at 625:39-625:44 (leading: Space)
+7562: Colon           ":" at 625:44-625:45
+7563: Ident           "float64" at 625:46-625:53 (leading: Space)
+7564: RParen          ")" at 625:53-625:54
+7565: Arrow           "->" at 625:55-625:57 (leading: Space)
+7566: Ident           "bool" at 625:58-625:62 (leading: Space)
+7567: Semicolon       ";" at 625:62-625:63
+7568: At              "@" at 626:5-626:6 (leading: Newline, Space)
+7569: Ident           "intrinsic" at 626:6-626:15
+7570: KwFn            "fn" at 626:16-626:18 (leading: Space)
+7571: Ident           "__ge" at 626:19-626:23 (leading: Space)
+7572: LParen          "(" at 626:23-626:24
+7573: Ident           "self" at 626:24-626:28
+7574: Colon           ":" at 626:28-626:29
+7575: Ident           "float64" at 626:30-626:37 (leading: Space)
+7576: Comma           "," at 626:37-626:38
+7577: Ident           "other" at 626:39-626:44 (leading: Space)
+7578: Colon           ":" at 626:44-626:45
+7579: Ident           "float64" at 626:46-626:53 (leading: Space)
+7580: RParen          ")" at 626:53-626:54
+7581: Arrow           "->" at 626:55-626:57 (leading: Space)
+7582: Ident           "bool" at 626:58-626:62 (leading: Space)
+7583: Semicolon       ";" at 626:62-626:63
+7584: At              "@" at 627:5-627:6 (leading: Newline, Space)
+7585: Ident           "intrinsic" at 627:6-627:15
+7586: KwFn            "fn" at 627:16-627:18 (leading: Space)
+7587: Ident           "__gt" at 627:19-627:23 (leading: Space)
+7588: LParen          "(" at 627:23-627:24
+7589: Ident           "self" at 627:24-627:28
+7590: Colon           ":" at 627:28-627:29
+7591: Ident           "float64" at 627:30-627:37 (leading: Space)
+7592: Comma           "," at 627:37-627:38
+7593: Ident           "other" at 627:39-627:44 (leading: Space)
+7594: Colon           ":" at 627:44-627:45
+7595: Ident           "float64" at 627:46-627:53 (leading: Space)
+7596: RParen          ")" at 627:53-627:54
+7597: Arrow           "->" at 627:55-627:57 (leading: Space)
+7598: Ident           "bool" at 627:58-627:62 (leading: Space)
+7599: Semicolon       ";" at 627:62-627:63
+7600: At              "@" at 628:5-628:6 (leading: Newline, Space)
+7601: Ident           "intrinsic" at 628:6-628:15
+7602: KwFn            "fn" at 628:16-628:18 (leading: Space)
+7603: Ident           "__pos" at 628:19-628:24 (leading: Space)
+7604: LParen          "(" at 628:24-628:25
+7605: Ident           "self" at 628:25-628:29
+7606: Colon           ":" at 628:29-628:30
+7607: Ident           "float64" at 628:31-628:38 (leading: Space)
+7608: RParen          ")" at 628:38-628:39
+7609: Arrow           "->" at 628:40-628:42 (leading: Space)
+7610: Ident           "float64" at 628:43-628:50 (leading: Space)
+7611: Semicolon       ";" at 628:50-628:51
+7612: At              "@" at 629:5-629:6 (leading: Newline, Space)
+7613: Ident           "intrinsic" at 629:6-629:15
+7614: KwFn            "fn" at 629:16-629:18 (leading: Space)
+7615: Ident           "__neg" at 629:19-629:24 (leading: Space)
+7616: LParen          "(" at 629:24-629:25
+7617: Ident           "self" at 629:25-629:29
+7618: Colon           ":" at 629:29-629:30
+7619: Ident           "float64" at 629:31-629:38 (leading: Space)
+7620: RParen          ")" at 629:38-629:39
+7621: Arrow           "->" at 629:40-629:42 (leading: Space)
+7622: Ident           "float64" at 629:43-629:50 (leading: Space)
+7623: Semicolon       ";" at 629:50-629:51
+7624: At              "@" at 630:5-630:6 (leading: Newline, Space)
+7625: Ident           "intrinsic" at 630:6-630:15
+7626: KwFn            "fn" at 630:16-630:18 (leading: Space)
+7627: Ident           "__abs" at 630:19-630:24 (leading: Space)
+7628: LParen          "(" at 630:24-630:25
+7629: Ident           "self" at 630:25-630:29
+7630: Colon           ":" at 630:29-630:30
+7631: Ident           "float64" at 630:31-630:38 (leading: Space)
+7632: RParen          ")" at 630:38-630:39
+7633: Arrow           "->" at 630:40-630:42 (leading: Space)
+7634: Ident           "float64" at 630:43-630:50 (leading: Space)
+7635: Semicolon       ";" at 630:50-630:51
+7636: At              "@" at 631:5-631:6 (leading: Newline, Space)
+7637: Ident           "intrinsic" at 631:6-631:15
+7638: KwFn            "fn" at 631:16-631:18 (leading: Space)
+7639: Ident           "__to" at 631:19-631:23 (leading: Space)
+7640: LParen          "(" at 631:23-631:24
+7641: Ident           "self" at 631:24-631:28
+7642: Colon           ":" at 631:28-631:29
+7643: Ident           "float64" at 631:30-631:37 (leading: Space)
+7644: Comma           "," at 631:37-631:38
+7645: Ident           "target" at 631:39-631:45 (leading: Space)
+7646: Colon           ":" at 631:45-631:46
+7647: Ident           "float" at 631:47-631:52 (leading: Space)
+7648: RParen          ")" at 631:52-631:53
+7649: Arrow           "->" at 631:54-631:56 (leading: Space)
+7650: Ident           "float" at 631:57-631:62 (leading: Space)
+7651: Semicolon       ";" at 631:62-631:63
+7652: At              "@" at 632:5-632:6 (leading: Newline, Space)
+7653: Ident           "intrinsic" at 632:6-632:15
+7654: At              "@" at 632:16-632:17 (leading: Space)
+7655: Ident           "overload" at 632:17-632:25
+7656: KwFn            "fn" at 632:26-632:28 (leading: Space)
+7657: Ident           "__to" at 632:29-632:33 (leading: Space)
+7658: LParen          "(" at 632:33-632:34
+7659: Ident           "self" at 632:34-632:38
+7660: Colon           ":" at 632:38-632:39
+7661: Ident           "float64" at 632:40-632:47 (leading: Space)
+7662: Comma           "," at 632:47-632:48
+7663: Ident           "target" at 632:49-632:55 (leading: Space)
+7664: Colon           ":" at 632:55-632:56
+7665: Ident           "float16" at 632:57-632:64 (leading: Space)
+7666: RParen          ")" at 632:64-632:65
+7667: Arrow           "->" at 632:66-632:68 (leading: Space)
+7668: Ident           "float16" at 632:69-632:76 (leading: Space)
+7669: Semicolon       ";" at 632:76-632:77
+7670: At              "@" at 633:5-633:6 (leading: Newline, Space)
+7671: Ident           "intrinsic" at 633:6-633:15
+7672: At              "@" at 633:16-633:17 (leading: Space)
+7673: Ident           "overload" at 633:17-633:25
+7674: KwFn            "fn" at 633:26-633:28 (leading: Space)
+7675: Ident           "__to" at 633:29-633:33 (leading: Space)
+7676: LParen          "(" at 633:33-633:34
+7677: Ident           "self" at 633:34-633:38
+7678: Colon           ":" at 633:38-633:39
+7679: Ident           "float64" at 633:40-633:47 (leading: Space)
+7680: Comma           "," at 633:47-633:48
+7681: Ident           "target" at 633:49-633:55 (leading: Space)
+7682: Colon           ":" at 633:55-633:56
+7683: Ident           "float32" at 633:57-633:64 (leading: Space)
+7684: RParen          ")" at 633:64-633:65
+7685: Arrow           "->" at 633:66-633:68 (leading: Space)
+7686: Ident           "float32" at 633:69-633:76 (leading: Space)
+7687: Semicolon       ";" at 633:76-633:77
+7688: At              "@" at 634:5-634:6 (leading: Newline, Space)
+7689: Ident           "intrinsic" at 634:6-634:15
+7690: KwPub           "pub" at 634:16-634:19 (leading: Space)
+7691: KwFn            "fn" at 634:20-634:22 (leading: Space)
+7692: Ident           "from_str" at 634:23-634:31 (leading: Space)
+7693: LParen          "(" at 634:31-634:32
+7694: Ident           "s" at 634:32-634:33
+7695: Colon           ":" at 634:33-634:34
+7696: Amp             "&" at 634:35-634:36 (leading: Space)
+7697: Ident           "string" at 634:36-634:42
+7698: RParen          ")" at 634:42-634:43
+7699: Arrow           "->" at 634:44-634:46 (leading: Space)
+7700: Ident           "Erring" at 634:47-634:53 (leading: Space)
+7701: Lt              "<" at 634:53-634:54
+7702: Ident           "float64" at 634:54-634:61
+7703: Comma           "," at 634:61-634:62
+7704: Ident           "Error" at 634:63-634:68 (leading: Space)
+7705: Gt              ">" at 634:68-634:69
+7706: Semicolon       ";" at 634:69-634:70
+7707: RBrace          "}" at 635:1-635:2 (leading: Newline)
+7708: KwExtern        "extern" at 637:1-637:7 (leading: Newline)
+7709: Lt              "<" at 637:7-637:8
+7710: Ident           "float" at 637:8-637:13
+7711: Gt              ">" at 637:13-637:14
+7712: LBrace          "{" at 637:15-637:16 (leading: Space)
+7713: At              "@" at 638:5-638:6 (leading: Newline, Space)
+7714: Ident           "intrinsic" at 638:6-638:15
+7715: KwFn            "fn" at 638:16-638:18 (leading: Space)
+7716: Ident           "__add" at 638:19-638:24 (leading: Space)
+7717: LParen          "(" at 638:24-638:25
+7718: Ident           "self" at 638:25-638:29
+7719: Colon           ":" at 638:29-638:30
+7720: Ident           "float" at 638:31-638:36 (leading: Space)
+7721: Comma           "," at 638:36-638:37
+7722: Ident           "other" at 638:38-638:43 (leading: Space)
+7723: Colon           ":" at 638:43-638:44
+7724: Ident           "float" at 638:45-638:50 (leading: Space)
+7725: RParen          ")" at 638:50-638:51
+7726: Arrow           "->" at 638:52-638:54 (leading: Space)
+7727: Ident           "float" at 638:55-638:60 (leading: Space)
+7728: Semicolon       ";" at 638:60-638:61
+7729: At              "@" at 639:5-639:6 (leading: Newline, Space)
+7730: Ident           "intrinsic" at 639:6-639:15
+7731: KwFn            "fn" at 639:16-639:18 (leading: Space)
+7732: Ident           "__sub" at 639:19-639:24 (leading: Space)
+7733: LParen          "(" at 639:24-639:25
+7734: Ident           "self" at 639:25-639:29
+7735: Colon           ":" at 639:29-639:30
+7736: Ident           "float" at 639:31-639:36 (leading: Space)
+7737: Comma           "," at 639:36-639:37
+7738: Ident           "other" at 639:38-639:43 (leading: Space)
+7739: Colon           ":" at 639:43-639:44
+7740: Ident           "float" at 639:45-639:50 (leading: Space)
+7741: RParen          ")" at 639:50-639:51
+7742: Arrow           "->" at 639:52-639:54 (leading: Space)
+7743: Ident           "float" at 639:55-639:60 (leading: Space)
+7744: Semicolon       ";" at 639:60-639:61
+7745: At              "@" at 640:5-640:6 (leading: Newline, Space)
+7746: Ident           "intrinsic" at 640:6-640:15
+7747: KwFn            "fn" at 640:16-640:18 (leading: Space)
+7748: Ident           "__mul" at 640:19-640:24 (leading: Space)
+7749: LParen          "(" at 640:24-640:25
+7750: Ident           "self" at 640:25-640:29
+7751: Colon           ":" at 640:29-640:30
+7752: Ident           "float" at 640:31-640:36 (leading: Space)
+7753: Comma           "," at 640:36-640:37
+7754: Ident           "other" at 640:38-640:43 (leading: Space)
+7755: Colon           ":" at 640:43-640:44
+7756: Ident           "float" at 640:45-640:50 (leading: Space)
+7757: RParen          ")" at 640:50-640:51
+7758: Arrow           "->" at 640:52-640:54 (leading: Space)
+7759: Ident           "float" at 640:55-640:60 (leading: Space)
+7760: Semicolon       ";" at 640:60-640:61
+7761: At              "@" at 641:5-641:6 (leading: Newline, Space)
+7762: Ident           "intrinsic" at 641:6-641:15
+7763: KwFn            "fn" at 641:16-641:18 (leading: Space)
+7764: Ident           "__div" at 641:19-641:24 (leading: Space)
+7765: LParen          "(" at 641:24-641:25
+7766: Ident           "self" at 641:25-641:29
+7767: Colon           ":" at 641:29-641:30
+7768: Ident           "float" at 641:31-641:36 (leading: Space)
+7769: Comma           "," at 641:36-641:37
+7770: Ident           "other" at 641:38-641:43 (leading: Space)
+7771: Colon           ":" at 641:43-641:44
+7772: Ident           "float" at 641:45-641:50 (leading: Space)
+7773: RParen          ")" at 641:50-641:51
+7774: Arrow           "->" at 641:52-641:54 (leading: Space)
+7775: Ident           "float" at 641:55-641:60 (leading: Space)
+7776: Semicolon       ";" at 641:60-641:61
+7777: At              "@" at 642:5-642:6 (leading: Newline, Space)
+7778: Ident           "intrinsic" at 642:6-642:15
+7779: KwFn            "fn" at 642:16-642:18 (leading: Space)
+7780: Ident           "__mod" at 642:19-642:24 (leading: Space)
+7781: LParen          "(" at 642:24-642:25
+7782: Ident           "self" at 642:25-642:29
+7783: Colon           ":" at 642:29-642:30
+7784: Ident           "float" at 642:31-642:36 (leading: Space)
+7785: Comma           "," at 642:36-642:37
+7786: Ident           "other" at 642:38-642:43 (leading: Space)
+7787: Colon           ":" at 642:43-642:44
+7788: Ident           "float" at 642:45-642:50 (leading: Space)
+7789: RParen          ")" at 642:50-642:51
+7790: Arrow           "->" at 642:52-642:54 (leading: Space)
+7791: Ident           "float" at 642:55-642:60 (leading: Space)
+7792: Semicolon       ";" at 642:60-642:61
+7793: At              "@" at 643:5-643:6 (leading: Newline, Space)
+7794: Ident           "intrinsic" at 643:6-643:15
+7795: KwFn            "fn" at 643:16-643:18 (leading: Space)
+7796: Ident           "__lt" at 643:19-643:23 (leading: Space)
+7797: LParen          "(" at 643:23-643:24
+7798: Ident           "self" at 643:24-643:28
+7799: Colon           ":" at 643:28-643:29
+7800: Ident           "float" at 643:30-643:35 (leading: Space)
+7801: Comma           "," at 643:35-643:36
+7802: Ident           "other" at 643:37-643:42 (leading: Space)
+7803: Colon           ":" at 643:42-643:43
+7804: Ident           "float" at 643:44-643:49 (leading: Space)
+7805: RParen          ")" at 643:49-643:50
+7806: Arrow           "->" at 643:51-643:53 (leading: Space)
+7807: Ident           "bool" at 643:54-643:58 (leading: Space)
+7808: Semicolon       ";" at 643:58-643:59
+7809: At              "@" at 644:5-644:6 (leading: Newline, Space)
+7810: Ident           "intrinsic" at 644:6-644:15
+7811: KwFn            "fn" at 644:16-644:18 (leading: Space)
+7812: Ident           "__le" at 644:19-644:23 (leading: Space)
+7813: LParen          "(" at 644:23-644:24
+7814: Ident           "self" at 644:24-644:28
+7815: Colon           ":" at 644:28-644:29
+7816: Ident           "float" at 644:30-644:35 (leading: Space)
+7817: Comma           "," at 644:35-644:36
+7818: Ident           "other" at 644:37-644:42 (leading: Space)
+7819: Colon           ":" at 644:42-644:43
+7820: Ident           "float" at 644:44-644:49 (leading: Space)
+7821: RParen          ")" at 644:49-644:50
+7822: Arrow           "->" at 644:51-644:53 (leading: Space)
+7823: Ident           "bool" at 644:54-644:58 (leading: Space)
+7824: Semicolon       ";" at 644:58-644:59
+7825: At              "@" at 645:5-645:6 (leading: Newline, Space)
+7826: Ident           "intrinsic" at 645:6-645:15
+7827: KwFn            "fn" at 645:16-645:18 (leading: Space)
+7828: Ident           "__eq" at 645:19-645:23 (leading: Space)
+7829: LParen          "(" at 645:23-645:24
+7830: Ident           "self" at 645:24-645:28
+7831: Colon           ":" at 645:28-645:29
+7832: Ident           "float" at 645:30-645:35 (leading: Space)
+7833: Comma           "," at 645:35-645:36
+7834: Ident           "other" at 645:37-645:42 (leading: Space)
+7835: Colon           ":" at 645:42-645:43
+7836: Ident           "float" at 645:44-645:49 (leading: Space)
+7837: RParen          ")" at 645:49-645:50
+7838: Arrow           "->" at 645:51-645:53 (leading: Space)
+7839: Ident           "bool" at 645:54-645:58 (leading: Space)
+7840: Semicolon       ";" at 645:58-645:59
+7841: At              "@" at 646:5-646:6 (leading: Newline, Space)
+7842: Ident           "intrinsic" at 646:6-646:15
+7843: KwFn            "fn" at 646:16-646:18 (leading: Space)
+7844: Ident           "__ne" at 646:19-646:23 (leading: Space)
+7845: LParen          "(" at 646:23-646:24
+7846: Ident           "self" at 646:24-646:28
+7847: Colon           ":" at 646:28-646:29
+7848: Ident           "float" at 646:30-646:35 (leading: Space)
+7849: Comma           "," at 646:35-646:36
+7850: Ident           "other" at 646:37-646:42 (leading: Space)
+7851: Colon           ":" at 646:42-646:43
+7852: Ident           "float" at 646:44-646:49 (leading: Space)
+7853: RParen          ")" at 646:49-646:50
+7854: Arrow           "->" at 646:51-646:53 (leading: Space)
+7855: Ident           "bool" at 646:54-646:58 (leading: Space)
+7856: Semicolon       ";" at 646:58-646:59
+7857: At              "@" at 647:5-647:6 (leading: Newline, Space)
+7858: Ident           "intrinsic" at 647:6-647:15
+7859: KwFn            "fn" at 647:16-647:18 (leading: Space)
+7860: Ident           "__ge" at 647:19-647:23 (leading: Space)
+7861: LParen          "(" at 647:23-647:24
+7862: Ident           "self" at 647:24-647:28
+7863: Colon           ":" at 647:28-647:29
+7864: Ident           "float" at 647:30-647:35 (leading: Space)
+7865: Comma           "," at 647:35-647:36
+7866: Ident           "other" at 647:37-647:42 (leading: Space)
+7867: Colon           ":" at 647:42-647:43
+7868: Ident           "float" at 647:44-647:49 (leading: Space)
+7869: RParen          ")" at 647:49-647:50
+7870: Arrow           "->" at 647:51-647:53 (leading: Space)
+7871: Ident           "bool" at 647:54-647:58 (leading: Space)
+7872: Semicolon       ";" at 647:58-647:59
+7873: At              "@" at 648:5-648:6 (leading: Newline, Space)
+7874: Ident           "intrinsic" at 648:6-648:15
+7875: KwFn            "fn" at 648:16-648:18 (leading: Space)
+7876: Ident           "__gt" at 648:19-648:23 (leading: Space)
+7877: LParen          "(" at 648:23-648:24
+7878: Ident           "self" at 648:24-648:28
+7879: Colon           ":" at 648:28-648:29
+7880: Ident           "float" at 648:30-648:35 (leading: Space)
+7881: Comma           "," at 648:35-648:36
+7882: Ident           "other" at 648:37-648:42 (leading: Space)
+7883: Colon           ":" at 648:42-648:43
+7884: Ident           "float" at 648:44-648:49 (leading: Space)
+7885: RParen          ")" at 648:49-648:50
+7886: Arrow           "->" at 648:51-648:53 (leading: Space)
+7887: Ident           "bool" at 648:54-648:58 (leading: Space)
+7888: Semicolon       ";" at 648:58-648:59
+7889: At              "@" at 649:5-649:6 (leading: Newline, Space)
+7890: Ident           "intrinsic" at 649:6-649:15
+7891: KwFn            "fn" at 649:16-649:18 (leading: Space)
+7892: Ident           "__pos" at 649:19-649:24 (leading: Space)
+7893: LParen          "(" at 649:24-649:25
+7894: Ident           "self" at 649:25-649:29
+7895: Colon           ":" at 649:29-649:30
+7896: Ident           "float" at 649:31-649:36 (leading: Space)
+7897: RParen          ")" at 649:36-649:37
+7898: Arrow           "->" at 649:38-649:40 (leading: Space)
+7899: Ident           "float" at 649:41-649:46 (leading: Space)
+7900: Semicolon       ";" at 649:46-649:47
+7901: At              "@" at 650:5-650:6 (leading: Newline, Space)
+7902: Ident           "intrinsic" at 650:6-650:15
+7903: KwFn            "fn" at 650:16-650:18 (leading: Space)
+7904: Ident           "__neg" at 650:19-650:24 (leading: Space)
+7905: LParen          "(" at 650:24-650:25
+7906: Ident           "self" at 650:25-650:29
+7907: Colon           ":" at 650:29-650:30
+7908: Ident           "float" at 650:31-650:36 (leading: Space)
+7909: RParen          ")" at 650:36-650:37
+7910: Arrow           "->" at 650:38-650:40 (leading: Space)
+7911: Ident           "float" at 650:41-650:46 (leading: Space)
+7912: Semicolon       ";" at 650:46-650:47
+7913: At              "@" at 651:5-651:6 (leading: Newline, Space)
+7914: Ident           "intrinsic" at 651:6-651:15
+7915: KwFn            "fn" at 651:16-651:18 (leading: Space)
+7916: Ident           "__abs" at 651:19-651:24 (leading: Space)
+7917: LParen          "(" at 651:24-651:25
+7918: Ident           "self" at 651:25-651:29
+7919: Colon           ":" at 651:29-651:30
+7920: Ident           "float" at 651:31-651:36 (leading: Space)
+7921: RParen          ")" at 651:36-651:37
+7922: Arrow           "->" at 651:38-651:40 (leading: Space)
+7923: Ident           "float" at 651:41-651:46 (leading: Space)
+7924: Semicolon       ";" at 651:46-651:47
+7925: At              "@" at 652:5-652:6 (leading: Newline, Space)
+7926: Ident           "intrinsic" at 652:6-652:15
+7927: KwFn            "fn" at 652:16-652:18 (leading: Space)
+7928: Ident           "__to" at 652:19-652:23 (leading: Space)
+7929: LParen          "(" at 652:23-652:24
+7930: Ident           "self" at 652:24-652:28
+7931: Colon           ":" at 652:28-652:29
+7932: Ident           "float" at 652:30-652:35 (leading: Space)
+7933: Comma           "," at 652:35-652:36
+7934: Ident           "target" at 652:37-652:43 (leading: Space)
+7935: Colon           ":" at 652:43-652:44
+7936: Ident           "string" at 652:45-652:51 (leading: Space)
+7937: RParen          ")" at 652:51-652:52
+7938: Arrow           "->" at 652:53-652:55 (leading: Space)
+7939: Ident           "string" at 652:56-652:62 (leading: Space)
+7940: Semicolon       ";" at 652:62-652:63
+7941: At              "@" at 653:5-653:6 (leading: Newline, Space)
+7942: Ident           "overload" at 653:6-653:14
+7943: KwPub           "pub" at 653:15-653:18 (leading: Space)
+7944: KwFn            "fn" at 653:19-653:21 (leading: Space)
+7945: Ident           "__to" at 653:22-653:26 (leading: Space)
+7946: LParen          "(" at 653:26-653:27
+7947: Ident           "self" at 653:27-653:31
+7948: Colon           ":" at 653:31-653:32
+7949: Amp             "&" at 653:33-653:34 (leading: Space)
+7950: Ident           "float" at 653:34-653:39
+7951: Comma           "," at 653:39-653:40
+7952: Underscore      "_" at 653:41-653:42 (leading: Space)
+7953: Colon           ":" at 653:42-653:43
+7954: Ident           "string" at 653:44-653:50 (leading: Space)
+7955: RParen          ")" at 653:50-653:51
+7956: Arrow           "->" at 653:52-653:54 (leading: Space)
+7957: Ident           "string" at 653:55-653:61 (leading: Space)
+7958: LBrace          "{" at 653:62-653:63 (leading: Space)
+7959: KwReturn        "return" at 654:9-654:15 (leading: Newline, Space)
+7960: LParen          "(" at 654:16-654:17 (leading: Space)
+7961: Star            "*" at 654:17-654:18
+7962: Ident           "self" at 654:18-654:22
+7963: RParen          ")" at 654:22-654:23
+7964: KwTo            "to" at 654:24-654:26 (leading: Space)
+7965: Ident           "string" at 654:27-654:33 (leading: Space)
+7966: Semicolon       ";" at 654:33-654:34
+7967: RBrace          "}" at 655:5-655:6 (leading: Newline, Space)
+7968: At              "@" at 656:5-656:6 (leading: Newline, Space)
+7969: Ident           "intrinsic" at 656:6-656:15
+7970: At              "@" at 656:16-656:17 (leading: Space)
+7971: Ident           "overload" at 656:17-656:25
+7972: KwFn            "fn" at 656:26-656:28 (leading: Space)
+7973: Ident           "__to" at 656:29-656:33 (leading: Space)
+7974: LParen          "(" at 656:33-656:34
+7975: Ident           "self" at 656:34-656:38
+7976: Colon           ":" at 656:38-656:39
+7977: Ident           "float" at 656:40-656:45 (leading: Space)
+7978: Comma           "," at 656:45-656:46
+7979: Ident           "target" at 656:47-656:53 (leading: Space)
+7980: Colon           ":" at 656:53-656:54
+7981: Ident           "int" at 656:55-656:58 (leading: Space)
+7982: RParen          ")" at 656:58-656:59
+7983: Arrow           "->" at 656:60-656:62 (leading: Space)
+7984: Ident           "int" at 656:63-656:66 (leading: Space)
+7985: Semicolon       ";" at 656:66-656:67
+7986: At              "@" at 657:5-657:6 (leading: Newline, Space)
+7987: Ident           "intrinsic" at 657:6-657:15
+7988: At              "@" at 657:16-657:17 (leading: Space)
+7989: Ident           "overload" at 657:17-657:25
+7990: KwFn            "fn" at 657:26-657:28 (leading: Space)
+7991: Ident           "__to" at 657:29-657:33 (leading: Space)
+7992: LParen          "(" at 657:33-657:34
+7993: Ident           "self" at 657:34-657:38
+7994: Colon           ":" at 657:38-657:39
+7995: Ident           "float" at 657:40-657:45 (leading: Space)
+7996: Comma           "," at 657:45-657:46
+7997: Ident           "target" at 657:47-657:53 (leading: Space)
+7998: Colon           ":" at 657:53-657:54
+7999: Ident           "uint" at 657:55-657:59 (leading: Space)
+8000: RParen          ")" at 657:59-657:60
+8001: Arrow           "->" at 657:61-657:63 (leading: Space)
+8002: Ident           "uint" at 657:64-657:68 (leading: Space)
+8003: Semicolon       ";" at 657:68-657:69
+8004: At              "@" at 658:5-658:6 (leading: Newline, Space)
+8005: Ident           "intrinsic" at 658:6-658:15
+8006: At              "@" at 658:16-658:17 (leading: Space)
+8007: Ident           "overload" at 658:17-658:25
+8008: KwFn            "fn" at 658:26-658:28 (leading: Space)
+8009: Ident           "__to" at 658:29-658:33 (leading: Space)
+8010: LParen          "(" at 658:33-658:34
+8011: Ident           "self" at 658:34-658:38
+8012: Colon           ":" at 658:38-658:39
+8013: Ident           "float" at 658:40-658:45 (leading: Space)
+8014: Comma           "," at 658:45-658:46
+8015: Ident           "target" at 658:47-658:53 (leading: Space)
+8016: Colon           ":" at 658:53-658:54
+8017: Ident           "int8" at 658:55-658:59 (leading: Space)
+8018: RParen          ")" at 658:59-658:60
+8019: Arrow           "->" at 658:61-658:63 (leading: Space)
+8020: Ident           "int8" at 658:64-658:68 (leading: Space)
+8021: Semicolon       ";" at 658:68-658:69
+8022: At              "@" at 659:5-659:6 (leading: Newline, Space)
+8023: Ident           "intrinsic" at 659:6-659:15
+8024: At              "@" at 659:16-659:17 (leading: Space)
+8025: Ident           "overload" at 659:17-659:25
+8026: KwFn            "fn" at 659:26-659:28 (leading: Space)
+8027: Ident           "__to" at 659:29-659:33 (leading: Space)
+8028: LParen          "(" at 659:33-659:34
+8029: Ident           "self" at 659:34-659:38
+8030: Colon           ":" at 659:38-659:39
+8031: Ident           "float" at 659:40-659:45 (leading: Space)
+8032: Comma           "," at 659:45-659:46
+8033: Ident           "target" at 659:47-659:53 (leading: Space)
+8034: Colon           ":" at 659:53-659:54
+8035: Ident           "int16" at 659:55-659:60 (leading: Space)
+8036: RParen          ")" at 659:60-659:61
+8037: Arrow           "->" at 659:62-659:64 (leading: Space)
+8038: Ident           "int16" at 659:65-659:70 (leading: Space)
+8039: Semicolon       ";" at 659:70-659:71
+8040: At              "@" at 660:5-660:6 (leading: Newline, Space)
+8041: Ident           "intrinsic" at 660:6-660:15
+8042: At              "@" at 660:16-660:17 (leading: Space)
+8043: Ident           "overload" at 660:17-660:25
+8044: KwFn            "fn" at 660:26-660:28 (leading: Space)
+8045: Ident           "__to" at 660:29-660:33 (leading: Space)
+8046: LParen          "(" at 660:33-660:34
+8047: Ident           "self" at 660:34-660:38
+8048: Colon           ":" at 660:38-660:39
+8049: Ident           "float" at 660:40-660:45 (leading: Space)
+8050: Comma           "," at 660:45-660:46
+8051: Ident           "target" at 660:47-660:53 (leading: Space)
+8052: Colon           ":" at 660:53-660:54
+8053: Ident           "int32" at 660:55-660:60 (leading: Space)
+8054: RParen          ")" at 660:60-660:61
+8055: Arrow           "->" at 660:62-660:64 (leading: Space)
+8056: Ident           "int32" at 660:65-660:70 (leading: Space)
+8057: Semicolon       ";" at 660:70-660:71
+8058: At              "@" at 661:5-661:6 (leading: Newline, Space)
+8059: Ident           "intrinsic" at 661:6-661:15
+8060: At              "@" at 661:16-661:17 (leading: Space)
+8061: Ident           "overload" at 661:17-661:25
+8062: KwFn            "fn" at 661:26-661:28 (leading: Space)
+8063: Ident           "__to" at 661:29-661:33 (leading: Space)
+8064: LParen          "(" at 661:33-661:34
+8065: Ident           "self" at 661:34-661:38
+8066: Colon           ":" at 661:38-661:39
+8067: Ident           "float" at 661:40-661:45 (leading: Space)
+8068: Comma           "," at 661:45-661:46
+8069: Ident           "target" at 661:47-661:53 (leading: Space)
+8070: Colon           ":" at 661:53-661:54
+8071: Ident           "int64" at 661:55-661:60 (leading: Space)
+8072: RParen          ")" at 661:60-661:61
+8073: Arrow           "->" at 661:62-661:64 (leading: Space)
+8074: Ident           "int64" at 661:65-661:70 (leading: Space)
+8075: Semicolon       ";" at 661:70-661:71
+8076: At              "@" at 662:5-662:6 (leading: Newline, Space)
+8077: Ident           "intrinsic" at 662:6-662:15
+8078: At              "@" at 662:16-662:17 (leading: Space)
+8079: Ident           "overload" at 662:17-662:25
+8080: KwFn            "fn" at 662:26-662:28 (leading: Space)
+8081: Ident           "__to" at 662:29-662:33 (leading: Space)
+8082: LParen          "(" at 662:33-662:34
+8083: Ident           "self" at 662:34-662:38
+8084: Colon           ":" at 662:38-662:39
+8085: Ident           "float" at 662:40-662:45 (leading: Space)
+8086: Comma           "," at 662:45-662:46
+8087: Ident           "target" at 662:47-662:53 (leading: Space)
+8088: Colon           ":" at 662:53-662:54
+8089: Ident           "uint8" at 662:55-662:60 (leading: Space)
+8090: RParen          ")" at 662:60-662:61
+8091: Arrow           "->" at 662:62-662:64 (leading: Space)
+8092: Ident           "uint8" at 662:65-662:70 (leading: Space)
+8093: Semicolon       ";" at 662:70-662:71
+8094: At              "@" at 663:5-663:6 (leading: Newline, Space)
+8095: Ident           "intrinsic" at 663:6-663:15
+8096: At              "@" at 663:16-663:17 (leading: Space)
+8097: Ident           "overload" at 663:17-663:25
+8098: KwFn            "fn" at 663:26-663:28 (leading: Space)
+8099: Ident           "__to" at 663:29-663:33 (leading: Space)
+8100: LParen          "(" at 663:33-663:34
+8101: Ident           "self" at 663:34-663:38
+8102: Colon           ":" at 663:38-663:39
+8103: Ident           "float" at 663:40-663:45 (leading: Space)
+8104: Comma           "," at 663:45-663:46
+8105: Ident           "target" at 663:47-663:53 (leading: Space)
+8106: Colon           ":" at 663:53-663:54
+8107: Ident           "uint16" at 663:55-663:61 (leading: Space)
+8108: RParen          ")" at 663:61-663:62
+8109: Arrow           "->" at 663:63-663:65 (leading: Space)
+8110: Ident           "uint16" at 663:66-663:72 (leading: Space)
+8111: Semicolon       ";" at 663:72-663:73
+8112: At              "@" at 664:5-664:6 (leading: Newline, Space)
+8113: Ident           "intrinsic" at 664:6-664:15
+8114: At              "@" at 664:16-664:17 (leading: Space)
+8115: Ident           "overload" at 664:17-664:25
+8116: KwFn            "fn" at 664:26-664:28 (leading: Space)
+8117: Ident           "__to" at 664:29-664:33 (leading: Space)
+8118: LParen          "(" at 664:33-664:34
+8119: Ident           "self" at 664:34-664:38
+8120: Colon           ":" at 664:38-664:39
+8121: Ident           "float" at 664:40-664:45 (leading: Space)
+8122: Comma           "," at 664:45-664:46
+8123: Ident           "target" at 664:47-664:53 (leading: Space)
+8124: Colon           ":" at 664:53-664:54
+8125: Ident           "uint32" at 664:55-664:61 (leading: Space)
+8126: RParen          ")" at 664:61-664:62
+8127: Arrow           "->" at 664:63-664:65 (leading: Space)
+8128: Ident           "uint32" at 664:66-664:72 (leading: Space)
+8129: Semicolon       ";" at 664:72-664:73
+8130: At              "@" at 665:5-665:6 (leading: Newline, Space)
+8131: Ident           "intrinsic" at 665:6-665:15
+8132: At              "@" at 665:16-665:17 (leading: Space)
+8133: Ident           "overload" at 665:17-665:25
+8134: KwFn            "fn" at 665:26-665:28 (leading: Space)
+8135: Ident           "__to" at 665:29-665:33 (leading: Space)
+8136: LParen          "(" at 665:33-665:34
+8137: Ident           "self" at 665:34-665:38
+8138: Colon           ":" at 665:38-665:39
+8139: Ident           "float" at 665:40-665:45 (leading: Space)
+8140: Comma           "," at 665:45-665:46
+8141: Ident           "target" at 665:47-665:53 (leading: Space)
+8142: Colon           ":" at 665:53-665:54
+8143: Ident           "uint64" at 665:55-665:61 (leading: Space)
+8144: RParen          ")" at 665:61-665:62
+8145: Arrow           "->" at 665:63-665:65 (leading: Space)
+8146: Ident           "uint64" at 665:66-665:72 (leading: Space)
+8147: Semicolon       ";" at 665:72-665:73
+8148: At              "@" at 666:5-666:6 (leading: Newline, Space)
+8149: Ident           "intrinsic" at 666:6-666:15
+8150: At              "@" at 666:16-666:17 (leading: Space)
+8151: Ident           "overload" at 666:17-666:25
+8152: KwFn            "fn" at 666:26-666:28 (leading: Space)
+8153: Ident           "__to" at 666:29-666:33 (leading: Space)
+8154: LParen          "(" at 666:33-666:34
+8155: Ident           "self" at 666:34-666:38
+8156: Colon           ":" at 666:38-666:39
+8157: Ident           "float" at 666:40-666:45 (leading: Space)
+8158: Comma           "," at 666:45-666:46
+8159: Ident           "target" at 666:47-666:53 (leading: Space)
+8160: Colon           ":" at 666:53-666:54
+8161: Ident           "float16" at 666:55-666:62 (leading: Space)
+8162: RParen          ")" at 666:62-666:63
+8163: Arrow           "->" at 666:64-666:66 (leading: Space)
+8164: Ident           "float16" at 666:67-666:74 (leading: Space)
+8165: Semicolon       ";" at 666:74-666:75
+8166: At              "@" at 667:5-667:6 (leading: Newline, Space)
+8167: Ident           "intrinsic" at 667:6-667:15
+8168: At              "@" at 667:16-667:17 (leading: Space)
+8169: Ident           "overload" at 667:17-667:25
+8170: KwFn            "fn" at 667:26-667:28 (leading: Space)
+8171: Ident           "__to" at 667:29-667:33 (leading: Space)
+8172: LParen          "(" at 667:33-667:34
+8173: Ident           "self" at 667:34-667:38
+8174: Colon           ":" at 667:38-667:39
+8175: Ident           "float" at 667:40-667:45 (leading: Space)
+8176: Comma           "," at 667:45-667:46
+8177: Ident           "target" at 667:47-667:53 (leading: Space)
+8178: Colon           ":" at 667:53-667:54
+8179: Ident           "float32" at 667:55-667:62 (leading: Space)
+8180: RParen          ")" at 667:62-667:63
+8181: Arrow           "->" at 667:64-667:66 (leading: Space)
+8182: Ident           "float32" at 667:67-667:74 (leading: Space)
+8183: Semicolon       ";" at 667:74-667:75
+8184: At              "@" at 668:5-668:6 (leading: Newline, Space)
+8185: Ident           "intrinsic" at 668:6-668:15
+8186: At              "@" at 668:16-668:17 (leading: Space)
+8187: Ident           "overload" at 668:17-668:25
+8188: KwFn            "fn" at 668:26-668:28 (leading: Space)
+8189: Ident           "__to" at 668:29-668:33 (leading: Space)
+8190: LParen          "(" at 668:33-668:34
+8191: Ident           "self" at 668:34-668:38
+8192: Colon           ":" at 668:38-668:39
+8193: Ident           "float" at 668:40-668:45 (leading: Space)
+8194: Comma           "," at 668:45-668:46
+8195: Ident           "target" at 668:47-668:53 (leading: Space)
+8196: Colon           ":" at 668:53-668:54
+8197: Ident           "float64" at 668:55-668:62 (leading: Space)
+8198: RParen          ")" at 668:62-668:63
+8199: Arrow           "->" at 668:64-668:66 (leading: Space)
+8200: Ident           "float64" at 668:67-668:74 (leading: Space)
+8201: Semicolon       ";" at 668:74-668:75
+8202: At              "@" at 670:5-670:6 (leading: Newline, Space, LineComment, Newline, Space)
+8203: Ident           "intrinsic" at 670:6-670:15
+8204: KwPub           "pub" at 670:16-670:19 (leading: Space)
+8205: KwFn            "fn" at 670:20-670:22 (leading: Space)
+8206: Ident           "from_str" at 670:23-670:31 (leading: Space)
+8207: LParen          "(" at 670:31-670:32
+8208: Ident           "s" at 670:32-670:33
+8209: Colon           ":" at 670:33-670:34
+8210: Amp             "&" at 670:35-670:36 (leading: Space)
+8211: Ident           "string" at 670:36-670:42
+8212: RParen          ")" at 670:42-670:43
+8213: Arrow           "->" at 670:44-670:46 (leading: Space)
+8214: Ident           "Erring" at 670:47-670:53 (leading: Space)
+8215: Lt              "<" at 670:53-670:54
+8216: Ident           "float" at 670:54-670:59
+8217: Comma           "," at 670:59-670:60
+8218: Ident           "Error" at 670:61-670:66 (leading: Space)
+8219: Gt              ">" at 670:66-670:67
+8220: Semicolon       ";" at 670:67-670:68
+8221: RBrace          "}" at 671:1-671:2 (leading: Newline)
+8222: KwExtern        "extern" at 673:1-673:7 (leading: Newline)
+8223: Lt              "<" at 673:7-673:8
+8224: Ident           "string" at 673:8-673:14
+8225: Gt              ">" at 673:14-673:15
+8226: LBrace          "{" at 673:16-673:17 (leading: Space)
+8227: At              "@" at 674:5-674:6 (leading: Newline, Space)
+8228: Ident           "intrinsic" at 674:6-674:15
+8229: KwFn            "fn" at 674:16-674:18 (leading: Space)
+8230: Ident           "__add" at 674:19-674:24 (leading: Space)
+8231: LParen          "(" at 674:24-674:25
+8232: Ident           "self" at 674:25-674:29
+8233: Colon           ":" at 674:29-674:30
+8234: Amp             "&" at 674:31-674:32 (leading: Space)
+8235: Ident           "string" at 674:32-674:38
+8236: Comma           "," at 674:38-674:39
+8237: Ident           "other" at 674:40-674:45 (leading: Space)
+8238: Colon           ":" at 674:45-674:46
+8239: Amp             "&" at 674:47-674:48 (leading: Space)
+8240: Ident           "string" at 674:48-674:54
+8241: RParen          ")" at 674:54-674:55
+8242: Arrow           "->" at 674:56-674:58 (leading: Space)
+8243: Ident           "string" at 674:59-674:65 (leading: Space)
+8244: Semicolon       ";" at 674:65-674:66
+8245: At              "@" at 675:5-675:6 (leading: Newline, Space)
+8246: Ident           "intrinsic" at 675:6-675:15
+8247: KwFn            "fn" at 675:16-675:18 (leading: Space)
+8248: Ident           "__mul" at 675:19-675:24 (leading: Space)
+8249: LParen          "(" at 675:24-675:25
+8250: Ident           "self" at 675:25-675:29
+8251: Colon           ":" at 675:29-675:30
+8252: Amp             "&" at 675:31-675:32 (leading: Space)
+8253: Ident           "string" at 675:32-675:38
+8254: Comma           "," at 675:38-675:39
+8255: Ident           "other" at 675:40-675:45 (leading: Space)
+8256: Colon           ":" at 675:45-675:46
+8257: Ident           "int" at 675:47-675:50 (leading: Space)
+8258: RParen          ")" at 675:50-675:51
+8259: Arrow           "->" at 675:52-675:54 (leading: Space)
+8260: Ident           "string" at 675:55-675:61 (leading: Space)
+8261: Semicolon       ";" at 675:61-675:62
+8262: At              "@" at 676:5-676:6 (leading: Newline, Space)
+8263: Ident           "overload" at 676:6-676:14
+8264: KwPub           "pub" at 676:15-676:18 (leading: Space)
+8265: KwFn            "fn" at 676:19-676:21 (leading: Space)
+8266: Ident           "__mul" at 676:22-676:27 (leading: Space)
+8267: LParen          "(" at 676:27-676:28
+8268: Ident           "self" at 676:28-676:32
+8269: Colon           ":" at 676:32-676:33
+8270: Amp             "&" at 676:34-676:35 (leading: Space)
+8271: Ident           "string" at 676:35-676:41
+8272: Comma           "," at 676:41-676:42
+8273: Ident           "other" at 676:43-676:48 (leading: Space)
+8274: Colon           ":" at 676:48-676:49
+8275: Ident           "uint" at 676:50-676:54 (leading: Space)
+8276: RParen          ")" at 676:54-676:55
+8277: Arrow           "->" at 676:56-676:58 (leading: Space)
+8278: Ident           "string" at 676:59-676:65 (leading: Space)
+8279: LBrace          "{" at 676:66-676:67 (leading: Space)
+8280: KwReturn        "return" at 677:9-677:15 (leading: Newline, Space)
+8281: Ident           "self" at 677:16-677:20 (leading: Space)
+8282: Star            "*" at 677:21-677:22 (leading: Space)
+8283: LParen          "(" at 677:23-677:24 (leading: Space)
+8284: Ident           "other" at 677:24-677:29
+8285: KwTo            "to" at 677:30-677:32 (leading: Space)
+8286: Ident           "int" at 677:33-677:36 (leading: Space)
+8287: RParen          ")" at 677:36-677:37
+8288: Semicolon       ";" at 677:37-677:38
+8289: RBrace          "}" at 678:5-678:6 (leading: Newline, Space)
+8290: At              "@" at 679:5-679:6 (leading: Newline, Space)
+8291: Ident           "intrinsic" at 679:6-679:15
+8292: KwFn            "fn" at 679:16-679:18 (leading: Space)
+8293: Ident           "__eq" at 679:19-679:23 (leading: Space)
+8294: LParen          "(" at 679:23-679:24
+8295: Ident           "self" at 679:24-679:28
+8296: Colon           ":" at 679:28-679:29
+8297: Amp             "&" at 679:30-679:31 (leading: Space)
+8298: Ident           "string" at 679:31-679:37
+8299: Comma           "," at 679:37-679:38
+8300: Ident           "other" at 679:39-679:44 (leading: Space)
+8301: Colon           ":" at 679:44-679:45
+8302: Amp             "&" at 679:46-679:47 (leading: Space)
+8303: Ident           "string" at 679:47-679:53
+8304: RParen          ")" at 679:53-679:54
+8305: Arrow           "->" at 679:55-679:57 (leading: Space)
+8306: Ident           "bool" at 679:58-679:62 (leading: Space)
+8307: Semicolon       ";" at 679:62-679:63
+8308: At              "@" at 680:5-680:6 (leading: Newline, Space)
+8309: Ident           "intrinsic" at 680:6-680:15
+8310: KwFn            "fn" at 680:16-680:18 (leading: Space)
+8311: Ident           "__ne" at 680:19-680:23 (leading: Space)
+8312: LParen          "(" at 680:23-680:24
+8313: Ident           "self" at 680:24-680:28
+8314: Colon           ":" at 680:28-680:29
+8315: Amp             "&" at 680:30-680:31 (leading: Space)
+8316: Ident           "string" at 680:31-680:37
+8317: Comma           "," at 680:37-680:38
+8318: Ident           "other" at 680:39-680:44 (leading: Space)
+8319: Colon           ":" at 680:44-680:45
+8320: Amp             "&" at 680:46-680:47 (leading: Space)
+8321: Ident           "string" at 680:47-680:53
+8322: RParen          ")" at 680:53-680:54
+8323: Arrow           "->" at 680:55-680:57 (leading: Space)
+8324: Ident           "bool" at 680:58-680:62 (leading: Space)
+8325: Semicolon       ";" at 680:62-680:63
+8326: At              "@" at 681:5-681:6 (leading: Newline, Space)
+8327: Ident           "intrinsic" at 681:6-681:15
+8328: KwFn            "fn" at 681:16-681:18 (leading: Space)
+8329: Ident           "__to" at 681:19-681:23 (leading: Space)
+8330: LParen          "(" at 681:23-681:24
+8331: Ident           "self" at 681:24-681:28
+8332: Colon           ":" at 681:28-681:29
+8333: Amp             "&" at 681:30-681:31 (leading: Space)
+8334: Ident           "string" at 681:31-681:37
+8335: Comma           "," at 681:37-681:38
+8336: Ident           "target" at 681:39-681:45 (leading: Space)
+8337: Colon           ":" at 681:45-681:46
+8338: Ident           "int" at 681:47-681:50 (leading: Space)
+8339: RParen          ")" at 681:50-681:51
+8340: Arrow           "->" at 681:52-681:54 (leading: Space)
+8341: Ident           "int" at 681:55-681:58 (leading: Space)
+8342: Semicolon       ";" at 681:58-681:59
+8343: At              "@" at 682:5-682:6 (leading: Newline, Space)
+8344: Ident           "intrinsic" at 682:6-682:15
+8345: At              "@" at 682:16-682:17 (leading: Space)
+8346: Ident           "overload" at 682:17-682:25
+8347: KwFn            "fn" at 682:26-682:28 (leading: Space)
+8348: Ident           "__to" at 682:29-682:33 (leading: Space)
+8349: LParen          "(" at 682:33-682:34
+8350: Ident           "self" at 682:34-682:38
+8351: Colon           ":" at 682:38-682:39
+8352: Amp             "&" at 682:40-682:41 (leading: Space)
+8353: Ident           "string" at 682:41-682:47
+8354: Comma           "," at 682:47-682:48
+8355: Ident           "target" at 682:49-682:55 (leading: Space)
+8356: Colon           ":" at 682:55-682:56
+8357: Ident           "uint" at 682:57-682:61 (leading: Space)
+8358: RParen          ")" at 682:61-682:62
+8359: Arrow           "->" at 682:63-682:65 (leading: Space)
+8360: Ident           "uint" at 682:66-682:70 (leading: Space)
+8361: Semicolon       ";" at 682:70-682:71
+8362: At              "@" at 683:5-683:6 (leading: Newline, Space)
+8363: Ident           "intrinsic" at 683:6-683:15
+8364: At              "@" at 683:16-683:17 (leading: Space)
+8365: Ident           "overload" at 683:17-683:25
+8366: KwFn            "fn" at 683:26-683:28 (leading: Space)
+8367: Ident           "__to" at 683:29-683:33 (leading: Space)
+8368: LParen          "(" at 683:33-683:34
+8369: Ident           "self" at 683:34-683:38
+8370: Colon           ":" at 683:38-683:39
+8371: Amp             "&" at 683:40-683:41 (leading: Space)
+8372: Ident           "string" at 683:41-683:47
+8373: Comma           "," at 683:47-683:48
+8374: Ident           "target" at 683:49-683:55 (leading: Space)
+8375: Colon           ":" at 683:55-683:56
+8376: Ident           "float" at 683:57-683:62 (leading: Space)
+8377: RParen          ")" at 683:62-683:63
+8378: Arrow           "->" at 683:64-683:66 (leading: Space)
+8379: Ident           "float" at 683:67-683:72 (leading: Space)
+8380: Semicolon       ";" at 683:72-683:73
+8381: At              "@" at 684:5-684:6 (leading: Newline, Space)
+8382: Ident           "overload" at 684:6-684:14
+8383: KwPub           "pub" at 684:15-684:18 (leading: Space)
+8384: KwFn            "fn" at 684:19-684:21 (leading: Space)
+8385: Ident           "__to" at 684:22-684:26 (leading: Space)
+8386: LParen          "(" at 684:26-684:27
+8387: Ident           "self" at 684:27-684:31
+8388: Colon           ":" at 684:31-684:32
+8389: Amp             "&" at 684:33-684:34 (leading: Space)
+8390: Ident           "string" at 684:34-684:40
+8391: Comma           "," at 684:40-684:41
+8392: Underscore      "_" at 684:42-684:43 (leading: Space)
+8393: Colon           ":" at 684:43-684:44
+8394: Ident           "string" at 684:45-684:51 (leading: Space)
+8395: RParen          ")" at 684:51-684:52
+8396: Arrow           "->" at 684:53-684:55 (leading: Space)
+8397: Ident           "string" at 684:56-684:62 (leading: Space)
+8398: LBrace          "{" at 684:63-684:64 (leading: Space)
+8399: KwReturn        "return" at 685:9-685:15 (leading: Newline, Space)
+8400: Ident           "self" at 685:16-685:20 (leading: Space)
+8401: Dot             "." at 685:20-685:21
+8402: Ident           "__clone" at 685:21-685:28
+8403: LParen          "(" at 685:28-685:29
+8404: RParen          ")" at 685:29-685:30
+8405: Semicolon       ";" at 685:30-685:31
+8406: RBrace          "}" at 686:5-686:6 (leading: Newline, Space)
+8407: At              "@" at 687:5-687:6 (leading: Newline, Space)
+8408: Ident           "overload" at 687:6-687:14
+8409: KwPub           "pub" at 688:5-688:8 (leading: Newline, Space)
+8410: KwFn            "fn" at 688:9-688:11 (leading: Space)
+8411: Ident           "__to" at 688:12-688:16 (leading: Space)
+8412: LParen          "(" at 688:16-688:17
+8413: Ident           "self" at 688:17-688:21
+8414: Colon           ":" at 688:21-688:22
+8415: Amp             "&" at 688:23-688:24 (leading: Space)
+8416: Ident           "string" at 688:24-688:30
+8417: Comma           "," at 688:30-688:31
+8418: Underscore      "_" at 688:32-688:33 (leading: Space)
+8419: Colon           ":" at 688:33-688:34
+8420: Ident           "byte" at 688:35-688:39 (leading: Space)
+8421: LBracket        "[" at 688:39-688:40
+8422: RBracket        "]" at 688:40-688:41
+8423: RParen          ")" at 688:41-688:42
+8424: Arrow           "->" at 688:43-688:45 (leading: Space)
+8425: Ident           "byte" at 688:46-688:50 (leading: Space)
+8426: LBracket        "[" at 688:50-688:51
+8427: RBracket        "]" at 688:51-688:52
+8428: LBrace          "{" at 688:53-688:54 (leading: Space)
+8429: KwLet           "let" at 689:9-689:12 (leading: Newline, Space)
+8430: KwMut           "mut" at 689:13-689:16 (leading: Space)
+8431: Ident           "out" at 689:17-689:20 (leading: Space)
+8432: Colon           ":" at 689:20-689:21
+8433: Ident           "byte" at 689:22-689:26 (leading: Space)
+8434: LBracket        "[" at 689:26-689:27
+8435: RBracket        "]" at 689:27-689:28
+8436: Assign          "=" at 689:29-689:30 (leading: Space)
+8437: LBracket        "[" at 689:31-689:32 (leading: Space)
+8438: RBracket        "]" at 689:32-689:33
+8439: Semicolon       ";" at 689:33-689:34
+8440: Ident           "rt_array_append_raw_bytes" at 690:9-690:34 (leading: Newline, Space)
+8441: LParen          "(" at 690:34-690:35
+8442: Amp             "&" at 690:35-690:36
+8443: KwMut           "mut" at 690:36-690:39
+8444: Ident           "out" at 690:40-690:43 (leading: Space)
+8445: Comma           "," at 690:43-690:44
+8446: Ident           "rt_string_ptr" at 690:45-690:58 (leading: Space)
+8447: LParen          "(" at 690:58-690:59
+8448: Ident           "self" at 690:59-690:63
+8449: RParen          ")" at 690:63-690:64
+8450: Comma           "," at 690:64-690:65
+8451: Ident           "rt_string_len_bytes" at 690:66-690:85 (leading: Space)
+8452: LParen          "(" at 690:85-690:86
+8453: Ident           "self" at 690:86-690:90
+8454: RParen          ")" at 690:90-690:91
+8455: KwTo            "to" at 690:92-690:94 (leading: Space)
+8456: Ident           "uint64" at 690:95-690:101 (leading: Space)
+8457: RParen          ")" at 690:101-690:102
+8458: Semicolon       ";" at 690:102-690:103
+8459: KwReturn        "return" at 691:9-691:15 (leading: Newline, Space)
+8460: Ident           "out" at 691:16-691:19 (leading: Space)
+8461: Semicolon       ";" at 691:19-691:20
+8462: RBrace          "}" at 692:5-692:6 (leading: Newline, Space)
+8463: At              "@" at 693:5-693:6 (leading: Newline, Space)
+8464: Ident           "intrinsic" at 693:6-693:15
+8465: KwFn            "fn" at 693:16-693:18 (leading: Space)
+8466: Ident           "__len" at 693:19-693:24 (leading: Space)
+8467: LParen          "(" at 693:24-693:25
+8468: Ident           "self" at 693:25-693:29
+8469: Colon           ":" at 693:29-693:30
+8470: Amp             "&" at 693:31-693:32 (leading: Space)
+8471: Ident           "string" at 693:32-693:38
+8472: RParen          ")" at 693:38-693:39
+8473: Arrow           "->" at 693:40-693:42 (leading: Space)
+8474: Ident           "uint" at 693:43-693:47 (leading: Space)
+8475: Semicolon       ";" at 693:47-693:48
+8476: At              "@" at 694:5-694:6 (leading: Newline, Space)
+8477: Ident           "intrinsic" at 694:6-694:15
+8478: KwFn            "fn" at 694:16-694:18 (leading: Space)
+8479: Ident           "__clone" at 694:19-694:26 (leading: Space)
+8480: LParen          "(" at 694:26-694:27
+8481: Ident           "self" at 694:27-694:31
+8482: Colon           ":" at 694:31-694:32
+8483: Amp             "&" at 694:33-694:34 (leading: Space)
+8484: Ident           "string" at 694:34-694:40
+8485: RParen          ")" at 694:40-694:41
+8486: Arrow           "->" at 694:42-694:44 (leading: Space)
+8487: Ident           "string" at 694:45-694:51 (leading: Space)
+8488: Semicolon       ";" at 694:51-694:52
+8489: At              "@" at 695:5-695:6 (leading: Newline, Space)
+8490: Ident           "intrinsic" at 695:6-695:15
+8491: At              "@" at 695:16-695:17 (leading: Space)
+8492: Ident           "overload" at 695:17-695:25
+8493: KwFn            "fn" at 695:26-695:28 (leading: Space)
+8494: Ident           "__index" at 695:29-695:36 (leading: Space)
+8495: LParen          "(" at 695:36-695:37
+8496: Ident           "self" at 695:37-695:41
+8497: Colon           ":" at 695:41-695:42
+8498: Amp             "&" at 695:43-695:44 (leading: Space)
+8499: Ident           "string" at 695:44-695:50
+8500: Comma           "," at 695:50-695:51
+8501: Ident           "index" at 695:52-695:57 (leading: Space)
+8502: Colon           ":" at 695:57-695:58
+8503: Ident           "int" at 695:59-695:62 (leading: Space)
+8504: RParen          ")" at 695:62-695:63
+8505: Arrow           "->" at 695:64-695:66 (leading: Space)
+8506: Ident           "uint32" at 695:67-695:73 (leading: Space)
+8507: Semicolon       ";" at 695:73-695:74
+8508: At              "@" at 696:5-696:6 (leading: Newline, Space)
+8509: Ident           "intrinsic" at 696:6-696:15
+8510: At              "@" at 696:16-696:17 (leading: Space)
+8511: Ident           "overload" at 696:17-696:25
+8512: KwFn            "fn" at 696:26-696:28 (leading: Space)
+8513: Ident           "__index" at 696:29-696:36 (leading: Space)
+8514: LParen          "(" at 696:36-696:37
+8515: Ident           "self" at 696:37-696:41
+8516: Colon           ":" at 696:41-696:42
+8517: Amp             "&" at 696:43-696:44 (leading: Space)
+8518: Ident           "string" at 696:44-696:50
+8519: Comma           "," at 696:50-696:51
+8520: Ident           "index" at 696:52-696:57 (leading: Space)
+8521: Colon           ":" at 696:57-696:58
+8522: Ident           "Range" at 696:59-696:64 (leading: Space)
+8523: Lt              "<" at 696:64-696:65
+8524: Ident           "int" at 696:65-696:68
+8525: Gt              ">" at 696:68-696:69
+8526: RParen          ")" at 696:69-696:70
+8527: Arrow           "->" at 696:71-696:73 (leading: Space)
+8528: Ident           "string" at 696:74-696:80 (leading: Space)
+8529: Semicolon       ";" at 696:80-696:81
+8530: RBrace          "}" at 697:1-697:2 (leading: Newline)
+8531: At              "@" at 699:1-699:2 (leading: Newline)
+8532: Ident           "intrinsic" at 699:2-699:11
+8533: KwPub           "pub" at 700:1-700:4 (leading: Newline)
+8534: KwType          "type" at 700:5-700:9 (leading: Space)
+8535: Ident           "BytesView" at 700:10-700:19 (leading: Space)
+8536: Assign          "=" at 700:20-700:21 (leading: Space)
+8537: LBrace          "{" at 700:22-700:23 (leading: Space)
+8538: Ident           "owner" at 701:5-701:10 (leading: Newline, Space)
+8539: Colon           ":" at 701:10-701:11
+8540: Ident           "string" at 701:12-701:18 (leading: Space)
+8541: Comma           "," at 701:18-701:19
+8542: Ident           "ptr" at 702:5-702:8 (leading: Newline, Space)
+8543: Colon           ":" at 702:8-702:9
+8544: Star            "*" at 702:10-702:11 (leading: Space)
+8545: Ident           "byte" at 702:11-702:15
+8546: Comma           "," at 702:15-702:16
+8547: Ident           "len" at 703:5-703:8 (leading: Newline, Space)
+8548: Colon           ":" at 703:8-703:9
+8549: Ident           "uint" at 703:10-703:14 (leading: Space)
+8550: Comma           "," at 703:14-703:15
+8551: RBrace          "}" at 704:1-704:2 (leading: Newline)
+8552: Semicolon       ";" at 704:2-704:3
+8553: KwExtern        "extern" at 706:1-706:7 (leading: Newline)
+8554: Lt              "<" at 706:7-706:8
+8555: Ident           "BytesView" at 706:8-706:17
+8556: Gt              ">" at 706:17-706:18
+8557: LBrace          "{" at 706:19-706:20 (leading: Space)
+8558: At              "@" at 707:5-707:6 (leading: Newline, Space)
+8559: Ident           "intrinsic" at 707:6-707:15
+8560: KwFn            "fn" at 707:16-707:18 (leading: Space)
+8561: Ident           "__len" at 707:19-707:24 (leading: Space)
+8562: LParen          "(" at 707:24-707:25
+8563: Ident           "self" at 707:25-707:29
+8564: Colon           ":" at 707:29-707:30
+8565: Amp             "&" at 707:31-707:32 (leading: Space)
+8566: Ident           "BytesView" at 707:32-707:41
+8567: RParen          ")" at 707:41-707:42
+8568: Arrow           "->" at 707:43-707:45 (leading: Space)
+8569: Ident           "uint" at 707:46-707:50 (leading: Space)
+8570: Semicolon       ";" at 707:50-707:51
+8571: At              "@" at 708:5-708:6 (leading: Newline, Space)
+8572: Ident           "intrinsic" at 708:6-708:15
+8573: KwFn            "fn" at 708:16-708:18 (leading: Space)
+8574: Ident           "__index" at 708:19-708:26 (leading: Space)
+8575: LParen          "(" at 708:26-708:27
+8576: Ident           "self" at 708:27-708:31
+8577: Colon           ":" at 708:31-708:32
+8578: Amp             "&" at 708:33-708:34 (leading: Space)
+8579: Ident           "BytesView" at 708:34-708:43
+8580: Comma           "," at 708:43-708:44
+8581: Ident           "index" at 708:45-708:50 (leading: Space)
+8582: Colon           ":" at 708:50-708:51
+8583: Ident           "int" at 708:52-708:55 (leading: Space)
+8584: RParen          ")" at 708:55-708:56
+8585: Arrow           "->" at 708:57-708:59 (leading: Space)
+8586: Ident           "uint8" at 708:60-708:65 (leading: Space)
+8587: Semicolon       ";" at 708:65-708:66
+8588: At              "@" at 709:5-709:6 (leading: Newline, Space)
+8589: Ident           "intrinsic" at 709:6-709:15
+8590: At              "@" at 709:16-709:17 (leading: Space)
+8591: Ident           "overload" at 709:17-709:25
+8592: KwFn            "fn" at 709:26-709:28 (leading: Space)
+8593: Ident           "__index" at 709:29-709:36 (leading: Space)
+8594: LParen          "(" at 709:36-709:37
+8595: Ident           "self" at 709:37-709:41
+8596: Colon           ":" at 709:41-709:42
+8597: Amp             "&" at 709:43-709:44 (leading: Space)
+8598: Ident           "BytesView" at 709:44-709:53
+8599: Comma           "," at 709:53-709:54
+8600: Ident           "index" at 709:55-709:60 (leading: Space)
+8601: Colon           ":" at 709:60-709:61
+8602: Ident           "int64" at 709:62-709:67 (leading: Space)
+8603: RParen          ")" at 709:67-709:68
+8604: Arrow           "->" at 709:69-709:71 (leading: Space)
+8605: Ident           "uint8" at 709:72-709:77 (leading: Space)
+8606: Semicolon       ";" at 709:77-709:78
+8607: RBrace          "}" at 710:1-710:2 (leading: Newline)
+8608: KwExtern        "extern" at 712:1-712:7 (leading: Newline)
+8609: Lt              "<" at 712:7-712:8
+8610: Ident           "bool" at 712:8-712:12
+8611: Gt              ">" at 712:12-712:13
+8612: LBrace          "{" at 712:14-712:15 (leading: Space)
+8613: At              "@" at 713:5-713:6 (leading: Newline, Space)
+8614: Ident           "intrinsic" at 713:6-713:15
+8615: KwFn            "fn" at 713:16-713:18 (leading: Space)
+8616: Ident           "__eq" at 713:19-713:23 (leading: Space)
+8617: LParen          "(" at 713:23-713:24
+8618: Ident           "self" at 713:24-713:28
+8619: Colon           ":" at 713:28-713:29
+8620: Ident           "bool" at 713:30-713:34 (leading: Space)
+8621: Comma           "," at 713:34-713:35
+8622: Ident           "other" at 713:36-713:41 (leading: Space)
+8623: Colon           ":" at 713:41-713:42
+8624: Ident           "bool" at 713:43-713:47 (leading: Space)
+8625: RParen          ")" at 713:47-713:48
+8626: Arrow           "->" at 713:49-713:51 (leading: Space)
+8627: Ident           "bool" at 713:52-713:56 (leading: Space)
+8628: Semicolon       ";" at 713:56-713:57
+8629: At              "@" at 714:5-714:6 (leading: Newline, Space)
+8630: Ident           "intrinsic" at 714:6-714:15
+8631: KwFn            "fn" at 714:16-714:18 (leading: Space)
+8632: Ident           "__ne" at 714:19-714:23 (leading: Space)
+8633: LParen          "(" at 714:23-714:24
+8634: Ident           "self" at 714:24-714:28
+8635: Colon           ":" at 714:28-714:29
+8636: Ident           "bool" at 714:30-714:34 (leading: Space)
+8637: Comma           "," at 714:34-714:35
+8638: Ident           "other" at 714:36-714:41 (leading: Space)
+8639: Colon           ":" at 714:41-714:42
+8640: Ident           "bool" at 714:43-714:47 (leading: Space)
+8641: RParen          ")" at 714:47-714:48
+8642: Arrow           "->" at 714:49-714:51 (leading: Space)
+8643: Ident           "bool" at 714:52-714:56 (leading: Space)
+8644: Semicolon       ";" at 714:56-714:57
+8645: At              "@" at 715:5-715:6 (leading: Newline, Space)
+8646: Ident           "intrinsic" at 715:6-715:15
+8647: KwFn            "fn" at 715:16-715:18 (leading: Space)
+8648: Ident           "__not" at 715:19-715:24 (leading: Space)
+8649: LParen          "(" at 715:24-715:25
+8650: Ident           "self" at 715:25-715:29
+8651: Colon           ":" at 715:29-715:30
+8652: Ident           "bool" at 715:31-715:35 (leading: Space)
+8653: RParen          ")" at 715:35-715:36
+8654: Arrow           "->" at 715:37-715:39 (leading: Space)
+8655: Ident           "bool" at 715:40-715:44 (leading: Space)
+8656: Semicolon       ";" at 715:44-715:45
+8657: At              "@" at 716:5-716:6 (leading: Newline, Space)
+8658: Ident           "intrinsic" at 716:6-716:15
+8659: KwFn            "fn" at 716:16-716:18 (leading: Space)
+8660: Ident           "__to" at 716:19-716:23 (leading: Space)
+8661: LParen          "(" at 716:23-716:24
+8662: Ident           "self" at 716:24-716:28
+8663: Colon           ":" at 716:28-716:29
+8664: Ident           "bool" at 716:30-716:34 (leading: Space)
+8665: Comma           "," at 716:34-716:35
+8666: Ident           "target" at 716:36-716:42 (leading: Space)
+8667: Colon           ":" at 716:42-716:43
+8668: Ident           "string" at 716:44-716:50 (leading: Space)
+8669: RParen          ")" at 716:50-716:51
+8670: Arrow           "->" at 716:52-716:54 (leading: Space)
+8671: Ident           "string" at 716:55-716:61 (leading: Space)
+8672: Semicolon       ";" at 716:61-716:62
+8673: At              "@" at 717:5-717:6 (leading: Newline, Space)
+8674: Ident           "overload" at 717:6-717:14
+8675: KwPub           "pub" at 717:15-717:18 (leading: Space)
+8676: KwFn            "fn" at 717:19-717:21 (leading: Space)
+8677: Ident           "__to" at 717:22-717:26 (leading: Space)
+8678: LParen          "(" at 717:26-717:27
+8679: Ident           "self" at 717:27-717:31
+8680: Colon           ":" at 717:31-717:32
+8681: Amp             "&" at 717:33-717:34 (leading: Space)
+8682: Ident           "bool" at 717:34-717:38
+8683: Comma           "," at 717:38-717:39
+8684: Underscore      "_" at 717:40-717:41 (leading: Space)
+8685: Colon           ":" at 717:41-717:42
+8686: Ident           "string" at 717:43-717:49 (leading: Space)
+8687: RParen          ")" at 717:49-717:50
+8688: Arrow           "->" at 717:51-717:53 (leading: Space)
+8689: Ident           "string" at 717:54-717:60 (leading: Space)
+8690: LBrace          "{" at 717:61-717:62 (leading: Space)
+8691: KwReturn        "return" at 718:9-718:15 (leading: Newline, Space)
+8692: LParen          "(" at 718:16-718:17 (leading: Space)
+8693: Star            "*" at 718:17-718:18
+8694: Ident           "self" at 718:18-718:22
+8695: RParen          ")" at 718:22-718:23
+8696: KwTo            "to" at 718:24-718:26 (leading: Space)
+8697: Ident           "string" at 718:27-718:33 (leading: Space)
+8698: Semicolon       ";" at 718:33-718:34
+8699: RBrace          "}" at 719:5-719:6 (leading: Newline, Space)
+8700: At              "@" at 720:5-720:6 (leading: Newline, Space)
+8701: Ident           "intrinsic" at 720:6-720:15
+8702: At              "@" at 720:16-720:17 (leading: Space)
+8703: Ident           "overload" at 720:17-720:25
+8704: KwFn            "fn" at 720:26-720:28 (leading: Space)
+8705: Ident           "__to" at 720:29-720:33 (leading: Space)
+8706: LParen          "(" at 720:33-720:34
+8707: Ident           "self" at 720:34-720:38
+8708: Colon           ":" at 720:38-720:39
+8709: Ident           "bool" at 720:40-720:44 (leading: Space)
+8710: Comma           "," at 720:44-720:45
+8711: Ident           "target" at 720:46-720:52 (leading: Space)
+8712: Colon           ":" at 720:52-720:53
+8713: Ident           "int" at 720:54-720:57 (leading: Space)
+8714: RParen          ")" at 720:57-720:58
+8715: Arrow           "->" at 720:59-720:61 (leading: Space)
+8716: Ident           "int" at 720:62-720:65 (leading: Space)
+8717: Semicolon       ";" at 720:65-720:66
+8718: At              "@" at 722:5-722:6 (leading: Newline, Space, LineComment, Newline, Space)
+8719: Ident           "intrinsic" at 722:6-722:15
+8720: KwPub           "pub" at 722:16-722:19 (leading: Space)
+8721: KwFn            "fn" at 722:20-722:22 (leading: Space)
+8722: Ident           "from_str" at 722:23-722:31 (leading: Space)
+8723: LParen          "(" at 722:31-722:32
+8724: Ident           "s" at 722:32-722:33
+8725: Colon           ":" at 722:33-722:34
+8726: Amp             "&" at 722:35-722:36 (leading: Space)
+8727: Ident           "string" at 722:36-722:42
+8728: RParen          ")" at 722:42-722:43
+8729: Arrow           "->" at 722:44-722:46 (leading: Space)
+8730: Ident           "Erring" at 722:47-722:53 (leading: Space)
+8731: Lt              "<" at 722:53-722:54
+8732: Ident           "bool" at 722:54-722:58
+8733: Comma           "," at 722:58-722:59
+8734: Ident           "Error" at 722:60-722:65 (leading: Space)
+8735: Gt              ">" at 722:65-722:66
+8736: Semicolon       ";" at 722:66-722:67
+8737: RBrace          "}" at 723:1-723:2 (leading: Newline)
+8738: KwExtern        "extern" at 725:1-725:7 (leading: Newline)
+8739: Lt              "<" at 725:7-725:8
+8740: Ident           "Array" at 725:8-725:13
+8741: Lt              "<" at 725:13-725:14
+8742: Ident           "T" at 725:14-725:15
+8743: Shr             ">>" at 725:15-725:17
+8744: LBrace          "{" at 725:18-725:19 (leading: Space)
+8745: At              "@" at 726:5-726:6 (leading: Newline, Space)
+8746: Ident           "intrinsic" at 726:6-726:15
+8747: KwFn            "fn" at 726:16-726:18 (leading: Space)
+8748: Ident           "__add" at 726:19-726:24 (leading: Space)
+8749: LParen          "(" at 726:24-726:25
+8750: Ident           "self" at 726:25-726:29
+8751: Colon           ":" at 726:29-726:30
+8752: Amp             "&" at 726:31-726:32 (leading: Space)
+8753: Ident           "Array" at 726:32-726:37
+8754: Lt              "<" at 726:37-726:38
+8755: Ident           "T" at 726:38-726:39
+8756: Gt              ">" at 726:39-726:40
+8757: Comma           "," at 726:40-726:41
+8758: Ident           "other" at 726:42-726:47 (leading: Space)
+8759: Colon           ":" at 726:47-726:48
+8760: Amp             "&" at 726:49-726:50 (leading: Space)
+8761: Ident           "Array" at 726:50-726:55
+8762: Lt              "<" at 726:55-726:56
+8763: Ident           "T" at 726:56-726:57
+8764: Gt              ">" at 726:57-726:58
+8765: RParen          ")" at 726:58-726:59
+8766: Arrow           "->" at 726:60-726:62 (leading: Space)
+8767: Ident           "Array" at 726:63-726:68 (leading: Space)
+8768: Lt              "<" at 726:68-726:69
+8769: Ident           "T" at 726:69-726:70
+8770: Gt              ">" at 726:70-726:71
+8771: Semicolon       ";" at 726:71-726:72
+8772: At              "@" at 727:5-727:6 (leading: Newline, Space)
+8773: Ident           "intrinsic" at 727:6-727:15
+8774: KwFn            "fn" at 727:16-727:18 (leading: Space)
+8775: Ident           "__index" at 727:19-727:26 (leading: Space)
+8776: LParen          "(" at 727:26-727:27
+8777: Ident           "self" at 727:27-727:31
+8778: Colon           ":" at 727:31-727:32
+8779: Amp             "&" at 727:33-727:34 (leading: Space)
+8780: Ident           "Array" at 727:34-727:39
+8781: Lt              "<" at 727:39-727:40
+8782: Ident           "T" at 727:40-727:41
+8783: Gt              ">" at 727:41-727:42
+8784: Comma           "," at 727:42-727:43
+8785: Ident           "index" at 727:44-727:49 (leading: Space)
+8786: Colon           ":" at 727:49-727:50
+8787: Ident           "int" at 727:51-727:54 (leading: Space)
+8788: RParen          ")" at 727:54-727:55
+8789: Arrow           "->" at 727:56-727:58 (leading: Space)
+8790: Amp             "&" at 727:59-727:60 (leading: Space)
+8791: Ident           "T" at 727:60-727:61
+8792: Semicolon       ";" at 727:61-727:62
+8793: At              "@" at 728:5-728:6 (leading: Newline, Space)
+8794: Ident           "intrinsic" at 728:6-728:15
+8795: At              "@" at 728:16-728:17 (leading: Space)
+8796: Ident           "overload" at 728:17-728:25
+8797: KwFn            "fn" at 728:26-728:28 (leading: Space)
+8798: Ident           "__index" at 728:29-728:36 (leading: Space)
+8799: LParen          "(" at 728:36-728:37
+8800: Ident           "self" at 728:37-728:41
+8801: Colon           ":" at 728:41-728:42
+8802: Amp             "&" at 728:43-728:44 (leading: Space)
+8803: Ident           "Array" at 728:44-728:49
+8804: Lt              "<" at 728:49-728:50
+8805: Ident           "T" at 728:50-728:51
+8806: Gt              ">" at 728:51-728:52
+8807: Comma           "," at 728:52-728:53
+8808: Ident           "index" at 728:54-728:59 (leading: Space)
+8809: Colon           ":" at 728:59-728:60
+8810: Ident           "Range" at 728:61-728:66 (leading: Space)
+8811: Lt              "<" at 728:66-728:67
+8812: Ident           "int" at 728:67-728:70
+8813: Gt              ">" at 728:70-728:71
+8814: RParen          ")" at 728:71-728:72
+8815: Arrow           "->" at 728:73-728:75 (leading: Space)
+8816: Ident           "Array" at 728:76-728:81 (leading: Space)
+8817: Lt              "<" at 728:81-728:82
+8818: Ident           "T" at 728:82-728:83
+8819: Gt              ">" at 728:83-728:84
+8820: Semicolon       ";" at 728:84-728:85
+8821: At              "@" at 729:5-729:6 (leading: Newline, Space)
+8822: Ident           "intrinsic" at 729:6-729:15
+8823: KwFn            "fn" at 729:16-729:18 (leading: Space)
+8824: Ident           "__index_set" at 729:19-729:30 (leading: Space)
+8825: LParen          "(" at 729:30-729:31
+8826: Ident           "self" at 729:31-729:35
+8827: Colon           ":" at 729:35-729:36
+8828: Amp             "&" at 729:37-729:38 (leading: Space)
+8829: KwMut           "mut" at 729:38-729:41
+8830: Ident           "Array" at 729:42-729:47 (leading: Space)
+8831: Lt              "<" at 729:47-729:48
+8832: Ident           "T" at 729:48-729:49
+8833: Gt              ">" at 729:49-729:50
+8834: Comma           "," at 729:50-729:51
+8835: Ident           "index" at 729:52-729:57 (leading: Space)
+8836: Colon           ":" at 729:57-729:58
+8837: Ident           "int" at 729:59-729:62 (leading: Space)
+8838: Comma           "," at 729:62-729:63
+8839: Ident           "value" at 729:64-729:69 (leading: Space)
+8840: Colon           ":" at 729:69-729:70
+8841: Ident           "T" at 729:71-729:72 (leading: Space)
+8842: RParen          ")" at 729:72-729:73
+8843: Arrow           "->" at 729:74-729:76 (leading: Space)
+8844: NothingLit      "nothing" at 729:77-729:84 (leading: Space)
+8845: Semicolon       ";" at 729:84-729:85
+8846: At              "@" at 730:5-730:6 (leading: Newline, Space)
+8847: Ident           "intrinsic" at 730:6-730:15
+8848: KwFn            "fn" at 730:16-730:18 (leading: Space)
+8849: Ident           "__range" at 730:19-730:26 (leading: Space)
+8850: LParen          "(" at 730:26-730:27
+8851: Ident           "self" at 730:27-730:31
+8852: Colon           ":" at 730:31-730:32
+8853: Amp             "&" at 730:33-730:34 (leading: Space)
+8854: Ident           "Array" at 730:34-730:39
+8855: Lt              "<" at 730:39-730:40
+8856: Ident           "T" at 730:40-730:41
+8857: Gt              ">" at 730:41-730:42
+8858: RParen          ")" at 730:42-730:43
+8859: Arrow           "->" at 730:44-730:46 (leading: Space)
+8860: Ident           "Range" at 730:47-730:52 (leading: Space)
+8861: Lt              "<" at 730:52-730:53
+8862: Ident           "T" at 730:53-730:54
+8863: Gt              ">" at 730:54-730:55
+8864: Semicolon       ";" at 730:55-730:56
+8865: At              "@" at 731:5-731:6 (leading: Newline, Space)
+8866: Ident           "intrinsic" at 731:6-731:15
+8867: KwFn            "fn" at 731:16-731:18 (leading: Space)
+8868: Ident           "__len" at 731:19-731:24 (leading: Space)
+8869: LParen          "(" at 731:24-731:25
+8870: Ident           "self" at 731:25-731:29
+8871: Colon           ":" at 731:29-731:30
+8872: Amp             "&" at 731:31-731:32 (leading: Space)
+8873: Ident           "Array" at 731:32-731:37
+8874: Lt              "<" at 731:37-731:38
+8875: Ident           "T" at 731:38-731:39
+8876: Gt              ">" at 731:39-731:40
+8877: RParen          ")" at 731:40-731:41
+8878: Arrow           "->" at 731:42-731:44 (leading: Space)
+8879: Ident           "uint" at 731:45-731:49 (leading: Space)
+8880: Semicolon       ";" at 731:49-731:50
+8881: RBrace          "}" at 732:1-732:2 (leading: Newline)
+8882: KwExtern        "extern" at 734:1-734:7 (leading: Newline)
+8883: Lt              "<" at 734:7-734:8
+8884: Ident           "ArrayFixed" at 734:8-734:18
+8885: Lt              "<" at 734:18-734:19
+8886: Ident           "T" at 734:19-734:20
+8887: Comma           "," at 734:20-734:21
+8888: Ident           "N" at 734:22-734:23 (leading: Space)
+8889: Shr             ">>" at 734:23-734:25
+8890: LBrace          "{" at 734:26-734:27 (leading: Space)
+8891: At              "@" at 735:5-735:6 (leading: Newline, Space)
+8892: Ident           "intrinsic" at 735:6-735:15
+8893: KwFn            "fn" at 735:16-735:18 (leading: Space)
+8894: Ident           "__add" at 735:19-735:24 (leading: Space)
+8895: LParen          "(" at 735:24-735:25
+8896: Ident           "self" at 735:25-735:29
+8897: Colon           ":" at 735:29-735:30
+8898: Amp             "&" at 735:31-735:32 (leading: Space)
+8899: Ident           "ArrayFixed" at 735:32-735:42
+8900: Lt              "<" at 735:42-735:43
+8901: Ident           "T" at 735:43-735:44
+8902: Comma           "," at 735:44-735:45
+8903: Ident           "N" at 735:46-735:47 (leading: Space)
+8904: Gt              ">" at 735:47-735:48
+8905: Comma           "," at 735:48-735:49
+8906: Ident           "other" at 735:50-735:55 (leading: Space)
+8907: Colon           ":" at 735:55-735:56
+8908: Amp             "&" at 735:57-735:58 (leading: Space)
+8909: Ident           "ArrayFixed" at 735:58-735:68
+8910: Lt              "<" at 735:68-735:69
+8911: Ident           "T" at 735:69-735:70
+8912: Comma           "," at 735:70-735:71
+8913: Ident           "N" at 735:72-735:73 (leading: Space)
+8914: Gt              ">" at 735:73-735:74
+8915: RParen          ")" at 735:74-735:75
+8916: Arrow           "->" at 735:76-735:78 (leading: Space)
+8917: Ident           "ArrayFixed" at 735:79-735:89 (leading: Space)
+8918: Lt              "<" at 735:89-735:90
+8919: Ident           "T" at 735:90-735:91
+8920: Comma           "," at 735:91-735:92
+8921: Ident           "N" at 735:93-735:94 (leading: Space)
+8922: Gt              ">" at 735:94-735:95
+8923: Semicolon       ";" at 735:95-735:96
+8924: At              "@" at 736:5-736:6 (leading: Newline, Space)
+8925: Ident           "intrinsic" at 736:6-736:15
+8926: KwFn            "fn" at 736:16-736:18 (leading: Space)
+8927: Ident           "__index" at 736:19-736:26 (leading: Space)
+8928: LParen          "(" at 736:26-736:27
+8929: Ident           "self" at 736:27-736:31
+8930: Colon           ":" at 736:31-736:32
+8931: Amp             "&" at 736:33-736:34 (leading: Space)
+8932: Ident           "ArrayFixed" at 736:34-736:44
+8933: Lt              "<" at 736:44-736:45
+8934: Ident           "T" at 736:45-736:46
+8935: Comma           "," at 736:46-736:47
+8936: Ident           "N" at 736:48-736:49 (leading: Space)
+8937: Gt              ">" at 736:49-736:50
+8938: Comma           "," at 736:50-736:51
+8939: Ident           "index" at 736:52-736:57 (leading: Space)
+8940: Colon           ":" at 736:57-736:58
+8941: Ident           "int" at 736:59-736:62 (leading: Space)
+8942: RParen          ")" at 736:62-736:63
+8943: Arrow           "->" at 736:64-736:66 (leading: Space)
+8944: Amp             "&" at 736:67-736:68 (leading: Space)
+8945: Ident           "T" at 736:68-736:69
+8946: Semicolon       ";" at 736:69-736:70
+8947: At              "@" at 737:5-737:6 (leading: Newline, Space)
+8948: Ident           "intrinsic" at 737:6-737:15
+8949: At              "@" at 737:16-737:17 (leading: Space)
+8950: Ident           "overload" at 737:17-737:25
+8951: KwFn            "fn" at 737:26-737:28 (leading: Space)
+8952: Ident           "__index" at 737:29-737:36 (leading: Space)
+8953: LParen          "(" at 737:36-737:37
+8954: Ident           "self" at 737:37-737:41
+8955: Colon           ":" at 737:41-737:42
+8956: Amp             "&" at 737:43-737:44 (leading: Space)
+8957: Ident           "ArrayFixed" at 737:44-737:54
+8958: Lt              "<" at 737:54-737:55
+8959: Ident           "T" at 737:55-737:56
+8960: Comma           "," at 737:56-737:57
+8961: Ident           "N" at 737:58-737:59 (leading: Space)
+8962: Gt              ">" at 737:59-737:60
+8963: Comma           "," at 737:60-737:61
+8964: Ident           "index" at 737:62-737:67 (leading: Space)
+8965: Colon           ":" at 737:67-737:68
+8966: Ident           "Range" at 737:69-737:74 (leading: Space)
+8967: Lt              "<" at 737:74-737:75
+8968: Ident           "int" at 737:75-737:78
+8969: Gt              ">" at 737:78-737:79
+8970: RParen          ")" at 737:79-737:80
+8971: Arrow           "->" at 737:81-737:83 (leading: Space)
+8972: Ident           "Array" at 737:84-737:89 (leading: Space)
+8973: Lt              "<" at 737:89-737:90
+8974: Ident           "T" at 737:90-737:91
+8975: Gt              ">" at 737:91-737:92
+8976: Semicolon       ";" at 737:92-737:93
+8977: At              "@" at 738:5-738:6 (leading: Newline, Space)
+8978: Ident           "intrinsic" at 738:6-738:15
+8979: KwFn            "fn" at 738:16-738:18 (leading: Space)
+8980: Ident           "__index_set" at 738:19-738:30 (leading: Space)
+8981: LParen          "(" at 738:30-738:31
+8982: Ident           "self" at 738:31-738:35
+8983: Colon           ":" at 738:35-738:36
+8984: Amp             "&" at 738:37-738:38 (leading: Space)
+8985: KwMut           "mut" at 738:38-738:41
+8986: Ident           "ArrayFixed" at 738:42-738:52 (leading: Space)
+8987: Lt              "<" at 738:52-738:53
+8988: Ident           "T" at 738:53-738:54
+8989: Comma           "," at 738:54-738:55
+8990: Ident           "N" at 738:56-738:57 (leading: Space)
+8991: Gt              ">" at 738:57-738:58
+8992: Comma           "," at 738:58-738:59
+8993: Ident           "index" at 738:60-738:65 (leading: Space)
+8994: Colon           ":" at 738:65-738:66
+8995: Ident           "int" at 738:67-738:70 (leading: Space)
+8996: Comma           "," at 738:70-738:71
+8997: Ident           "value" at 738:72-738:77 (leading: Space)
+8998: Colon           ":" at 738:77-738:78
+8999: Ident           "T" at 738:79-738:80 (leading: Space)
+9000: RParen          ")" at 738:80-738:81
+9001: Arrow           "->" at 738:82-738:84 (leading: Space)
+9002: NothingLit      "nothing" at 738:85-738:92 (leading: Space)
+9003: Semicolon       ";" at 738:92-738:93
+9004: At              "@" at 739:5-739:6 (leading: Newline, Space)
+9005: Ident           "intrinsic" at 739:6-739:15
+9006: KwFn            "fn" at 739:16-739:18 (leading: Space)
+9007: Ident           "__range" at 739:19-739:26 (leading: Space)
+9008: LParen          "(" at 739:26-739:27
+9009: Ident           "self" at 739:27-739:31
+9010: Colon           ":" at 739:31-739:32
+9011: Amp             "&" at 739:33-739:34 (leading: Space)
+9012: Ident           "ArrayFixed" at 739:34-739:44
+9013: Lt              "<" at 739:44-739:45
+9014: Ident           "T" at 739:45-739:46
+9015: Comma           "," at 739:46-739:47
+9016: Ident           "N" at 739:48-739:49 (leading: Space)
+9017: Gt              ">" at 739:49-739:50
+9018: RParen          ")" at 739:50-739:51
+9019: Arrow           "->" at 739:52-739:54 (leading: Space)
+9020: Ident           "Range" at 739:55-739:60 (leading: Space)
+9021: Lt              "<" at 739:60-739:61
+9022: Ident           "T" at 739:61-739:62
+9023: Gt              ">" at 739:62-739:63
+9024: Semicolon       ";" at 739:63-739:64
+9025: At              "@" at 740:5-740:6 (leading: Newline, Space)
+9026: Ident           "intrinsic" at 740:6-740:15
+9027: KwFn            "fn" at 740:16-740:18 (leading: Space)
+9028: Ident           "__len" at 740:19-740:24 (leading: Space)
+9029: LParen          "(" at 740:24-740:25
+9030: Ident           "self" at 740:25-740:29
+9031: Colon           ":" at 740:29-740:30
+9032: Amp             "&" at 740:31-740:32 (leading: Space)
+9033: Ident           "ArrayFixed" at 740:32-740:42
+9034: Lt              "<" at 740:42-740:43
+9035: Ident           "T" at 740:43-740:44
+9036: Comma           "," at 740:44-740:45
+9037: Ident           "N" at 740:46-740:47 (leading: Space)
+9038: Gt              ">" at 740:47-740:48
+9039: RParen          ")" at 740:48-740:49
+9040: Arrow           "->" at 740:50-740:52 (leading: Space)
+9041: Ident           "uint" at 740:53-740:57 (leading: Space)
+9042: Semicolon       ";" at 740:57-740:58
+9043: RBrace          "}" at 741:1-741:2 (leading: Newline)
+9044: At              "@" at 743:1-743:2 (leading: Newline)
+9045: Ident           "intrinsic" at 743:2-743:11
+9046: KwPub           "pub" at 744:1-744:4 (leading: Newline)
+9047: KwFn            "fn" at 744:5-744:7 (leading: Space)
+9048: Ident           "default" at 744:8-744:15 (leading: Space)
+9049: Lt              "<" at 744:15-744:16
+9050: Ident           "T" at 744:16-744:17
+9051: Gt              ">" at 744:17-744:18
+9052: LParen          "(" at 744:18-744:19
+9053: RParen          ")" at 744:19-744:20
+9054: Arrow           "->" at 744:21-744:23 (leading: Space)
+9055: Ident           "T" at 744:24-744:25 (leading: Space)
+9056: Semicolon       ";" at 744:25-744:26
+9057: At              "@" at 746:1-746:2 (leading: Newline)
+9058: Ident           "intrinsic" at 746:2-746:11
+9059: KwPub           "pub" at 747:1-747:4 (leading: Newline)
+9060: KwFn            "fn" at 747:5-747:7 (leading: Space)
+9061: Ident           "size_of" at 747:8-747:15 (leading: Space)
+9062: Lt              "<" at 747:15-747:16
+9063: Ident           "T" at 747:16-747:17
+9064: Gt              ">" at 747:17-747:18
+9065: LParen          "(" at 747:18-747:19
+9066: RParen          ")" at 747:19-747:20
+9067: Arrow           "->" at 747:21-747:23 (leading: Space)
+9068: Ident           "uint" at 747:24-747:28 (leading: Space)
+9069: Semicolon       ";" at 747:28-747:29
+9070: At              "@" at 749:1-749:2 (leading: Newline)
+9071: Ident           "intrinsic" at 749:2-749:11
+9072: KwPub           "pub" at 750:1-750:4 (leading: Newline)
+9073: KwFn            "fn" at 750:5-750:7 (leading: Space)
+9074: Ident           "align_of" at 750:8-750:16 (leading: Space)
+9075: Lt              "<" at 750:16-750:17
+9076: Ident           "T" at 750:17-750:18
+9077: Gt              ">" at 750:18-750:19
+9078: LParen          "(" at 750:19-750:20
+9079: RParen          ")" at 750:20-750:21
+9080: Arrow           "->" at 750:22-750:24 (leading: Space)
+9081: Ident           "uint" at 750:25-750:29 (leading: Space)
+9082: Semicolon       ";" at 750:29-750:30
+9083: KwPub           "pub" at 752:1-752:4 (leading: Newline)
+9084: KwContract      "contract" at 752:5-752:13 (leading: Space)
+9085: Ident           "ErrorLike" at 752:14-752:23 (leading: Space)
+9086: LBrace          "{" at 752:23-752:24
+9087: KwField         "field" at 753:5-753:10 (leading: Newline, Space)
+9088: Ident           "message" at 753:11-753:18 (leading: Space)
+9089: Colon           ":" at 753:18-753:19
+9090: Ident           "string" at 753:20-753:26 (leading: Space)
+9091: Semicolon       ";" at 753:26-753:27
+9092: KwField         "field" at 754:5-754:10 (leading: Newline, Space)
+9093: Ident           "code" at 754:11-754:15 (leading: Space)
+9094: Colon           ":" at 754:15-754:16
+9095: Ident           "uint" at 754:17-754:21 (leading: Space)
+9096: Semicolon       ";" at 754:21-754:22
+9097: RBrace          "}" at 755:1-755:2 (leading: Newline)
+9098: At              "@" at 757:1-757:2 (leading: Newline)
+9099: Ident           "intrinsic" at 757:2-757:11
+9100: KwPub           "pub" at 758:1-758:4 (leading: Newline)
+9101: KwFn            "fn" at 758:5-758:7 (leading: Space)
+9102: Ident           "exit" at 758:8-758:12 (leading: Space)
+9103: Lt              "<" at 758:12-758:13
+9104: Ident           "E" at 758:13-758:14
+9105: Colon           ":" at 758:14-758:15
+9106: Ident           "ErrorLike" at 758:16-758:25 (leading: Space)
+9107: Gt              ">" at 758:25-758:26
+9108: LParen          "(" at 758:26-758:27
+9109: Ident           "e" at 758:27-758:28
+9110: Colon           ":" at 758:28-758:29
+9111: Ident           "E" at 758:30-758:31 (leading: Space)
+9112: RParen          ")" at 758:31-758:32
+9113: Arrow           "->" at 758:33-758:35 (leading: Space)
+9114: NothingLit      "nothing" at 758:36-758:43 (leading: Space)
+9115: Semicolon       ";" at 758:43-758:44
+9116: At              "@" at 760:1-760:2 (leading: Newline)
+9117: Ident           "intrinsic" at 760:2-760:11
+9118: KwPub           "pub" at 761:1-761:4 (leading: Newline)
+9119: KwFn            "fn" at 761:5-761:7 (leading: Space)
+9120: Ident           "rt_panic" at 761:8-761:16 (leading: Space)
+9121: LParen          "(" at 761:16-761:17
+9122: Ident           "ptr" at 761:17-761:20
+9123: Colon           ":" at 761:20-761:21
+9124: Star            "*" at 761:22-761:23 (leading: Space)
+9125: Ident           "byte" at 761:23-761:27
+9126: Comma           "," at 761:27-761:28
+9127: Ident           "length" at 761:29-761:35 (leading: Space)
+9128: Colon           ":" at 761:35-761:36
+9129: Ident           "uint" at 761:37-761:41 (leading: Space)
+9130: RParen          ")" at 761:41-761:42
+9131: Arrow           "->" at 761:43-761:45 (leading: Space)
+9132: NothingLit      "nothing" at 761:46-761:53 (leading: Space)
+9133: Semicolon       ";" at 761:53-761:54
+9134: KwPub           "pub" at 763:1-763:4 (leading: Newline)
+9135: KwFn            "fn" at 763:5-763:7 (leading: Space)
+9136: Ident           "panic" at 763:8-763:13 (leading: Space)
+9137: LParen          "(" at 763:13-763:14
+9138: Ident           "msg" at 763:14-763:17
+9139: Colon           ":" at 763:17-763:18
+9140: Ident           "string" at 763:19-763:25 (leading: Space)
+9141: RParen          ")" at 763:25-763:26
+9142: Arrow           "->" at 763:27-763:29 (leading: Space)
+9143: NothingLit      "nothing" at 763:30-763:37 (leading: Space)
+9144: LBrace          "{" at 763:38-763:39 (leading: Space)
+9145: KwLet           "let" at 764:5-764:8 (leading: Newline, Space)
+9146: Ident           "ptr" at 764:9-764:12 (leading: Space)
+9147: Assign          "=" at 764:13-764:14 (leading: Space)
+9148: Ident           "rt_string_ptr" at 764:15-764:28 (leading: Space)
+9149: LParen          "(" at 764:28-764:29
+9150: Amp             "&" at 764:29-764:30
+9151: Ident           "msg" at 764:30-764:33
+9152: RParen          ")" at 764:33-764:34
+9153: Semicolon       ";" at 764:34-764:35
+9154: KwLet           "let" at 765:5-765:8 (leading: Newline, Space)
+9155: Ident           "length" at 765:9-765:15 (leading: Space)
+9156: Assign          "=" at 765:16-765:17 (leading: Space)
+9157: Ident           "rt_string_len_bytes" at 765:18-765:37 (leading: Space)
+9158: LParen          "(" at 765:37-765:38
+9159: Amp             "&" at 765:38-765:39
+9160: Ident           "msg" at 765:39-765:42
+9161: RParen          ")" at 765:42-765:43
+9162: Semicolon       ";" at 765:43-765:44
+9163: Ident           "rt_panic" at 766:5-766:13 (leading: Newline, Space)
+9164: LParen          "(" at 766:13-766:14
+9165: Ident           "ptr" at 766:14-766:17
+9166: Comma           "," at 766:17-766:18
+9167: Ident           "length" at 766:19-766:25 (leading: Space)
+9168: RParen          ")" at 766:25-766:26
+9169: Semicolon       ";" at 766:26-766:27
+9170: RBrace          "}" at 767:1-767:2 (leading: Newline)
+9171: At              "@" at 769:1-769:2 (leading: Newline)
+9172: Ident           "intrinsic" at 769:2-769:11
+9173: KwPub           "pub" at 770:1-770:4 (leading: Newline)
+9174: KwType          "type" at 770:5-770:9 (leading: Space)
+9175: Ident           "RwLock" at 770:10-770:16 (leading: Space)
+9176: Assign          "=" at 770:17-770:18 (leading: Space)
+9177: LBrace          "{" at 770:19-770:20 (leading: Space)
+9178: Ident           "__opaque" at 771:5-771:13 (leading: Newline, Space)
+9179: Colon           ":" at 771:13-771:14
+9180: Star            "*" at 771:15-771:16 (leading: Space)
+9181: Ident           "byte" at 771:16-771:20
+9182: Comma           "," at 771:20-771:21
+9183: RBrace          "}" at 772:1-772:2 (leading: Newline)
+9184: Semicolon       ";" at 772:2-772:3
+9185: KwExtern        "extern" at 774:1-774:7 (leading: Newline)
+9186: Lt              "<" at 774:7-774:8
+9187: Ident           "RwLock" at 774:8-774:14
+9188: Gt              ">" at 774:14-774:15
+9189: LBrace          "{" at 774:16-774:17 (leading: Space)
+9190: At              "@" at 775:5-775:6 (leading: Newline, Space)
+9191: Ident           "intrinsic" at 775:6-775:15
+9192: KwPub           "pub" at 775:16-775:19 (leading: Space)
+9193: KwFn            "fn" at 775:20-775:22 (leading: Space)
+9194: Ident           "new" at 775:23-775:26 (leading: Space)
+9195: LParen          "(" at 775:26-775:27
+9196: RParen          ")" at 775:27-775:28
+9197: Arrow           "->" at 775:29-775:31 (leading: Space)
+9198: Ident           "RwLock" at 775:32-775:38 (leading: Space)
+9199: Semicolon       ";" at 775:38-775:39
+9200: At              "@" at 776:5-776:6 (leading: Newline, Space)
+9201: Ident           "intrinsic" at 776:6-776:15
+9202: KwPub           "pub" at 776:16-776:19 (leading: Space)
+9203: KwFn            "fn" at 776:20-776:22 (leading: Space)
+9204: Ident           "read_lock" at 776:23-776:32 (leading: Space)
+9205: LParen          "(" at 776:32-776:33
+9206: Ident           "self" at 776:33-776:37
+9207: Colon           ":" at 776:37-776:38
+9208: Amp             "&" at 776:39-776:40 (leading: Space)
+9209: KwMut           "mut" at 776:40-776:43
+9210: Ident           "RwLock" at 776:44-776:50 (leading: Space)
+9211: RParen          ")" at 776:50-776:51
+9212: Arrow           "->" at 776:52-776:54 (leading: Space)
+9213: NothingLit      "nothing" at 776:55-776:62 (leading: Space)
+9214: Semicolon       ";" at 776:62-776:63
+9215: At              "@" at 777:5-777:6 (leading: Newline, Space)
+9216: Ident           "intrinsic" at 777:6-777:15
+9217: KwPub           "pub" at 777:16-777:19 (leading: Space)
+9218: KwFn            "fn" at 777:20-777:22 (leading: Space)
+9219: Ident           "read_unlock" at 777:23-777:34 (leading: Space)
+9220: LParen          "(" at 777:34-777:35
+9221: Ident           "self" at 777:35-777:39
+9222: Colon           ":" at 777:39-777:40
+9223: Amp             "&" at 777:41-777:42 (leading: Space)
+9224: KwMut           "mut" at 777:42-777:45
+9225: Ident           "RwLock" at 777:46-777:52 (leading: Space)
+9226: RParen          ")" at 777:52-777:53
+9227: Arrow           "->" at 777:54-777:56 (leading: Space)
+9228: NothingLit      "nothing" at 777:57-777:64 (leading: Space)
+9229: Semicolon       ";" at 777:64-777:65
+9230: At              "@" at 778:5-778:6 (leading: Newline, Space)
+9231: Ident           "intrinsic" at 778:6-778:15
+9232: KwPub           "pub" at 778:16-778:19 (leading: Space)
+9233: KwFn            "fn" at 778:20-778:22 (leading: Space)
+9234: Ident           "write_lock" at 778:23-778:33 (leading: Space)
+9235: LParen          "(" at 778:33-778:34
+9236: Ident           "self" at 778:34-778:38
+9237: Colon           ":" at 778:38-778:39
+9238: Amp             "&" at 778:40-778:41 (leading: Space)
+9239: KwMut           "mut" at 778:41-778:44
+9240: Ident           "RwLock" at 778:45-778:51 (leading: Space)
+9241: RParen          ")" at 778:51-778:52
+9242: Arrow           "->" at 778:53-778:55 (leading: Space)
+9243: NothingLit      "nothing" at 778:56-778:63 (leading: Space)
+9244: Semicolon       ";" at 778:63-778:64
+9245: At              "@" at 779:5-779:6 (leading: Newline, Space)
+9246: Ident           "intrinsic" at 779:6-779:15
+9247: KwPub           "pub" at 779:16-779:19 (leading: Space)
+9248: KwFn            "fn" at 779:20-779:22 (leading: Space)
+9249: Ident           "write_unlock" at 779:23-779:35 (leading: Space)
+9250: LParen          "(" at 779:35-779:36
+9251: Ident           "self" at 779:36-779:40
+9252: Colon           ":" at 779:40-779:41
+9253: Amp             "&" at 779:42-779:43 (leading: Space)
+9254: KwMut           "mut" at 779:43-779:46
+9255: Ident           "RwLock" at 779:47-779:53 (leading: Space)
+9256: RParen          ")" at 779:53-779:54
+9257: Arrow           "->" at 779:55-779:57 (leading: Space)
+9258: NothingLit      "nothing" at 779:58-779:65 (leading: Space)
+9259: Semicolon       ";" at 779:65-779:66
+9260: At              "@" at 780:5-780:6 (leading: Newline, Space)
+9261: Ident           "intrinsic" at 780:6-780:15
+9262: KwPub           "pub" at 780:16-780:19 (leading: Space)
+9263: KwFn            "fn" at 780:20-780:22 (leading: Space)
+9264: Ident           "try_read_lock" at 780:23-780:36 (leading: Space)
+9265: LParen          "(" at 780:36-780:37
+9266: Ident           "self" at 780:37-780:41
+9267: Colon           ":" at 780:41-780:42
+9268: Amp             "&" at 780:43-780:44 (leading: Space)
+9269: KwMut           "mut" at 780:44-780:47
+9270: Ident           "RwLock" at 780:48-780:54 (leading: Space)
+9271: RParen          ")" at 780:54-780:55
+9272: Arrow           "->" at 780:56-780:58 (leading: Space)
+9273: Ident           "bool" at 780:59-780:63 (leading: Space)
+9274: Semicolon       ";" at 780:63-780:64
+9275: At              "@" at 781:5-781:6 (leading: Newline, Space)
+9276: Ident           "intrinsic" at 781:6-781:15
+9277: KwPub           "pub" at 781:16-781:19 (leading: Space)
+9278: KwFn            "fn" at 781:20-781:22 (leading: Space)
+9279: Ident           "try_write_lock" at 781:23-781:37 (leading: Space)
+9280: LParen          "(" at 781:37-781:38
+9281: Ident           "self" at 781:38-781:42
+9282: Colon           ":" at 781:42-781:43
+9283: Amp             "&" at 781:44-781:45 (leading: Space)
+9284: KwMut           "mut" at 781:45-781:48
+9285: Ident           "RwLock" at 781:49-781:55 (leading: Space)
+9286: RParen          ")" at 781:55-781:56
+9287: Arrow           "->" at 781:57-781:59 (leading: Space)
+9288: Ident           "bool" at 781:60-781:64 (leading: Space)
+9289: Semicolon       ";" at 781:64-781:65
+9290: RBrace          "}" at 782:1-782:2 (leading: Newline)
+9291: At              "@" at 790:1-790:2 (leading: Newline, LineComment, Newline, LineComment, Newline, LineComment, Newline, LineComment, Newline, LineComment, Newline)
+9292: Ident           "intrinsic" at 790:2-790:11
+9293: KwPub           "pub" at 791:1-791:4 (leading: Newline)
+9294: KwFn            "fn" at 791:5-791:7 (leading: Space)
+9295: Ident           "atomic_load" at 791:8-791:19 (leading: Space)
+9296: LParen          "(" at 791:19-791:20
+9297: Ident           "ptr" at 791:20-791:23
+9298: Colon           ":" at 791:23-791:24
+9299: Amp             "&" at 791:25-791:26 (leading: Space)
+9300: Ident           "int" at 791:26-791:29
+9301: RParen          ")" at 791:29-791:30
+9302: Arrow           "->" at 791:31-791:33 (leading: Space)
+9303: Ident           "int" at 791:34-791:37 (leading: Space)
+9304: Semicolon       ";" at 791:37-791:38
+9305: At              "@" at 793:1-793:2 (leading: Newline)
+9306: Ident           "intrinsic" at 793:2-793:11
+9307: At              "@" at 794:1-794:2 (leading: Newline)
+9308: Ident           "overload" at 794:2-794:10
+9309: KwPub           "pub" at 795:1-795:4 (leading: Newline)
+9310: KwFn            "fn" at 795:5-795:7 (leading: Space)
+9311: Ident           "atomic_load" at 795:8-795:19 (leading: Space)
+9312: LParen          "(" at 795:19-795:20
+9313: Ident           "ptr" at 795:20-795:23
+9314: Colon           ":" at 795:23-795:24
+9315: Amp             "&" at 795:25-795:26 (leading: Space)
+9316: Ident           "uint" at 795:26-795:30
+9317: RParen          ")" at 795:30-795:31
+9318: Arrow           "->" at 795:32-795:34 (leading: Space)
+9319: Ident           "uint" at 795:35-795:39 (leading: Space)
+9320: Semicolon       ";" at 795:39-795:40
+9321: At              "@" at 797:1-797:2 (leading: Newline)
+9322: Ident           "intrinsic" at 797:2-797:11
+9323: At              "@" at 798:1-798:2 (leading: Newline)
+9324: Ident           "overload" at 798:2-798:10
+9325: KwPub           "pub" at 799:1-799:4 (leading: Newline)
+9326: KwFn            "fn" at 799:5-799:7 (leading: Space)
+9327: Ident           "atomic_load" at 799:8-799:19 (leading: Space)
+9328: LParen          "(" at 799:19-799:20
+9329: Ident           "ptr" at 799:20-799:23
+9330: Colon           ":" at 799:23-799:24
+9331: Amp             "&" at 799:25-799:26 (leading: Space)
+9332: Ident           "bool" at 799:26-799:30
+9333: RParen          ")" at 799:30-799:31
+9334: Arrow           "->" at 799:32-799:34 (leading: Space)
+9335: Ident           "bool" at 799:35-799:39 (leading: Space)
+9336: Semicolon       ";" at 799:39-799:40
+9337: At              "@" at 802:1-802:2 (leading: Newline, LineComment, Newline)
+9338: Ident           "intrinsic" at 802:2-802:11
+9339: KwPub           "pub" at 803:1-803:4 (leading: Newline)
+9340: KwFn            "fn" at 803:5-803:7 (leading: Space)
+9341: Ident           "atomic_store" at 803:8-803:20 (leading: Space)
+9342: LParen          "(" at 803:20-803:21
+9343: Ident           "ptr" at 803:21-803:24
+9344: Colon           ":" at 803:24-803:25
+9345: Amp             "&" at 803:26-803:27 (leading: Space)
+9346: KwMut           "mut" at 803:27-803:30
+9347: Ident           "int" at 803:31-803:34 (leading: Space)
+9348: Comma           "," at 803:34-803:35
+9349: Ident           "value" at 803:36-803:41 (leading: Space)
+9350: Colon           ":" at 803:41-803:42
+9351: Ident           "int" at 803:43-803:46 (leading: Space)
+9352: RParen          ")" at 803:46-803:47
+9353: Arrow           "->" at 803:48-803:50 (leading: Space)
+9354: NothingLit      "nothing" at 803:51-803:58 (leading: Space)
+9355: Semicolon       ";" at 803:58-803:59
+9356: At              "@" at 805:1-805:2 (leading: Newline)
+9357: Ident           "intrinsic" at 805:2-805:11
+9358: At              "@" at 806:1-806:2 (leading: Newline)
+9359: Ident           "overload" at 806:2-806:10
+9360: KwPub           "pub" at 807:1-807:4 (leading: Newline)
+9361: KwFn            "fn" at 807:5-807:7 (leading: Space)
+9362: Ident           "atomic_store" at 807:8-807:20 (leading: Space)
+9363: LParen          "(" at 807:20-807:21
+9364: Ident           "ptr" at 807:21-807:24
+9365: Colon           ":" at 807:24-807:25
+9366: Amp             "&" at 807:26-807:27 (leading: Space)
+9367: KwMut           "mut" at 807:27-807:30
+9368: Ident           "uint" at 807:31-807:35 (leading: Space)
+9369: Comma           "," at 807:35-807:36
+9370: Ident           "value" at 807:37-807:42 (leading: Space)
+9371: Colon           ":" at 807:42-807:43
+9372: Ident           "uint" at 807:44-807:48 (leading: Space)
+9373: RParen          ")" at 807:48-807:49
+9374: Arrow           "->" at 807:50-807:52 (leading: Space)
+9375: NothingLit      "nothing" at 807:53-807:60 (leading: Space)
+9376: Semicolon       ";" at 807:60-807:61
+9377: At              "@" at 809:1-809:2 (leading: Newline)
+9378: Ident           "intrinsic" at 809:2-809:11
+9379: At              "@" at 810:1-810:2 (leading: Newline)
+9380: Ident           "overload" at 810:2-810:10
+9381: KwPub           "pub" at 811:1-811:4 (leading: Newline)
+9382: KwFn            "fn" at 811:5-811:7 (leading: Space)
+9383: Ident           "atomic_store" at 811:8-811:20 (leading: Space)
+9384: LParen          "(" at 811:20-811:21
+9385: Ident           "ptr" at 811:21-811:24
+9386: Colon           ":" at 811:24-811:25
+9387: Amp             "&" at 811:26-811:27 (leading: Space)
+9388: KwMut           "mut" at 811:27-811:30
+9389: Ident           "bool" at 811:31-811:35 (leading: Space)
+9390: Comma           "," at 811:35-811:36
+9391: Ident           "value" at 811:37-811:42 (leading: Space)
+9392: Colon           ":" at 811:42-811:43
+9393: Ident           "bool" at 811:44-811:48 (leading: Space)
+9394: RParen          ")" at 811:48-811:49
+9395: Arrow           "->" at 811:50-811:52 (leading: Space)
+9396: NothingLit      "nothing" at 811:53-811:60 (leading: Space)
+9397: Semicolon       ";" at 811:60-811:61
+9398: At              "@" at 814:1-814:2 (leading: Newline, LineComment, Newline)
+9399: Ident           "intrinsic" at 814:2-814:11
+9400: KwPub           "pub" at 815:1-815:4 (leading: Newline)
+9401: KwFn            "fn" at 815:5-815:7 (leading: Space)
+9402: Ident           "atomic_exchange" at 815:8-815:23 (leading: Space)
+9403: LParen          "(" at 815:23-815:24
+9404: Ident           "ptr" at 815:24-815:27
+9405: Colon           ":" at 815:27-815:28
+9406: Amp             "&" at 815:29-815:30 (leading: Space)
+9407: KwMut           "mut" at 815:30-815:33
+9408: Ident           "int" at 815:34-815:37 (leading: Space)
+9409: Comma           "," at 815:37-815:38
+9410: Ident           "new_val" at 815:39-815:46 (leading: Space)
+9411: Colon           ":" at 815:46-815:47
+9412: Ident           "int" at 815:48-815:51 (leading: Space)
+9413: RParen          ")" at 815:51-815:52
+9414: Arrow           "->" at 815:53-815:55 (leading: Space)
+9415: Ident           "int" at 815:56-815:59 (leading: Space)
+9416: Semicolon       ";" at 815:59-815:60
+9417: At              "@" at 817:1-817:2 (leading: Newline)
+9418: Ident           "intrinsic" at 817:2-817:11
+9419: At              "@" at 818:1-818:2 (leading: Newline)
+9420: Ident           "overload" at 818:2-818:10
+9421: KwPub           "pub" at 819:1-819:4 (leading: Newline)
+9422: KwFn            "fn" at 819:5-819:7 (leading: Space)
+9423: Ident           "atomic_exchange" at 819:8-819:23 (leading: Space)
+9424: LParen          "(" at 819:23-819:24
+9425: Ident           "ptr" at 819:24-819:27
+9426: Colon           ":" at 819:27-819:28
+9427: Amp             "&" at 819:29-819:30 (leading: Space)
+9428: KwMut           "mut" at 819:30-819:33
+9429: Ident           "uint" at 819:34-819:38 (leading: Space)
+9430: Comma           "," at 819:38-819:39
+9431: Ident           "new_val" at 819:40-819:47 (leading: Space)
+9432: Colon           ":" at 819:47-819:48
+9433: Ident           "uint" at 819:49-819:53 (leading: Space)
+9434: RParen          ")" at 819:53-819:54
+9435: Arrow           "->" at 819:55-819:57 (leading: Space)
+9436: Ident           "uint" at 819:58-819:62 (leading: Space)
+9437: Semicolon       ";" at 819:62-819:63
+9438: At              "@" at 821:1-821:2 (leading: Newline)
+9439: Ident           "intrinsic" at 821:2-821:11
+9440: At              "@" at 822:1-822:2 (leading: Newline)
+9441: Ident           "overload" at 822:2-822:10
+9442: KwPub           "pub" at 823:1-823:4 (leading: Newline)
+9443: KwFn            "fn" at 823:5-823:7 (leading: Space)
+9444: Ident           "atomic_exchange" at 823:8-823:23 (leading: Space)
+9445: LParen          "(" at 823:23-823:24
+9446: Ident           "ptr" at 823:24-823:27
+9447: Colon           ":" at 823:27-823:28
+9448: Amp             "&" at 823:29-823:30 (leading: Space)
+9449: KwMut           "mut" at 823:30-823:33
+9450: Ident           "bool" at 823:34-823:38 (leading: Space)
+9451: Comma           "," at 823:38-823:39
+9452: Ident           "new_val" at 823:40-823:47 (leading: Space)
+9453: Colon           ":" at 823:47-823:48
+9454: Ident           "bool" at 823:49-823:53 (leading: Space)
+9455: RParen          ")" at 823:53-823:54
+9456: Arrow           "->" at 823:55-823:57 (leading: Space)
+9457: Ident           "bool" at 823:58-823:62 (leading: Space)
+9458: Semicolon       ";" at 823:62-823:63
+9459: At              "@" at 827:1-827:2 (leading: Newline, LineComment, Newline, LineComment, Newline)
+9460: Ident           "intrinsic" at 827:2-827:11
+9461: KwPub           "pub" at 828:1-828:4 (leading: Newline)
+9462: KwFn            "fn" at 828:5-828:7 (leading: Space)
+9463: Ident           "atomic_compare_exchange" at 828:8-828:31 (leading: Space)
+9464: LParen          "(" at 828:31-828:32
+9465: Ident           "ptr" at 828:32-828:35
+9466: Colon           ":" at 828:35-828:36
+9467: Amp             "&" at 828:37-828:38 (leading: Space)
+9468: KwMut           "mut" at 828:38-828:41
+9469: Ident           "int" at 828:42-828:45 (leading: Space)
+9470: Comma           "," at 828:45-828:46
+9471: Ident           "expected" at 828:47-828:55 (leading: Space)
+9472: Colon           ":" at 828:55-828:56
+9473: Ident           "int" at 828:57-828:60 (leading: Space)
+9474: Comma           "," at 828:60-828:61
+9475: Ident           "desired" at 828:62-828:69 (leading: Space)
+9476: Colon           ":" at 828:69-828:70
+9477: Ident           "int" at 828:71-828:74 (leading: Space)
+9478: RParen          ")" at 828:74-828:75
+9479: Arrow           "->" at 828:76-828:78 (leading: Space)
+9480: Ident           "bool" at 828:79-828:83 (leading: Space)
+9481: Semicolon       ";" at 828:83-828:84
+9482: At              "@" at 830:1-830:2 (leading: Newline)
+9483: Ident           "intrinsic" at 830:2-830:11
+9484: At              "@" at 831:1-831:2 (leading: Newline)
+9485: Ident           "overload" at 831:2-831:10
+9486: KwPub           "pub" at 832:1-832:4 (leading: Newline)
+9487: KwFn            "fn" at 832:5-832:7 (leading: Space)
+9488: Ident           "atomic_compare_exchange" at 832:8-832:31 (leading: Space)
+9489: LParen          "(" at 832:31-832:32
+9490: Ident           "ptr" at 832:32-832:35
+9491: Colon           ":" at 832:35-832:36
+9492: Amp             "&" at 832:37-832:38 (leading: Space)
+9493: KwMut           "mut" at 832:38-832:41
+9494: Ident           "uint" at 832:42-832:46 (leading: Space)
+9495: Comma           "," at 832:46-832:47
+9496: Ident           "expected" at 832:48-832:56 (leading: Space)
+9497: Colon           ":" at 832:56-832:57
+9498: Ident           "uint" at 832:58-832:62 (leading: Space)
+9499: Comma           "," at 832:62-832:63
+9500: Ident           "desired" at 832:64-832:71 (leading: Space)
+9501: Colon           ":" at 832:71-832:72
+9502: Ident           "uint" at 832:73-832:77 (leading: Space)
+9503: RParen          ")" at 832:77-832:78
+9504: Arrow           "->" at 832:79-832:81 (leading: Space)
+9505: Ident           "bool" at 832:82-832:86 (leading: Space)
+9506: Semicolon       ";" at 832:86-832:87
+9507: At              "@" at 834:1-834:2 (leading: Newline)
+9508: Ident           "intrinsic" at 834:2-834:11
+9509: At              "@" at 835:1-835:2 (leading: Newline)
+9510: Ident           "overload" at 835:2-835:10
+9511: KwPub           "pub" at 836:1-836:4 (leading: Newline)
+9512: KwFn            "fn" at 836:5-836:7 (leading: Space)
+9513: Ident           "atomic_compare_exchange" at 836:8-836:31 (leading: Space)
+9514: LParen          "(" at 836:31-836:32
+9515: Ident           "ptr" at 836:32-836:35
+9516: Colon           ":" at 836:35-836:36
+9517: Amp             "&" at 836:37-836:38 (leading: Space)
+9518: KwMut           "mut" at 836:38-836:41
+9519: Ident           "bool" at 836:42-836:46 (leading: Space)
+9520: Comma           "," at 836:46-836:47
+9521: Ident           "expected" at 836:48-836:56 (leading: Space)
+9522: Colon           ":" at 836:56-836:57
+9523: Ident           "bool" at 836:58-836:62 (leading: Space)
+9524: Comma           "," at 836:62-836:63
+9525: Ident           "desired" at 836:64-836:71 (leading: Space)
+9526: Colon           ":" at 836:71-836:72
+9527: Ident           "bool" at 836:73-836:77 (leading: Space)
+9528: RParen          ")" at 836:77-836:78
+9529: Arrow           "->" at 836:79-836:81 (leading: Space)
+9530: Ident           "bool" at 836:82-836:86 (leading: Space)
+9531: Semicolon       ";" at 836:86-836:87
+9532: At              "@" at 839:1-839:2 (leading: Newline, LineComment, Newline)
+9533: Ident           "intrinsic" at 839:2-839:11
+9534: KwPub           "pub" at 840:1-840:4 (leading: Newline)
+9535: KwFn            "fn" at 840:5-840:7 (leading: Space)
+9536: Ident           "atomic_fetch_add" at 840:8-840:24 (leading: Space)
+9537: LParen          "(" at 840:24-840:25
+9538: Ident           "ptr" at 840:25-840:28
+9539: Colon           ":" at 840:28-840:29
+9540: Amp             "&" at 840:30-840:31 (leading: Space)
+9541: KwMut           "mut" at 840:31-840:34
+9542: Ident           "int" at 840:35-840:38 (leading: Space)
+9543: Comma           "," at 840:38-840:39
+9544: Ident           "delta" at 840:40-840:45 (leading: Space)
+9545: Colon           ":" at 840:45-840:46
+9546: Ident           "int" at 840:47-840:50 (leading: Space)
+9547: RParen          ")" at 840:50-840:51
+9548: Arrow           "->" at 840:52-840:54 (leading: Space)
+9549: Ident           "int" at 840:55-840:58 (leading: Space)
+9550: Semicolon       ";" at 840:58-840:59
+9551: At              "@" at 842:1-842:2 (leading: Newline)
+9552: Ident           "intrinsic" at 842:2-842:11
+9553: At              "@" at 843:1-843:2 (leading: Newline)
+9554: Ident           "overload" at 843:2-843:10
+9555: KwPub           "pub" at 844:1-844:4 (leading: Newline)
+9556: KwFn            "fn" at 844:5-844:7 (leading: Space)
+9557: Ident           "atomic_fetch_add" at 844:8-844:24 (leading: Space)
+9558: LParen          "(" at 844:24-844:25
+9559: Ident           "ptr" at 844:25-844:28
+9560: Colon           ":" at 844:28-844:29
+9561: Amp             "&" at 844:30-844:31 (leading: Space)
+9562: KwMut           "mut" at 844:31-844:34
+9563: Ident           "uint" at 844:35-844:39 (leading: Space)
+9564: Comma           "," at 844:39-844:40
+9565: Ident           "delta" at 844:41-844:46 (leading: Space)
+9566: Colon           ":" at 844:46-844:47
+9567: Ident           "uint" at 844:48-844:52 (leading: Space)
+9568: RParen          ")" at 844:52-844:53
+9569: Arrow           "->" at 844:54-844:56 (leading: Space)
+9570: Ident           "uint" at 844:57-844:61 (leading: Space)
+9571: Semicolon       ";" at 844:61-844:62
+9572: At              "@" at 847:1-847:2 (leading: Newline, LineComment, Newline)
+9573: Ident           "intrinsic" at 847:2-847:11
+9574: KwPub           "pub" at 848:1-848:4 (leading: Newline)
+9575: KwFn            "fn" at 848:5-848:7 (leading: Space)
+9576: Ident           "atomic_fetch_sub" at 848:8-848:24 (leading: Space)
+9577: LParen          "(" at 848:24-848:25
+9578: Ident           "ptr" at 848:25-848:28
+9579: Colon           ":" at 848:28-848:29
+9580: Amp             "&" at 848:30-848:31 (leading: Space)
+9581: KwMut           "mut" at 848:31-848:34
+9582: Ident           "int" at 848:35-848:38 (leading: Space)
+9583: Comma           "," at 848:38-848:39
+9584: Ident           "delta" at 848:40-848:45 (leading: Space)
+9585: Colon           ":" at 848:45-848:46
+9586: Ident           "int" at 848:47-848:50 (leading: Space)
+9587: RParen          ")" at 848:50-848:51
+9588: Arrow           "->" at 848:52-848:54 (leading: Space)
+9589: Ident           "int" at 848:55-848:58 (leading: Space)
+9590: Semicolon       ";" at 848:58-848:59
+9591: At              "@" at 850:1-850:2 (leading: Newline)
+9592: Ident           "intrinsic" at 850:2-850:11
+9593: At              "@" at 851:1-851:2 (leading: Newline)
+9594: Ident           "overload" at 851:2-851:10
+9595: KwPub           "pub" at 852:1-852:4 (leading: Newline)
+9596: KwFn            "fn" at 852:5-852:7 (leading: Space)
+9597: Ident           "atomic_fetch_sub" at 852:8-852:24 (leading: Space)
+9598: LParen          "(" at 852:24-852:25
+9599: Ident           "ptr" at 852:25-852:28
+9600: Colon           ":" at 852:28-852:29
+9601: Amp             "&" at 852:30-852:31 (leading: Space)
+9602: KwMut           "mut" at 852:31-852:34
+9603: Ident           "uint" at 852:35-852:39 (leading: Space)
+9604: Comma           "," at 852:39-852:40
+9605: Ident           "delta" at 852:41-852:46 (leading: Space)
+9606: Colon           ":" at 852:46-852:47
+9607: Ident           "uint" at 852:48-852:52 (leading: Space)
+9608: RParen          ")" at 852:52-852:53
+9609: Arrow           "->" at 852:54-852:56 (leading: Space)
+9610: Ident           "uint" at 852:57-852:61 (leading: Space)
+9611: Semicolon       ";" at 852:61-852:62
+9612: At              "@" at 857:1-857:2 (leading: Newline, LineComment, Newline, LineComment, Newline)
+9613: Ident           "intrinsic" at 857:2-857:11
+9614: KwPub           "pub" at 858:1-858:4 (leading: Newline)
+9615: KwFn            "fn" at 858:5-858:7 (leading: Space)
+9616: Ident           "rt_argv" at 858:8-858:15 (leading: Space)
+9617: LParen          "(" at 858:15-858:16
+9618: RParen          ")" at 858:16-858:17
+9619: Arrow           "->" at 858:18-858:20 (leading: Space)
+9620: Ident           "string" at 858:21-858:27 (leading: Space)
+9621: LBracket        "[" at 858:27-858:28
+9622: RBracket        "]" at 858:28-858:29
+9623: Semicolon       ";" at 858:29-858:30
+9624: At              "@" at 861:1-861:2 (leading: Newline, LineComment, Newline)
+9625: Ident           "intrinsic" at 861:2-861:11
+9626: KwPub           "pub" at 862:1-862:4 (leading: Newline)
+9627: KwFn            "fn" at 862:5-862:7 (leading: Space)
+9628: Ident           "rt_stdin_read_all" at 862:8-862:25 (leading: Space)
+9629: LParen          "(" at 862:25-862:26
+9630: RParen          ")" at 862:26-862:27
+9631: Arrow           "->" at 862:28-862:30 (leading: Space)
+9632: Ident           "string" at 862:31-862:37 (leading: Space)
+9633: Semicolon       ";" at 862:37-862:38
+9634: At              "@" at 865:1-865:2 (leading: Newline, LineComment, Newline)
+9635: Ident           "intrinsic" at 865:2-865:11
+9636: KwPub           "pub" at 866:1-866:4 (leading: Newline)
+9637: KwFn            "fn" at 866:5-866:7 (leading: Space)
+9638: Ident           "rt_exit" at 866:8-866:15 (leading: Space)
+9639: LParen          "(" at 866:15-866:16
+9640: Ident           "code" at 866:16-866:20
+9641: Colon           ":" at 866:20-866:21
+9642: Ident           "int" at 866:22-866:25 (leading: Space)
+9643: RParen          ")" at 866:25-866:26
+9644: Arrow           "->" at 866:27-866:29 (leading: Space)
+9645: NothingLit      "nothing" at 866:30-866:37 (leading: Space)
+9646: Semicolon       ";" at 866:37-866:38
+9647: EOF             at 867:1-867:1

--- a/testdata/golden/hir/allow_to_conversion.hir
+++ b/testdata/golden/hir/allow_to_conversion.hir
@@ -2,18 +2,18 @@
 == HIR ==
 module 
 
-type Foo <struct> (sym=1397, type=0)
+type Foo <struct> (sym=1403, type=0)
 
-fn __to(self: type#1489, _: string) -> string (id=1, sym=1398) {
+fn __to(self: type#1493, _: string) -> string (id=1, sym=1404) {
   return "\"Foo\""
 }
 
-fn takes_string(s: string) -> int (id=2, sym=1399) {
+fn takes_string(s: string) -> int (id=2, sym=1405) {
   return 0
 }
 
-fn test_allow_to() -> int (id=3, sym=1400) {
-  let f: type#1489 =  { value = 1 }: type#1489
+fn test_allow_to() -> int (id=3, sym=1406) {
+  let f: type#1493 =  { value = 1 }: type#1493
   return takes_string(__to(f, default())): int
 }
 

--- a/testdata/golden/hir/array_indexing.hir
+++ b/testdata/golden/hir/array_indexing.hir
@@ -2,11 +2,11 @@
 == HIR ==
 module 
 
-fn test() -> nothing (id=1, sym=1397) {
-  let a: type#76 = [1, 2, 3, 4]: type#76
+fn test() -> nothing (id=1, sym=1403) {
+  let a: type#77 = [1, 2, 3, 4]: type#77
   let x: &int [&] = a[1]: &int
   let y: &int [&] = a[__neg(1): int]: &int
-  let slice: type#76 = a[rt_range_int_new(1, 3, false): type#187]: type#76
+  let slice: type#77 = a[rt_range_int_new(1, 3, false): type#188]: type#77
   return
 }
 

--- a/testdata/golden/hir/arrays.hir
+++ b/testdata/golden/hir/arrays.hir
@@ -2,11 +2,11 @@
 == HIR ==
 module 
 
-fn first(arr: type#1490) -> int (id=1, sym=1397) {
+fn first(arr: type#1494) -> int (id=1, sym=1403) {
   return arr[0]: &int
 }
 
-fn make_array() -> type#1490 (id=2, sym=1398) {
-  return [1, 2, 3]: type#1490
+fn make_array() -> type#1494 (id=2, sym=1404) {
+  return [1, 2, 3]: type#1494
 }
 

--- a/testdata/golden/hir/async_spawn.hir
+++ b/testdata/golden/hir/async_spawn.hir
@@ -2,14 +2,14 @@
 == HIR ==
 module 
 
-async fn inc(x: int [copy]) -> int (id=1, sym=1397) {
+async fn inc(x: int [copy]) -> int (id=1, sym=1403) {
   return __add(x, 1): int
 }
 
-async fn test() -> int (id=2, sym=1398) {
-  let t: type#1489 = spawn inc(5): type#1489: type#1489
+async fn test() -> int (id=2, sym=1404) {
+  let t: type#1493 = spawn inc(5): type#1493: type#1493
   return {
-    let __cmp1: type#1492 = await(t): type#1492
+    let __cmp1: type#1496 = await(t): type#1496
     if tag_test(__cmp1, Success): bool {
       let v: int [copy] = tag_payload(__cmp1, Success, 0): int
       return v

--- a/testdata/golden/hir/bitwise.hir
+++ b/testdata/golden/hir/bitwise.hir
@@ -2,7 +2,7 @@
 == HIR ==
 module 
 
-fn bit_ops(a: int [copy], b: int [copy]) -> int (id=1, sym=1397) {
+fn bit_ops(a: int [copy], b: int [copy]) -> int (id=1, sym=1403) {
   let and_result: int [copy] = __bit_and(a, b): int
   let or_result: int [copy] = __bit_or(a, b): int
   let xor_result: int [copy] = __bit_xor(a, b): int
@@ -11,7 +11,7 @@ fn bit_ops(a: int [copy], b: int [copy]) -> int (id=1, sym=1397) {
   return __bit_or(and_result, or_result): int
 }
 
-fn logical_ops(a: bool [copy], b: bool [copy]) -> bool (id=2, sym=1398) {
+fn logical_ops(a: bool [copy], b: bool [copy]) -> bool (id=2, sym=1404) {
   return ((a && b) || __not(a)): bool
 }
 

--- a/testdata/golden/hir/block_expr.hir
+++ b/testdata/golden/hir/block_expr.hir
@@ -2,7 +2,7 @@
 == HIR ==
 module 
 
-fn block_scope() -> int (id=1, sym=1397) {
+fn block_scope() -> int (id=1, sym=1403) {
   let x: int [copy] = 1
   {
     let y: int [copy] = 2
@@ -11,11 +11,11 @@ fn block_scope() -> int (id=1, sym=1397) {
   return x
 }
 
-async fn with_async_block() -> nothing (id=2, sym=1398) {
-  let t: type#581 = async {
+async fn with_async_block() -> nothing (id=2, sym=1404) {
+  let t: type#585 = async {
     let x: int [copy] = 1
     let y: int [copy] = __add(x, 1): int
-  }: type#581
+  }: type#585
   return
 }
 

--- a/testdata/golden/hir/casts.hir
+++ b/testdata/golden/hir/casts.hir
@@ -2,11 +2,11 @@
 == HIR ==
 module 
 
-fn to_float(x: int [copy]) -> float (id=1, sym=1397) {
+fn to_float(x: int [copy]) -> float (id=1, sym=1403) {
   return x to ?: float
 }
 
-fn explicit_int(x: int [copy]) -> int (id=2, sym=1398) {
+fn explicit_int(x: int [copy]) -> int (id=2, sym=1404) {
   return x to ?: int
 }
 

--- a/testdata/golden/hir/compare.hir
+++ b/testdata/golden/hir/compare.hir
@@ -2,7 +2,7 @@
 == HIR ==
 module 
 
-fn classify(x: int [copy]) -> int (id=1, sym=1397) {
+fn classify(x: int [copy]) -> int (id=1, sym=1403) {
   return {
     let __cmp1: int [copy] = x
     if (__cmp1 == 0): bool {

--- a/testdata/golden/hir/compare_tag.hir
+++ b/testdata/golden/hir/compare_tag.hir
@@ -2,9 +2,9 @@
 == HIR ==
 module 
 
-fn unwrap_or_zero(x: type#1489) -> int (id=1, sym=1397) {
+fn unwrap_or_zero(x: type#1493) -> int (id=1, sym=1403) {
   return {
-    let __cmp1: type#1489 = x
+    let __cmp1: type#1493 = x
     if tag_test(__cmp1, Some): bool {
       let v: int [copy] = tag_payload(__cmp1, Some, 0): int
       return v

--- a/testdata/golden/hir/control_flow.hir
+++ b/testdata/golden/hir/control_flow.hir
@@ -2,7 +2,7 @@
 == HIR ==
 module 
 
-fn abs(x: int [copy]) -> int (id=1, sym=1397) {
+fn abs(x: int [copy]) -> int (id=1, sym=1403) {
   if __lt(x, 0): bool {
     return __neg(x): int
   } else {
@@ -10,7 +10,7 @@ fn abs(x: int [copy]) -> int (id=1, sym=1397) {
   }
 }
 
-fn countdown(n: int [copy]) -> int (id=2, sym=1398) {
+fn countdown(n: int [copy]) -> int (id=2, sym=1404) {
   let mut i: int [copy] = n
   while __gt(i, 0): bool {
     (i = __sub(i, 1)): int

--- a/testdata/golden/hir/for_classic.hir
+++ b/testdata/golden/hir/for_classic.hir
@@ -2,7 +2,7 @@
 == HIR ==
 module 
 
-fn sum_to(n: int [copy]) -> int (id=1, sym=1397) {
+fn sum_to(n: int [copy]) -> int (id=1, sym=1403) {
   let mut total: int [copy] = 0
   {
     let mut i: int [copy] = 0

--- a/testdata/golden/hir/for_iter.hir
+++ b/testdata/golden/hir/for_iter.hir
@@ -2,12 +2,12 @@
 == HIR ==
 module 
 
-fn sum(arr: type#1490) -> int (id=1, sym=1397) {
+fn sum(arr: type#1494) -> int (id=1, sym=1403) {
   let mut total: int [copy] = 0
   {
-    let mut __iter1: type#187 = iter_init(arr): type#187
+    let mut __iter1: type#188 = iter_init(arr): type#188
     while true {
-      let __next2: type#1492 = iter_next(__iter1): type#1492
+      let __next2: type#1496 = iter_next(__iter1): type#1496
       if tag_test(__next2, nothing): bool {
         break
       }

--- a/testdata/golden/hir/for_range.hir
+++ b/testdata/golden/hir/for_range.hir
@@ -2,7 +2,7 @@
 == HIR ==
 module 
 
-fn sum_range(n: int [copy]) -> int (id=1, sym=1397) {
+fn sum_range(n: int [copy]) -> int (id=1, sym=1403) {
   let mut total: int [copy] = 0
   {
     let mut i: int [copy] = 0

--- a/testdata/golden/hir/indexing_ranges.hir
+++ b/testdata/golden/hir/indexing_ranges.hir
@@ -2,10 +2,10 @@
 == HIR ==
 module 
 
-type Box <struct> (sym=1397, type=0)
+type Box <struct> (sym=1403, type=0)
 
-fn test() -> int (id=1, sym=1399) {
-  let b: type#1489 =  { value = 1 }: type#1489
+fn test() -> int (id=1, sym=1405) {
+  let b: type#1493 =  { value = 1 }: type#1493
   return __index(b, rt_range_int_new(1, 2, false)): int
 }
 

--- a/testdata/golden/hir/loops_control.hir
+++ b/testdata/golden/hir/loops_control.hir
@@ -2,7 +2,7 @@
 == HIR ==
 module 
 
-fn find_first_positive(arr: type#1490) -> int (id=1, sym=1397) {
+fn find_first_positive(arr: type#1494) -> int (id=1, sym=1403) {
   {
     let mut i: int [copy] = 0
     let __end1: int [copy] = 5
@@ -20,7 +20,7 @@ fn find_first_positive(arr: type#1490) -> int (id=1, sym=1397) {
   return 0
 }
 
-fn sum_until_zero(arr: type#1490) -> int (id=2, sym=1398) {
+fn sum_until_zero(arr: type#1494) -> int (id=2, sym=1404) {
   let mut total: int [copy] = 0
   {
     let mut i: int [copy] = 0

--- a/testdata/golden/hir/option_erring.hir
+++ b/testdata/golden/hir/option_erring.hir
@@ -2,14 +2,14 @@
 == HIR ==
 module 
 
-fn maybe(x: int [copy]) -> type#1489 (id=1, sym=1397) {
+fn maybe(x: int [copy]) -> type#1493 (id=1, sym=1403) {
   if __gt(x, 0): bool {
-    return Some(x): type#1489
+    return Some(x): type#1493
   }
   return nothing
 }
 
-fn get_value(opt: type#1489) -> int (id=2, sym=1398) {
+fn get_value(opt: type#1493) -> int (id=2, sym=1404) {
   return safe(opt): int
 }
 

--- a/testdata/golden/hir/range_literals.hir
+++ b/testdata/golden/hir/range_literals.hir
@@ -2,13 +2,13 @@
 == HIR ==
 module 
 
-fn make_ranges() -> nothing (id=1, sym=1397) {
-  let a: type#187 = rt_range_int_new(1, 3, false): type#187
-  let b: type#187 = rt_range_int_new(1, 3, true): type#187
-  let c: type#187 = rt_range_int_from_start(1, false): type#187
-  let d: type#187 = rt_range_int_to_end(3, false): type#187
-  let e: type#187 = rt_range_int_to_end(3, true): type#187
-  let f: type#187 = rt_range_int_full(false): type#187
+fn make_ranges() -> nothing (id=1, sym=1403) {
+  let a: type#188 = rt_range_int_new(1, 3, false): type#188
+  let b: type#188 = rt_range_int_new(1, 3, true): type#188
+  let c: type#188 = rt_range_int_from_start(1, false): type#188
+  let d: type#188 = rt_range_int_to_end(3, false): type#188
+  let e: type#188 = rt_range_int_to_end(3, true): type#188
+  let f: type#188 = rt_range_int_full(false): type#188
   return
 }
 

--- a/testdata/golden/hir/references.hir
+++ b/testdata/golden/hir/references.hir
@@ -2,12 +2,12 @@
 == HIR ==
 module 
 
-fn increment(x: &mut int [&mut]) -> nothing (id=1, sym=1397) {
+fn increment(x: &mut int [&mut]) -> nothing (id=1, sym=1403) {
   ((* x) = __add((* x), 1)): int
   return
 }
 
-fn read_ref(x: &int [&]) -> int (id=2, sym=1398) {
+fn read_ref(x: &int [&]) -> int (id=2, sym=1404) {
   return (* x): int
 }
 

--- a/testdata/golden/hir/simple_func.hir
+++ b/testdata/golden/hir/simple_func.hir
@@ -2,11 +2,11 @@
 == HIR ==
 module 
 
-fn add(a: int [copy], b: int [copy]) -> int (id=1, sym=1397) {
+fn add(a: int [copy], b: int [copy]) -> int (id=1, sym=1403) {
   return __add(a, b): int
 }
 
-fn main() -> nothing (id=2, sym=1398) {
+fn main() -> nothing (id=2, sym=1404) {
   let x: int [copy] = add(1, 2): int
   let y: int [copy] = __add(x, 3): int
   return

--- a/testdata/golden/hir/structs.hir
+++ b/testdata/golden/hir/structs.hir
@@ -2,13 +2,13 @@
 == HIR ==
 module 
 
-type Point <struct> (sym=1397, type=0)
+type Point <struct> (sym=1403, type=0)
 
-fn origin() -> type#1489 (id=1, sym=1398) {
-  return  { x = 0, y = 0 }: type#1489
+fn origin() -> type#1493 (id=1, sym=1404) {
+  return  { x = 0, y = 0 }: type#1493
 }
 
-fn move_point(p: type#1489, dx: int [copy], dy: int [copy]) -> type#1489 (id=2, sym=1399) {
-  return  { x = __add(p.x, dx): int, y = __add(p.y, dy): int }: type#1489
+fn move_point(p: type#1493, dx: int [copy], dy: int [copy]) -> type#1493 (id=2, sym=1405) {
+  return  { x = __add(p.x, dx): int, y = __add(p.y, dy): int }: type#1493
 }
 

--- a/testdata/golden/hir/tuples.hir
+++ b/testdata/golden/hir/tuples.hir
@@ -2,11 +2,11 @@
 == HIR ==
 module 
 
-fn swap(a: int [copy], b: int [copy]) -> type#1489 (id=1, sym=1397) {
-  return (b, a): type#1491
+fn swap(a: int [copy], b: int [copy]) -> type#1493 (id=1, sym=1403) {
+  return (b, a): type#1495
 }
 
-fn get_first(t: type#1492) -> int (id=2, sym=1398) {
+fn get_first(t: type#1496) -> int (id=2, sym=1404) {
   return t.0: int
 }
 

--- a/testdata/golden/hir_borrow/drop_releases_borrow.hir
+++ b/testdata/golden/hir_borrow/drop_releases_borrow.hir
@@ -2,7 +2,7 @@
 == HIR ==
 module 
 
-fn t() -> nothing (id=1, sym=1397) {
+fn t() -> nothing (id=1, sym=1403) {
   let mut x: int [copy] = 1
   let r: &int [&] = (& x): &int
   drop r
@@ -11,13 +11,13 @@ fn t() -> nothing (id=1, sym=1397) {
 }
 
 borrow edges:
-  L2795(r) (&) borrows L2794(x) at 0:51-53 scope=S3
+  L2807(r) (&) borrows L2806(x) at 0:51-53 scope=S3
 events:
-  borrow_start L2795(r) -> L2794(x) (&) at 0:51-53 scope=S3 note="B1"
-  drop L2795(r) -> L2794(x) at 0:59-67 scope=S3 note="B1"
-  borrow_end L2795(r) -> L2794(x) at 0:59-67 scope=S3 note="drop B1"
-  write L2794(x) at 0:72-77 scope=S3
+  borrow_start L2807(r) -> L2806(x) (&) at 0:51-53 scope=S3 note="B1"
+  drop L2807(r) -> L2806(x) at 0:59-67 scope=S3 note="B1"
+  borrow_end L2807(r) -> L2806(x) at 0:59-67 scope=S3 note="drop B1"
+  write L2806(x) at 0:72-77 scope=S3
 move plan:
-  L2794(x): MoveCopy (copy type)
-  L2795(r): MoveCopy (copy type)
+  L2806(x): MoveCopy (copy type)
+  L2807(r): MoveCopy (copy type)
 

--- a/testdata/golden/hir_borrow/drop_returned_borrow.hir
+++ b/testdata/golden/hir_borrow/drop_returned_borrow.hir
@@ -2,28 +2,28 @@
 == HIR ==
 module 
 
-@entrypoint fn main() -> nothing (id=1, sym=1397) {
-  let mut xs: type#76 = [1, 2, 3]: type#76
+@entrypoint fn main() -> nothing (id=1, sym=1403) {
+  let mut xs: type#77 = [1, 2, 3]: type#77
   let item: &mut int [&mut] = get_mut((&mut xs), 0): &mut int
   ((* item) = 10): int
   drop item
-  let shared: &type#76 [&] = (& xs): &type#76
+  let shared: &type#77 [&] = (& xs): &type#77
   print(__to((* shared[0]))): nothing
   return nothing
 }
 
 borrow edges:
-  L2795(item) (&mut) borrows L2794(xs) at 0:95-97 scope=S3
-  L2796(shared) (&) borrows L2794(xs) at 0:167-170 scope=S3
+  L2807(item) (&mut) borrows L2806(xs) at 0:95-97 scope=S3
+  L2808(shared) (&) borrows L2806(xs) at 0:167-170 scope=S3
 events:
-  borrow_start L2795(item) -> L2794(xs) (&mut) at 0:95-97 scope=S3 note="B1"
-  write L2795(item) at 0:114-124 scope=S3 note="write_through_mut_ref"
-  drop L2795(item) -> L2794(xs) at 0:130-141 scope=S3 note="B1"
-  borrow_end L2795(item) -> L2794(xs) at 0:130-141 scope=S3 note="drop B1"
-  borrow_start L2796(shared) -> L2794(xs) (&) at 0:167-170 scope=S3 note="B2"
-  borrow_end L2796(shared) -> L2794(xs) scope=S3 note="scope_end B2"
+  borrow_start L2807(item) -> L2806(xs) (&mut) at 0:95-97 scope=S3 note="B1"
+  write L2807(item) at 0:114-124 scope=S3 note="write_through_mut_ref"
+  drop L2807(item) -> L2806(xs) at 0:130-141 scope=S3 note="B1"
+  borrow_end L2807(item) -> L2806(xs) at 0:130-141 scope=S3 note="drop B1"
+  borrow_start L2808(shared) -> L2806(xs) (&) at 0:167-170 scope=S3 note="B2"
+  borrow_end L2808(shared) -> L2806(xs) scope=S3 note="scope_end B2"
 move plan:
-  L2794(xs): MoveNeedsDrop (non-copy (drop))
-  L2795(item): MoveAllowed (non-copy reference)
-  L2796(shared): MoveCopy (copy type)
+  L2806(xs): MoveNeedsDrop (non-copy (drop))
+  L2807(item): MoveAllowed (non-copy reference)
+  L2808(shared): MoveCopy (copy type)
 

--- a/testdata/golden/hir_borrow/invalid/move_forbidden_when_borrowed.hir
+++ b/testdata/golden/hir_borrow/invalid/move_forbidden_when_borrowed.hir
@@ -3,7 +3,7 @@ error SEM3020 testdata/golden/hir_borrow/invalid/move_forbidden_when_borrowed.sg
 == HIR ==
 module 
 
-fn t() -> nothing (id=1, sym=1397) {
+fn t() -> nothing (id=1, sym=1403) {
   let x: string = "\"hi\""
   let r: &string [&] = (& x): &string
   let y: string = x
@@ -11,13 +11,13 @@ fn t() -> nothing (id=1, sym=1397) {
 }
 
 borrow edges:
-  L2795(r) (&) borrows L2794(x) at 0:56-58 scope=S3
+  L2807(r) (&) borrows L2806(x) at 0:56-58 scope=S3
 events:
-  borrow_start L2795(r) -> L2794(x) (&) at 0:56-58 scope=S3 note="B1"
-  move L2794(x) at 0:80-81 scope=S3 note="issue=frozen borrow=B1"
-  borrow_end L2795(r) -> L2794(x) scope=S3 note="scope_end B1"
+  borrow_start L2807(r) -> L2806(x) (&) at 0:56-58 scope=S3 note="B1"
+  move L2806(x) at 0:80-81 scope=S3 note="issue=frozen borrow=B1"
+  borrow_end L2807(r) -> L2806(x) scope=S3 note="scope_end B1"
 move plan:
-  L2794(x): MoveForbidden (move blocked by frozen (B1))
-  L2795(r): MoveCopy (copy type)
-  L2796(y): MoveNeedsDrop (non-copy (drop))
+  L2806(x): MoveForbidden (move blocked by frozen (B1))
+  L2807(r): MoveCopy (copy type)
+  L2808(y): MoveNeedsDrop (non-copy (drop))
 

--- a/testdata/golden/hir_borrow/invalid/mut_borrow_excludes_other.hir
+++ b/testdata/golden/hir_borrow/invalid/mut_borrow_excludes_other.hir
@@ -3,7 +3,7 @@ error SEM3018 testdata/golden/hir_borrow/invalid/mut_borrow_excludes_other.sg:4:
 == HIR ==
 module 
 
-fn t() -> nothing (id=1, sym=1397) {
+fn t() -> nothing (id=1, sym=1403) {
   let mut x: int [copy] = 1
   let m: &mut int [&mut] = (&mut x): &mut int
   let r: &int [&] = (& x): &int
@@ -11,13 +11,13 @@ fn t() -> nothing (id=1, sym=1397) {
 }
 
 borrow edges:
-  L2795(m) (&mut) borrows L2794(x) at 0:55-61 scope=S3
+  L2807(m) (&mut) borrows L2806(x) at 0:55-61 scope=S3
 events:
-  borrow_start L2795(m) -> L2794(x) (&mut) at 0:55-61 scope=S3 note="B1"
-  borrow_start _ -> L2794(x) at 0:81-83 scope=S3 note="issue=conflict_mut borrow=B1"
-  borrow_end L2795(m) -> L2794(x) scope=S3 note="scope_end B1"
+  borrow_start L2807(m) -> L2806(x) (&mut) at 0:55-61 scope=S3 note="B1"
+  borrow_start _ -> L2806(x) at 0:81-83 scope=S3 note="issue=conflict_mut borrow=B1"
+  borrow_end L2807(m) -> L2806(x) scope=S3 note="scope_end B1"
 move plan:
-  L2794(x): MoveCopy (copy type)
-  L2795(m): MoveAllowed (non-copy reference)
-  L2796(r): MoveCopy (copy type)
+  L2806(x): MoveCopy (copy type)
+  L2807(m): MoveAllowed (non-copy reference)
+  L2808(r): MoveCopy (copy type)
 

--- a/testdata/golden/hir_borrow/invalid/shared_borrow_blocks_mutation.hir
+++ b/testdata/golden/hir_borrow/invalid/shared_borrow_blocks_mutation.hir
@@ -3,7 +3,7 @@ error SEM3019 testdata/golden/hir_borrow/invalid/shared_borrow_blocks_mutation.s
 == HIR ==
 module 
 
-fn t() -> nothing (id=1, sym=1397) {
+fn t() -> nothing (id=1, sym=1403) {
   let mut x: int [copy] = 1
   let r: &int [&] = (& x): &int
   (x = 2): int
@@ -11,12 +11,12 @@ fn t() -> nothing (id=1, sym=1397) {
 }
 
 borrow edges:
-  L2795(r) (&) borrows L2794(x) at 0:51-53 scope=S3
+  L2807(r) (&) borrows L2806(x) at 0:51-53 scope=S3
 events:
-  borrow_start L2795(r) -> L2794(x) (&) at 0:51-53 scope=S3 note="B1"
-  write L2794(x) at 0:59-64 scope=S3 note="issue=frozen borrow=B1"
-  borrow_end L2795(r) -> L2794(x) scope=S3 note="scope_end B1"
+  borrow_start L2807(r) -> L2806(x) (&) at 0:51-53 scope=S3 note="B1"
+  write L2806(x) at 0:59-64 scope=S3 note="issue=frozen borrow=B1"
+  borrow_end L2807(r) -> L2806(x) scope=S3 note="scope_end B1"
 move plan:
-  L2794(x): MoveForbidden (write blocked by frozen (B1))
-  L2795(r): MoveCopy (copy type)
+  L2806(x): MoveForbidden (write blocked by frozen (B1))
+  L2807(r): MoveCopy (copy type)
 

--- a/testdata/golden/hir_borrow/invalid/spawn_escape.hir
+++ b/testdata/golden/hir_borrow/invalid/spawn_escape.hir
@@ -4,7 +4,7 @@ error SEM3021 testdata/golden/hir_borrow/invalid/spawn_escape.sg:6:27 cannot sen
 == HIR ==
 module 
 
-async fn use_ref(x: &int [&]) -> nothing (id=1, sym=1397) {
+async fn use_ref(x: &int [&]) -> nothing (id=1, sym=1403) {
 }
 
 borrow edges:
@@ -12,25 +12,25 @@ borrow edges:
 events:
   <none>
 move plan:
-  L2795(x): MoveCopy (copy type)
+  L2807(x): MoveCopy (copy type)
 
-async fn t() -> nothing (id=2, sym=1398) {
+async fn t() -> nothing (id=2, sym=1404) {
   let mut x: int [copy] = 1
   let r: &int [&] = (& x): &int
-  let t: type#581 = spawn use_ref(r): type#581: type#581
-  await(t): type#1490
+  let t: type#585 = spawn use_ref(r): type#585: type#585
+  await(t): type#1494
   return
 }
 
 borrow edges:
-  L2797(r) (&) borrows L2796(x) at 0:87-89 scope=S5
+  L2809(r) (&) borrows L2808(x) at 0:87-89 scope=S5
 events:
-  borrow_start L2797(r) -> L2796(x) (&) at 0:87-89 scope=S5 note="B1"
-  spawn_escape L2797(r) -> L2796(x) at 0:117-118 scope=S5 note="B1"
-  move L2798(t) at 0:125-126 scope=S5
-  borrow_end L2797(r) -> L2796(x) scope=S5 note="scope_end B1"
+  borrow_start L2809(r) -> L2808(x) (&) at 0:87-89 scope=S5 note="B1"
+  spawn_escape L2809(r) -> L2808(x) at 0:117-118 scope=S5 note="B1"
+  move L2810(t) at 0:125-126 scope=S5
+  borrow_end L2809(r) -> L2808(x) scope=S5 note="scope_end B1"
 move plan:
-  L2796(x): MoveCopy (copy type)
-  L2797(r): MoveForbidden (task escape)
-  L2798(t): MoveNeedsDrop (non-copy (drop))
+  L2808(x): MoveCopy (copy type)
+  L2809(r): MoveForbidden (task escape)
+  L2810(t): MoveNeedsDrop (non-copy (drop))
 

--- a/testdata/golden/mir/array_field_mut_ref_reborrow.mir
+++ b/testdata/golden/mir/array_field_mut_ref_reborrow.mir
@@ -6,7 +6,7 @@ funcs=2
 
 fn add_borrower:
   locals:
-    L0: &mut type#1489 [refmut] name=entry
+    L0: &mut type#1493 [refmut] name=entry
     L1: &string [copy,ref] name=client_id
     L2: bool [copy] name=tmp_call1
     L3: bool [copy] name=tmp_call2
@@ -24,14 +24,14 @@ fn add_borrower:
 
 fn main:
   locals:
-    L0: type#1489 name=entry
-    L1: type#80 name=tmp_arr1
-    L2: type#1489 name=tmp_struct2
+    L0: type#1493 name=entry
+    L1: type#81 name=tmp_arr1
+    L2: type#1493 name=tmp_struct2
     L3: uint [copy] name=tmp_call3
     L4: int [copy] name=tmp_cast4
   bb0:
     L1 = array_lit []
-    L2 = struct_lit type#1489 {borrowers=move L1}
+    L2 = struct_lit type#1493 {borrowers=move L1}
     L0 = move L2
     call add_borrower(addr_of_mut L0, addr_of G0)
     call add_borrower(addr_of_mut L0, addr_of G0)

--- a/testdata/golden/mir/array_fixed_struct.mir
+++ b/testdata/golden/mir/array_fixed_struct.mir
@@ -4,20 +4,20 @@ funcs=1
 
 fn main:
   locals:
-    L0: type#1492 name=pts
-    L1: type#1489 name=tmp_struct1
-    L2: type#1489 name=tmp_struct2
-    L3: type#1492 name=tmp_arr3
+    L0: type#1496 name=pts
+    L1: type#1493 name=tmp_struct1
+    L2: type#1493 name=tmp_struct2
+    L3: type#1496 name=tmp_arr3
     L4: int [copy] name=tmp_idx4
-    L5: type#1489 name=tmp_un5
+    L5: type#1493 name=tmp_un5
     L6: int [copy] name=tmp_field6
     L7: int [copy] name=tmp_idx7
-    L8: type#1489 name=tmp_un8
+    L8: type#1493 name=tmp_un8
     L9: int [copy] name=tmp_field9
     L10: int [copy] name=tmp_call10
   bb0:
-    L1 = struct_lit type#1489 {x=const 1, y=const 2}
-    L2 = struct_lit type#1489 {x=const 3, y=const 4}
+    L1 = struct_lit type#1493 {x=const 1, y=const 2}
+    L2 = struct_lit type#1493 {x=const 3, y=const 4}
     L3 = array_lit [move L1, move L2]
     L0 = move L3
     L4 = const 0

--- a/testdata/golden/mir/array_len.mir
+++ b/testdata/golden/mir/array_len.mir
@@ -4,8 +4,8 @@ funcs=1
 
 fn main:
   locals:
-    L0: type#76 name=arr
-    L1: type#76 name=tmp_arr1
+    L0: type#77 name=arr
+    L1: type#77 name=tmp_arr1
     L2: uint [copy] name=len_arr
     L3: uint [copy] name=tmp_call2
   bb0:

--- a/testdata/golden/mir/entrypoint_argv.mir
+++ b/testdata/golden/mir/entrypoint_argv.mir
@@ -9,7 +9,7 @@ fn __surge_start:
     L2: int [copy] name=x
     L3: bool [copy] name=has_arg0
     L4: string name=arg_str0
-    L5: type#770 name=arg_parsed0
+    L5: type#775 name=arg_parsed0
     L6: bool [copy] name=arg_ok0
     L7: type#48 name=entry_err
     L8: int name=entry_ret

--- a/testdata/golden/mir/entrypoint_returns_custom.mir
+++ b/testdata/golden/mir/entrypoint_returns_custom.mir
@@ -4,7 +4,7 @@ funcs=3
 
 fn __surge_start:
   locals:
-    L0: type#1489 name=entry_ret
+    L0: type#1493 name=entry_ret
     L1: int [copy] name=code
   bb0:
     L0 = call main()
@@ -14,7 +14,7 @@ fn __surge_start:
 
 fn __to:
   locals:
-    L0: type#1489 name=self
+    L0: type#1493 name=self
     L1: int [copy] name=_target
     L2: int [copy] name=tmp_field1
   bb0:
@@ -23,7 +23,7 @@ fn __to:
 
 fn main:
   locals:
-    L0: type#1489 name=tmp_struct1
+    L0: type#1493 name=tmp_struct1
   bb0:
-    L0 = struct_lit type#1489 {code=const 42}
+    L0 = struct_lit type#1493 {code=const 42}
     return move L0

--- a/testdata/golden/mir/entrypoint_stdin.mir
+++ b/testdata/golden/mir/entrypoint_stdin.mir
@@ -6,7 +6,7 @@ fn __surge_start:
   locals:
     L0: string name=stdin
     L1: int [copy] name=x
-    L2: type#770 name=stdin_parsed
+    L2: type#775 name=stdin_parsed
     L3: bool [copy] name=stdin_ok
     L4: int name=entry_ret
     L5: int [copy] name=code

--- a/testdata/golden/mir/erring_option_nested_tag.mir
+++ b/testdata/golden/mir/erring_option_nested_tag.mir
@@ -15,36 +15,36 @@ fn __surge_start:
 fn demo:
   locals:
     L0: bool [copy] name=flag
-    L1: type#1492 name=tmp_call1
-    L2: type#1493 name=tmp_call2
-    L3: type#1490 name=tmp_cast3
-    L4: type#1494 name=tmp_call4
-    L5: type#1490 name=tmp_cast5
+    L1: type#1496 name=tmp_call1
+    L2: type#1497 name=tmp_call2
+    L3: type#1494 name=tmp_cast3
+    L4: type#1498 name=tmp_call4
+    L5: type#1494 name=tmp_cast5
   bb0:
     if copy L0 then bb1 else bb2
   bb1:
     L1 = call Some(const "\"x\"")
     L2 = call Success(move L1)
-    L3 = cast move L2 to type#1490
+    L3 = cast move L2 to type#1494
     return move L3
   bb2:
     L4 = call Success(const nothing)
-    L5 = cast move L4 to type#1490
+    L5 = cast move L4 to type#1494
     return move L5
 
 fn main:
   locals:
-    L0: type#1490 name=v
-    L1: type#1490 name=tmp_call1
-    L2: type#1490 name=__cmp1
+    L0: type#1494 name=v
+    L1: type#1494 name=tmp_call1
+    L2: type#1494 name=__cmp1
     L3: bool [copy] name=tmp_tagtest2
-    L4: type#1489 name=tmp_payload3
+    L4: type#1493 name=tmp_payload3
     L5: bool [copy] name=tmp_tagtest4
     L6: string name=s
-    L7: type#1489 name=tmp_payload5
+    L7: type#1493 name=tmp_payload5
     L8: string name=tmp_payload6
     L9: bool [copy] name=tmp_tagtest7
-    L10: type#1489 name=tmp_payload8
+    L10: type#1493 name=tmp_payload8
     L11: bool [copy] name=tmp_tagtest9
     L12: type#48 name=err
   bb0:

--- a/testdata/golden/mir/imported_magic_methods.mir
+++ b/testdata/golden/mir/imported_magic_methods.mir
@@ -17,53 +17,53 @@ fn __surge_start:
 
 fn main:
   locals:
-    L0: type#1489 name=empty
-    L1: type#1489 name=tmp_struct1
+    L0: type#1493 name=empty
+    L1: type#1493 name=tmp_struct1
     L2: bool [copy] name=tmp_call2
     L3: int [copy] name=tmp_cast3
-    L4: type#1489 name=original
-    L5: type#1489 name=tmp_struct4
-    L6: type#1489 name=cloned
-    L7: type#1489 name=tmp_call5
+    L4: type#1493 name=original
+    L5: type#1493 name=tmp_struct4
+    L6: type#1493 name=cloned
+    L7: type#1493 name=tmp_call5
     L8: bool [copy] name=tmp_call6
-    L9: type#1490 name=flag
-    L10: type#1490 name=tmp_struct7
+    L9: type#1494 name=flag
+    L10: type#1494 name=tmp_struct7
     L11: bool [copy] name=tmp_call8
     L12: int [copy] name=tmp_cast9
     L13: int [copy] name=converted
     L14: int [copy] name=tmp_call10
     L15: int [copy] name=tmp_call11
     L16: bool [copy] name=tmp_call12
-    L17: type#1491 name=bag
-    L18: type#76 name=tmp_arr13
-    L19: type#1491 name=tmp_struct14
+    L17: type#1495 name=bag
+    L18: type#77 name=tmp_arr13
+    L19: type#1495 name=tmp_struct14
     L20: int [copy] name=tmp_call15
     L21: int [copy] name=tmp_call16
     L22: bool [copy] name=tmp_call17
     L23: int [copy] name=sum
-    L24: type#187 name=__iter1
-    L25: type#187 name=tmp_call18
-    L26: type#187 name=tmp_iter19
-    L27: type#1506 name=__next2
-    L28: type#1506 name=tmp_next20
+    L24: type#188 name=__iter1
+    L25: type#188 name=tmp_call18
+    L26: type#188 name=tmp_iter19
+    L27: type#1510 name=__next2
+    L28: type#1510 name=tmp_next20
     L29: bool [copy] name=tmp_tagtest21
     L30: int [copy] name=v
     L31: int [copy] name=tmp_payload22
     L32: int [copy] name=tmp_call23
     L33: bool [copy] name=tmp_call24
     L34: int [copy] name=typed_sum
-    L35: type#187 name=__iter3
-    L36: type#187 name=tmp_call25
-    L37: type#187 name=tmp_iter26
-    L38: type#1506 name=__next4
-    L39: type#1506 name=tmp_next27
+    L35: type#188 name=__iter3
+    L36: type#188 name=tmp_call25
+    L37: type#188 name=tmp_iter26
+    L38: type#1510 name=__next4
+    L39: type#1510 name=tmp_next27
     L40: bool [copy] name=tmp_tagtest28
     L41: int [copy] name=typed
     L42: int [copy] name=tmp_payload29
     L43: int [copy] name=tmp_call30
     L44: bool [copy] name=tmp_call31
   bb0:
-    L1 = struct_lit type#1489 {value=const "\"\""}
+    L1 = struct_lit type#1493 {value=const "\"\""}
     L0 = move L1
     L2 = call __not(addr_of L0)
     if copy L2 then bb1 else bb2
@@ -73,7 +73,7 @@ fn main:
   bb2:
     return const 1
   bb3:
-    L5 = struct_lit type#1489 {value=const "\"ok\""}
+    L5 = struct_lit type#1493 {value=const "\"ok\""}
     L4 = move L5
     L7 = call __clone(addr_of L4)
     L6 = move L7
@@ -82,7 +82,7 @@ fn main:
   bb4:
     return const 2
   bb5:
-    L10 = struct_lit type#1490 {value=const 1}
+    L10 = struct_lit type#1494 {value=const 1}
     L9 = move L10
     L11 = call __bool(addr_of L9)
     if copy L11 then bb6 else bb7
@@ -101,7 +101,7 @@ fn main:
     return const 4
   bb10:
     L18 = array_lit [const 1, const 2, const 3]
-    L19 = struct_lit type#1491 {values=move L18}
+    L19 = struct_lit type#1495 {values=move L18}
     L17 = move L19
     L20 = call __index_set(addr_of_mut L17, const 1, const 9)
     L21 = call __index(addr_of L17, const 1)

--- a/testdata/golden/mir/imported_operator_overload.mir
+++ b/testdata/golden/mir/imported_operator_overload.mir
@@ -14,19 +14,19 @@ fn __surge_start:
 
 fn main:
   locals:
-    L0: type#1489 [copy] name=digest
+    L0: type#1493 [copy] name=digest
     L1: uint64 [copy] name=tmp_cast1
-    L2: type#1489 [copy] name=tmp_struct2
-    L3: type#1489 [copy] name=same
+    L2: type#1493 [copy] name=tmp_struct2
+    L3: type#1493 [copy] name=same
     L4: uint64 [copy] name=tmp_cast3
-    L5: type#1489 [copy] name=tmp_struct4
+    L5: type#1493 [copy] name=tmp_struct4
     L6: bool [copy] name=tmp_call5
   bb0:
     L1 = cast const 42 to uint64
-    L2 = struct_lit type#1489 {value=copy L1}
+    L2 = struct_lit type#1493 {value=copy L1}
     L0 = copy L2
     L4 = cast const 42 to uint64
-    L5 = struct_lit type#1489 {value=copy L4}
+    L5 = struct_lit type#1493 {value=copy L4}
     L3 = copy L5
     L6 = call __ne(copy L0, copy L3)
     if copy L6 then bb1 else bb2

--- a/testdata/golden/mir/is_heir_ops.mir
+++ b/testdata/golden/mir/is_heir_ops.mir
@@ -14,19 +14,19 @@ fn __surge_start:
 
 fn main:
   locals:
-    L0: type#1490 name=x
-    L1: type#1490 name=tmp_struct1
+    L0: type#1494 name=x
+    L1: type#1494 name=tmp_struct1
     L2: bool [copy] name=a
     L3: bool [copy] name=tmp_is2
     L4: bool [copy] name=b
     L5: bool [copy] name=tmp_heir3
     L6: bool [copy] name=tmp_logic4
   bb0:
-    L1 = struct_lit type#1490 {x=const 1, y=const 2}
+    L1 = struct_lit type#1494 {x=const 1, y=const 2}
     L0 = move L1
-    L3 = type_test copy L0 is type#1490
+    L3 = type_test copy L0 is type#1494
     L2 = copy L3
-    L5 = heir_test copy L0 heir type#1489
+    L5 = heir_test copy L0 heir type#1493
     L4 = copy L5
     if copy L2 then bb1 else bb2
   bb1:

--- a/testdata/golden/mir/magic_methods_repro.mir
+++ b/testdata/golden/mir/magic_methods_repro.mir
@@ -6,8 +6,8 @@ funcs=7
 
 fn __bool:
   locals:
-    L0: &type#1490 [copy,ref] name=self
-    L1: type#1490 name=tmp_un1
+    L0: &type#1494 [copy,ref] name=self
+    L1: type#1494 name=tmp_un1
     L2: int [copy] name=tmp_field2
     L3: bool [copy] name=tmp_call3
   bb0:
@@ -18,17 +18,17 @@ fn __bool:
 
 fn __clone:
   locals:
-    L0: &type#1489 [copy,ref] name=self
+    L0: &type#1493 [copy,ref] name=self
     L1: string name=tmp_call1
-    L2: type#1489 name=tmp_struct2
+    L2: type#1493 name=tmp_struct2
   bb0:
     L1 = call __clone(addr_of (*L0).value)
-    L2 = struct_lit type#1489 {value=move L1}
+    L2 = struct_lit type#1493 {value=move L1}
     return move L2
 
 fn __index:
   locals:
-    L0: &type#1491 [copy,ref] name=self
+    L0: &type#1495 [copy,ref] name=self
     L1: int [copy] name=index
     L2: int [copy] name=tmp_idx1
     L3: int [copy] name=tmp_un2
@@ -39,7 +39,7 @@ fn __index:
 
 fn __index_set:
   locals:
-    L0: &mut type#1491 [refmut] name=self
+    L0: &mut type#1495 [refmut] name=self
     L1: int [copy] name=index
     L2: int [copy] name=value
     L3: int [copy] name=tmp_idx1
@@ -50,7 +50,7 @@ fn __index_set:
 
 fn __not:
   locals:
-    L0: &type#1489 [copy,ref] name=self
+    L0: &type#1493 [copy,ref] name=self
     L1: bool [copy] name=tmp_call1
   bb0:
     L1 = call __eq(addr_of (*L0).value, addr_of G0)
@@ -58,15 +58,15 @@ fn __not:
 
 fn __range:
   locals:
-    L0: &type#1491 [copy,ref] name=self
-    L1: type#187 name=tmp_call1
+    L0: &type#1495 [copy,ref] name=self
+    L1: type#188 name=tmp_call1
   bb0:
     L1 = call __range::<int>(addr_of (*L0).values)
     return move L1
 
 fn __to:
   locals:
-    L0: &type#1489 [copy,ref] name=self
+    L0: &type#1493 [copy,ref] name=self
     L1: int [copy] name=_
   bb0:
     return const 7

--- a/testdata/golden/mir/magic_ops_call.mir
+++ b/testdata/golden/mir/magic_ops_call.mir
@@ -4,19 +4,19 @@ funcs=5
 
 fn __add:
   locals:
-    L0: &type#1489 [copy,ref] name=self
-    L1: &type#1489 [copy,ref] name=other
-    L2: type#1489 name=tmp_un1
+    L0: &type#1493 [copy,ref] name=self
+    L1: &type#1493 [copy,ref] name=other
+    L2: type#1493 name=tmp_un1
     L3: int [copy] name=tmp_field2
-    L4: type#1489 name=tmp_un3
+    L4: type#1493 name=tmp_un3
     L5: int [copy] name=tmp_field4
     L6: int [copy] name=tmp_call5
-    L7: type#1489 name=tmp_un6
+    L7: type#1493 name=tmp_un6
     L8: int [copy] name=tmp_field7
-    L9: type#1489 name=tmp_un8
+    L9: type#1493 name=tmp_un8
     L10: int [copy] name=tmp_field9
     L11: int [copy] name=tmp_call10
-    L12: type#1489 name=tmp_struct11
+    L12: type#1493 name=tmp_struct11
   bb0:
     L2 = (* copy L0)
     L3 = field copy L2.x
@@ -28,22 +28,22 @@ fn __add:
     L9 = (* copy L1)
     L10 = field copy L9.y
     L11 = call __add(copy L8, copy L10)
-    L12 = struct_lit type#1489 {x=copy L6, y=copy L11}
+    L12 = struct_lit type#1493 {x=copy L6, y=copy L11}
     return move L12
 
 fn __eq:
   locals:
-    L0: &type#1489 [copy,ref] name=self
-    L1: &type#1489 [copy,ref] name=other
+    L0: &type#1493 [copy,ref] name=self
+    L1: &type#1493 [copy,ref] name=other
     L2: bool [copy] name=tmp_logic1
-    L3: type#1489 name=tmp_un2
+    L3: type#1493 name=tmp_un2
     L4: int [copy] name=tmp_field3
-    L5: type#1489 name=tmp_un4
+    L5: type#1493 name=tmp_un4
     L6: int [copy] name=tmp_field5
     L7: bool [copy] name=tmp_call6
-    L8: type#1489 name=tmp_un7
+    L8: type#1493 name=tmp_un7
     L9: int [copy] name=tmp_field8
-    L10: type#1489 name=tmp_un9
+    L10: type#1493 name=tmp_un9
     L11: int [copy] name=tmp_field10
     L12: bool [copy] name=tmp_call11
   bb0:
@@ -69,11 +69,11 @@ fn __eq:
 
 fn __lt:
   locals:
-    L0: &type#1489 [copy,ref] name=self
-    L1: &type#1489 [copy,ref] name=other
-    L2: type#1489 name=tmp_un1
+    L0: &type#1493 [copy,ref] name=self
+    L1: &type#1493 [copy,ref] name=other
+    L2: type#1493 name=tmp_un1
     L3: int [copy] name=tmp_field2
-    L4: type#1489 name=tmp_un3
+    L4: type#1493 name=tmp_un3
     L5: int [copy] name=tmp_field4
     L6: bool [copy] name=tmp_call5
   bb0:
@@ -86,14 +86,14 @@ fn __lt:
 
 fn __neg:
   locals:
-    L0: &type#1489 [copy,ref] name=self
-    L1: type#1489 name=tmp_un1
+    L0: &type#1493 [copy,ref] name=self
+    L1: type#1493 name=tmp_un1
     L2: int [copy] name=tmp_field2
     L3: int [copy] name=tmp_call3
-    L4: type#1489 name=tmp_un4
+    L4: type#1493 name=tmp_un4
     L5: int [copy] name=tmp_field5
     L6: int [copy] name=tmp_call6
-    L7: type#1489 name=tmp_struct7
+    L7: type#1493 name=tmp_struct7
   bb0:
     L1 = (* copy L0)
     L2 = field copy L1.x
@@ -101,31 +101,31 @@ fn __neg:
     L4 = (* copy L0)
     L5 = field copy L4.y
     L6 = call __neg(copy L5)
-    L7 = struct_lit type#1489 {x=copy L3, y=copy L6}
+    L7 = struct_lit type#1493 {x=copy L3, y=copy L6}
     return move L7
 
 fn main:
   locals:
-    L0: type#1489 name=a
-    L1: type#1489 name=tmp_struct1
-    L2: type#1489 name=b
-    L3: type#1489 name=tmp_struct2
-    L4: type#1489 name=c
-    L5: type#1489 name=tmp_call3
+    L0: type#1493 name=a
+    L1: type#1493 name=tmp_struct1
+    L2: type#1493 name=b
+    L3: type#1493 name=tmp_struct2
+    L4: type#1493 name=c
+    L5: type#1493 name=tmp_call3
     L6: bool [copy] name=eq
     L7: bool [copy] name=tmp_call4
     L8: bool [copy] name=lt
     L9: bool [copy] name=tmp_call5
-    L10: type#1489 name=neg
-    L11: type#1489 name=tmp_call6
+    L10: type#1493 name=neg
+    L11: type#1493 name=tmp_call6
     L12: bool [copy] name=tmp_logic7
     L13: int [copy] name=tmp_field8
     L14: int [copy] name=tmp_field9
     L15: int [copy] name=tmp_call10
   bb0:
-    L1 = struct_lit type#1489 {x=const 1, y=const 2}
+    L1 = struct_lit type#1493 {x=const 1, y=const 2}
     L0 = move L1
-    L3 = struct_lit type#1489 {x=const 3, y=const 4}
+    L3 = struct_lit type#1493 {x=const 3, y=const 4}
     L2 = move L3
     L5 = call __add(addr_of L0, addr_of L2)
     L4 = move L5

--- a/testdata/golden/mir/magic_ops_call_nonplace.mir
+++ b/testdata/golden/mir/magic_ops_call_nonplace.mir
@@ -8,19 +8,19 @@ funcs=4
 
 fn __add:
   locals:
-    L0: &type#1489 [copy,ref] name=self
-    L1: &type#1489 [copy,ref] name=other
-    L2: type#1489 name=tmp_un1
+    L0: &type#1493 [copy,ref] name=self
+    L1: &type#1493 [copy,ref] name=other
+    L2: type#1493 name=tmp_un1
     L3: int [copy] name=tmp_field2
-    L4: type#1489 name=tmp_un3
+    L4: type#1493 name=tmp_un3
     L5: int [copy] name=tmp_field4
     L6: int [copy] name=tmp_call5
-    L7: type#1489 name=tmp_un6
+    L7: type#1493 name=tmp_un6
     L8: int [copy] name=tmp_field7
-    L9: type#1489 name=tmp_un8
+    L9: type#1493 name=tmp_un8
     L10: int [copy] name=tmp_field9
     L11: int [copy] name=tmp_call10
-    L12: type#1489 name=tmp_struct11
+    L12: type#1493 name=tmp_struct11
   bb0:
     L2 = (* copy L0)
     L3 = field copy L2.x
@@ -32,19 +32,19 @@ fn __add:
     L9 = (* copy L1)
     L10 = field copy L9.y
     L11 = call __add(copy L8, copy L10)
-    L12 = struct_lit type#1489 {x=copy L6, y=copy L11}
+    L12 = struct_lit type#1493 {x=copy L6, y=copy L11}
     return move L12
 
 fn __neg:
   locals:
-    L0: &type#1489 [copy,ref] name=self
-    L1: type#1489 name=tmp_un1
+    L0: &type#1493 [copy,ref] name=self
+    L1: type#1493 name=tmp_un1
     L2: int [copy] name=tmp_field2
     L3: int [copy] name=tmp_call3
-    L4: type#1489 name=tmp_un4
+    L4: type#1493 name=tmp_un4
     L5: int [copy] name=tmp_field5
     L6: int [copy] name=tmp_call6
-    L7: type#1489 name=tmp_struct7
+    L7: type#1493 name=tmp_struct7
   bb0:
     L1 = (* copy L0)
     L2 = field copy L1.x
@@ -52,16 +52,16 @@ fn __neg:
     L4 = (* copy L0)
     L5 = field copy L4.y
     L6 = call __neg(copy L5)
-    L7 = struct_lit type#1489 {x=copy L3, y=copy L6}
+    L7 = struct_lit type#1493 {x=copy L3, y=copy L6}
     return move L7
 
 fn __to:
   locals:
-    L0: &type#1489 [copy,ref] name=self
+    L0: &type#1493 [copy,ref] name=self
     L1: int [copy] name=target
-    L2: type#1489 name=tmp_un1
+    L2: type#1493 name=tmp_un1
     L3: int [copy] name=tmp_field2
-    L4: type#1489 name=tmp_un3
+    L4: type#1493 name=tmp_un3
     L5: int [copy] name=tmp_field4
     L6: int [copy] name=tmp_call5
   bb0:
@@ -74,14 +74,14 @@ fn __to:
 
 fn main:
   locals:
-    L0: type#1489 name=p1
-    L1: type#1489 name=tmp_struct1
-    L2: type#1489 name=p2
-    L3: type#1489 name=tmp_struct2
-    L4: type#1489 name=sum
-    L5: type#1489 name=tmp_call3
-    L6: type#1489 name=neg
-    L7: type#1489 name=tmp_call4
+    L0: type#1493 name=p1
+    L1: type#1493 name=tmp_struct1
+    L2: type#1493 name=p2
+    L3: type#1493 name=tmp_struct2
+    L4: type#1493 name=sum
+    L5: type#1493 name=tmp_call3
+    L6: type#1493 name=neg
+    L7: type#1493 name=tmp_call4
     L8: string name=s
     L9: string name=tmp_call5
     L10: string name=tmp_ref6
@@ -89,9 +89,9 @@ fn main:
     L12: int [copy] name=tmp_call8
     L13: int [copy] name=tmp_call9
   bb0:
-    L1 = struct_lit type#1489 {x=const 1, y=const 2}
+    L1 = struct_lit type#1493 {x=const 1, y=const 2}
     L0 = move L1
-    L3 = struct_lit type#1489 {x=const 3, y=const 4}
+    L3 = struct_lit type#1493 {x=const 3, y=const 4}
     L2 = move L3
     L5 = call __add(addr_of L0, addr_of L2)
     L4 = move L5

--- a/testdata/golden/mir/method_call.mir
+++ b/testdata/golden/mir/method_call.mir
@@ -4,19 +4,19 @@ funcs=2
 
 fn add:
   locals:
-    L0: &type#1489 [copy,ref] name=self
-    L1: &type#1489 [copy,ref] name=other
-    L2: type#1489 name=tmp_un1
+    L0: &type#1493 [copy,ref] name=self
+    L1: &type#1493 [copy,ref] name=other
+    L2: type#1493 name=tmp_un1
     L3: int [copy] name=tmp_field2
-    L4: type#1489 name=tmp_un3
+    L4: type#1493 name=tmp_un3
     L5: int [copy] name=tmp_field4
     L6: int [copy] name=tmp_call5
-    L7: type#1489 name=tmp_un6
+    L7: type#1493 name=tmp_un6
     L8: int [copy] name=tmp_field7
-    L9: type#1489 name=tmp_un8
+    L9: type#1493 name=tmp_un8
     L10: int [copy] name=tmp_field9
     L11: int [copy] name=tmp_call10
-    L12: type#1489 name=tmp_struct11
+    L12: type#1493 name=tmp_struct11
   bb0:
     L2 = (* copy L0)
     L3 = field copy L2.x
@@ -28,24 +28,24 @@ fn add:
     L9 = (* copy L1)
     L10 = field copy L9.y
     L11 = call __add(copy L8, copy L10)
-    L12 = struct_lit type#1489 {x=copy L6, y=copy L11}
+    L12 = struct_lit type#1493 {x=copy L6, y=copy L11}
     return move L12
 
 fn main:
   locals:
-    L0: type#1489 name=p1
-    L1: type#1489 name=tmp_struct1
-    L2: type#1489 name=p2
-    L3: type#1489 name=tmp_struct2
-    L4: type#1489 name=p3
-    L5: type#1489 name=tmp_call3
+    L0: type#1493 name=p1
+    L1: type#1493 name=tmp_struct1
+    L2: type#1493 name=p2
+    L3: type#1493 name=tmp_struct2
+    L4: type#1493 name=p3
+    L5: type#1493 name=tmp_call3
     L6: int [copy] name=tmp_field4
     L7: int [copy] name=tmp_field5
     L8: int [copy] name=tmp_call6
   bb0:
-    L1 = struct_lit type#1489 {x=const 1, y=const 2}
+    L1 = struct_lit type#1493 {x=const 1, y=const 2}
     L0 = move L1
-    L3 = struct_lit type#1489 {x=const 3, y=const 4}
+    L3 = struct_lit type#1493 {x=const 3, y=const 4}
     L2 = move L3
     L5 = call add(addr_of L0, addr_of L2)
     L4 = move L5

--- a/testdata/golden/mir/operator_repro.mir
+++ b/testdata/golden/mir/operator_repro.mir
@@ -4,8 +4,8 @@ funcs=2
 
 fn __eq:
   locals:
-    L0: type#1489 [copy] name=self
-    L1: type#1489 [copy] name=other
+    L0: type#1493 [copy] name=self
+    L1: type#1493 [copy] name=other
     L2: uint64 [copy] name=tmp_field1
     L3: uint64 [copy] name=tmp_field2
     L4: bool [copy] name=tmp_call3
@@ -17,8 +17,8 @@ fn __eq:
 
 fn __ne:
   locals:
-    L0: type#1489 [copy] name=self
-    L1: type#1489 [copy] name=other
+    L0: type#1493 [copy] name=self
+    L1: type#1493 [copy] name=other
     L2: uint64 [copy] name=tmp_field1
     L3: uint64 [copy] name=tmp_field2
     L4: bool [copy] name=tmp_call3

--- a/testdata/golden/mir/option_match.mir
+++ b/testdata/golden/mir/option_match.mir
@@ -4,9 +4,9 @@ funcs=1
 
 fn unwrap_or_zero:
   locals:
-    L0: type#1489 name=x
+    L0: type#1493 name=x
     L1: int [copy] name=tmp_block1
-    L2: type#1489 name=__cmp1
+    L2: type#1493 name=__cmp1
     L3: bool [copy] name=tmp_tagtest2
     L4: int [copy] name=v
     L5: int [copy] name=tmp_payload3

--- a/testdata/golden/mono/generic_type_ctor.mono
+++ b/testdata/golden/mono/generic_type_ctor.mono
@@ -2,9 +2,9 @@
 == MONO ==
 funcs=1 types=1
 fn main() -> nothing (id=2147483649, sym=2415919105) {
-  let b: type#1492 =  { v = 1 }: type#1492
+  let b: type#1496 =  { v = 1 }: type#1496
   return
 }
 
 types:
-  type Box::<int> = type#1492
+  type Box::<int> = type#1496

--- a/testdata/golden/mono/option_ctor_int.mono
+++ b/testdata/golden/mono/option_ctor_int.mono
@@ -2,11 +2,11 @@
 == MONO ==
 funcs=2 types=2
 fn main() -> nothing (id=2147483649, sym=2415919105) {
-  let x: type#1490 = Some(1): type#1491 to type#1490: type#1490
+  let x: type#1494 = Some(1): type#1495 to type#1494: type#1494
   return
 }
 fn Some::<int> (sym=2415919106)
 
 types:
-  type Option::<int> = type#1490
-  type Option::<int> = type#1490
+  type Option::<int> = type#1494
+  type Option::<int> = type#1494

--- a/testdata/golden/mono/option_implicit_wrap.mono
+++ b/testdata/golden/mono/option_implicit_wrap.mono
@@ -2,12 +2,12 @@
 == MONO ==
 funcs=2 types=2
 fn main() -> nothing (id=2147483649, sym=2415919105) {
-  let x: type#1490 = Some(1): type#1490
-  let y: type#1490 = Some(42): type#1490
+  let x: type#1494 = Some(1): type#1494
+  let y: type#1494 = Some(42): type#1494
   return
 }
 fn Some::<int> (sym=2415919106)
 
 types:
-  type Option::<int> = type#1490
-  type Option::<int> = type#1490
+  type Option::<int> = type#1494
+  type Option::<int> = type#1494

--- a/testdata/golden/sema/invalid/array_view_resize.ast
+++ b/testdata/golden/sema/invalid/array_view_resize.ast
@@ -1,4 +1,4 @@
-array_view_resize.sg (span: 2:1-43:1)
+array_view_resize.sg (span: 2:1-64:1)
 ├─ Item[0]: Fn (span: 2:1-6:2)
 │  ├─ Name: push_view
 │  ├─ Params: ()
@@ -113,21 +113,90 @@ array_view_resize.sg (span: 2:1-43:1)
 │        │  └─ Value: expr#81: a[[1..3]]
 │        └─ Stmt[2]: Expr (span: 35:5-35:35)
 │           └─ Expr: expr#87: array_reserve(&mut v, 8 to uint)
-└─ Item[6]: Fn (span: 38:1-42:2)
-   ├─ Name: rt_array_push_view
+├─ Item[6]: Fn (span: 38:1-42:2)
+│  ├─ Name: rt_array_push_view
+│  ├─ Params: ()
+│  ├─ Return: nothing
+│  └─ Body:
+│     └─ Stmt[0]: Block (span: 38:36-42:2)
+│        ├─ Stmt[0]: Let (span: 39:5-39:34)
+│        │  ├─ Name: a
+│        │  ├─ Mutable: true
+│        │  ├─ Type: int[]
+│        │  └─ Value: expr#91: <ExprKind(8)>
+│        ├─ Stmt[1]: Let (span: 40:5-40:27)
+│        │  ├─ Name: v
+│        │  ├─ Mutable: true
+│        │  ├─ Type: <inferred>
+│        │  └─ Value: expr#97: a[[1..3]]
+│        └─ Stmt[2]: Expr (span: 41:5-41:30)
+│           └─ Expr: expr#102: rt_array_push(&mut v, 6)
+├─ Item[7]: Fn (span: 44:1-48:2)
+│  ├─ Name: append_string_view
+│  ├─ Params: ()
+│  ├─ Return: nothing
+│  └─ Body:
+│     └─ Stmt[0]: Block (span: 44:36-48:2)
+│        ├─ Stmt[0]: Let (span: 45:5-45:53)
+│        │  ├─ Name: a
+│        │  ├─ Mutable: true
+│        │  ├─ Type: byte[]
+│        │  └─ Value: expr#109: <ExprKind(8)>
+│        ├─ Stmt[1]: Let (span: 46:5-46:27)
+│        │  ├─ Name: v
+│        │  ├─ Mutable: true
+│        │  ├─ Type: <inferred>
+│        │  └─ Value: expr#115: a[[1..3]]
+│        └─ Stmt[2]: Expr (span: 47:5-47:27)
+│           └─ Expr: expr#120: v.append_string(&"x")
+├─ Item[8]: Fn (span: 50:1-56:2)
+│  ├─ Name: append_bytes_view_view
+│  ├─ Params: ()
+│  ├─ Return: nothing
+│  └─ Body:
+│     └─ Stmt[0]: Block (span: 50:40-56:2)
+│        ├─ Stmt[0]: Let (span: 51:5-51:53)
+│        │  ├─ Name: a
+│        │  ├─ Mutable: true
+│        │  ├─ Type: byte[]
+│        │  └─ Value: expr#127: <ExprKind(8)>
+│        ├─ Stmt[1]: Let (span: 52:5-52:27)
+│        │  ├─ Name: v
+│        │  ├─ Mutable: true
+│        │  ├─ Type: <inferred>
+│        │  └─ Value: expr#133: a[[1..3]]
+│        ├─ Stmt[2]: Let (span: 53:5-53:25)
+│        │  ├─ Name: s
+│        │  ├─ Mutable: false
+│        │  ├─ Type: string
+│        │  └─ Value: expr#134: "x"
+│        ├─ Stmt[3]: Let (span: 54:5-54:27)
+│        │  ├─ Name: bytes
+│        │  ├─ Mutable: false
+│        │  ├─ Type: <inferred>
+│        │  └─ Value: expr#137: s.bytes()
+│        └─ Stmt[4]: Expr (span: 55:5-55:33)
+│           └─ Expr: expr#142: v.append_bytes_view(&bytes)
+└─ Item[9]: Fn (span: 58:1-63:2)
+   ├─ Name: rt_array_append_raw_bytes_view
    ├─ Params: ()
    ├─ Return: nothing
    └─ Body:
-      └─ Stmt[0]: Block (span: 38:36-42:2)
-         ├─ Stmt[0]: Let (span: 39:5-39:34)
+      └─ Stmt[0]: Block (span: 58:48-63:2)
+         ├─ Stmt[0]: Let (span: 59:5-59:53)
          │  ├─ Name: a
          │  ├─ Mutable: true
-         │  ├─ Type: int[]
-         │  └─ Value: expr#91: <ExprKind(8)>
-         ├─ Stmt[1]: Let (span: 40:5-40:27)
+         │  ├─ Type: byte[]
+         │  └─ Value: expr#149: <ExprKind(8)>
+         ├─ Stmt[1]: Let (span: 60:5-60:27)
          │  ├─ Name: v
          │  ├─ Mutable: true
          │  ├─ Type: <inferred>
-         │  └─ Value: expr#97: a[[1..3]]
-         └─ Stmt[2]: Expr (span: 41:5-41:30)
-            └─ Expr: expr#102: rt_array_push(&mut v, 6)
+         │  └─ Value: expr#155: a[[1..3]]
+         ├─ Stmt[2]: Let (span: 61:5-61:25)
+         │  ├─ Name: s
+         │  ├─ Mutable: false
+         │  ├─ Type: string
+         │  └─ Value: expr#156: "x"
+         └─ Stmt[3]: Expr (span: 62:5-62:68)
+            └─ Expr: expr#166: rt_array_append_raw_bytes(&mut v, rt_string_ptr(&s), 1 to uint64)

--- a/testdata/golden/sema/invalid/array_view_resize.diag
+++ b/testdata/golden/sema/invalid/array_view_resize.diag
@@ -5,3 +5,6 @@ error SEM3015 testdata/golden/sema/invalid/array_view_resize.sg:23:16 array view
 error SEM3015 testdata/golden/sema/invalid/array_view_resize.sg:29:23 array view is not resizable; array_pop requires an owned array
 error SEM3015 testdata/golden/sema/invalid/array_view_resize.sg:35:19 array view is not resizable; array_reserve requires an owned array
 error SEM3015 testdata/golden/sema/invalid/array_view_resize.sg:41:19 array view is not resizable; rt_array_push requires an owned array
+error SEM3015 testdata/golden/sema/invalid/array_view_resize.sg:47:5 array view is not resizable; append_string requires an owned array
+error SEM3015 testdata/golden/sema/invalid/array_view_resize.sg:55:5 array view is not resizable; append_bytes_view requires an owned array
+error SEM3015 testdata/golden/sema/invalid/array_view_resize.sg:62:31 array view is not resizable; rt_array_append_raw_bytes requires an owned array

--- a/testdata/golden/sema/invalid/array_view_resize.fmt
+++ b/testdata/golden/sema/invalid/array_view_resize.fmt
@@ -40,3 +40,24 @@ fn rt_array_push_view() -> nothing {
     let mut v = a[[1..3]];
     rt_array_push(&mut v, 6);
 }
+
+fn append_string_view() -> nothing {
+    let mut a: byte[] = [65:byte, 66:byte, 67:byte];
+    let mut v = a[[1..3]];
+    v.append_string(&"x");
+}
+
+fn append_bytes_view_view() -> nothing {
+    let mut a: byte[] = [65:byte, 66:byte, 67:byte];
+    let mut v = a[[1..3]];
+    let s: string = "x";
+    let bytes = s.bytes();
+    v.append_bytes_view(&bytes);
+}
+
+fn rt_array_append_raw_bytes_view() -> nothing {
+    let mut a: byte[] = [65:byte, 66:byte, 67:byte];
+    let mut v = a[[1..3]];
+    let s: string = "x";
+    rt_array_append_raw_bytes(&mut v, rt_string_ptr(&s), 1:uint64);
+}

--- a/testdata/golden/sema/invalid/array_view_resize.sg
+++ b/testdata/golden/sema/invalid/array_view_resize.sg
@@ -40,3 +40,24 @@ fn rt_array_push_view() -> nothing {
     let mut v = a[[1..3]];
     rt_array_push(&mut v, 6);
 }
+
+fn append_string_view() -> nothing {
+    let mut a: byte[] = [65:byte, 66:byte, 67:byte];
+    let mut v = a[[1..3]];
+    v.append_string(&"x");
+}
+
+fn append_bytes_view_view() -> nothing {
+    let mut a: byte[] = [65:byte, 66:byte, 67:byte];
+    let mut v = a[[1..3]];
+    let s: string = "x";
+    let bytes = s.bytes();
+    v.append_bytes_view(&bytes);
+}
+
+fn rt_array_append_raw_bytes_view() -> nothing {
+    let mut a: byte[] = [65:byte, 66:byte, 67:byte];
+    let mut v = a[[1..3]];
+    let s: string = "x";
+    rt_array_append_raw_bytes(&mut v, rt_string_ptr(&s), 1:uint64);
+}

--- a/testdata/golden/sema/invalid/array_view_resize.tokens
+++ b/testdata/golden/sema/invalid/array_view_resize.tokens
@@ -321,4 +321,189 @@
 321: RParen          ")" at 41:28-41:29
 322: Semicolon       ";" at 41:29-41:30
 323: RBrace          "}" at 42:1-42:2 (leading: Newline)
-324: EOF             at 43:1-43:1
+324: KwFn            "fn" at 44:1-44:3 (leading: Newline)
+325: Ident           "append_string_view" at 44:4-44:22 (leading: Space)
+326: LParen          "(" at 44:22-44:23
+327: RParen          ")" at 44:23-44:24
+328: Arrow           "->" at 44:25-44:27 (leading: Space)
+329: NothingLit      "nothing" at 44:28-44:35 (leading: Space)
+330: LBrace          "{" at 44:36-44:37 (leading: Space)
+331: KwLet           "let" at 45:5-45:8 (leading: Newline, Space)
+332: KwMut           "mut" at 45:9-45:12 (leading: Space)
+333: Ident           "a" at 45:13-45:14 (leading: Space)
+334: Colon           ":" at 45:14-45:15
+335: Ident           "byte" at 45:16-45:20 (leading: Space)
+336: LBracket        "[" at 45:20-45:21
+337: RBracket        "]" at 45:21-45:22
+338: Assign          "=" at 45:23-45:24 (leading: Space)
+339: LBracket        "[" at 45:25-45:26 (leading: Space)
+340: IntLit          "65" at 45:26-45:28
+341: Colon           ":" at 45:28-45:29
+342: Ident           "byte" at 45:29-45:33
+343: Comma           "," at 45:33-45:34
+344: IntLit          "66" at 45:35-45:37 (leading: Space)
+345: Colon           ":" at 45:37-45:38
+346: Ident           "byte" at 45:38-45:42
+347: Comma           "," at 45:42-45:43
+348: IntLit          "67" at 45:44-45:46 (leading: Space)
+349: Colon           ":" at 45:46-45:47
+350: Ident           "byte" at 45:47-45:51
+351: RBracket        "]" at 45:51-45:52
+352: Semicolon       ";" at 45:52-45:53
+353: KwLet           "let" at 46:5-46:8 (leading: Newline, Space)
+354: KwMut           "mut" at 46:9-46:12 (leading: Space)
+355: Ident           "v" at 46:13-46:14 (leading: Space)
+356: Assign          "=" at 46:15-46:16 (leading: Space)
+357: Ident           "a" at 46:17-46:18 (leading: Space)
+358: LBracket        "[" at 46:18-46:19
+359: LBracket        "[" at 46:19-46:20
+360: IntLit          "1" at 46:20-46:21
+361: DotDot          ".." at 46:21-46:23
+362: IntLit          "3" at 46:23-46:24
+363: RBracket        "]" at 46:24-46:25
+364: RBracket        "]" at 46:25-46:26
+365: Semicolon       ";" at 46:26-46:27
+366: Ident           "v" at 47:5-47:6 (leading: Newline, Space)
+367: Dot             "." at 47:6-47:7
+368: Ident           "append_string" at 47:7-47:20
+369: LParen          "(" at 47:20-47:21
+370: Amp             "&" at 47:21-47:22
+371: StringLit       "\"x\"" at 47:22-47:25
+372: RParen          ")" at 47:25-47:26
+373: Semicolon       ";" at 47:26-47:27
+374: RBrace          "}" at 48:1-48:2 (leading: Newline)
+375: KwFn            "fn" at 50:1-50:3 (leading: Newline)
+376: Ident           "append_bytes_view_view" at 50:4-50:26 (leading: Space)
+377: LParen          "(" at 50:26-50:27
+378: RParen          ")" at 50:27-50:28
+379: Arrow           "->" at 50:29-50:31 (leading: Space)
+380: NothingLit      "nothing" at 50:32-50:39 (leading: Space)
+381: LBrace          "{" at 50:40-50:41 (leading: Space)
+382: KwLet           "let" at 51:5-51:8 (leading: Newline, Space)
+383: KwMut           "mut" at 51:9-51:12 (leading: Space)
+384: Ident           "a" at 51:13-51:14 (leading: Space)
+385: Colon           ":" at 51:14-51:15
+386: Ident           "byte" at 51:16-51:20 (leading: Space)
+387: LBracket        "[" at 51:20-51:21
+388: RBracket        "]" at 51:21-51:22
+389: Assign          "=" at 51:23-51:24 (leading: Space)
+390: LBracket        "[" at 51:25-51:26 (leading: Space)
+391: IntLit          "65" at 51:26-51:28
+392: Colon           ":" at 51:28-51:29
+393: Ident           "byte" at 51:29-51:33
+394: Comma           "," at 51:33-51:34
+395: IntLit          "66" at 51:35-51:37 (leading: Space)
+396: Colon           ":" at 51:37-51:38
+397: Ident           "byte" at 51:38-51:42
+398: Comma           "," at 51:42-51:43
+399: IntLit          "67" at 51:44-51:46 (leading: Space)
+400: Colon           ":" at 51:46-51:47
+401: Ident           "byte" at 51:47-51:51
+402: RBracket        "]" at 51:51-51:52
+403: Semicolon       ";" at 51:52-51:53
+404: KwLet           "let" at 52:5-52:8 (leading: Newline, Space)
+405: KwMut           "mut" at 52:9-52:12 (leading: Space)
+406: Ident           "v" at 52:13-52:14 (leading: Space)
+407: Assign          "=" at 52:15-52:16 (leading: Space)
+408: Ident           "a" at 52:17-52:18 (leading: Space)
+409: LBracket        "[" at 52:18-52:19
+410: LBracket        "[" at 52:19-52:20
+411: IntLit          "1" at 52:20-52:21
+412: DotDot          ".." at 52:21-52:23
+413: IntLit          "3" at 52:23-52:24
+414: RBracket        "]" at 52:24-52:25
+415: RBracket        "]" at 52:25-52:26
+416: Semicolon       ";" at 52:26-52:27
+417: KwLet           "let" at 53:5-53:8 (leading: Newline, Space)
+418: Ident           "s" at 53:9-53:10 (leading: Space)
+419: Colon           ":" at 53:10-53:11
+420: Ident           "string" at 53:12-53:18 (leading: Space)
+421: Assign          "=" at 53:19-53:20 (leading: Space)
+422: StringLit       "\"x\"" at 53:21-53:24 (leading: Space)
+423: Semicolon       ";" at 53:24-53:25
+424: KwLet           "let" at 54:5-54:8 (leading: Newline, Space)
+425: Ident           "bytes" at 54:9-54:14 (leading: Space)
+426: Assign          "=" at 54:15-54:16 (leading: Space)
+427: Ident           "s" at 54:17-54:18 (leading: Space)
+428: Dot             "." at 54:18-54:19
+429: Ident           "bytes" at 54:19-54:24
+430: LParen          "(" at 54:24-54:25
+431: RParen          ")" at 54:25-54:26
+432: Semicolon       ";" at 54:26-54:27
+433: Ident           "v" at 55:5-55:6 (leading: Newline, Space)
+434: Dot             "." at 55:6-55:7
+435: Ident           "append_bytes_view" at 55:7-55:24
+436: LParen          "(" at 55:24-55:25
+437: Amp             "&" at 55:25-55:26
+438: Ident           "bytes" at 55:26-55:31
+439: RParen          ")" at 55:31-55:32
+440: Semicolon       ";" at 55:32-55:33
+441: RBrace          "}" at 56:1-56:2 (leading: Newline)
+442: KwFn            "fn" at 58:1-58:3 (leading: Newline)
+443: Ident           "rt_array_append_raw_bytes_view" at 58:4-58:34 (leading: Space)
+444: LParen          "(" at 58:34-58:35
+445: RParen          ")" at 58:35-58:36
+446: Arrow           "->" at 58:37-58:39 (leading: Space)
+447: NothingLit      "nothing" at 58:40-58:47 (leading: Space)
+448: LBrace          "{" at 58:48-58:49 (leading: Space)
+449: KwLet           "let" at 59:5-59:8 (leading: Newline, Space)
+450: KwMut           "mut" at 59:9-59:12 (leading: Space)
+451: Ident           "a" at 59:13-59:14 (leading: Space)
+452: Colon           ":" at 59:14-59:15
+453: Ident           "byte" at 59:16-59:20 (leading: Space)
+454: LBracket        "[" at 59:20-59:21
+455: RBracket        "]" at 59:21-59:22
+456: Assign          "=" at 59:23-59:24 (leading: Space)
+457: LBracket        "[" at 59:25-59:26 (leading: Space)
+458: IntLit          "65" at 59:26-59:28
+459: Colon           ":" at 59:28-59:29
+460: Ident           "byte" at 59:29-59:33
+461: Comma           "," at 59:33-59:34
+462: IntLit          "66" at 59:35-59:37 (leading: Space)
+463: Colon           ":" at 59:37-59:38
+464: Ident           "byte" at 59:38-59:42
+465: Comma           "," at 59:42-59:43
+466: IntLit          "67" at 59:44-59:46 (leading: Space)
+467: Colon           ":" at 59:46-59:47
+468: Ident           "byte" at 59:47-59:51
+469: RBracket        "]" at 59:51-59:52
+470: Semicolon       ";" at 59:52-59:53
+471: KwLet           "let" at 60:5-60:8 (leading: Newline, Space)
+472: KwMut           "mut" at 60:9-60:12 (leading: Space)
+473: Ident           "v" at 60:13-60:14 (leading: Space)
+474: Assign          "=" at 60:15-60:16 (leading: Space)
+475: Ident           "a" at 60:17-60:18 (leading: Space)
+476: LBracket        "[" at 60:18-60:19
+477: LBracket        "[" at 60:19-60:20
+478: IntLit          "1" at 60:20-60:21
+479: DotDot          ".." at 60:21-60:23
+480: IntLit          "3" at 60:23-60:24
+481: RBracket        "]" at 60:24-60:25
+482: RBracket        "]" at 60:25-60:26
+483: Semicolon       ";" at 60:26-60:27
+484: KwLet           "let" at 61:5-61:8 (leading: Newline, Space)
+485: Ident           "s" at 61:9-61:10 (leading: Space)
+486: Colon           ":" at 61:10-61:11
+487: Ident           "string" at 61:12-61:18 (leading: Space)
+488: Assign          "=" at 61:19-61:20 (leading: Space)
+489: StringLit       "\"x\"" at 61:21-61:24 (leading: Space)
+490: Semicolon       ";" at 61:24-61:25
+491: Ident           "rt_array_append_raw_bytes" at 62:5-62:30 (leading: Newline, Space)
+492: LParen          "(" at 62:30-62:31
+493: Amp             "&" at 62:31-62:32
+494: KwMut           "mut" at 62:32-62:35
+495: Ident           "v" at 62:36-62:37 (leading: Space)
+496: Comma           "," at 62:37-62:38
+497: Ident           "rt_string_ptr" at 62:39-62:52 (leading: Space)
+498: LParen          "(" at 62:52-62:53
+499: Amp             "&" at 62:53-62:54
+500: Ident           "s" at 62:54-62:55
+501: RParen          ")" at 62:55-62:56
+502: Comma           "," at 62:56-62:57
+503: IntLit          "1" at 62:58-62:59 (leading: Space)
+504: Colon           ":" at 62:59-62:60
+505: Ident           "uint64" at 62:60-62:66
+506: RParen          ")" at 62:66-62:67
+507: Semicolon       ";" at 62:67-62:68
+508: RBrace          "}" at 63:1-63:2 (leading: Newline)
+509: EOF             at 64:1-64:1

--- a/testdata/llvm_parity/byte_array_append_string.sg
+++ b/testdata/llvm_parity/byte_array_append_string.sg
@@ -1,0 +1,34 @@
+fn print_from_bytes(bytes: &byte[]) -> nothing {
+    compare string.from_bytes(bytes) {
+        Success(text) => print(text);
+        _ => print("invalid");
+    };
+    return nothing;
+}
+
+@entrypoint
+fn main() -> int {
+    let value: string = "{\"v\":\"x\"}";
+    let view = value.bytes();
+
+    let mut out: byte[] = [];
+    out.append_string(&"VALUE ");
+    out.append_bytes_view(&view);
+    out.push(10:byte);
+
+    if out.__len() != 16:uint {
+        return 1;
+    }
+    if out[0] != 86:byte || out[15] != 10:byte {
+        return 2;
+    }
+
+    let copied: byte[] = "OK" to byte[];
+    if copied.__len() != 2:uint || copied[0] != 79:byte || copied[1] != 75:byte {
+        return 3;
+    }
+
+    print_from_bytes(&out);
+    print_from_bytes(&copied);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add a native `rt_array_append_raw_bytes` helper for bulk byte-array appends
- expose `byte[]` helpers for appending `string` and `BytesView` contents without per-byte `push`
- route `string to byte[]` through the bulk append path and cover it in LLVM/VM parity

## Benchmark
Measured with `surgekv/benchmarks/server_probe` in release mode, using this branch compiler/runtime. Baseline was local `main` before this branch.

| probe | baseline ns/op | branch ns/op |
| --- | ---: | ---: |
| `line_bytes_to_array_server` | 29,898 | 1,017 |
| `line_bytes_value_server` | 30,316 | 28,315 |
| `value_line_bytes_manual_string` | 29,355 | 28,481 |
| `get_pipeline_cheap_direct_response` | 70,970 | 69,555 |

The hypothesis is confirmed for `string to byte[]`: materializing a byte array from a string is now ~29x faster in this probe. Manual `BytesView[i]` + `push` loops are still slow, as expected, so surgekv has to adopt `append_string` / `append_bytes_view` or the optimized cast before the full pipeline benefits. This PR intentionally does not include the separate network string-write optimization.

## Verification
- `go test ./internal/vm -run 'TestLLVMParity/byte_array_append_string'`
- `go test ./internal/backend/llvm ./internal/vm -run 'Test.*Array|TestLLVMParity/byte_array_append_string'`
- pre-commit `make check` passed: Go tests with `SURGE_SKIP_TIMEOUT_TESTS=1`, golangci-lint, C checks, file-size check
- `make cfmt-check`
- `make c-warnings`
- `CC=gcc make c-warnings`
- `SURGE_STDLIB=/home/zov/projects/surge/surge /tmp/surge-byte-array-bulk build --release benchmarks/server_probe` and `./target/release/server_probe`
- sentrux: `quality_signal=6221`; rule violations are existing complexity/fan-out hotspots outside this diff

Note: a raw local `go test ./...` without `SURGE_SKIP_TIMEOUT_TESTS=1` still fails on existing VM/timeout cases; representative failures were reproduced on clean `origin/main` before this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `append_string` method to byte arrays for efficient appending of a string’s raw UTF-8 bytes.
  * Added `append_bytes_view` method to byte arrays for appending raw bytes from a `BytesView`.

* **Improvements**
  * Introduced a low-level raw-bytes append intrinsic used to speed up string → `byte[]` conversion.
  * Expanded array-view append/resize validation to cover these new append-style operations.

* **Tests**
  * Added LLVM parity coverage for the new byte-array append behavior and updated golden fixtures accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->