### PR TITLE
fix(llvm): box async ref parameters

### DIFF
--- a/STATS.md
+++ b/STATS.md
@@ -33,12 +33,12 @@
 ## 🧪 Test files
 
 - **Files:** 179
-- **Lines of code:** 36726
+- **Lines of code:** 36731
 
 ## 📈 Total volume (code + tests)
 
 - **Files:** 864
-- **Lines of code:** 194003
+- **Lines of code:** 194008
 
 ## 📊 Percentage breakdown
 

--- a/STATS.md
+++ b/STATS.md
@@ -5,14 +5,14 @@
 ## 📊 Main code (without tests)
 
 - **Files:** 685 (Go: 654, C: 31)
-- **Lines of code:** 157199 (Go: 142876, C: 14323)
+- **Lines of code:** 157258 (Go: 142935, C: 14323)
 
 ## 📁 Directory breakdown
 
 | Directory | Files | Lines |
 |------------|--------|-------|
 | `cmd/` | 28 | 4819 |
-| `internal/` | 624 | 137498 |
+| `internal/` | 624 | 137553 |
 | `runtime/native/` (C code) | 31 | 14323 |
 
 ## 🏆 Top 10 packages by size
@@ -21,7 +21,7 @@
 |---|-------|-------|
 | 1 | `internal/sema` | 28573 |
 | 2 | `internal/vm` | 23263 |
-| 3 | `internal/backend/llvm` | 12162 |
+| 3 | `internal/backend/llvm` | 12217 |
 | 4 | `internal/mir` | 10330 |
 | 5 | `internal/parser` | 8960 |
 | 6 | `internal/hir` | 7156 |
@@ -32,13 +32,13 @@
 
 ## 🧪 Test files
 
-- **Files:** 177
-- **Lines of code:** 36569
+- **Files:** 178
+- **Lines of code:** 36638
 
 ## 📈 Total volume (code + tests)
 
-- **Files:** 862
-- **Lines of code:** 193768
+- **Files:** 863
+- **Lines of code:** 193896
 
 ## 📊 Percentage breakdown
 

--- a/STATS.md
+++ b/STATS.md
@@ -5,14 +5,14 @@
 ## 📊 Main code (without tests)
 
 - **Files:** 685 (Go: 654, C: 31)
-- **Lines of code:** 157258 (Go: 142935, C: 14323)
+- **Lines of code:** 157277 (Go: 142954, C: 14323)
 
 ## 📁 Directory breakdown
 
 | Directory | Files | Lines |
 |------------|--------|-------|
 | `cmd/` | 28 | 4819 |
-| `internal/` | 624 | 137553 |
+| `internal/` | 624 | 137572 |
 | `runtime/native/` (C code) | 31 | 14323 |
 
 ## 🏆 Top 10 packages by size
@@ -21,7 +21,7 @@
 |---|-------|-------|
 | 1 | `internal/sema` | 28573 |
 | 2 | `internal/vm` | 23263 |
-| 3 | `internal/backend/llvm` | 12217 |
+| 3 | `internal/backend/llvm` | 12236 |
 | 4 | `internal/mir` | 10330 |
 | 5 | `internal/parser` | 8960 |
 | 6 | `internal/hir` | 7156 |
@@ -32,13 +32,13 @@
 
 ## 🧪 Test files
 
-- **Files:** 178
-- **Lines of code:** 36638
+- **Files:** 179
+- **Lines of code:** 36726
 
 ## 📈 Total volume (code + tests)
 
-- **Files:** 863
-- **Lines of code:** 193896
+- **Files:** 864
+- **Lines of code:** 194003
 
 ## 📊 Percentage breakdown
 

