### PR TITLE
perf(runtime): reduce local ready wake churn

### DIFF
--- a/STATS.md
+++ b/STATS.md
@@ -5,7 +5,7 @@
 ## 📊 Main code (without tests)
 
 - **Files:** 685 (Go: 654, C: 31)
-- **Lines of code:** 157299 (Go: 143031, C: 14268)
+- **Lines of code:** 157303 (Go: 143031, C: 14272)
 
 ## 📁 Directory breakdown
 
@@ -13,7 +13,7 @@
 |------------|--------|-------|
 | `cmd/` | 28 | 4819 |
 | `internal/` | 624 | 137649 |
-| `runtime/native/` (C code) | 31 | 14268 |
+| `runtime/native/` (C code) | 31 | 14272 |
 
 ## 🏆 Top 10 packages by size
 
@@ -38,7 +38,7 @@
 ## 📈 Total volume (code + tests)
 
 - **Files:** 864
-- **Lines of code:** 194071
+- **Lines of code:** 194075
 
 ## 📊 Percentage breakdown
 

--- a/benchmarks/native/README.md
+++ b/benchmarks/native/README.md
@@ -36,7 +36,7 @@ Troubleshoot runtime latency with:
 ```bash
 SURGE_TRACE_EXEC=1 ./target/release/your_program 2>trace.log
 kill -USR1 <pid>
-rg 'TRACE_EXEC|TRACE_NET|TRACE_EXEC_SNAPSHOT' trace.log
+rg 'TRACE_EXEC|TRACE_NET|TRACE_EXEC_SNAPSHOT|SCHED_TRACE' trace.log
 ```
 
 Read the counters this way:
@@ -45,6 +45,9 @@ Read the counters this way:
   `channel_task_blocking_recv`: sync channel fallback from task context.
 - `channel_handoff_yield`: direct async channel handoffs.
 - `compensation_started` and `compensation_high_water`: worker-pinning fallback.
+- `SCHED_TRACE local`, `inject`, `steal`, and `events`: scheduler source mix.
+  High `steal` or high `worker_sleep`/`worker_wake` on sequential request/reply
+  paths usually means worker-pool wake churn, not net poll rebuild cost.
 - `io_poll_timeouts`, `io_poll_wake_fd`, and `io_poll_net_ready`: net poll
   progress and timeout-driven tails.
 - `io_waiter_scan_entries`, `io_poll_rebuilds`, and
@@ -62,7 +65,8 @@ show the selected scheduler shape instead of an aggregate from the whole fixture
 
 The net request/reply probe prints three layers: `echo` for minimal socket
 read/write, `direct` for socket task response writes, and `manager` for the
-same response behind a channel request/reply hop.
+same response behind a channel request/reply hop. It enables both
+`SURGE_TRACE_EXEC=1` and `SURGE_SCHED_TRACE=1` for each server run.
 
 Default channel placement keeps generic wakes local-first, while no-signal
 handoff wakes use inject placement. Use `SURGE_CHANNEL_WAKE_INJECT=1` only for

--- a/docs/RUNTIME.md
+++ b/docs/RUNTIME.md
@@ -187,6 +187,14 @@ Default mode is `parallel`. `SURGE_SCHED=seeded` makes scheduler choices
 deterministic for the same seed and the same external event order. It does not
 control OS scheduling, socket readiness order, FFI, or blocking pool timing.
 
+Worker-local pushes are local-first but not always cross-worker wakeups. A
+single item appended to the current worker's local queue is left for that worker
+to consume on its next scheduler turn. Once the local queue contains more than
+one ready task, the runtime signals `ready_cv` so idle workers can steal the
+extra work. Global inject pushes and external wakes still signal immediately.
+Before a worker enters the sync channel compatibility wait path, its local ready
+work is moved to inject and broadcast to preserve progress.
+
 Worker count:
 
 - `SURGE_THREADS=<n>` overrides executor worker count.
@@ -311,6 +319,12 @@ Useful `TRACE_EXEC` fields:
 - `compensation_started`, `compensation_high_water`: worker-pinning fallback.
 - `waiters_*`, `tasks_*`, `local_total`, `inject_len`: scheduler shape at a
   snapshot.
+
+Useful `SCHED_TRACE` fields:
+
+- `local`, `inject`, `steal`: how many tasks were popped from worker-local
+  queues, the global inject queue, or another worker's local queue.
+- `events`: total scheduler pops covered by the summary line.
 
 Useful `TRACE_NET` fields:
 

--- a/docs/RUNTIME.ru.md
+++ b/docs/RUNTIME.ru.md
@@ -190,6 +190,14 @@ flowchart TD
 событий. Он не контролирует OS scheduling, порядок socket readiness, FFI или
 timing blocking pool.
 
