### PR TITLE
trace: add net waiter runtime counters

### DIFF
--- a/STATS.md
+++ b/STATS.md
@@ -5,7 +5,7 @@
 ## 📊 Main code (without tests)
 
 - **Files:** 685 (Go: 654, C: 31)
-- **Lines of code:** 157277 (Go: 143031, C: 14246)
+- **Lines of code:** 157299 (Go: 143031, C: 14268)
 
 ## 📁 Directory breakdown
 
@@ -13,7 +13,7 @@
 |------------|--------|-------|
 | `cmd/` | 28 | 4819 |
 | `internal/` | 624 | 137649 |
-| `runtime/native/` (C code) | 31 | 14246 |
+| `runtime/native/` (C code) | 31 | 14268 |
 
 ## 🏆 Top 10 packages by size
 
@@ -33,12 +33,12 @@
 ## 🧪 Test files
 
 - **Files:** 179
-- **Lines of code:** 36759
+- **Lines of code:** 36772
 
 ## 📈 Total volume (code + tests)
 
 - **Files:** 864
-- **Lines of code:** 194036
+- **Lines of code:** 194071
 
 ## 📊 Percentage breakdown
 

--- a/benchmarks/native/README.md
+++ b/benchmarks/native/README.md
@@ -47,6 +47,8 @@ Read the counters this way:
 - `compensation_started` and `compensation_high_water`: worker-pinning fallback.
 - `io_poll_timeouts`, `io_poll_wake_fd`, and `io_poll_net_ready`: net poll
   progress and timeout-driven tails.
+- `io_waiter_scan_entries`, `io_poll_rebuilds`, and
+  `io_poll_dedup_checks`: net waiter-list scan and poll-set rebuild cost.
 
 The fixture also prints scheduler-shape rows:
 

--- a/docs/RUNTIME.md
+++ b/docs/RUNTIME.md
@@ -317,7 +317,13 @@ Useful `TRACE_NET` fields:
 - `io_poll_calls`, `io_poll_timeouts`, `io_poll_timeout_max_ms`;
 - `io_poll_wake_fd`, `io_poll_net_ready`, `io_poll_errors`;
 - `io_poll_waiters_last`, `io_poll_waiters_max`, `io_poll_waiters_total`;
-- `io_direct_waits`: direct task parks for network readiness.
+- `io_direct_waits`: direct task parks for network readiness;
+- `io_waiter_scan_entries`, `io_waiter_net_entries`: generic waiter-list scan
+  cost for net polling;
+- `io_poll_rebuilds`, `io_poll_allocs`, `io_poll_dedup_checks`: current poll
+  set rebuild cost;
+- `io_waiter_complete_calls`, `io_waiter_completed`: net readiness wake/remove
+  activity.
 
 For a healthy direct async channel request/reply path, expect
 `channel_task_blocking_send=0`, `channel_task_blocking_recv=0`, and

--- a/docs/RUNTIME.ru.md
+++ b/docs/RUNTIME.ru.md
@@ -321,7 +321,13 @@ Runtime tracing отделен от compiler tracing в `docs/TRACING.ru.md`.
 - `io_poll_calls`, `io_poll_timeouts`, `io_poll_timeout_max_ms`;
 - `io_poll_wake_fd`, `io_poll_net_ready`, `io_poll_errors`;
 - `io_poll_waiters_last`, `io_poll_waiters_max`, `io_poll_waiters_total`;
-- `io_direct_waits`: прямые парковки задач на network readiness.
+- `io_direct_waits`: прямые парковки задач на network readiness;
+- `io_waiter_scan_entries`, `io_waiter_net_entries`: стоимость сканирования
+  общего waiter-list для net polling;
+- `io_poll_rebuilds`, `io_poll_allocs`, `io_poll_dedup_checks`: стоимость
+  текущей пересборки poll set;
+- `io_waiter_complete_calls`, `io_waiter_completed`: wake/remove активность
+  для net readiness.
 
 Для здорового прямого async channel request/reply path ожидаются
 `channel_task_blocking_send=0`, `channel_task_blocking_recv=0` и