--- a/internal/backend/llvm/builtins.go
+++ b/internal/backend/llvm/builtins.go
@@ -12,6 +12,7 @@ func runtimeDecls() []builtinDecl {
 		{name: "rt_alloc", ret: "ptr", params: []string{"i64", "i64"}},
 		{name: "rt_free", ret: "void", params: []string{"ptr", "i64", "i64"}},
 		{name: "rt_realloc", ret: "ptr", params: []string{"ptr", "i64", "i64", "i64"}},
+		{name: "llvm.trap", ret: "void", params: nil},
 		{name: "rt_memcpy", ret: "void", params: []string{"ptr", "ptr", "i64"}},
 		{name: "rt_memmove", ret: "void", params: []string{"ptr", "ptr", "i64"}},
 		{name: "rt_array_append_raw_bytes", ret: "void", params: []string{"ptr", "ptr", "i64"}},

--- a/internal/backend/llvm/emit_async_ref_params_test.go
+++ b/internal/backend/llvm/emit_async_ref_params_test.go
@@ -1,0 +1,88 @@
+package llvm
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func TestEmitAsyncSharedRefParamIsBoxedAndAllocationChecked(t *testing.T) {
+	sourceCode := `async fn read_ref(x: &int) -> int {
+    checkpoint().await();
+    return *x;
+}
+
+@entrypoint
+fn main() -> int {
+    let value: int = 3;
+    compare read_ref(&value).await() {
+        Success(v) => return v;
+        Cancelled() => return 9;
+    };
+}
+`
+
+	mirMod, result := lowerMIRFromSource(t, sourceCode)
+	fn := findMIRFunc(t, mirMod, "read_ref")
+	ir, err := EmitModule(mirMod, result.Sema.TypeInterner, result.Symbols.Table)
+	if err != nil {
+		t.Fatalf("emit LLVM IR: %v", err)
+	}
+	body := findLLVMFuncBody(t, ir, fmt.Sprintf("fn.%d", fn.ID))
+
+	for _, want := range []string{
+		"call ptr @rt_alloc(i64 8, i64 8)",
+		"icmp eq ptr",
+		"call void @llvm.trap()",
+		"unreachable",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("async shared ref constructor missing %q:\n%s", want, body)
+		}
+	}
+}
+
+func TestEmitAsyncMutableRefParamKeepsCallerAlias(t *testing.T) {
+	sourceCode := `async fn bump(x: &mut int) -> nothing {
+    checkpoint().await();
+    *x = *x + 1;
+    return nothing;
+}
+
+@entrypoint
+fn main() -> int {
+    let mut value: int = 1;
+    compare bump(&mut value).await() {
+        Success(_) => return value;
+        Cancelled() => return 9;
+    };
+}
+`
+
+	mirMod, result := lowerMIRFromSource(t, sourceCode)
+	fn := findMIRFunc(t, mirMod, "bump")
+	ir, err := EmitModule(mirMod, result.Sema.TypeInterner, result.Symbols.Table)
+	if err != nil {
+		t.Fatalf("emit LLVM IR: %v", err)
+	}
+	body := findLLVMFuncBody(t, ir, fmt.Sprintf("fn.%d", fn.ID))
+
+	if strings.Contains(body, "call ptr @rt_alloc(i64 8, i64 8)") {
+		t.Fatalf("async mutable ref constructor must not box the caller alias:\n%s", body)
+	}
+	if !strings.Contains(body, "store ptr %p0, ptr %l0") {
+		t.Fatalf("async mutable ref constructor should store original pointer alias:\n%s", body)
+	}
+}
+
+func findLLVMFuncBody(t *testing.T, ir, name string) string {
+	t.Helper()
+
+	re := regexp.MustCompile(`(?s)define [^{]+ @` + regexp.QuoteMeta(name) + `\([^)]*\) \{.*?\n\}`)
+	body := re.FindString(ir)
+	if body == "" {
+		t.Fatalf("missing LLVM function %s:\n%s", name, ir)
+	}
+	return body
+}

--- a/internal/backend/llvm/emit_async_ref_params_test.go
+++ b/internal/backend/llvm/emit_async_ref_params_test.go
@@ -68,8 +68,13 @@ fn main() -> int {
 	}
 	body := findLLVMFuncBody(t, ir, fmt.Sprintf("fn.%d", fn.ID))
 
