### PR TITLE
perf(runtime): reduce multi-worker net wake latency

### DIFF
--- a/STATS.md
+++ b/STATS.md
@@ -5,7 +5,7 @@
 ## 📊 Main code (without tests)
 
 - **Files:** 685 (Go: 654, C: 31)
-- **Lines of code:** 157945 (Go: 143361, C: 14584)
+- **Lines of code:** 158008 (Go: 143361, C: 14647)
 
 ## 📁 Directory breakdown
 
@@ -13,7 +13,7 @@
 |------------|--------|-------|
 | `cmd/` | 28 | 4819 |
 | `internal/` | 624 | 137979 |
-| `runtime/native/` (C code) | 31 | 14584 |
+| `runtime/native/` (C code) | 31 | 14647 |
 
 ## 🏆 Top 10 packages by size
 
@@ -38,7 +38,7 @@
 ## 📈 Total volume (code + tests)
 
 - **Files:** 866
-- **Lines of code:** 194836
+- **Lines of code:** 194899
 
 ## 📊 Percentage breakdown
 

--- a/STATS.md
+++ b/STATS.md
@@ -5,7 +5,7 @@
 ## 📊 Main code (without tests)
 
 - **Files:** 685 (Go: 654, C: 31)
-- **Lines of code:** 158008 (Go: 143361, C: 14647)
+- **Lines of code:** 158011 (Go: 143361, C: 14650)
 
 ## 📁 Directory breakdown
 
@@ -13,7 +13,7 @@
 |------------|--------|-------|
 | `cmd/` | 28 | 4819 |
 | `internal/` | 624 | 137979 |
-| `runtime/native/` (C code) | 31 | 14647 |
+| `runtime/native/` (C code) | 31 | 14650 |
 
 ## 🏆 Top 10 packages by size
 
@@ -38,7 +38,7 @@
 ## 📈 Total volume (code + tests)
 
 - **Files:** 866
-- **Lines of code:** 194899
+- **Lines of code:** 194902
 
 ## 📊 Percentage breakdown
 