+Worker-local push остается local-first, но не всегда будит другие worker'ы.
+Если в local queue текущего worker'а добавлен один ready task, этот worker
+заберет его на следующем обороте планировщика. Когда в local queue уже больше
+одной ready task, runtime сигналит `ready_cv`, чтобы idle workers могли украсть
+лишнюю работу. Global inject pushes и внешние wakes по-прежнему сигналят сразу.
+Перед входом worker'а в sync channel compatibility wait path его local ready
+work переносится в inject и будится broadcast'ом, чтобы сохранить progress.
+
 Количество worker'ов:
 
 - `SURGE_THREADS=<n>` переопределяет число executor workers.
@@ -315,6 +323,12 @@ Runtime tracing отделен от compiler tracing в `docs/TRACING.ru.md`.
 - `channel_handoff_yield`: direct async channel handoff yields.
 - `compensation_started`, `compensation_high_water`: fallback для pinned workers.
 - `waiters_*`, `tasks_*`, `local_total`, `inject_len`: форма scheduler snapshot.
+
+Полезные поля `SCHED_TRACE`:
+
+- `local`, `inject`, `steal`: сколько задач взято из worker-local queues,
+  global inject queue или local queue другого worker'а.
+- `events`: общее число scheduler pops в summary line.
 
 Полезные поля `TRACE_NET`:
 

