### PR TITLE
bench: isolate native channel trace probes

### DIFF
--- a/benchmarks/native/README.md
+++ b/benchmarks/native/README.md
@@ -15,6 +15,7 @@ Useful overrides:
 ```bash
 SURGE_CHANNEL_BENCH_MODES="1 2 4 8 default" ./scripts/bench_native_channels.sh
 SURGE_CHANNEL_BENCH_REPORT=/tmp/channel.md ./scripts/bench_native_channels.sh
+SURGE_CHANNEL_TRACE_PROBES="channel_reused_reply" ./scripts/bench_native_channels.sh
 SURGE_CHANNEL_WAKE_INJECT=1 SURGE_CHANNEL_BENCH_REPORT=/tmp/channel-inject.md ./scripts/bench_native_channels.sh
 ```
 
@@ -41,7 +42,12 @@ Read the counters this way:
 The fixture also prints scheduler-shape rows:
 
 - `channel_ping_pong`: direct async send/recv handoff between two tasks.
+- `channel_reused_reply`: request/reply over one reused reply channel.
+- `channel_new_reply`: request/reply with a new reply channel per request.
 - `channel_sync_new_reply`: sync wrapper fallback called from an async task.
+
+`bench_native_channels.sh` runs runtime trace one probe at a time so counters
+show the selected scheduler shape instead of an aggregate from the whole fixture.
 
 Default channel placement keeps generic wakes local-first, while no-signal
 handoff wakes use inject placement. Use `SURGE_CHANNEL_WAKE_INJECT=1` only for

--- a/benchmarks/native/channel_request_reply/main.sg
+++ b/benchmarks/native/channel_request_reply/main.sg
@@ -251,15 +251,43 @@ async fn bench_channel_sync_new_reply(iterations: int) -> nothing {
     return nothing;
 }
 
-@entrypoint
-fn main() -> int {
+@entrypoint("argv")
+fn main(probe: string = "all") -> int {
     let iterations: int = 20000;
     let sync_iterations: int = iterations / 4;
-    bench_empty_loop(iterations);
-    bench_response_bytes(iterations);
-    let _ = bench_channel_ping_pong(iterations).await();
-    let _ = bench_channel_reused_reply(iterations).await();
-    let _ = bench_channel_new_reply(iterations).await();
-    let _ = bench_channel_sync_new_reply(sync_iterations).await();
-    return 0;
+    if probe == "all" {
+        bench_empty_loop(iterations);
+        bench_response_bytes(iterations);
+        let _ = bench_channel_ping_pong(iterations).await();
+        let _ = bench_channel_reused_reply(iterations).await();
+        let _ = bench_channel_new_reply(iterations).await();
+        let _ = bench_channel_sync_new_reply(sync_iterations).await();
+        return 0;
+    }
+    if probe == "empty_loop" {
+        bench_empty_loop(iterations);
+        return 0;
+    }
+    if probe == "response_bytes" {
+        bench_response_bytes(iterations);
+        return 0;
+    }
+    if probe == "channel_ping_pong" {
+        let _ = bench_channel_ping_pong(iterations).await();
+        return 0;
+    }
+    if probe == "channel_reused_reply" {
+        let _ = bench_channel_reused_reply(iterations).await();
+        return 0;
+    }
+    if probe == "channel_new_reply" {
+        let _ = bench_channel_new_reply(iterations).await();
+        return 0;
+    }
+    if probe == "channel_sync_new_reply" {
+        let _ = bench_channel_sync_new_reply(sync_iterations).await();
+        return 0;
+    }
+    print("unknown probe: " + probe);
+    return 2;
 }

--- a/scripts/bench_native_channels.sh
+++ b/scripts/bench_native_channels.sh
@@ -5,6 +5,7 @@ root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 fixture="$root/benchmarks/native/channel_request_reply"
 report="${SURGE_CHANNEL_BENCH_REPORT:-$root/build/benchmarks/native-channel-request-reply.md}"
 modes="${SURGE_CHANNEL_BENCH_MODES:-1 2 4 8 default}"
+trace_probes="${SURGE_CHANNEL_TRACE_PROBES:-channel_ping_pong channel_reused_reply channel_new_reply channel_sync_new_reply}"
 surge="${SURGE:-$root/surge}"
 channel_wake_policy="handoff-inject"
 if [[ -n "${SURGE_CHANNEL_WAKE_INJECT:-}" && "${SURGE_CHANNEL_WAKE_INJECT:-}" != "0" ]]; then
@@ -76,8 +77,9 @@ mkdir -p "$(dirname "$report")"
 	echo "- surge: $("$surge" version --full | tr '\n' ' ' | sed 's/[[:space:]]*$//')"
 	echo "- fixture: ${fixture#$root/}"
 	echo "- modes: $modes"
+	echo "- trace probes: $trace_probes"
 	echo "- channel wake policy: $channel_wake_policy"
-	echo "- trace: separate SURGE_TRACE_EXEC=1 pass"
+	echo "- trace: separate per-probe SURGE_TRACE_EXEC=1 pass"
 	echo
 	echo "## Results"
 	echo
@@ -86,35 +88,41 @@ mkdir -p "$(dirname "$report")"
 } >"$report"
 
 for mode in $modes; do