--- a/runtime/native/rt_async_internal.h
+++ b/runtime/native/rt_async_internal.h
@@ -169,6 +169,7 @@ typedef struct {
     uint32_t worker_count;
     uint32_t running_count;
     uint32_t channel_blocked_workers;
+    uint8_t worker_net_polling;
     uint32_t compensation_count;
     uint32_t compensation_high_water;
     uint8_t sched_mode;
@@ -192,7 +193,8 @@ typedef struct {
 
 // Executor invariants:
 // - ex->lock owns tasks[], scopes[], waiters, inject/local queues, running_count,
-//   channel_blocked_workers, compensation_count/high-water, timer state, and shutdown flags.
+//   worker_net_polling, channel_blocked_workers, compensation_count/high-water, timer state, and
+//   shutdown flags.
 // - task status is atomic so external helpers can observe it, but transitions that
 //   touch queues or waiters still happen under ex->lock.
 // - waiters is a FIFO-by-key registration list. prepare_park may pre-register a
@@ -207,7 +209,7 @@ typedef struct {
 //   fallback for that path, not a normal async parking mechanism.
 // - The I/O thread is signaled when the executor becomes idle, when net waiters are
 //   registered, or when shutdown changes. Workers sleep on ready_cv only after they
-//   fail to find local, injected, or stealable ready work.
+//   fail to find local, injected, stealable, or immediately pollable net work.
 
 typedef struct rt_channel rt_channel;
 
@@ -347,6 +349,7 @@ uint8_t rt_channel_try_recv_status_locked(rt_executor* ex, void* channel, uint64
 uint8_t rt_channel_try_send_status_locked(rt_executor* ex, void* channel, uint64_t value_bits);
 void clear_select_timers(rt_executor* ex, rt_task* task);
 void ready_push(rt_executor* ex, uint64_t id);
+int ready_take_current_local_tail(rt_executor* ex, uint64_t id);
 int ready_pop(rt_executor* ex, uint64_t* out_id);
 void wake_task(rt_executor* ex, uint64_t id, int remove_waiter_flag);
 void wake_channel_task(rt_executor* ex, uint64_t id, int remove_waiter_flag);
@@ -381,6 +384,7 @@ void rt_channel_close(void* channel);
 int current_task_cancelled(rt_executor* ex);
 void cancel_task(rt_executor* ex, uint64_t id);
 void mark_done(rt_executor* ex, rt_task* task, uint8_t result_kind, uint64_t result_bits);
+void apply_poll_outcome(rt_executor* ex, rt_task* task, poll_outcome outcome);
 
 poll_outcome poll_task(rt_executor* ex, rt_task* task);
 poll_outcome poll_blocking_task(rt_executor* ex, rt_task* task);

--- a/runtime/native/rt_async_state.c
+++ b/runtime/native/rt_async_state.c
@@ -2179,6 +2179,9 @@ static void* rt_worker_main(void* arg) {
                 if (woke_net) {
                     continue;
                 }
+                if (ex->shutdown || worker_next_ready(ex, worker_id, &id)) {
+                    break;
+                }
             }
             // Sleep only after local, inject, and steal queues have been checked under ex->lock.
             trace_exec_inc(&trace_worker_sleep_total);

--- a/runtime/native/rt_async_state.c
+++ b/runtime/native/rt_async_state.c
@@ -699,7 +699,6 @@ static uint32_t rt_default_blocking_count(uint32_t workers) {
 static void rt_start_workers(rt_executor* ex);
 static void* rt_worker_main(void* arg);
 static void* rt_io_main(void* arg);
-static void apply_poll_outcome(rt_executor* ex, rt_task* task, poll_outcome outcome);
 static int runnable_is_empty(const rt_executor* ex);
 static int worker_next_ready(rt_executor* ex, uint32_t worker_id, uint64_t* out_id);
 static void maybe_start_compensation_worker_locked(rt_executor* ex);
@@ -1452,6 +1451,24 @@ void ready_push(rt_executor* ex, uint64_t id) {
     (void)ready_push_inner(ex, id, 0);
 }
 
+int ready_take_current_local_tail(rt_executor* ex, uint64_t id) {
+    // Caller holds ex->lock. This is intentionally narrow: it only removes the
+    // fresh child task that __task_create just pushed onto the current worker.
+    rt_deque* local = current_local_queue(ex);
+    if (local == NULL || local->len == 0 || local->buf == NULL) {
+        return 0;
+    }
+    size_t idx = local->head + local->len - 1;
+    if (local->buf[idx] != id) {
+        return 0;
+    }
+    local->len--;
+    if (local->len == 0) {
+        local->head = 0;
+    }
+    return 1;
+}
+
 static int ready_push_yielded_task(rt_executor* ex, uint64_t id) {
     // A yielding worker immediately re-enters the scheduler loop, so waking another
     // worker here mostly creates condvar churn for task-to-task handoffs.
@@ -1999,7 +2016,7 @@ void mark_done(rt_executor* ex, rt_task* task, uint8_t result_kind, uint64_t res
     }
 }
 
-static void apply_poll_outcome(rt_executor* ex, rt_task* task, poll_outcome outcome) {
+void apply_poll_outcome(rt_executor* ex, rt_task* task, poll_outcome outcome) {
     if (ex == NULL || task == NULL) {
         return;
     }
@@ -2139,6 +2156,7 @@ static void* rt_worker_main(void* arg) {
     rt_worker_ctx* ctx = (rt_worker_ctx*)arg;
     rt_executor* ex = ctx != NULL ? ctx->ex : NULL;
     uint32_t worker_id = ctx != NULL ? ctx->worker_id : 0;
+    const int worker_net_poll_slice_ms = 1;
     if (ex == NULL) {
         return NULL;
     }
@@ -2149,6 +2167,19 @@ static void* rt_worker_main(void* arg) {
         rt_lock(ex);
         uint64_t id = 0;
         while (!ex->shutdown && !worker_next_ready(ex, worker_id, &id)) {
+            if (has_net_waiters(ex) && !ex->worker_net_polling) {
+                // Avoid routing every idle-worker socket wake through the I/O thread
+                // and ready_cv. A short worker-side poll keeps single-client TCP
+                // latency low while still letting the dedicated I/O thread cover
+                // longer idle periods.
+                ex->worker_net_polling = 1;
+                int woke_net = poll_net_waiters(ex, worker_net_poll_slice_ms);
+                ex->worker_net_polling = 0;
+                pthread_cond_signal(&ex->io_cv);
+                if (woke_net) {
+                    continue;
+                }
+            }
             // Sleep only after local, inject, and steal queues have been checked under ex->lock.
             trace_exec_inc(&trace_worker_sleep_total);
             pthread_cond_wait(&ex->ready_cv, &ex->lock);

--- a/runtime/native/rt_async_task.c
+++ b/runtime/native/rt_async_task.c
@@ -5,6 +5,7 @@
 static rt_task* spawn_checkpoint_task_locked(rt_executor* ex);
 static rt_task* spawn_sleep_task_locked(rt_executor* ex, uint64_t delay);
 static void ensure_select_timers_cap(rt_task* task, size_t want);
+static void poll_ready_child_inline(rt_executor* ex, rt_task* current, rt_task* target);
 
 enum {
     SELECT_TASK = 0,
@@ -113,7 +114,11 @@ uint8_t rt_task_poll(void* task, uint64_t* out_bits) {
         rt_unlock(ex);
         return 0;
     }
-    if (task_status_load(target) != TASK_WAITING) {
+    if (target->kind == TASK_KIND_USER && task_status_load(target) == TASK_READY &&
+        task_enqueued_load(target) != 0 && ready_take_current_local_tail(ex, target->id)) {
+        poll_ready_child_inline(ex, current, target);
+    }
+    if (task_status_load(target) != TASK_WAITING && task_status_load(target) != TASK_DONE) {
         wake_task(ex, target->id, 1);
     }
     if (task_status_load(target) == TASK_DONE) {
@@ -132,6 +137,29 @@ uint8_t rt_task_poll(void* task, uint64_t* out_bits) {
     }
     rt_unlock(ex);
     return 0;
+}
+
+static void poll_ready_child_inline(rt_executor* ex, rt_task* current, rt_task* target) {
+    if (ex == NULL || current == NULL || target == NULL) {
+        return;
+    }
+    task_enqueued_store(target, 0);
+    task_status_store(target, TASK_RUNNING);
+    (void)task_wake_token_exchange(target, 0);
+    ex->running_count++;
+    rt_set_current_task(target);
+    rt_unlock(ex);
+
+    task_polling_enter(target);
+    poll_outcome outcome = poll_task(ex, target);
+    task_polling_exit(target);
+
+    rt_lock(ex);
+    if (ex->running_count > 0) {
+        ex->running_count--;
+    }
+    apply_poll_outcome(ex, target, outcome);
+    rt_set_current_task(current);
 }
 
 void rt_task_await(void* task, uint8_t* out_kind, uint64_t* out_bits) {

--- a/stats.md
+++ b/stats.md
@@ -32,3 +32,47 @@ Reports:
 
 Conclusion: direct readiness wait removes measurable single-client GET overhead,
 but it does not solve the broader `SURGE_THREADS=8` latency gap by itself.
+
+## 2026-06-24 - Worker-side net polling before sleep
+
+Change: multi-worker runtime workers now try a short `poll_net_waiters(1ms)`
+pass before sleeping on `ready_cv`. This avoids routing every idle-worker socket
+wake through the dedicated I/O thread and a condition-variable handoff.
+
+The same change also keeps the narrower inline-await optimization for freshly
+created child tasks that are still at the current worker local queue tail.
+
+Focused downstream benchmark:
+
+- downstream repo: `surgekv`, branch `codex/append-string-response-bytes`
+- topology: `SURGEKV_BENCH_WORKERS=1`, `SURGEKV_BENCH_SHARDS=1`
+- command shape: release build, `SURGEKV_BENCH_OPS="ping get"`,
+  `SURGEKV_BENCH_CLIENTS=1`, `SURGEKV_BENCH_REQUESTS=5000`
+
+| SURGE_THREADS | op | before worker poll avg us | worker poll avg us | delta |
+| ---: | --- | ---: | ---: | ---: |
+| 2 | ping | 225 | 150 | -33.3% |
+| 2 | get | 411 | 281 | -31.6% |
+
+Default downstream topology (`workers=8`, `shards=8`, `SURGE_THREADS=8`) also
+improves the single-client rows:
+
+| op | previous avg us | worker poll avg us | delta |
+| --- | ---: | ---: | ---: |
+| ping | 232-239 | 157 | ~-33% |
+| get | 473-485 | 337 | ~-30% |
+
+Native net fixture, `SURGE_THREADS=8`, remains below the original main baseline
+for direct request/reply, but the short worker poll is not a complete win for
+all synthetic rows:
+
+| mode | original main avg us | inline-only avg us | worker poll avg us |
+| --- | ---: | ---: | ---: |
+| echo seq | 207 | 95 | 101 |
+| direct seq | 193 | 137 | 150 |
+| manager seq | 218 | 201 | 211 |
+
+Conclusion: the remaining `SURGE_THREADS>1` TCP gap is primarily the worker/IO
+handoff model. Worker-side net polling is the first Surge-side change in this
+series that materially improves the live `surgekv` TCP hot path; multi-client
+GET still needs separate downstream/channel-topology work.


### PR DESCRIPTION
## Summary

- let idle worker threads run a short worker-side net poll before sleeping on `ready_cv`
- inline-poll freshly created awaited child tasks when they are still at the current worker local queue tail
- avoid waking an already completed child after inline polling
- update `STATS.md` and `stats.md` with the measured runtime evidence

Closes #151.

## Evidence

Focused downstream `surgekv`, `workers=1`, `shards=1`, `SURGE_THREADS=2`, clients=1, requests=5000:

| op | before worker poll avg us | after avg us |
| --- | ---: | ---: |
| ping | 225 | 150 |
| get | 411 | 281 |

Default downstream `surgekv`, `workers=8`, `shards=8`, `SURGE_THREADS=8`, clients=1, requests=5000:

| op | before avg us | after avg us |
| --- | ---: | ---: |
| ping | 232-239 | 157 |
| get | 473-485 | 337 |

Trace on minimal `PING` confirmed the intended mechanism: worker sleep/wake handoffs dropped from about 4696 to about 410 over 5000 requests.

## Checks

- `make check` via pre-commit
- `make build`
- `make c-warnings`
- `SURGE_STDLIB=/home/zov/projects/surge/surge go test ./internal/vm -run 'TestMTNetWaiterWakeupLatency|TestNativeNetSingleThreadBlockingChannelInAsyncServer|TestMTBlockingChannelHelpers|TestMTAsyncChannel' -count=1`
- `SURGE_STDLIB=/home/zov/projects/surge/surge go test ./internal/backend/llvm -run 'Async|Net|Task|Poll|Channel' -count=1`
- sentrux score: 6212


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved worker scheduling by performing a brief network readiness poll before workers enter their regular sleep path.
  * Enhanced handling of ready child tasks to reduce unnecessary wake-up paths and speed up polling.
* **Documentation**
  * Updated the performance notes in `stats.md` with a new worker-side network polling section and benchmark results.
  * Refreshed `STATS.md` metrics (including updated lines-of-code totals).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->