--- a/runtime/native/rt_async_state.c
+++ b/runtime/native/rt_async_state.c
@@ -1408,6 +1408,7 @@ static int ready_push_with_policy(
     if (!force_inject) {
         local = current_local_queue(ex);
     }
+    int signal_ready_now = signal_ready;
     if (local != NULL) {
         // Local queues are popped from the tail, so tail insertion is the local priority path.
         int ok = deque_push_tail(
@@ -1415,6 +1416,9 @@ static int ready_push_with_policy(
         if (!ok) {
             return 0;
         }
+        // A single local continuation is usually consumed by the current worker on its
+        // next scheduler turn; waking another worker often just creates steal/sleep churn.
+        signal_ready_now = signal_ready && local->len > 1;
     } else {
         int ok = front ? deque_push_head(&ex->inject,
                                          id,
@@ -1433,7 +1437,7 @@ static int ready_push_with_policy(
     if (ex->channel_blocked_workers > 0) {
         maybe_start_compensation_worker_locked(ex);
     }
-    if (signal_ready) {
+    if (signal_ready_now) {
         pthread_cond_signal(&ex->ready_cv);
     }
     return 1;

--- a/scripts/bench_native_net.sh
+++ b/scripts/bench_native_net.sh
@@ -184,7 +184,7 @@ mkdir -p "$(dirname "$report")"
 	echo "- patterns: $patterns"
 	echo "- requests: $requests"
 	echo "- pipeline depth: $pipeline_depth"
-	echo "- trace: per run SURGE_TRACE_EXEC=1"
+	echo "- trace: per run SURGE_TRACE_EXEC=1 SURGE_SCHED_TRACE=1"
 	echo
 	echo "## Results"
 	echo
@@ -198,7 +198,7 @@ for worker_count in $threads; do
 			port="$(pick_port)"
 			server_out="$(mktemp)"
 			trace_log="$(mktemp)"
-			SURGE_TRACE_EXEC=1 SURGE_THREADS="$worker_count" "$bench_bin" "$port" "$mode" >"$server_out" 2>"$trace_log" &
+			SURGE_TRACE_EXEC=1 SURGE_SCHED_TRACE=1 SURGE_THREADS="$worker_count" "$bench_bin" "$port" "$mode" >"$server_out" 2>"$trace_log" &
 			server_pid="$!"
 			if ! result="$(run_client "$port" "$mode" "$pattern")"; then
 				cat "$server_out" >&2 || true
@@ -215,13 +215,17 @@ for worker_count in $threads; do
 			read -r got_requests total_us avg_us p50_us p95_us <<<"$result"
 			printf '| %s | %s | %s | %s | %s | %s | %s | %s |\n' \
 				"$worker_count" "$mode" "$pattern" "$got_requests" "$total_us" "$avg_us" "$p50_us" "$p95_us" >>"$report"
-			printf '| %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s |\n' \
+			printf '| %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s |\n' \
 				"$worker_count" "$mode" "$pattern" \
 				"$(trace_value "$trace_log" TRACE_EXEC channel_task_blocking_send)" \
 				"$(trace_value "$trace_log" TRACE_EXEC channel_task_blocking_recv)" \
 				"$(trace_value "$trace_log" TRACE_EXEC channel_handoff_yield)" \
 				"$(trace_value "$trace_log" TRACE_EXEC compensation_started)" \
 				"$(trace_value "$trace_log" TRACE_EXEC_SNAPSHOT compensation_high_water)" \
+				"$(trace_value "$trace_log" SCHED_TRACE local)" \
+				"$(trace_value "$trace_log" SCHED_TRACE inject)" \
+				"$(trace_value "$trace_log" SCHED_TRACE steal)" \
+				"$(trace_value "$trace_log" SCHED_TRACE events)" \
 				"$(trace_value "$trace_log" TRACE_NET io_direct_waits)" \
 				"$(trace_value "$trace_log" TRACE_NET io_poll_calls)" \
 				"$(trace_value "$trace_log" TRACE_NET io_poll_net_ready)" \
@@ -242,8 +246,8 @@ cat >>"$report" <<'EOF'
 
 ## Runtime Trace
 
-| threads | mode | pattern | task-context blocking sends | task-context blocking recvs | handoff yields | compensation started | compensation high-water | net direct waits | net poll calls | net ready | net waiters total | waiter scan entries | net waiter entries | poll rebuilds | poll allocs | dedup checks | complete calls | completed waiters |
-| ---: | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| threads | mode | pattern | task-context blocking sends | task-context blocking recvs | handoff yields | compensation started | compensation high-water | sched local | sched inject | sched steal | sched events | net direct waits | net poll calls | net ready | net waiters total | waiter scan entries | net waiter entries | poll rebuilds | poll allocs | dedup checks | complete calls | completed waiters |
+| ---: | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
 EOF
 cat "$trace_rows" >>"$report"
 


### PR DESCRIPTION
Part of #151. This is the first behavior-changing scheduler optimization after the net/runtime instrumentation PRs.

## Summary
- avoid signaling idle workers when a worker appends a single task to its own local ready queue
- keep signaling for global inject pushes and for local queues with more than one ready task, so bursts can still be stolen by idle workers
- expose `SCHED_TRACE` local/inject/steal/events columns in the native net request/reply benchmark
- document the local queue signaling policy and update `STATS.md`

## Why
The previous counters showed that multi-worker sequential TCP latency was not dominated by net poll rebuilds. With `SURGE_THREADS>1`, net poll calls were tiny, but `worker_sleep`/`worker_wake` and scheduler `steal` counts were high. The hot path was waking idle workers just so they could steal a single local continuation that the owner worker would normally consume on its next scheduler turn.

This keeps local-first scheduling local for single continuations while preserving cross-worker progress when local queues accumulate extra work.

## Measurement
Local benchmark, `SURGE_NET_BENCH_REQUESTS=1000 ./scripts/bench_native_net.sh`:

| scenario | before | after |
| --- | ---: | ---: |
| 2 threads echo seq | ~254 us/op | 166.69 us/op |
| 2 threads direct seq | ~311 us/op | 173.46 us/op |
| 2 threads manager seq | ~323 us/op | 188.65 us/op |
| 4 threads echo seq | ~376 us/op | 173.62 us/op |
| 4 threads direct seq | ~379 us/op | 172.09 us/op |
| 4 threads manager seq | ~492 us/op | 191.18 us/op |
| 8 threads echo seq | ~433 us/op | 179.30 us/op |
| 8 threads direct seq | ~443 us/op | 182.30 us/op |
| 8 threads manager seq | ~512 us/op | 196.03 us/op |

Scheduler trace spot check on `echo seq` dropped steal/sleep churn from thousands to near-zero:

| threads | before steal | after steal | before worker_sleep | after worker_sleep |
| ---: | ---: | ---: | ---: | ---: |
| 2 | 812 | 0 | 1811 | 40 |
| 4 | 3142 | 2 | 4956 | 46 |
| 8 | 3710 | 0 | 6228 | 31 |

## Verification
- `make check`
- `go test ./internal/vm -count=1 -run 'TestMTCorrectnessChannels|TestMTCorrectnessWakeups|TestNativeNet.*Trace|TestNativeNetSingleThreadBlockingChannelInAsyncServer' --timeout 90s`
- `make c-check`
- `git diff --check`
- `./scripts/code_stats_md.sh > /tmp/surge-stats-check.md && diff -u STATS.md /tmp/surge-stats-check.md`
- `SURGE_NET_BENCH_REQUESTS=1000 SURGE_NET_BENCH_REPORT=/tmp/native-net-final-local-signal-threshold.md ./scripts/bench_native_net.sh`
- sentrux quality_signal: 6220; existing max_cc/no_god_files violations are unchanged and outside this diff


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded scheduler behavior documentation in English and Russian, covering worker-local queue operations and runtime tracing field meanings.

* **Benchmarking**
  * Enhanced native network benchmarks with scheduler tracing enabled, reporting additional scheduler-specific performance metrics in benchmark results.

* **Performance**
  * Refined scheduler task signaling logic to optimize worker wake-up behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->