-	if strings.Contains(body, "call ptr @rt_alloc(i64 8, i64 8)") {
-		t.Fatalf("async mutable ref constructor must not box the caller alias:\n%s", body)
+	prologueEnd := strings.Index(body, "\n  br ")
+	if prologueEnd < 0 {
+		t.Fatalf("missing constructor prologue terminator:\n%s", body)
+	}
+	prologue := body[:prologueEnd]
+	if strings.Contains(prologue, "call ptr @rt_alloc(") {
+		t.Fatalf("async mutable ref constructor must not box the caller alias:\n%s", prologue)
 	}
 	if !strings.Contains(body, "store ptr %p0, ptr %l0") {
 		t.Fatalf("async mutable ref constructor should store original pointer alias:\n%s", body)

--- a/internal/backend/llvm/emit_func.go
+++ b/internal/backend/llvm/emit_func.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"surge/internal/mir"
+	"surge/internal/types"
 )
 
 func (e *Emitter) emitFunction(f *mir.Func) error {
@@ -128,12 +129,66 @@ func (fe *funcEmitter) emitAllocas() error {
 }
 
 func (fe *funcEmitter) emitParamStores() error {
+	boxAsyncRefs := fe.shouldBoxAsyncRefParams()
 	for i, localID := range fe.paramLocals {
-		llvmTy, err := llvmLocalValueType(fe.emitter.types, fe.f.Locals[localID])
+		local := fe.f.Locals[localID]
+		llvmTy, err := llvmLocalValueType(fe.emitter.types, local)
 		if err != nil {
 			return err
 		}
-		fmt.Fprintf(&fe.emitter.buf, "  store %s %%p%d, ptr %%%s\n", llvmTy, i, fe.localAlloca[localID])
+		value := fmt.Sprintf("%%p%d", i)
+		if boxAsyncRefs && isRefType(fe.emitter.types, local.Type) {
+			boxed, err := fe.emitAsyncRefParamBox(value, local.Type)
+			if err != nil {
+				return err
+			}
+			value = boxed
+			llvmTy = "ptr"
+		}
+		fmt.Fprintf(&fe.emitter.buf, "  store %s %s, ptr %%%s\n", llvmTy, value, fe.localAlloca[localID])
 	}
 	return nil
+}
+
+func (fe *funcEmitter) shouldBoxAsyncRefParams() bool {
+	if fe == nil || fe.f == nil || fe.emitter == nil || fe.emitter.mod == nil {
+		return false
+	}
+	if isPollFunc(fe.f) || !isTaskType(fe.emitter.types, fe.f.Result) {
+		return false
+	}
+	pollName := fe.f.Name + "$poll"
+	for _, fn := range fe.emitter.mod.Funcs {
+		if fn != nil && fn.Name == pollName {
+			return true
+		}
+	}
+	return false
+}
+
+func (fe *funcEmitter) emitAsyncRefParamBox(paramValue string, refType types.TypeID) (string, error) {
+	valueType, ok := derefType(fe.emitter.types, refType)
+	if !ok {
+		return "", fmt.Errorf("async ref parameter has non-reference type")
+	}
+	valueLLVM, err := llvmValueType(fe.emitter.types, valueType)
+	if err != nil {
+		return "", err
+	}
+	size, align, err := llvmTypeSizeAlign(valueLLVM)
+	if err != nil {
+		return "", err
+	}
+	if size <= 0 {
+		size = 1
+	}
+	if align <= 0 {
+		align = 1
+	}
+	box := fe.nextTemp()
+	fmt.Fprintf(&fe.emitter.buf, "  %s = call ptr @rt_alloc(i64 %d, i64 %d)\n", box, size, align)
+	value := fe.nextTemp()
+	fmt.Fprintf(&fe.emitter.buf, "  %s = load %s, ptr %s\n", value, valueLLVM, paramValue)
+	fmt.Fprintf(&fe.emitter.buf, "  store %s %s, ptr %s\n", valueLLVM, value, box)
+	return box, nil
 }

--- a/internal/backend/llvm/emit_func.go
+++ b/internal/backend/llvm/emit_func.go
@@ -137,7 +137,7 @@ func (fe *funcEmitter) emitParamStores() error {
 			return err
 		}
 		value := fmt.Sprintf("%%p%d", i)
-		if boxAsyncRefs && isRefType(fe.emitter.types, local.Type) {
+		if boxAsyncRefs && isRefType(fe.emitter.types, local.Type) && !isMutableRefType(fe.emitter.types, local.Type) {
 			boxed, err := fe.emitAsyncRefParamBox(value, local.Type)
 			if err != nil {
 				return err
@@ -187,6 +187,15 @@ func (fe *funcEmitter) emitAsyncRefParamBox(paramValue string, refType types.Typ
 	}
 	box := fe.nextTemp()
 	fmt.Fprintf(&fe.emitter.buf, "  %s = call ptr @rt_alloc(i64 %d, i64 %d)\n", box, size, align)
+	isNull := fe.nextTemp()
+	trapBB := fe.nextInlineBlock()
+	okBB := fe.nextInlineBlock()
+	fmt.Fprintf(&fe.emitter.buf, "  %s = icmp eq ptr %s, null\n", isNull, box)
+	fmt.Fprintf(&fe.emitter.buf, "  br i1 %s, label %%%s, label %%%s\n", isNull, trapBB, okBB)
+	fmt.Fprintf(&fe.emitter.buf, "%s:\n", trapBB)
+	fmt.Fprintf(&fe.emitter.buf, "  call void @llvm.trap()\n")
+	fmt.Fprintf(&fe.emitter.buf, "  unreachable\n")
+	fmt.Fprintf(&fe.emitter.buf, "%s:\n", okBB)
 	value := fe.nextTemp()
 	fmt.Fprintf(&fe.emitter.buf, "  %s = load %s, ptr %s\n", value, valueLLVM, paramValue)
 	fmt.Fprintf(&fe.emitter.buf, "  store %s %s, ptr %s\n", valueLLVM, value, box)

--- a/internal/backend/llvm/emit_helpers_types.go
+++ b/internal/backend/llvm/emit_helpers_types.go
@@ -174,6 +174,15 @@ func isRefType(typesIn *types.Interner, id types.TypeID) bool {
 	return ok && tt.Kind == types.KindReference
 }
 
+func isMutableRefType(typesIn *types.Interner, id types.TypeID) bool {
+	if typesIn == nil || id == types.NoTypeID {
+		return false
+	}
+	id = resolveAliasAndOwn(typesIn, id)
+	tt, ok := typesIn.Lookup(id)
+	return ok && tt.Kind == types.KindReference && tt.Mutable
+}
+
 func isHandleValueType(typesIn *types.Interner, id types.TypeID) bool {
 	if typesIn == nil || id == types.NoTypeID {
 		return false

--- a/internal/vm/llvm_async_borrow_test.go
+++ b/internal/vm/llvm_async_borrow_test.go
@@ -1,0 +1,69 @@
+//go:build !golden
+// +build !golden
+
+package vm_test
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+)
+
+func TestLLVMNativeAsyncBorrowedRefsSurviveParentYield(t *testing.T) {
+	source := `type Router = {
+    chans: Channel<int>[],
+};
+
+async fn send_all(router: &Router, value: &int) -> nothing {
+    let count: int = router.chans.__len() to int;
+    let mut i: int = 0;
+    while i < count {
+        let ch: Channel<int> = router.chans[i];
+        ch.send(*value);
+        i = i + 1;
+    }
+    return nothing;
+}
+
+async fn read_after_wait(x: &int) -> int {
+    checkpoint().await();
+    return *x;
+}
+
+async fn run() -> int {
+    let ch = make_channel::<int>(8:uint);
+    let mut chans: Channel<int>[] = [];
+    chans.push(ch);
+    let router: Router = Router { chans = chans };
+    let value: int = 7;
+    let _ = send_all(&router, &value).await();
+    let sent = compare ch.recv() {
+        Some(v) => v;
+        nothing => 99;
+    };
+    let waited_value: int = 2;
+    let waited = compare read_after_wait(&waited_value).await() {
+        Success(v) => v;
+        Cancelled() => 80;
+    };
+    return sent + waited;
+}
+
+@entrypoint
+fn main() -> int {
+    compare run().await() {
+        Success(v) => return v;
+        Cancelled() => return 98;
+    };
+}
+`
+	root := repoRoot(t)
+	outputPath := buildLLVMProgramFromSource(t, source)
+	cmd := exec.Command(outputPath)
+	cmd.Dir = root
+	cmd.Env = overrideEnvVar(os.Environ(), "SURGE_THREADS", "4")
+	stdout, stderr, exitCode := runCommand(t, cmd, "")
+	if exitCode != 9 {
+		t.Fatalf("exit code: want 9, got %d\nstdout:\n%s\nstderr:\n%s", exitCode, stdout, stderr)
+	}
+}


### PR DESCRIPTION
## Summary
- Fix native async constructors so reference parameters are copied into stable heap backing slots before the initial task state is created.
- Prevent child tasks from keeping pointers to parent poll-frame stack slots after `rt_async_yield` unwinds the C stack.
- Add an LLVM native regression for the #152 `Channel[]` aggregate borrow and a borrowed ref that survives parent yield.
- Update `STATS.md`.

Fixes #152

## Verification
- `go test ./internal/backend/llvm -count=1`
- `go test ./internal/vm -run TestLLVMNativeAsyncBorrowedRefsSurviveParentYield -count=1`
- `go test ./internal/vm -run 'TestLLVMNativeAsyncBorrowedRefsSurviveParentYield|TestLLVMNativeHeapStats|TestLLVMNativeBufferedChannelAllocatesSingleBlock' -count=1`\n- `go test ./internal/backend/llvm ./internal/vm -run 'TestLLVMNativeAsyncBorrowedRefsSurviveParentYield|TestLLVMNativeHeapStats|TestLLVMNativeBufferedChannelAllocatesSingleBlock|TestCollectAddrOfTargetsProjectsFieldBorrowThroughReferenceLocal' -count=1`\n- Manual repro: `/tmp/issue152_repro.sg` native now exits 7 instead of 139.\n- sentrux score: 6222. `check_rules` still reports existing max_cc/no_god_files violations outside this diff.\n\n## Note\nA full `go test ./internal/backend/llvm ./internal/vm -count=1` still fails on existing broad VM/parity/stdlib diagnostics unrelated to this change (for example `unsupported intrinsic: __async_block$84`, time intrinsic destination, HTTP nosend diagnostics, numeric parity).\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage to confirm async borrowed references survive parent yields across multiple threads.
  * Added LLVM IR emission tests for async-ref parameters: shared refs are boxed with allocation/trap behavior, while mutable refs preserve the caller alias.
* **Improvements**
  * Improved LLVM emission for async-ref parameters by boxing shared refs in appropriate poll-task scenarios to enhance memory/lifetime safety.
* **Chores**
  * Updated codebase metrics documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->