--- a/internal/vm/mt_correctness_test.go
+++ b/internal/vm/mt_correctness_test.go
@@ -955,6 +955,19 @@ func requireNetTracePollCountersForReason(t *testing.T, stderr string, reason st
 	if !strings.Contains(line, "io_direct_waits=") {
 		t.Fatalf("missing direct IO wait counter in TRACE_NET\nline:\n%s\nstderr:\n%s", line, stderr)
 	}
+	for _, field := range []string{
+		"io_waiter_scan_entries=",
+		"io_waiter_net_entries=",
+		"io_poll_rebuilds=",
+		"io_poll_allocs=",
+		"io_poll_dedup_checks=",
+		"io_waiter_complete_calls=",
+		"io_waiter_completed=",
+	} {
+		if !strings.Contains(line, field) {
+			t.Fatalf("missing %s counter in TRACE_NET\nline:\n%s\nstderr:\n%s", field, line, stderr)
+		}
+	}
 }
 
 func TestNativeNetSingleThreadBlockingChannelInAsyncServer(t *testing.T) {

--- a/runtime/native/rt_net.c
+++ b/runtime/native/rt_net.c
@@ -82,20 +82,34 @@ static _Atomic uint64_t net_poll_waiters_last;
 static _Atomic uint64_t net_poll_waiters_max;
 static _Atomic uint64_t net_poll_waiters_total;
 static _Atomic uint64_t net_direct_wait_total;
+static _Atomic uint64_t net_waiter_scan_entries_total;
+static _Atomic uint64_t net_waiter_net_entries_total;
+static _Atomic uint64_t net_poll_rebuilds_total;
+static _Atomic uint64_t net_poll_allocs_total;
+static _Atomic uint64_t net_poll_dedup_checks_total;
+static _Atomic uint64_t net_waiter_complete_calls_total;
+static _Atomic uint64_t net_waiter_completed_total;
 
 #define NET_TRACE_DUMP_FORMAT                                                                      \
     "TRACE_NET reason=%s io_poll_calls=%llu io_poll_timeouts=%llu "                                \
     "io_poll_wake_fd=%llu io_poll_net_ready=%llu io_poll_errors=%llu "                             \
     "io_poll_timeout_last_ms=%llu io_poll_timeout_max_ms=%llu "                                    \
     "io_poll_waiters_last=%llu io_poll_waiters_max=%llu "                                          \
-    "io_poll_waiters_total=%llu io_direct_waits=%llu\n"
+    "io_poll_waiters_total=%llu io_direct_waits=%llu "                                             \
+    "io_waiter_scan_entries=%llu io_waiter_net_entries=%llu "                                      \
+    "io_poll_rebuilds=%llu io_poll_allocs=%llu io_poll_dedup_checks=%llu "                         \
+    "io_waiter_complete_calls=%llu io_waiter_completed=%llu\n"
 #define NET_TRACE_DUMP_ARGS(reason)                                                                \
     (reason), net_trace_load(&net_poll_calls_total), net_trace_load(&net_poll_timeouts_total),     \
         net_trace_load(&net_poll_wake_fd_total), net_trace_load(&net_poll_ready_total),            \
         net_trace_load(&net_poll_errors_total), net_trace_load(&net_poll_timeout_last_ms),         \
         net_trace_load(&net_poll_timeout_max_ms), net_trace_load(&net_poll_waiters_last),          \
         net_trace_load(&net_poll_waiters_max), net_trace_load(&net_poll_waiters_total),            \
-        net_trace_load(&net_direct_wait_total)
+        net_trace_load(&net_direct_wait_total), net_trace_load(&net_waiter_scan_entries_total),    \
+        net_trace_load(&net_waiter_net_entries_total), net_trace_load(&net_poll_rebuilds_total),   \
+        net_trace_load(&net_poll_allocs_total), net_trace_load(&net_poll_dedup_checks_total),      \
+        net_trace_load(&net_waiter_complete_calls_total),                                          \
+        net_trace_load(&net_waiter_completed_total)
 
 static unsigned long long net_trace_load(const _Atomic uint64_t* counter) {
     return (unsigned long long)atomic_load_explicit(counter, memory_order_relaxed);
@@ -207,8 +221,10 @@ static void net_poll_wake_drain(void) {
 }
 
 static void complete_net_waiters(rt_executor* ex, waker_key key) {
+    net_trace_inc(&net_waiter_complete_calls_total);
     uint64_t task_id = 0;
     while (pop_waiter(ex, key, &task_id)) {
+        net_trace_inc(&net_waiter_completed_total);
         const rt_task* task = get_task(ex, task_id);
         if (task == NULL || task_status_load(task) == TASK_DONE) {
             continue;
@@ -825,6 +841,8 @@ int poll_net_waiters(rt_executor* ex, int timeout_ms) {
     if (fds == NULL) {
         return 0;
     }
+    net_trace_inc(&net_poll_allocs_total);
+    net_trace_add(&net_waiter_scan_entries_total, ex->waiters_len);
     size_t count = 0;
     for (size_t i = 0; i < ex->waiters_len; i++) {
         waiter w = ex->waiters[i];
@@ -832,12 +850,14 @@ int poll_net_waiters(rt_executor* ex, int timeout_ms) {
         if (kind != WAKER_NET_ACCEPT && kind != WAKER_NET_READ && kind != WAKER_NET_WRITE) {
             continue;
         }
+        net_trace_inc(&net_waiter_net_entries_total);
         int fd = (int)w.key.id;
         if (fd <= 0) {
             continue;
         }
         size_t idx = count;
         for (size_t j = 0; j < count; j++) {
+            net_trace_inc(&net_poll_dedup_checks_total);
             if (fds[j].fd == fd) {
                 idx = j;
                 break;
@@ -870,6 +890,8 @@ int poll_net_waiters(rt_executor* ex, int timeout_ms) {
         rt_free((uint8_t*)fds, (uint64_t)cap * (uint64_t)sizeof(NetPollFd), _Alignof(NetPollFd));
         return 0;
     }
+    net_trace_inc(&net_poll_allocs_total);
+    net_trace_inc(&net_poll_rebuilds_total);
     net_trace_inc(&net_poll_calls_total);
     uint64_t requested_timeout_ms = net_trace_timeout_ms(timeout_ms);
     net_trace_store(&net_poll_timeout_last_ms, requested_timeout_ms);

--- a/scripts/bench_native_net.sh
+++ b/scripts/bench_native_net.sh
@@ -215,7 +215,7 @@ for worker_count in $threads; do
 			read -r got_requests total_us avg_us p50_us p95_us <<<"$result"
 			printf '| %s | %s | %s | %s | %s | %s | %s | %s |\n' \
 				"$worker_count" "$mode" "$pattern" "$got_requests" "$total_us" "$avg_us" "$p50_us" "$p95_us" >>"$report"
-			printf '| %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s |\n' \
+			printf '| %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s |\n' \
 				"$worker_count" "$mode" "$pattern" \
 				"$(trace_value "$trace_log" TRACE_EXEC channel_task_blocking_send)" \
 				"$(trace_value "$trace_log" TRACE_EXEC channel_task_blocking_recv)" \
@@ -225,7 +225,14 @@ for worker_count in $threads; do
 				"$(trace_value "$trace_log" TRACE_NET io_direct_waits)" \
 				"$(trace_value "$trace_log" TRACE_NET io_poll_calls)" \
 				"$(trace_value "$trace_log" TRACE_NET io_poll_net_ready)" \
-				"$(trace_value "$trace_log" TRACE_NET io_poll_waiters_total)" >>"$trace_rows"
+				"$(trace_value "$trace_log" TRACE_NET io_poll_waiters_total)" \
+				"$(trace_value "$trace_log" TRACE_NET io_waiter_scan_entries)" \
+				"$(trace_value "$trace_log" TRACE_NET io_waiter_net_entries)" \
+				"$(trace_value "$trace_log" TRACE_NET io_poll_rebuilds)" \
+				"$(trace_value "$trace_log" TRACE_NET io_poll_allocs)" \
+				"$(trace_value "$trace_log" TRACE_NET io_poll_dedup_checks)" \
+				"$(trace_value "$trace_log" TRACE_NET io_waiter_complete_calls)" \
+				"$(trace_value "$trace_log" TRACE_NET io_waiter_completed)" >>"$trace_rows"
 			rm -f "$server_out" "$trace_log"
 		done
 	done
@@ -235,8 +242,8 @@ cat >>"$report" <<'EOF'
 
 ## Runtime Trace
 
-| threads | mode | pattern | task-context blocking sends | task-context blocking recvs | handoff yields | compensation started | compensation high-water | net direct waits | net poll calls | net ready | net waiters total |
-| ---: | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| threads | mode | pattern | task-context blocking sends | task-context blocking recvs | handoff yields | compensation started | compensation high-water | net direct waits | net poll calls | net ready | net waiters total | waiter scan entries | net waiter entries | poll rebuilds | poll allocs | dedup checks | complete calls | completed waiters |
+| ---: | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
 EOF
 cat "$trace_rows" >>"$report"
 


### PR DESCRIPTION
Part of #151. This is PR 2 from the runtime/net refactor plan: instrumentation only, no runtime behavior changes.

## Summary
- add TRACE_NET counters for generic waiter scan, net waiter entries, poll rebuilds/allocs/dedup checks, and net waiter complete/remove activity
- expose the new counters in the native net request/reply benchmark report
- document the counters in runtime docs and assert their presence in native net trace tests
- update STATS.md for generated line-count changes

## Measurement
- make check
- go test ./internal/vm -run 'TestNativeNet.*Trace|TestMT.*Net|TestNativeNetSingleThreadBlockingChannelInAsyncServer' --timeout 90s
- make c-check
- git diff --check
- SURGE_NET_BENCH_REQUESTS=1000 SURGE_NET_BENCH_REPORT=/tmp/native-net-waiter-counters-full.md ./scripts/bench_native_net.sh
- sentrux quality_signal: 6220; existing rules violations are unchanged and outside this diff

## Signal
On this machine, SURGE_THREADS=1 echo seq shows substantial current poll rebuild traffic:
- avg ~61 us/op
- io_poll_rebuilds=2425
- io_poll_allocs=4850
- io_waiter_scan_entries=7271
- io_waiter_completed=936

But the multi-worker latency jump remains with very small net waiter/rebuild counts:
- SURGE_THREADS=2 echo seq avg ~254 us/op, io_poll_rebuilds=27
- SURGE_THREADS=4 echo seq avg ~376 us/op, io_poll_rebuilds=3
- SURGE_THREADS=8 echo seq avg ~433 us/op, io_poll_rebuilds=1

So fd-indexed net waiter registry may still be useful for single-worker / many-waiter cases, but it is unlikely to explain the whole #151 multi-worker gap by itself. Next step should inspect scheduler ready/wake placement or worker coordination around sequential live TCP.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded runtime tracing documentation with additional network-related metrics and counter descriptions.

* **Tests**
  * Enhanced test validation for additional runtime network trace counters.

* **Chores**
  * Extended network tracing instrumentation with new performance counters.
  * Updated benchmark script output format to report additional runtime metrics.
  * Updated project statistics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->