-	trace_log="$(mktemp)"
 	if [[ "$mode" == "default" ]]; then
 		output="$(env -u SURGE_THREADS "$bench_bin")"
-		env -u SURGE_THREADS SURGE_TRACE_EXEC=1 "$bench_bin" >/dev/null 2>"$trace_log"
 	else
 		output="$(SURGE_THREADS="$mode" "$bench_bin")"
-		SURGE_TRACE_EXEC=1 SURGE_THREADS="$mode" "$bench_bin" >/dev/null 2>"$trace_log"
 	fi
 	while IFS= read -r line; do
 		[[ "$line" == \|* ]] || continue
 		printf '| %s |%s\n' "$mode" "${line#|}" >>"$report"
 	done <<<"$output"
-	printf '| %s | %s | %s | %s | %s | %s | %s |\n' \
-		"$mode" \
-		"$(trace_value "$trace_log" TRACE_EXEC channel_blocking_wait)" \
-		"$(trace_value "$trace_log" TRACE_EXEC channel_task_blocking_send)" \
-		"$(trace_value "$trace_log" TRACE_EXEC channel_task_blocking_recv)" \
-		"$(trace_value "$trace_log" TRACE_EXEC channel_handoff_yield)" \
-		"$(trace_value "$trace_log" TRACE_EXEC compensation_started)" \
-		"$(trace_value "$trace_log" TRACE_EXEC_SNAPSHOT compensation_high_water)" >>"$trace_rows"
-	rm -f "$trace_log"
+	for probe in $trace_probes; do
+		trace_log="$(mktemp)"
+		if [[ "$mode" == "default" ]]; then
+			env -u SURGE_THREADS SURGE_TRACE_EXEC=1 "$bench_bin" "$probe" >/dev/null 2>"$trace_log"
+		else
+			SURGE_TRACE_EXEC=1 SURGE_THREADS="$mode" "$bench_bin" "$probe" >/dev/null 2>"$trace_log"
+		fi
+		printf '| %s | %s | %s | %s | %s | %s | %s | %s |\n' \
+			"$mode" \
+			"$probe" \
+			"$(trace_value "$trace_log" TRACE_EXEC channel_blocking_wait)" \
+			"$(trace_value "$trace_log" TRACE_EXEC channel_task_blocking_send)" \
+			"$(trace_value "$trace_log" TRACE_EXEC channel_task_blocking_recv)" \
+			"$(trace_value "$trace_log" TRACE_EXEC channel_handoff_yield)" \
+			"$(trace_value "$trace_log" TRACE_EXEC compensation_started)" \
+			"$(trace_value "$trace_log" TRACE_EXEC_SNAPSHOT compensation_high_water)" >>"$trace_rows"
+		rm -f "$trace_log"
+	done
 done
 
 cat >>"$report" <<'EOF'
 
 ## Runtime Trace
 
-| mode | channel blocking waits | task-context blocking sends | task-context blocking recvs | handoff yields | compensation started | compensation high-water |
-| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| mode | probe | channel blocking waits | task-context blocking sends | task-context blocking recvs | handoff yields | compensation started | compensation high-water |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
 EOF
 cat "$trace_rows" >>"$report"
 
@@ -126,6 +134,7 @@ cat >>"$report" <<'EOF'
 - `channel_new_reply` keeps the older per-request reply-channel shape visible.
 - `channel_ping_pong` measures direct async send/recv handoff between two tasks.
 - `channel_sync_new_reply` measures the sync-wrapper fallback from async task context.
+- Runtime trace rows run one probe at a time so sync-wrapper fallback counters do not pollute async probe counters.
 - This is a manual benchmark. Do not wire it into `make check`; use it for before/after runtime PRs.
 EOF
 


### PR DESCRIPTION
Part of #151.

## Summary
- add an argv probe selector to the native channel request/reply fixture
- run `SURGE_TRACE_EXEC=1` once per selected probe in `bench_native_channels.sh`
- document `SURGE_CHANNEL_TRACE_PROBES` and the per-probe trace behavior

## Measurement
- `make build`
- `make check`
- `SURGE_CHANNEL_BENCH_MODES="1 2 4 8" SURGE_CHANNEL_BENCH_REPORT=/tmp/native-channel-trace-probes-full.md ./scripts/bench_native_channels.sh`
- sentrux `quality_signal`: 6221; existing rules violations are outside this diff

## Signal
The new trace split shows `channel_reused_reply` and `channel_new_reply` do not hit task-context blocking send/recv counters. The sync fallback counters are isolated to `channel_sync_new_reply`, which removes the previous aggregate-trace noise before we decide on the next runtime refactor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to select and run individual trace probes during benchmarking
  * Per-probe metrics collection and reporting in benchmark results

* **Documentation**
  * Enhanced benchmarking documentation with runtime probe configuration options
  * Clarified available probe types and trace execution methodology

<!-- end of auto-generated comment: release notes by coderabbit.ai -->