### PR TITLE
feat(stdlib): add fused byte uint64 parser

### DIFF
--- a/STATS.md
+++ b/STATS.md
@@ -5,23 +5,23 @@
 ## 📊 Main code (without tests)
 
 - **Files:** 685 (Go: 654, C: 31)
-- **Lines of code:** 158011 (Go: 143361, C: 14650)
+- **Lines of code:** 158284 (Go: 143568, C: 14716)
 
 ## 📁 Directory breakdown
 
 | Directory | Files | Lines |
 |------------|--------|-------|
 | `cmd/` | 28 | 4819 |
-| `internal/` | 624 | 137979 |
-| `runtime/native/` (C code) | 31 | 14650 |
+| `internal/` | 624 | 138186 |
+| `runtime/native/` (C code) | 31 | 14716 |
 
 ## 🏆 Top 10 packages by size
 
 | # | Package | Lines |
 |---|-------|-------|
 | 1 | `internal/sema` | 28574 |
-| 2 | `internal/vm` | 23337 |
-| 3 | `internal/backend/llvm` | 12456 |
+| 2 | `internal/vm` | 23484 |
+| 3 | `internal/backend/llvm` | 12516 |
 | 4 | `internal/mir` | 10464 |
 | 5 | `internal/parser` | 8960 |
 | 6 | `internal/hir` | 7156 |
@@ -33,12 +33,12 @@
 ## 🧪 Test files
 
 - **Files:** 181
-- **Lines of code:** 36891
+- **Lines of code:** 36941
 
 ## 📈 Total volume (code + tests)
 
 - **Files:** 866
-- **Lines of code:** 194902
+- **Lines of code:** 195225
 
 ## 📊 Percentage breakdown
 

--- a/STATS.md
+++ b/STATS.md
@@ -5,14 +5,14 @@
 ## 📊 Main code (without tests)
 
 - **Files:** 685 (Go: 654, C: 31)
-- **Lines of code:** 158284 (Go: 143568, C: 14716)
+- **Lines of code:** 158311 (Go: 143595, C: 14716)
 
 ## 📁 Directory breakdown
 
 | Directory | Files | Lines |
 |------------|--------|-------|
 | `cmd/` | 28 | 4819 |
-| `internal/` | 624 | 138186 |
+| `internal/` | 624 | 138213 |
 | `runtime/native/` (C code) | 31 | 14716 |
 
 ## 🏆 Top 10 packages by size
@@ -20,8 +20,8 @@
 | # | Package | Lines |
 |---|-------|-------|
 | 1 | `internal/sema` | 28574 |
-| 2 | `internal/vm` | 23484 |
-| 3 | `internal/backend/llvm` | 12516 |
+| 2 | `internal/vm` | 23493 |
+| 3 | `internal/backend/llvm` | 12534 |
 | 4 | `internal/mir` | 10464 |
 | 5 | `internal/parser` | 8960 |
 | 6 | `internal/hir` | 7156 |
@@ -33,12 +33,12 @@
 ## 🧪 Test files
 
 - **Files:** 181
-- **Lines of code:** 36941
+- **Lines of code:** 36942
 
 ## 📈 Total volume (code + tests)
 
 - **Files:** 866
-- **Lines of code:** 195225
+- **Lines of code:** 195253
 
 ## 📊 Percentage breakdown
 

--- a/benchmarks/native/byte_lines/main.sg
+++ b/benchmarks/native/byte_lines/main.sg
@@ -143,11 +143,10 @@ fn bench_byte_tokens(src: &byte[], rounds: uint) -> uint64 {
     let mut checksum: uint64 = 0:uint64;
     let mut round: uint = 0:uint;
     while round < rounds {
-        let data: byte[] = src[[0..src.__len() to int]];
-        let mut r: by.ByteRange = by.all(&data);
+        let mut r: by.ByteRange = by.all(src);
         let mut done: bool = false;
         while !done {
-            compare by.next_ascii_token(&data, r) {
+            compare by.next_ascii_token(src, r) {
                 Some(split) => {
                     checksum = checksum + (by.range_len(split.head) to uint64);
                     r = split.tail;
@@ -203,15 +202,14 @@ fn bench_byte_dispatch(src: &byte[], rounds: uint) -> uint64 {
     let mut checksum: uint64 = 0:uint64;
     let mut round: uint = 0:uint;
     while round < rounds {
-        let data: byte[] = src[[0..src.__len() to int]];
-        let mut r: by.ByteRange = by.all(&data);
+        let mut r: by.ByteRange = by.all(src);
         let mut done: bool = false;
         while !done {
-            compare by.next_ascii_token(&data, r) {
+            compare by.next_ascii_token(src, r) {
                 Some(split) => {
-                    if by.range_eq_ascii(&data, split.head, &ping) {
+                    if by.range_eq_ascii(src, split.head, &ping) {
                         checksum = checksum + 1:uint64;
-                    } else if by.range_eq_ascii(&data, split.head, &get) {
+                    } else if by.range_eq_ascii(src, split.head, &get) {
                         checksum = checksum + 2:uint64;
                     } else {
                         checksum = checksum + 7:uint64;

--- a/benchmarks/native/byte_lines/main.sg
+++ b/benchmarks/native/byte_lines/main.sg
@@ -384,7 +384,7 @@ fn main() -> int {
     print("number_rounds=" + (number_rounds to string) + " number_bytes=" + (number_payload.__len() to string));
     let number_string_us: int64 = time_string_numbers(&number_payload, number_rounds);
     let number_byte_us: int64 = time_byte_numbers(&number_payload, number_rounds);
-    if string_us <= 0:int64 || byte_us <= 0:int64 || token_string_us <= 0:int64 || token_byte_us <= 0:int64 || dispatch_string_us <= 0:int64 || dispatch_byte_us <= 0:int64 || number_string_us <= 0:int64 || number_byte_us <= 0:int64 {
+    if string_us < 0:int64 || byte_us < 0:int64 || token_string_us < 0:int64 || token_byte_us < 0:int64 || dispatch_string_us < 0:int64 || dispatch_byte_us < 0:int64 || number_string_us < 0:int64 || number_byte_us < 0:int64 {
         return 1;
     }
     return 0;

--- a/benchmarks/native/byte_lines/main.sg
+++ b/benchmarks/native/byte_lines/main.sg
@@ -17,6 +17,29 @@ fn make_payload(lines: uint, width: uint) -> byte[] {
     return out;
 }
 
+fn append_bytes(out: &mut byte[], src: &byte[]) -> nothing {
+    let mut i: int = 0;
+    let end: int = src.__len() to int;
+    while i < end {
+        let b: byte = clone(src[i]);
+        out.push(b);
+        i = i + 1;
+    }
+    return nothing;
+}
+
+fn make_token_payload(records: uint) -> byte[] {
+    let pattern: byte[] = "PING key 42 " to byte[];
+    let mut out: byte[] = [];
+    out.reserve(records * pattern.__len());
+    let mut i: uint = 0:uint;
+    while i < records {
+        append_bytes(&mut out, &pattern);
+        i = i + 1:uint;
+    }
+    return out;
+}
+
 fn elapsed_us(start: time.Duration) -> int64 {
     let now: time.Duration = time.Duration.now();
     let delta: time.Duration = now.sub(start);
@@ -79,6 +102,56 @@ fn bench_byte_lines(src: &byte[], rounds: uint) -> uint64 {
     return checksum;
 }
 
+fn bench_string_tokens(src: &byte[], rounds: uint) -> uint64 {
+    let mut checksum: uint64 = 0:uint64;
+    let mut round: uint = 0:uint;
+    while round < rounds {
+        let text = compare string.from_bytes(src) {
+            Success(v) => v;
+            _ => {
+                return checksum;
+            }
+        };
+        let parts = text.split(" ");
+        let count: int = parts.__len() to int;
+        let mut i: int = 0;
+        while i < count {
+            let token: string = clone(parts[i]);
+            if token.__len() != 0:uint {
+                checksum = checksum + (token.__len() to uint64);
+            }
+            i = i + 1;
+        }
+        round = round + 1:uint;
+    }
+    return checksum;
+}
+
+fn bench_byte_tokens(src: &byte[], rounds: uint) -> uint64 {
+    let mut checksum: uint64 = 0:uint64;
+    let mut round: uint = 0:uint;
+    while round < rounds {
+        let data: byte[] = src[[0..src.__len() to int]];
+        let mut r: by.ByteRange = by.all(&data);
+        let mut done: bool = false;
+        while !done {
+            compare by.next_ascii_token(&data, r) {
+                Some(split) => {
+                    checksum = checksum + (by.range_len(split.head) to uint64);
+                    r = split.tail;
+                    0:int;
+                }
+                nothing => {
+                    done = true;
+                    0:int;
+                }
+            };
+        }
+        round = round + 1:uint;
+    }
+    return checksum;
+}
+
 fn time_string_lines(src: &byte[], rounds: uint) -> int64 {
     let started: time.Duration = time.Duration.now();
     let checksum: uint64 = bench_string_lines(src, rounds);
@@ -95,16 +168,37 @@ fn time_byte_lines(src: &byte[], rounds: uint) -> int64 {
     return total;
 }
 
+fn time_string_tokens(src: &byte[], rounds: uint) -> int64 {
+    let started: time.Duration = time.Duration.now();
+    let checksum: uint64 = bench_string_tokens(src, rounds);
+    let total: int64 = elapsed_us(started);
+    print("token_string_us=" + (total to string) + " checksum=" + (checksum to string));
+    return total;
+}
+
+fn time_byte_tokens(src: &byte[], rounds: uint) -> int64 {
+    let started: time.Duration = time.Duration.now();
+    let checksum: uint64 = bench_byte_tokens(src, rounds);
+    let total: int64 = elapsed_us(started);
+    print("token_byte_us=" + (total to string) + " checksum=" + (checksum to string));
+    return total;
+}
+
 @entrypoint
 fn main() -> int {
     let rounds: uint = 200:uint;
+    let token_rounds: uint = 100:uint;
     let lines: uint = 256:uint;
     let width: uint = 32:uint;
     let payload: byte[] = make_payload(lines, width);
+    let token_payload: byte[] = make_token_payload(128:uint);
     print("rounds=" + (rounds to string) + " lines=" + (lines to string) + " width=" + (width to string) + " bytes=" + (payload.__len() to string));
     let string_us: int64 = time_string_lines(&payload, rounds);
     let byte_us: int64 = time_byte_lines(&payload, rounds);
-    if string_us <= 0:int64 || byte_us <= 0:int64 {
+    print("token_rounds=" + (token_rounds to string) + " token_bytes=" + (token_payload.__len() to string));
+    let token_string_us: int64 = time_string_tokens(&token_payload, token_rounds);
+    let token_byte_us: int64 = time_byte_tokens(&token_payload, token_rounds);
+    if string_us <= 0:int64 || byte_us <= 0:int64 || token_string_us <= 0:int64 || token_byte_us <= 0:int64 {
         return 1;
     }
     return 0;

--- a/benchmarks/native/byte_lines/main.sg
+++ b/benchmarks/native/byte_lines/main.sg
@@ -52,6 +52,18 @@ fn make_dispatch_payload(records: uint) -> byte[] {
     return out;
 }
 
+fn make_number_payload(records: uint) -> byte[] {
+    let pattern: byte[] = "42 18446744073709551615 7 1024 " to byte[];
+    let mut out: byte[] = [];
+    out.reserve(records * pattern.__len());
+    let mut i: uint = 0:uint;
+    while i < records {
+        append_bytes(&mut out, &pattern);
+        i = i + 1:uint;
+    }
+    return out;
+}
+
 fn elapsed_us(start: time.Duration) -> int64 {
     let now: time.Duration = time.Duration.now();
     let delta: time.Duration = now.sub(start);
@@ -228,6 +240,62 @@ fn bench_byte_dispatch(src: &byte[], rounds: uint) -> uint64 {
     return checksum;
 }
 
+fn bench_string_numbers(src: &byte[], rounds: uint) -> uint64 {
+    let mut checksum: uint64 = 0:uint64;
+    let mut round: uint = 0:uint;
+    while round < rounds {
+        let text = compare string.from_bytes(src) {
+            Success(v) => v;
+            _ => {
+                return checksum;
+            }
+        };
+        let parts = text.split(" ");
+        let count: int = parts.__len() to int;
+        let mut i: int = 0;
+        while i < count {
+            let token: string = clone(parts[i]);
+            if token.__len() != 0:uint {
+                compare uint64.from_str(&token) {
+                    Success(v) => {
+                        checksum = checksum + v;
+                    }
+                    _ => {
+                        return checksum;
+                    }
+                };
+            }
+            i = i + 1;
+        }
+        round = round + 1:uint;
+    }
+    return checksum;
+}
+
+fn bench_byte_numbers(src: &byte[], rounds: uint) -> uint64 {
+    let mut checksum: uint64 = 0:uint64;
+    let mut round: uint = 0:uint;
+    while round < rounds {
+        let mut r: by.ByteRange = by.all(src);
+        let mut done: bool = false;
+        while !done {
+            compare by.next_uint64_ascii_token(src, r) {
+                Some(value) => {
+                    checksum = checksum + value.value;
+                    r = value.tail;
+                    0:int;
+                }
+                nothing => {
+                    done = true;
+                    0:int;
+                }
+            };
+        }
+        round = round + 1:uint;
+    }
+    return checksum;
+}
+
 fn time_string_lines(src: &byte[], rounds: uint) -> int64 {
     let started: time.Duration = time.Duration.now();
     let checksum: uint64 = bench_string_lines(src, rounds);
@@ -276,16 +344,34 @@ fn time_byte_dispatch(src: &byte[], rounds: uint) -> int64 {
     return total;
 }
 
+fn time_string_numbers(src: &byte[], rounds: uint) -> int64 {
+    let started: time.Duration = time.Duration.now();
+    let checksum: uint64 = bench_string_numbers(src, rounds);
+    let total: int64 = elapsed_us(started);
+    print("number_string_us=" + (total to string) + " checksum=" + (checksum to string));
+    return total;
+}
+
+fn time_byte_numbers(src: &byte[], rounds: uint) -> int64 {
+    let started: time.Duration = time.Duration.now();
+    let checksum: uint64 = bench_byte_numbers(src, rounds);
+    let total: int64 = elapsed_us(started);
+    print("number_byte_us=" + (total to string) + " checksum=" + (checksum to string));
+    return total;
+}
+
 @entrypoint
 fn main() -> int {
     let rounds: uint = 200:uint;
     let token_rounds: uint = 100:uint;
     let dispatch_rounds: uint = 100:uint;
+    let number_rounds: uint = 100:uint;
     let lines: uint = 256:uint;
     let width: uint = 32:uint;
     let payload: byte[] = make_payload(lines, width);
     let token_payload: byte[] = make_token_payload(128:uint);
     let dispatch_payload: byte[] = make_dispatch_payload(128:uint);
+    let number_payload: byte[] = make_number_payload(128:uint);
     print("rounds=" + (rounds to string) + " lines=" + (lines to string) + " width=" + (width to string) + " bytes=" + (payload.__len() to string));
     let string_us: int64 = time_string_lines(&payload, rounds);
     let byte_us: int64 = time_byte_lines(&payload, rounds);
@@ -295,7 +381,10 @@ fn main() -> int {
     print("dispatch_rounds=" + (dispatch_rounds to string) + " dispatch_bytes=" + (dispatch_payload.__len() to string));
     let dispatch_string_us: int64 = time_string_dispatch(&dispatch_payload, dispatch_rounds);
     let dispatch_byte_us: int64 = time_byte_dispatch(&dispatch_payload, dispatch_rounds);
-    if string_us <= 0:int64 || byte_us <= 0:int64 || token_string_us <= 0:int64 || token_byte_us <= 0:int64 || dispatch_string_us <= 0:int64 || dispatch_byte_us <= 0:int64 {
+    print("number_rounds=" + (number_rounds to string) + " number_bytes=" + (number_payload.__len() to string));
+    let number_string_us: int64 = time_string_numbers(&number_payload, number_rounds);
+    let number_byte_us: int64 = time_byte_numbers(&number_payload, number_rounds);
+    if string_us <= 0:int64 || byte_us <= 0:int64 || token_string_us <= 0:int64 || token_byte_us <= 0:int64 || dispatch_string_us <= 0:int64 || dispatch_byte_us <= 0:int64 || number_string_us <= 0:int64 || number_byte_us <= 0:int64 {
         return 1;
     }
     return 0;

--- a/benchmarks/native/byte_lines/main.sg
+++ b/benchmarks/native/byte_lines/main.sg
@@ -1,0 +1,111 @@
+import stdlib/bytes as by;
+import stdlib/time as time;
+
+fn make_payload(lines: uint, width: uint) -> byte[] {
+    let mut out: byte[] = [];
+    out.reserve(lines * (width + 1:uint));
+    let mut line: uint = 0:uint;
+    while line < lines {
+        let mut i: uint = 0:uint;
+        while i < width {
+            out.push((65:uint + ((line + i) % 26:uint)) to byte);
+            i = i + 1:uint;
+        }
+        out.push(10:byte);
+        line = line + 1:uint;
+    }
+    return out;
+}
+
+fn elapsed_us(start: time.Duration) -> int64 {
+    let now: time.Duration = time.Duration.now();
+    let delta: time.Duration = now.sub(start);
+    return delta.as_micros();
+}
+
+fn bench_string_lines(src: &byte[], rounds: uint) -> uint64 {
+    let lf: string = "\n";
+    let mut checksum: uint64 = 0:uint64;
+    let mut round: uint = 0:uint;
+    while round < rounds {
+        let text = compare string.from_bytes(src) {
+            Success(v) => v;
+            _ => {
+                return checksum;
+            }
+        };
+        let mut start: int = 0;
+        let mut done: bool = false;
+        while !done {
+            let pos: int = string_find_from(&text, &lf, start);
+            if pos < 0 {
+                done = true;
+            } else {
+                checksum = checksum + ((pos - start) to uint64);
+                start = pos + 1;
+            }
+        }
+        round = round + 1:uint;
+    }
+    return checksum;
+}
+
+fn bench_byte_lines(src: &byte[], rounds: uint) -> uint64 {
+    let mut checksum: uint64 = 0:uint64;
+    let mut round: uint = 0:uint;
+    while round < rounds {
+        let owned: byte[] = src[[0..src.__len() to int]];
+        let mut buf: by.ByteBuffer = { data = owned, start = 0:uint };
+        let mut done: bool = false;
+        while !done {
+            compare buf.peek_line_lf() {
+                Some(line) => {
+                    let current: by.ByteRange = buf.range();
+                    checksum = checksum + (by.range_len(line.body) to uint64);
+                    compare buf.consume(line.next - current.start) {
+                        Success(_) => {}
+                        _ => {
+                            return checksum;
+                        }
+                    };
+                }
+                nothing => {
+                    done = true;
+                }
+            };
+        }
+        round = round + 1:uint;
+    }
+    return checksum;
+}
+
+fn time_string_lines(src: &byte[], rounds: uint) -> int64 {
+    let started: time.Duration = time.Duration.now();
+    let checksum: uint64 = bench_string_lines(src, rounds);
+    let total: int64 = elapsed_us(started);
+    print("string_line_us=" + (total to string) + " checksum=" + (checksum to string));
+    return total;
+}
+
+fn time_byte_lines(src: &byte[], rounds: uint) -> int64 {
+    let started: time.Duration = time.Duration.now();
+    let checksum: uint64 = bench_byte_lines(src, rounds);
+    let total: int64 = elapsed_us(started);
+    print("byte_line_us=" + (total to string) + " checksum=" + (checksum to string));
+    return total;
+}
+
+@entrypoint
+fn main() -> int {
+    let rounds: uint = 200:uint;
+    let lines: uint = 256:uint;
+    let width: uint = 32:uint;
+    let payload: byte[] = make_payload(lines, width);
+    print("rounds=" + (rounds to string) + " lines=" + (lines to string) + " width=" + (width to string) + " bytes=" + (payload.__len() to string));
+    let string_us: int64 = time_string_lines(&payload, rounds);
+    let byte_us: int64 = time_byte_lines(&payload, rounds);
+    if string_us <= 0:int64 || byte_us <= 0:int64 {
+        return 1;
+    }
+    return 0;
+}

--- a/benchmarks/native/byte_lines/main.sg
+++ b/benchmarks/native/byte_lines/main.sg
@@ -40,6 +40,18 @@ fn make_token_payload(records: uint) -> byte[] {
     return out;
 }
 
+fn make_dispatch_payload(records: uint) -> byte[] {
+    let pattern: byte[] = "PING GET UNKNOWN PING GET MISSING " to byte[];
+    let mut out: byte[] = [];
+    out.reserve(records * pattern.__len());
+    let mut i: uint = 0:uint;
+    while i < records {
+        append_bytes(&mut out, &pattern);
+        i = i + 1:uint;
+    }
+    return out;
+}
+
 fn elapsed_us(start: time.Duration) -> int64 {
     let now: time.Duration = time.Duration.now();
     let delta: time.Duration = now.sub(start);
@@ -152,6 +164,72 @@ fn bench_byte_tokens(src: &byte[], rounds: uint) -> uint64 {
     return checksum;
 }
 
+fn bench_string_dispatch(src: &byte[], rounds: uint) -> uint64 {
+    let ping: string = "PING";
+    let get: string = "GET";
+    let mut checksum: uint64 = 0:uint64;
+    let mut round: uint = 0:uint;
+    while round < rounds {
+        let text = compare string.from_bytes(src) {
+            Success(v) => v;
+            _ => {
+                return checksum;
+            }
+        };
+        let parts = text.split(" ");
+        let count: int = parts.__len() to int;
+        let mut i: int = 0;
+        while i < count {
+            let token: string = clone(parts[i]);
+            if token.__len() != 0:uint {
+                if token == ping {
+                    checksum = checksum + 1:uint64;
+                } else if token == get {
+                    checksum = checksum + 2:uint64;
+                } else {
+                    checksum = checksum + 7:uint64;
+                }
+            }
+            i = i + 1;
+        }
+        round = round + 1:uint;
+    }
+    return checksum;
+}
+
+fn bench_byte_dispatch(src: &byte[], rounds: uint) -> uint64 {
+    let ping: string = "PING";
+    let get: string = "GET";
+    let mut checksum: uint64 = 0:uint64;
+    let mut round: uint = 0:uint;
+    while round < rounds {
+        let data: byte[] = src[[0..src.__len() to int]];
+        let mut r: by.ByteRange = by.all(&data);
+        let mut done: bool = false;
+        while !done {
+            compare by.next_ascii_token(&data, r) {
+                Some(split) => {
+                    if by.range_eq_ascii(&data, split.head, &ping) {
+                        checksum = checksum + 1:uint64;
+                    } else if by.range_eq_ascii(&data, split.head, &get) {
+                        checksum = checksum + 2:uint64;
+                    } else {
+                        checksum = checksum + 7:uint64;
+                    }
+                    r = split.tail;
+                    0:int;
+                }
+                nothing => {
+                    done = true;
+                    0:int;
+                }
+            };
+        }
+        round = round + 1:uint;
+    }
+    return checksum;
+}
+
 fn time_string_lines(src: &byte[], rounds: uint) -> int64 {
     let started: time.Duration = time.Duration.now();
     let checksum: uint64 = bench_string_lines(src, rounds);
@@ -184,21 +262,42 @@ fn time_byte_tokens(src: &byte[], rounds: uint) -> int64 {
     return total;
 }
 
+fn time_string_dispatch(src: &byte[], rounds: uint) -> int64 {
+    let started: time.Duration = time.Duration.now();
+    let checksum: uint64 = bench_string_dispatch(src, rounds);
+    let total: int64 = elapsed_us(started);
+    print("dispatch_string_us=" + (total to string) + " checksum=" + (checksum to string));
+    return total;
+}
+
+fn time_byte_dispatch(src: &byte[], rounds: uint) -> int64 {
+    let started: time.Duration = time.Duration.now();
+    let checksum: uint64 = bench_byte_dispatch(src, rounds);
+    let total: int64 = elapsed_us(started);
+    print("dispatch_byte_us=" + (total to string) + " checksum=" + (checksum to string));
+    return total;
+}
+
 @entrypoint
 fn main() -> int {
     let rounds: uint = 200:uint;
     let token_rounds: uint = 100:uint;
+    let dispatch_rounds: uint = 100:uint;
     let lines: uint = 256:uint;
     let width: uint = 32:uint;
     let payload: byte[] = make_payload(lines, width);
     let token_payload: byte[] = make_token_payload(128:uint);
+    let dispatch_payload: byte[] = make_dispatch_payload(128:uint);
     print("rounds=" + (rounds to string) + " lines=" + (lines to string) + " width=" + (width to string) + " bytes=" + (payload.__len() to string));
     let string_us: int64 = time_string_lines(&payload, rounds);
     let byte_us: int64 = time_byte_lines(&payload, rounds);
     print("token_rounds=" + (token_rounds to string) + " token_bytes=" + (token_payload.__len() to string));
     let token_string_us: int64 = time_string_tokens(&token_payload, token_rounds);
     let token_byte_us: int64 = time_byte_tokens(&token_payload, token_rounds);
-    if string_us <= 0:int64 || byte_us <= 0:int64 || token_string_us <= 0:int64 || token_byte_us <= 0:int64 {
+    print("dispatch_rounds=" + (dispatch_rounds to string) + " dispatch_bytes=" + (dispatch_payload.__len() to string));
+    let dispatch_string_us: int64 = time_string_dispatch(&dispatch_payload, dispatch_rounds);
+    let dispatch_byte_us: int64 = time_byte_dispatch(&dispatch_payload, dispatch_rounds);
+    if string_us <= 0:int64 || byte_us <= 0:int64 || token_string_us <= 0:int64 || token_byte_us <= 0:int64 || dispatch_string_us <= 0:int64 || dispatch_byte_us <= 0:int64 {
         return 1;
     }
     return 0;

--- a/benchmarks/native/byte_lines/surge.toml
+++ b/benchmarks/native/byte_lines/surge.toml
@@ -1,0 +1,7 @@
+[package]
+name = "byte_lines"
+root = "."
+version = "0.1.0"
+
+[run]
+main = "main.sg"

--- a/core/intrinsics.sg
+++ b/core/intrinsics.sg
@@ -132,6 +132,7 @@ extern<TcpConn> {
 @intrinsic fn rt_array_append_raw_bytes(a: &mut byte[], ptr: *byte, length: uint64) -> nothing;
 @intrinsic fn rt_byte_array_append_range(dst: &mut byte[], src: &byte[], start: uint64, length: uint64) -> nothing;
 @intrinsic fn rt_byte_array_drop_prefix(a: &mut byte[], count: uint64) -> nothing;
+@intrinsic fn rt_byte_parse_uint64_token(data: &byte[], start: uint64, end: uint64, value: &mut uint64, next: &mut uint64) -> bool;
 
 // Map access intrinsics
 @intrinsic fn rt_map_new<K, V>() -> Map<K, V>;

--- a/docs/2026-06-23-stdlib-bytes-specs.md
+++ b/docs/2026-06-23-stdlib-bytes-specs.md
@@ -1,7 +1,7 @@
 # `stdlib/bytes` Design Spec
 
-> Status: roadmap design; range/compact and LF/CRLF line scanning slices are
-> shipped.
+> Status: roadmap design; range/compact, LF/CRLF line scanning, and ASCII
+> token slices are shipped.
 > Date: 2026-06-23.
 > Scope: standard-library byte helpers for protocol and binary hot paths.
 
@@ -289,6 +289,14 @@ Shipped in the line-scanning slice:
 - `ByteBuffer.peek_line_lf` and `ByteBuffer.peek_line_crlf`.
 - `benchmarks/native/byte_lines` plus `scripts/bench_native_byte_lines.sh`.
 
+Shipped in the ASCII token slice:
+
+- `ByteSplit`.
+- ASCII predicates and case/hex helpers.
+- `trim_ascii`, `trim_ascii_start`, and `trim_ascii_end`.
+- `split_once_byte` and `next_ascii_token`.
+- `scripts/bench_native_byte_lines.sh` also reports token extraction timings.
+
 Still optional:
 
 - `rt_byte_find(buf: &byte[], start: uint, end: uint, needle: byte)`.
@@ -375,11 +383,14 @@ The first shipped slice covers:
 - `ByteBuffer.peek_line_lf`, `ByteBuffer.peek_line_crlf`
 - LF and CRLF line endings
 - Lines split across chunks
+- ASCII predicates and case/hex helpers
+- ASCII whitespace trimming
+- `split_once_byte`
+- `next_ascii_token`
 
 The implementation PR should add focused tests for:
 
 - Empty ranges and invalid ranges.
-- ASCII whitespace trimming.
 - Case-sensitive and case-insensitive literal compare.
 - Integer parsing, including overflow.
 - Buffer consume and compact behavior.

--- a/docs/2026-06-23-stdlib-bytes-specs.md
+++ b/docs/2026-06-23-stdlib-bytes-specs.md
@@ -191,13 +191,20 @@ They are intended for small protocol literals such as `GET`, `PING`, and
 ## Numeric Parse Helpers
 
 ```sg
-pub fn parse_uint_ascii(data: &byte[], range: ByteRange) -> Erring<uint, Error>;
-pub fn parse_int_ascii(data: &byte[], range: ByteRange) -> Erring<int, Error>;
-pub fn parse_hex_uint_ascii(data: &byte[], range: ByteRange) -> Erring<uint, Error>;
+pub fn parse_uint64_ascii(data: &byte[], range: ByteRange) -> Erring<uint64, Error>;
+pub fn parse_int64_ascii(data: &byte[], range: ByteRange) -> Erring<int64, Error>;
+pub fn parse_hex_uint64_ascii(data: &byte[], range: ByteRange) -> Erring<uint64, Error>;
 ```
 
 These functions parse ASCII digits only. They should reject empty input,
 whitespace, signs in unsigned values, and overflow.
+
+Numeric parsing is not shipped yet. A pure Surge `parse_uint64_ascii` prototype
+was correct but did not beat the current `string.from_bytes + split +
+uint.from_str` benchmark after safety checks were added (`~0.90x` in a
+single-run probe). The next numeric slice should either fuse token scanning with
+numeric parsing or add a narrow runtime byte-range parse intrinsic; do not ship
+a slower range helper just to complete the surface.
 
 ## Conversion Helpers
 
@@ -358,7 +365,7 @@ Add a standalone benchmark under this repo, not under an external project:
 - Current string line path vs `ByteBuffer.peek_line_lf`.
 - Current string token path vs `next_ascii_token`.
 - Current string command dispatch vs `next_ascii_token + range_eq_ascii`.
-- `parse_uint_ascii` for small and large integers.
+- Fixed-width or fused numeric parsing for small and large integers.
 - `byte[]` response builder for simple text and value responses.
 - Buffer append, consume, and compact with realistic network chunk sizes.
 

--- a/docs/2026-06-23-stdlib-bytes-specs.md
+++ b/docs/2026-06-23-stdlib-bytes-specs.md
@@ -1,7 +1,7 @@
 # `stdlib/bytes` Design Spec
 
-> Status: roadmap design; range/compact, LF/CRLF line scanning, and ASCII
-> token slices are shipped.
+> Status: roadmap design; range/compact, LF/CRLF line scanning, ASCII token,
+> and byte-range literal compare slices are shipped.
 > Date: 2026-06-23.
 > Scope: standard-library byte helpers for protocol and binary hot paths.
 
@@ -155,9 +155,9 @@ The return value is an absolute byte offset in `data`. `find_crlf` returns the
 offset of `\r`.
 
 `find_byte` is the first search helper that should get runtime support if pure
-Surge loops are too slow. The first native line benchmark did not justify that
-intrinsic: `ByteBuffer.peek_line_lf` was about `7.67x` faster than the string
-conversion path without `rt_byte_find`.
+Surge loops are too slow. The native benchmark does not justify that intrinsic
+yet: `ByteBuffer.peek_line_lf` is about `7.6x` faster than the string conversion
+path without `rt_byte_find`.
 
 ## Range Helpers
 
@@ -297,6 +297,11 @@ Shipped in the ASCII token slice:
 - `split_once_byte` and `next_ascii_token`.
 - `scripts/bench_native_byte_lines.sh` also reports token extraction timings.
 
+Shipped in the literal compare slice:
+
+- `range_eq`, `range_eq_ascii`, `range_eq_ascii_ci`, and `starts_with_ascii`.
+- `scripts/bench_native_byte_lines.sh` also reports command-dispatch timings.
+
 Still optional:
 
 - `rt_byte_find(buf: &byte[], start: uint, end: uint, needle: byte)`.
@@ -352,7 +357,7 @@ Add a standalone benchmark under this repo, not under an external project:
 
 - Current string line path vs `ByteBuffer.peek_line_lf`.
 - Current string token path vs `next_ascii_token`.
-- `range_eq_ascii` command dispatch for `PING`, `GET`, and unknown commands.
+- Current string command dispatch vs `next_ascii_token + range_eq_ascii`.
 - `parse_uint_ascii` for small and large integers.
 - `byte[]` response builder for simple text and value responses.
 - Buffer append, consume, and compact with realistic network chunk sizes.
@@ -387,11 +392,14 @@ The first shipped slice covers:
 - ASCII whitespace trimming
 - `split_once_byte`
 - `next_ascii_token`
+- `range_eq`
+- `range_eq_ascii`
+- `range_eq_ascii_ci`
+- `starts_with_ascii`
 
 The implementation PR should add focused tests for:
 
 - Empty ranges and invalid ranges.
-- Case-sensitive and case-insensitive literal compare.
 - Integer parsing, including overflow.
 - Buffer consume and compact behavior.
 - Explicit string conversion failure on invalid UTF-8.

--- a/docs/2026-06-23-stdlib-bytes-specs.md
+++ b/docs/2026-06-23-stdlib-bytes-specs.md
@@ -191,20 +191,31 @@ They are intended for small protocol literals such as `GET`, `PING`, and
 ## Numeric Parse Helpers
 
 ```sg
+pub type ByteUint64 = {
+    value: uint64,
+    tail: ByteRange,
+};
+
+pub fn next_uint64_ascii_token(data: &byte[], range: ByteRange) -> Option<ByteUint64>;
+```
+
+The shipped numeric slice is intentionally fused: it trims leading ASCII
+whitespace, parses one decimal `uint64`, and returns the remaining range in one
+runtime-backed pass. It rejects empty input, non-digit token bytes, signs, and
+overflow by returning `nothing`.
+
+Standalone numeric parse helpers are still not shipped:
+
+```sg
 pub fn parse_uint64_ascii(data: &byte[], range: ByteRange) -> Erring<uint64, Error>;
 pub fn parse_int64_ascii(data: &byte[], range: ByteRange) -> Erring<int64, Error>;
 pub fn parse_hex_uint64_ascii(data: &byte[], range: ByteRange) -> Erring<uint64, Error>;
 ```
 
-These functions parse ASCII digits only. They should reject empty input,
-whitespace, signs in unsigned values, and overflow.
-
-Numeric parsing is not shipped yet. A pure Surge `parse_uint64_ascii` prototype
-was correct but did not beat the current `string.from_bytes + split +
-uint.from_str` benchmark after safety checks were added (`~0.90x` in a
-single-run probe). The next numeric slice should either fuse token scanning with
-numeric parsing or add a narrow runtime byte-range parse intrinsic; do not ship
-a slower range helper just to complete the surface.
+A pure Surge `parse_uint64_ascii` prototype was correct but did not beat the
+current `string.from_bytes + split + uint.from_str` benchmark after safety
+checks were added (`~0.90x` in a single-run probe). Do not ship separate parse
+helpers until a benchmark proves they add value beyond the fused token parser.
 
 ## Conversion Helpers
 
@@ -399,6 +410,7 @@ The first shipped slice covers:
 - ASCII whitespace trimming
 - `split_once_byte`
 - `next_ascii_token`
+- `next_uint64_ascii_token`
 - `range_eq`
 - `range_eq_ascii`
 - `range_eq_ascii_ci`

--- a/docs/2026-06-23-stdlib-bytes-specs.md
+++ b/docs/2026-06-23-stdlib-bytes-specs.md
@@ -1,7 +1,7 @@
 # `stdlib/bytes` Design Spec
 
-> Status: roadmap design; the first range/compact slice is shipped in this
-> branch.
+> Status: roadmap design; range/compact and LF/CRLF line scanning slices are
+> shipped.
 > Date: 2026-06-23.
 > Scope: standard-library byte helpers for protocol and binary hot paths.
 
@@ -155,7 +155,9 @@ The return value is an absolute byte offset in `data`. `find_crlf` returns the
 offset of `\r`.
 
 `find_byte` is the first search helper that should get runtime support if pure
-Surge loops are too slow.
+Surge loops are too slow. The first native line benchmark did not justify that
+intrinsic: `ByteBuffer.peek_line_lf` was about `7.67x` faster than the string
+conversion path without `rt_byte_find`.
 
 ## Range Helpers
 
@@ -280,6 +282,13 @@ Shipped in the first runtime-backed slice:
 - `rt_byte_array_append_range(dst: &mut byte[], src: &byte[], start: uint, len: uint)`.
 - `rt_byte_array_drop_prefix(buf: &mut byte[], count: uint)`.
 
+Shipped in the line-scanning slice:
+
+- `ByteLine`.
+- `find_byte`, `find_lf`, and `find_crlf`.
+- `ByteBuffer.peek_line_lf` and `ByteBuffer.peek_line_crlf`.
+- `benchmarks/native/byte_lines` plus `scripts/bench_native_byte_lines.sh`.
+
 Still optional:
 
 - `rt_byte_find(buf: &byte[], start: uint, end: uint, needle: byte)`.
@@ -362,12 +371,14 @@ The first shipped slice covers:
 - `ByteBuffer.clear_keep_capacity`
 - VM and LLVM/native parity for valid ranges, invalid ranges, source array
   views, and buffer compaction.
+- `find_byte`, `find_lf`, `find_crlf`
+- `ByteBuffer.peek_line_lf`, `ByteBuffer.peek_line_crlf`
+- LF and CRLF line endings
+- Lines split across chunks
 
 The implementation PR should add focused tests for:
 
 - Empty ranges and invalid ranges.
-- LF and CRLF line endings.
-- Lines split across chunks.
 - ASCII whitespace trimming.
 - Case-sensitive and case-insensitive literal compare.
 - Integer parsing, including overflow.

--- a/docs/STDLIB.md
+++ b/docs/STDLIB.md
@@ -888,6 +888,10 @@ Public API:
 - `trim_ascii_end(data: &byte[], range: ByteRange) -> ByteRange`
 - `split_once_byte(data: &byte[], range: ByteRange, sep: byte) -> Option<ByteSplit>`
 - `next_ascii_token(data: &byte[], range: ByteRange) -> Option<ByteSplit>`
+- `range_eq(data: &byte[], range: ByteRange, expected: &byte[]) -> bool`
+- `range_eq_ascii(data: &byte[], range: ByteRange, expected: &string) -> bool`
+- `range_eq_ascii_ci(data: &byte[], range: ByteRange, expected: &string) -> bool`
+- `starts_with_ascii(data: &byte[], range: ByteRange, expected: &string) -> bool`
 - `copy_range(data: &byte[], range: ByteRange) -> Erring<byte[], Error>`
 - `buffer() -> ByteBuffer`
 - `buffer_from(data: byte[]) -> ByteBuffer`
@@ -905,6 +909,7 @@ Behavior:
 - `ByteSplit.head` points at the token or left side; `ByteSplit.tail` points at the remaining range.
 - Search helpers return absolute byte offsets and `nothing` for invalid ranges or missing delimiters.
 - `trim_ascii*` returns an empty range for invalid input. It only treats ASCII space, tab, LF, and CR as whitespace.
+- Compare helpers return `false` for invalid ranges. The `*_ascii` variants compare against `expected.bytes()` without allocating.
 - Invalid ranges return `BYTES_ERR_INVALID_RANGE`; malformed input should not panic.
 - `copy_range`, `append_bytes_range`, and `compact` use runtime-backed byte-array intrinsics on both VM and LLVM/native. They avoid per-byte Surge loops for the common byte-buffer hot path.
 - `clear_keep_capacity` drops array contents without releasing capacity.
@@ -958,7 +963,7 @@ fn next_line(input: byte[]) -> Option<by.ByteLine> {
 
 Reality note:
 
-- The shipped slices cover copy/append/compact primitives, LF/CRLF line scanning, ASCII helpers, trimming, split, and token extraction. Numeric parsing, literal compare helpers, and richer protocol helpers remain planned in the design spec.
+- The shipped slices cover copy/append/compact primitives, LF/CRLF line scanning, ASCII helpers, trimming, split, token extraction, and literal compare helpers. Numeric parsing and richer protocol helpers remain planned in the design spec.
 
 ---
 

--- a/docs/STDLIB.md
+++ b/docs/STDLIB.md
@@ -871,23 +871,30 @@ Public API:
 
 - `BYTES_ERR_INVALID_RANGE`
 - `type ByteRange`
+- `type ByteLine`
 - `type ByteBuffer`
 - `range(start: uint, end: uint) -> ByteRange`
 - `all(data: &byte[]) -> ByteRange`
 - `range_len(range: ByteRange) -> uint`
 - `is_valid_range(data: &byte[], range: ByteRange) -> bool`
+- `find_byte(data: &byte[], range: ByteRange, needle: byte) -> Option<uint>`
+- `find_lf(data: &byte[], range: ByteRange) -> Option<uint>`
+- `find_crlf(data: &byte[], range: ByteRange) -> Option<uint>`
 - `copy_range(data: &byte[], range: ByteRange) -> Erring<byte[], Error>`
 - `buffer() -> ByteBuffer`
 - `buffer_from(data: byte[]) -> ByteBuffer`
 - `Array<byte>.append_bytes_range(data: &byte[], range: ByteRange) -> Erring<nothing, Error>`
 - `Array<byte>.clear_keep_capacity() -> nothing`
 - `ByteBuffer.len()`, `is_empty()`, `range()`
+- `ByteBuffer.peek_line_lf()`, `peek_line_crlf()`
 - `ByteBuffer.append_range(...)`, `consume(...)`, `compact()`
 - `ByteBuffer.clear_keep_capacity()`, `clear()`
 
 Behavior:
 
 - `ByteRange` is half-open: `[start, end)`.
+- `ByteLine.body` points at line bytes without the terminator; `ByteLine.next` is the absolute offset after the terminator.
+- Search helpers return absolute byte offsets and `nothing` for invalid ranges or missing delimiters.
 - Invalid ranges return `BYTES_ERR_INVALID_RANGE`; malformed input should not panic.
 - `copy_range`, `append_bytes_range`, and `compact` use runtime-backed byte-array intrinsics on both VM and LLVM/native. They avoid per-byte Surge loops for the common byte-buffer hot path.
 - `clear_keep_capacity` drops array contents without releasing capacity.
@@ -928,9 +935,20 @@ fn consume_prefix(input: byte[]) -> Erring<by.ByteBuffer, Error> {
 }
 ```
 
+Example: peek a line without converting the input buffer to `string`
+
+```sg
+import stdlib/bytes as by;
+
+fn next_line(input: byte[]) -> Option<by.ByteLine> {
+    let buf: by.ByteBuffer = by.buffer_from(input);
+    return buf.peek_line_lf();
+}
+```
+
 Reality note:
 
-- This is the first shipped slice of `stdlib/bytes`, focused on copy/append/compact primitives. Search, ASCII parsing, line scanning, and richer protocol helpers remain planned in the design spec.
+- The shipped slices cover copy/append/compact primitives and LF/CRLF line scanning. ASCII trimming, token extraction, numeric parsing, literal compare helpers, and richer protocol helpers remain planned in the design spec.
 
 ---
 

--- a/docs/STDLIB.md
+++ b/docs/STDLIB.md
@@ -873,6 +873,7 @@ Public API:
 - `type ByteRange`
 - `type ByteLine`
 - `type ByteSplit`
+- `type ByteUint64`
 - `type ByteBuffer`
 - `range(start: uint, end: uint) -> ByteRange`
 - `all(data: &byte[]) -> ByteRange`
@@ -888,6 +889,7 @@ Public API:
 - `trim_ascii_end(data: &byte[], range: ByteRange) -> ByteRange`
 - `split_once_byte(data: &byte[], range: ByteRange, sep: byte) -> Option<ByteSplit>`
 - `next_ascii_token(data: &byte[], range: ByteRange) -> Option<ByteSplit>`
+- `next_uint64_ascii_token(data: &byte[], range: ByteRange) -> Option<ByteUint64>`
 - `range_eq(data: &byte[], range: ByteRange, expected: &byte[]) -> bool`
 - `range_eq_ascii(data: &byte[], range: ByteRange, expected: &string) -> bool`
 - `range_eq_ascii_ci(data: &byte[], range: ByteRange, expected: &string) -> bool`
@@ -907,8 +909,10 @@ Behavior:
 - `ByteRange` is half-open: `[start, end)`.
 - `ByteLine.body` points at line bytes without the terminator; `ByteLine.next` is the absolute offset after the terminator.
 - `ByteSplit.head` points at the token or left side; `ByteSplit.tail` points at the remaining range.
+- `ByteUint64.value` is the parsed decimal value; `ByteUint64.tail` starts at the whitespace or range end after the number.
 - Search helpers return absolute byte offsets and `nothing` for invalid ranges or missing delimiters.
 - `trim_ascii*` returns an empty range for invalid input. It only treats ASCII space, tab, LF, and CR as whitespace.
+- `next_uint64_ascii_token` skips leading ASCII whitespace, parses decimal `uint64`, rejects empty input, non-digit token bytes, and overflow, and returns `nothing` for invalid ranges.
 - Compare helpers return `false` for invalid ranges. The `*_ascii` variants compare against `expected.bytes()` without allocating.
 - Invalid ranges return `BYTES_ERR_INVALID_RANGE`; malformed input should not panic.
 - `copy_range`, `append_bytes_range`, and `compact` use runtime-backed byte-array intrinsics on both VM and LLVM/native. They avoid per-byte Surge loops for the common byte-buffer hot path.

--- a/docs/STDLIB.md
+++ b/docs/STDLIB.md
@@ -872,14 +872,22 @@ Public API:
 - `BYTES_ERR_INVALID_RANGE`
 - `type ByteRange`
 - `type ByteLine`
+- `type ByteSplit`
 - `type ByteBuffer`
 - `range(start: uint, end: uint) -> ByteRange`
 - `all(data: &byte[]) -> ByteRange`
 - `range_len(range: ByteRange) -> uint`
 - `is_valid_range(data: &byte[], range: ByteRange) -> bool`
+- `is_ascii_ws(...)`, `is_ascii_digit(...)`, `is_ascii_alpha(...)`, `is_ascii_alnum(...)`
+- `is_ascii_hex_digit(...)`, `ascii_to_lower(...)`, `ascii_to_upper(...)`, `ascii_hex_value(...)`
 - `find_byte(data: &byte[], range: ByteRange, needle: byte) -> Option<uint>`
 - `find_lf(data: &byte[], range: ByteRange) -> Option<uint>`
 - `find_crlf(data: &byte[], range: ByteRange) -> Option<uint>`
+- `trim_ascii(data: &byte[], range: ByteRange) -> ByteRange`
+- `trim_ascii_start(data: &byte[], range: ByteRange) -> ByteRange`
+- `trim_ascii_end(data: &byte[], range: ByteRange) -> ByteRange`
+- `split_once_byte(data: &byte[], range: ByteRange, sep: byte) -> Option<ByteSplit>`
+- `next_ascii_token(data: &byte[], range: ByteRange) -> Option<ByteSplit>`
 - `copy_range(data: &byte[], range: ByteRange) -> Erring<byte[], Error>`
 - `buffer() -> ByteBuffer`
 - `buffer_from(data: byte[]) -> ByteBuffer`
@@ -894,7 +902,9 @@ Behavior:
 
 - `ByteRange` is half-open: `[start, end)`.
 - `ByteLine.body` points at line bytes without the terminator; `ByteLine.next` is the absolute offset after the terminator.
+- `ByteSplit.head` points at the token or left side; `ByteSplit.tail` points at the remaining range.
 - Search helpers return absolute byte offsets and `nothing` for invalid ranges or missing delimiters.
+- `trim_ascii*` returns an empty range for invalid input. It only treats ASCII space, tab, LF, and CR as whitespace.
 - Invalid ranges return `BYTES_ERR_INVALID_RANGE`; malformed input should not panic.
 - `copy_range`, `append_bytes_range`, and `compact` use runtime-backed byte-array intrinsics on both VM and LLVM/native. They avoid per-byte Surge loops for the common byte-buffer hot path.
 - `clear_keep_capacity` drops array contents without releasing capacity.
@@ -948,7 +958,7 @@ fn next_line(input: byte[]) -> Option<by.ByteLine> {
 
 Reality note:
 
-- The shipped slices cover copy/append/compact primitives and LF/CRLF line scanning. ASCII trimming, token extraction, numeric parsing, literal compare helpers, and richer protocol helpers remain planned in the design spec.
+- The shipped slices cover copy/append/compact primitives, LF/CRLF line scanning, ASCII helpers, trimming, split, and token extraction. Numeric parsing, literal compare helpers, and richer protocol helpers remain planned in the design spec.
 
 ---
 

--- a/docs/STDLIB.md
+++ b/docs/STDLIB.md
@@ -967,7 +967,7 @@ fn next_line(input: byte[]) -> Option<by.ByteLine> {
 
 Reality note:
 
-- The shipped slices cover copy/append/compact primitives, LF/CRLF line scanning, ASCII helpers, trimming, split, token extraction, and literal compare helpers. Numeric parsing and richer protocol helpers remain planned in the design spec.
+- The shipped slices cover copy/append/compact primitives, LF/CRLF line scanning, ASCII helpers, trimming, split, token extraction, literal compare helpers, and fused `next_uint64_ascii_token` parsing. Additional standalone numeric helpers and richer protocol helpers remain planned in the design spec.
 
 ---
 

--- a/docs/STDLIB.ru.md
+++ b/docs/STDLIB.ru.md
@@ -888,6 +888,10 @@ import stdlib/bytes as by;
 - `trim_ascii_end(data: &byte[], range: ByteRange) -> ByteRange`
 - `split_once_byte(data: &byte[], range: ByteRange, sep: byte) -> Option<ByteSplit>`
 - `next_ascii_token(data: &byte[], range: ByteRange) -> Option<ByteSplit>`
+- `range_eq(data: &byte[], range: ByteRange, expected: &byte[]) -> bool`
+- `range_eq_ascii(data: &byte[], range: ByteRange, expected: &string) -> bool`
+- `range_eq_ascii_ci(data: &byte[], range: ByteRange, expected: &string) -> bool`
+- `starts_with_ascii(data: &byte[], range: ByteRange, expected: &string) -> bool`
 - `copy_range(data: &byte[], range: ByteRange) -> Erring<byte[], Error>`
 - `buffer() -> ByteBuffer`
 - `buffer_from(data: byte[]) -> ByteBuffer`
@@ -905,6 +909,7 @@ import stdlib/bytes as by;
 - `ByteSplit.head` указывает на token или левую часть; `ByteSplit.tail` указывает на оставшийся range.
 - Search helper'ы возвращают абсолютные byte offsets и `nothing` для невалидных диапазонов или отсутствующих delimiter'ов.
 - `trim_ascii*` возвращает пустой range для невалидного input. Whitespace — только ASCII space, tab, LF и CR.
+- Compare helper'ы возвращают `false` для невалидных ranges. Варианты `*_ascii` сравнивают с `expected.bytes()` без allocation.
 - Невалидные диапазоны возвращают `BYTES_ERR_INVALID_RANGE`; обычный malformed input не должен приводить к panic.
 - `copy_range`, `append_bytes_range` и `compact` используют runtime-backed byte-array intrinsics в VM и LLVM/native. Для типичного hot path с byte buffer они не идут через per-byte Surge loops.
 - `clear_keep_capacity` очищает содержимое массива, сохраняя capacity.
@@ -958,7 +963,7 @@ fn next_line(input: byte[]) -> Option<by.ByteLine> {
 
 Замечание про реальность:
 
-- Shipped slices покрывают copy/append/compact primitives, LF/CRLF line scanning, ASCII helper'ы, trimming, split и token extraction. Numeric parsing, literal compare helper'ы и более богатые protocol helper'ы остаются в design spec.
+- Shipped slices покрывают copy/append/compact primitives, LF/CRLF line scanning, ASCII helper'ы, trimming, split, token extraction и literal compare helper'ы. Numeric parsing и более богатые protocol helper'ы остаются в design spec.
 
 ---
 

--- a/docs/STDLIB.ru.md
+++ b/docs/STDLIB.ru.md
@@ -872,14 +872,22 @@ import stdlib/bytes as by;
 - `BYTES_ERR_INVALID_RANGE`
 - `type ByteRange`
 - `type ByteLine`
+- `type ByteSplit`
 - `type ByteBuffer`
 - `range(start: uint, end: uint) -> ByteRange`
 - `all(data: &byte[]) -> ByteRange`
 - `range_len(range: ByteRange) -> uint`
 - `is_valid_range(data: &byte[], range: ByteRange) -> bool`
+- `is_ascii_ws(...)`, `is_ascii_digit(...)`, `is_ascii_alpha(...)`, `is_ascii_alnum(...)`
+- `is_ascii_hex_digit(...)`, `ascii_to_lower(...)`, `ascii_to_upper(...)`, `ascii_hex_value(...)`
 - `find_byte(data: &byte[], range: ByteRange, needle: byte) -> Option<uint>`
 - `find_lf(data: &byte[], range: ByteRange) -> Option<uint>`
 - `find_crlf(data: &byte[], range: ByteRange) -> Option<uint>`
+- `trim_ascii(data: &byte[], range: ByteRange) -> ByteRange`
+- `trim_ascii_start(data: &byte[], range: ByteRange) -> ByteRange`
+- `trim_ascii_end(data: &byte[], range: ByteRange) -> ByteRange`
+- `split_once_byte(data: &byte[], range: ByteRange, sep: byte) -> Option<ByteSplit>`
+- `next_ascii_token(data: &byte[], range: ByteRange) -> Option<ByteSplit>`
 - `copy_range(data: &byte[], range: ByteRange) -> Erring<byte[], Error>`
 - `buffer() -> ByteBuffer`
 - `buffer_from(data: byte[]) -> ByteBuffer`
@@ -894,7 +902,9 @@ import stdlib/bytes as by;
 
 - `ByteRange` полуоткрытый: `[start, end)`.
 - `ByteLine.body` указывает на байты строки без терминатора; `ByteLine.next` — абсолютный offset после терминатора.
+- `ByteSplit.head` указывает на token или левую часть; `ByteSplit.tail` указывает на оставшийся range.
 - Search helper'ы возвращают абсолютные byte offsets и `nothing` для невалидных диапазонов или отсутствующих delimiter'ов.
+- `trim_ascii*` возвращает пустой range для невалидного input. Whitespace — только ASCII space, tab, LF и CR.
 - Невалидные диапазоны возвращают `BYTES_ERR_INVALID_RANGE`; обычный malformed input не должен приводить к panic.
 - `copy_range`, `append_bytes_range` и `compact` используют runtime-backed byte-array intrinsics в VM и LLVM/native. Для типичного hot path с byte buffer они не идут через per-byte Surge loops.
 - `clear_keep_capacity` очищает содержимое массива, сохраняя capacity.
@@ -948,7 +958,7 @@ fn next_line(input: byte[]) -> Option<by.ByteLine> {
 
 Замечание про реальность:
 
-- Shipped slices покрывают copy/append/compact primitives и LF/CRLF line scanning. ASCII trimming, token extraction, numeric parsing, literal compare helper'ы и более богатые protocol helper'ы остаются в design spec.
+- Shipped slices покрывают copy/append/compact primitives, LF/CRLF line scanning, ASCII helper'ы, trimming, split и token extraction. Numeric parsing, literal compare helper'ы и более богатые protocol helper'ы остаются в design spec.
 
 ---
 

--- a/docs/STDLIB.ru.md
+++ b/docs/STDLIB.ru.md
@@ -871,23 +871,30 @@ import stdlib/bytes as by;
 
 - `BYTES_ERR_INVALID_RANGE`
 - `type ByteRange`
+- `type ByteLine`
 - `type ByteBuffer`
 - `range(start: uint, end: uint) -> ByteRange`
 - `all(data: &byte[]) -> ByteRange`
 - `range_len(range: ByteRange) -> uint`
 - `is_valid_range(data: &byte[], range: ByteRange) -> bool`
+- `find_byte(data: &byte[], range: ByteRange, needle: byte) -> Option<uint>`
+- `find_lf(data: &byte[], range: ByteRange) -> Option<uint>`
+- `find_crlf(data: &byte[], range: ByteRange) -> Option<uint>`
 - `copy_range(data: &byte[], range: ByteRange) -> Erring<byte[], Error>`
 - `buffer() -> ByteBuffer`
 - `buffer_from(data: byte[]) -> ByteBuffer`
 - `Array<byte>.append_bytes_range(data: &byte[], range: ByteRange) -> Erring<nothing, Error>`
 - `Array<byte>.clear_keep_capacity() -> nothing`
 - `ByteBuffer.len()`, `is_empty()`, `range()`
+- `ByteBuffer.peek_line_lf()`, `peek_line_crlf()`
 - `ByteBuffer.append_range(...)`, `consume(...)`, `compact()`
 - `ByteBuffer.clear_keep_capacity()`, `clear()`
 
 Поведение:
 
 - `ByteRange` полуоткрытый: `[start, end)`.
+- `ByteLine.body` указывает на байты строки без терминатора; `ByteLine.next` — абсолютный offset после терминатора.
+- Search helper'ы возвращают абсолютные byte offsets и `nothing` для невалидных диапазонов или отсутствующих delimiter'ов.
 - Невалидные диапазоны возвращают `BYTES_ERR_INVALID_RANGE`; обычный malformed input не должен приводить к panic.
 - `copy_range`, `append_bytes_range` и `compact` используют runtime-backed byte-array intrinsics в VM и LLVM/native. Для типичного hot path с byte buffer они не идут через per-byte Surge loops.
 - `clear_keep_capacity` очищает содержимое массива, сохраняя capacity.
@@ -928,9 +935,20 @@ fn consume_prefix(input: byte[]) -> Erring<by.ByteBuffer, Error> {
 }
 ```
 
+Пример: peek line без преобразования input buffer в `string`
+
+```sg
+import stdlib/bytes as by;
+
+fn next_line(input: byte[]) -> Option<by.ByteLine> {
+    let buf: by.ByteBuffer = by.buffer_from(input);
+    return buf.peek_line_lf();
+}
+```
+
 Замечание про реальность:
 
-- Это первый shipped slice `stdlib/bytes`, сфокусированный на copy/append/compact primitives. Search, ASCII parsing, line scanning и более богатые protocol helper'ы остаются в design spec.
+- Shipped slices покрывают copy/append/compact primitives и LF/CRLF line scanning. ASCII trimming, token extraction, numeric parsing, literal compare helper'ы и более богатые protocol helper'ы остаются в design spec.
 
 ---
 

--- a/docs/STDLIB.ru.md
+++ b/docs/STDLIB.ru.md
@@ -967,7 +967,7 @@ fn next_line(input: byte[]) -> Option<by.ByteLine> {
 
 Замечание про реальность:
 
-- Shipped slices покрывают copy/append/compact primitives, LF/CRLF line scanning, ASCII helper'ы, trimming, split, token extraction и literal compare helper'ы. Numeric parsing и более богатые protocol helper'ы остаются в design spec.
+- Shipped slices покрывают copy/append/compact primitives, LF/CRLF line scanning, ASCII helper'ы, trimming, split, token extraction, literal compare helper'ы и fused `next_uint64_ascii_token`. Отдельные/расширенные numeric helper'ы и более богатые protocol helper'ы остаются в design spec.
 
 ---
 

--- a/docs/STDLIB.ru.md
+++ b/docs/STDLIB.ru.md
@@ -873,6 +873,7 @@ import stdlib/bytes as by;
 - `type ByteRange`
 - `type ByteLine`
 - `type ByteSplit`
+- `type ByteUint64`
 - `type ByteBuffer`
 - `range(start: uint, end: uint) -> ByteRange`
 - `all(data: &byte[]) -> ByteRange`
@@ -888,6 +889,7 @@ import stdlib/bytes as by;
 - `trim_ascii_end(data: &byte[], range: ByteRange) -> ByteRange`
 - `split_once_byte(data: &byte[], range: ByteRange, sep: byte) -> Option<ByteSplit>`
 - `next_ascii_token(data: &byte[], range: ByteRange) -> Option<ByteSplit>`
+- `next_uint64_ascii_token(data: &byte[], range: ByteRange) -> Option<ByteUint64>`
 - `range_eq(data: &byte[], range: ByteRange, expected: &byte[]) -> bool`
 - `range_eq_ascii(data: &byte[], range: ByteRange, expected: &string) -> bool`
 - `range_eq_ascii_ci(data: &byte[], range: ByteRange, expected: &string) -> bool`
@@ -907,8 +909,10 @@ import stdlib/bytes as by;
 - `ByteRange` полуоткрытый: `[start, end)`.
 - `ByteLine.body` указывает на байты строки без терминатора; `ByteLine.next` — абсолютный offset после терминатора.
 - `ByteSplit.head` указывает на token или левую часть; `ByteSplit.tail` указывает на оставшийся range.
+- `ByteUint64.value` содержит распарсенное decimal-значение; `ByteUint64.tail` начинается на whitespace или конце range после числа.
 - Search helper'ы возвращают абсолютные byte offsets и `nothing` для невалидных диапазонов или отсутствующих delimiter'ов.
 - `trim_ascii*` возвращает пустой range для невалидного input. Whitespace — только ASCII space, tab, LF и CR.
+- `next_uint64_ascii_token` пропускает ведущий ASCII whitespace, парсит decimal `uint64`, отвергает пустой input, нецифровые байты внутри token и overflow, а для invalid ranges возвращает `nothing`.
 - Compare helper'ы возвращают `false` для невалидных ranges. Варианты `*_ascii` сравнивают с `expected.bytes()` без allocation.
 - Невалидные диапазоны возвращают `BYTES_ERR_INVALID_RANGE`; обычный malformed input не должен приводить к panic.
 - `copy_range`, `append_bytes_range` и `compact` используют runtime-backed byte-array intrinsics в VM и LLVM/native. Для типичного hot path с byte buffer они не идут через per-byte Surge loops.

--- a/internal/backend/llvm/builtins.go
+++ b/internal/backend/llvm/builtins.go
@@ -22,6 +22,7 @@ func runtimeDecls() []builtinDecl {
 		{name: "rt_array_append_raw_bytes", ret: "void", params: []string{"ptr", "ptr", "i64"}},
 		{name: "rt_byte_array_append_range", ret: "void", params: []string{"ptr", "ptr", "i64", "i64"}},
 		{name: "rt_byte_array_drop_prefix", ret: "void", params: []string{"ptr", "i64"}},
+		{name: "rt_byte_parse_uint64_token", ret: "i1", params: []string{"ptr", "i64", "i64", "ptr", "ptr"}},
 		{name: "rt_write_stdout", ret: "i64", params: []string{"ptr", "i64"}},
 		{name: "rt_write_stderr", ret: "i64", params: []string{"ptr", "i64"}},
 		{name: "rt_entropy_bytes", ret: "ptr", params: []string{"i64"}},

--- a/internal/backend/llvm/emit_calls_test.go
+++ b/internal/backend/llvm/emit_calls_test.go
@@ -147,6 +147,38 @@ fn main() -> int {
 	}
 }
 
+func TestEmitFixedWidthUintFromStrUsesI64ParseValue(t *testing.T) {
+	sourceCode := `@entrypoint
+fn main() -> int {
+    let text: string = "42";
+    let parsed = compare uint64.from_str(&text) {
+        Success(v) => v;
+        _ => {
+            return 1;
+        }
+    };
+    if parsed == 42:uint64 {
+        return 0;
+    }
+    return 2;
+}
+`
+
+	ir := emitLLVMFromSource(t, sourceCode)
+
+	if !strings.Contains(ir, "call i1 @rt_parse_uint(") {
+		t.Fatalf("expected uint parser call in IR:\n%s", ir)
+	}
+	parseWindowRe := regexp.MustCompile(`(?s)call i1 @rt_parse_uint\(.*?(?:\n.*?){0,8}`)
+	parseWindow := parseWindowRe.FindString(ir)
+	if parseWindow == "" {
+		t.Fatalf("cannot find uint parser window in IR:\n%s", ir)
+	}
+	if strings.Contains(parseWindow, "rt_biguint_to_u64") {
+		t.Fatalf("fixed-width uint from_str must not treat raw i64 parse output as BigUint ptr:\n%s", ir)
+	}
+}
+
 func findI64FunctionBodyContaining(t *testing.T, ir, needle string) string {
 	t.Helper()
 

--- a/internal/backend/llvm/emit_calls_test.go
+++ b/internal/backend/llvm/emit_calls_test.go
@@ -169,12 +169,12 @@ fn main() -> int {
 	if !strings.Contains(ir, "call i1 @rt_parse_uint(") {
 		t.Fatalf("expected uint parser call in IR:\n%s", ir)
 	}
-	parseWindowRe := regexp.MustCompile(`(?s)call i1 @rt_parse_uint\(.*?(?:\n.*?){0,8}`)
-	parseWindow := parseWindowRe.FindString(ir)
-	if parseWindow == "" {
-		t.Fatalf("cannot find uint parser window in IR:\n%s", ir)
+	bodyRe := regexp.MustCompile(`(?s)define (?:ptr|i64) @fn\.\d+\([^)]*\) \{.*?rt_parse_uint.*?\n\}`)
+	body := bodyRe.FindString(ir)
+	if body == "" {
+		t.Fatalf("cannot find uint parser function body in IR:\n%s", ir)
 	}
-	if strings.Contains(parseWindow, "rt_biguint_to_u64") {
+	if strings.Contains(body, "rt_biguint_to_u64") {
 		t.Fatalf("fixed-width uint from_str must not treat raw i64 parse output as BigUint ptr:\n%s", ir)
 	}
 }

--- a/internal/backend/llvm/emit_intrinsics_array.go
+++ b/internal/backend/llvm/emit_intrinsics_array.go
@@ -35,6 +35,8 @@ func (fe *funcEmitter) emitArrayIntrinsic(call *mir.CallInstr) (bool, error) {
 		return true, fe.emitByteArrayAppendRange(call)
 	case "rt_byte_array_drop_prefix":
 		return true, fe.emitByteArrayDropPrefix(call)
+	case "rt_byte_parse_uint64_token":
+		return true, fe.emitByteParseUint64Token(call)
 	default:
 		return false, nil
 	}
@@ -542,4 +544,61 @@ func (fe *funcEmitter) emitByteArrayDropPrefix(call *mir.CallInstr) error {
 	}
 	fmt.Fprintf(&fe.emitter.buf, "  call void @rt_byte_array_drop_prefix(ptr %s, i64 %s)\n", slot, count64)
 	return nil
+}
+
+func (fe *funcEmitter) emitByteParseUint64Token(call *mir.CallInstr) error {
+	if len(call.Args) != 5 {
+		return fmt.Errorf("rt_byte_parse_uint64_token requires 5 arguments")
+	}
+	dataHead, err := fe.emitByteArrayHandle(&call.Args[0])
+	if err != nil {
+		return err
+	}
+	start64, err := fe.emitUint64BitsOperand(&call.Args[1])
+	if err != nil {
+		return err
+	}
+	end64, err := fe.emitUint64BitsOperand(&call.Args[2])
+	if err != nil {
+		return err
+	}
+	valuePtr, valueTy, err := fe.emitValueOperand(&call.Args[3])
+	if err != nil {
+		return err
+	}
+	if valueTy != "ptr" {
+		return fmt.Errorf("rt_byte_parse_uint64_token value out param must be ptr, got %s", valueTy)
+	}
+	nextPtr, nextTy, err := fe.emitValueOperand(&call.Args[4])
+	if err != nil {
+		return err
+	}
+	if nextTy != "ptr" {
+		return fmt.Errorf("rt_byte_parse_uint64_token next out param must be ptr, got %s", nextTy)
+	}
+	tmp := fe.nextTemp()
+	fmt.Fprintf(&fe.emitter.buf, "  %s = call i1 @rt_byte_parse_uint64_token(ptr %s, i64 %s, i64 %s, ptr %s, ptr %s)\n", tmp, dataHead, start64, end64, valuePtr, nextPtr)
+	if !call.HasDst {
+		return nil
+	}
+	ptr, dstTy, err := fe.emitPlacePtr(call.Dst)
+	if err != nil {
+		return err
+	}
+	if dstTy != "i1" {
+		dstTy = "i1"
+	}
+	fmt.Fprintf(&fe.emitter.buf, "  store %s %s, ptr %s\n", dstTy, tmp, ptr)
+	return nil
+}
+
+func (fe *funcEmitter) emitUint64BitsOperand(op *mir.Operand) (string, error) {
+	val, ty, err := fe.emitValueOperand(op)
+	if err != nil {
+		return "", err
+	}
+	if ty == "i64" {
+		return val, nil
+	}
+	return fe.coerceIntToI64(val, ty, operandValueType(fe.emitter.types, op))
 }

--- a/internal/backend/llvm/emit_intrinsics_array_test.go
+++ b/internal/backend/llvm/emit_intrinsics_array_test.go
@@ -19,12 +19,19 @@ func TestEmitByteArrayAppendRangePassesSourceArrayHandle(t *testing.T) {
     return nothing;
 }
 
+fn parse_token(src: &byte[]) -> bool {
+    let mut value: uint64 = 0:uint64;
+    let mut next: uint64 = 0:uint64;
+    return rt_byte_parse_uint64_token(src, 0:uint64, src.__len() to uint64, &mut value, &mut next);
+}
+
 @entrypoint
 fn main() -> int {
     let source: byte[] = "abcd" to byte[];
     let mut out: byte[] = [];
     append_range(&mut out, &source);
     rt_byte_array_drop_prefix(&mut out, 1:uint64);
+    let _ = parse_token(&source);
     return out.__len() to int;
 }
 `
@@ -47,5 +54,16 @@ fn main() -> int {
 	}
 	if !regexp.MustCompile(`call void @rt_byte_array_drop_prefix\(`).MatchString(ir) {
 		t.Fatalf("expected byte drop-prefix intrinsic in IR:\n%s", ir)
+	}
+	if !regexp.MustCompile(`call i1 @rt_byte_parse_uint64_token\(`).MatchString(ir) {
+		t.Fatalf("expected byte uint64 token parse intrinsic in IR:\n%s", ir)
+	}
+	parseRe := regexp.MustCompile(`call i1 @rt_byte_parse_uint64_token\(ptr (%t\d+),`)
+	parseMatches := parseRe.FindStringSubmatch(ir)
+	if len(parseMatches) != 2 {
+		t.Fatalf("expected byte uint64 token parser source to be a loaded temp:\n%s", ir)
+	}
+	if !strings.Contains(ir, parseMatches[1]+" = load ptr, ptr ") {
+		t.Fatalf("rt_byte_parse_uint64_token source was not loaded as an array handle:\n%s", ir)
 	}
 }

--- a/internal/backend/llvm/emit_intrinsics_numeric.go
+++ b/internal/backend/llvm/emit_intrinsics_numeric.go
@@ -541,9 +541,9 @@ func (fe *funcEmitter) emitParseStringValue(strVal string, dstType types.TypeID)
 		}
 		val := fe.nextTemp()
 		fmt.Fprintf(&fe.emitter.buf, "  %s = load i64, ptr %s\n", val, outPtr)
-		srcType := builtins.Int
+		srcType := builtins.Int64
 		if !info.signed {
-			srcType = builtins.Uint
+			srcType = builtins.Uint64
 		}
 		casted, castTy, err := fe.emitNumericCast(val, "i64", srcType, dstType)
 		if err != nil {

--- a/internal/backend/llvm/emit_intrinsics_numeric.go
+++ b/internal/backend/llvm/emit_intrinsics_numeric.go
@@ -541,6 +541,24 @@ func (fe *funcEmitter) emitParseStringValue(strVal string, dstType types.TypeID)
 		}
 		val := fe.nextTemp()
 		fmt.Fprintf(&fe.emitter.buf, "  %s = load i64, ptr %s\n", val, outPtr)
+		if info.bits < 64 {
+			rangeOK := fe.nextTemp()
+			if info.signed {
+				minVal := -int64(1) << (info.bits - 1)
+				maxVal := int64(1)<<(info.bits-1) - 1
+				minOK := fe.nextTemp()
+				fmt.Fprintf(&fe.emitter.buf, "  %s = icmp sge i64 %s, %d\n", minOK, val, minVal)
+				maxOK := fe.nextTemp()
+				fmt.Fprintf(&fe.emitter.buf, "  %s = icmp sle i64 %s, %d\n", maxOK, val, maxVal)
+				fmt.Fprintf(&fe.emitter.buf, "  %s = and i1 %s, %s\n", rangeOK, minOK, maxOK)
+			} else {
+				maxVal := (uint64(1) << info.bits) - 1
+				fmt.Fprintf(&fe.emitter.buf, "  %s = icmp ule i64 %s, %d\n", rangeOK, val, maxVal)
+			}
+			parsedAndInRange := fe.nextTemp()
+			fmt.Fprintf(&fe.emitter.buf, "  %s = and i1 %s, %s\n", parsedAndInRange, okVal, rangeOK)
+			okVal = parsedAndInRange
+		}
 		srcType := builtins.Int64
 		if !info.signed {
 			srcType = builtins.Uint64

--- a/internal/vm/intrinsic.go
+++ b/internal/vm/intrinsic.go
@@ -120,6 +120,8 @@ func (vm *VM) callIntrinsic(frame *Frame, call *mir.CallInstr, writes *[]LocalWr
 		return vm.handleByteArrayAppendRange(frame, call, writes)
 	case "rt_byte_array_drop_prefix":
 		return vm.handleByteArrayDropPrefix(frame, call, writes)
+	case "rt_byte_parse_uint64_token":
+		return vm.handleByteParseUint64Token(frame, call, writes)
 
 	case "rt_map_new":
 		return vm.handleMapNew(frame, call, writes)

--- a/internal/vm/intrinsic_array.go
+++ b/internal/vm/intrinsic_array.go
@@ -454,13 +454,16 @@ func (vm *VM) handleByteParseUint64Token(frame *Frame, call *mir.CallInstr, writ
 
 	ok := false
 	var value uint64
-	next := 0
+	next, nextErr := vm.toUint64ForCast(startVal)
+	if nextErr != nil {
+		next = 0
+	}
 	start, startErr := vm.uintValueToInt(startVal, "byte parse start out of range")
 	end, endErr := vm.uintValueToInt(endVal, "byte parse end out of range")
 	if startErr != nil || endErr != nil {
 		ok = false
 	} else {
-		next = start
+		next = uint64(start) //nolint:gosec // start is non-negative after uintValueToInt.
 		if dataVal.Kind == VKRef || dataVal.Kind == VKRefMut {
 			loaded, loadErr := vm.loadLocationRaw(dataVal.Loc)
 			if loadErr != nil {
@@ -476,7 +479,7 @@ func (vm *VM) handleByteParseUint64Token(frame *Frame, call *mir.CallInstr, writ
 			return viewErr
 		}
 		if start <= end && start <= view.length && end <= view.length {
-			next = end
+			next = uint64(end) //nolint:gosec // end is non-negative after uintValueToInt.
 			i := start
 			for i < end {
 				b, convErr := vm.valueToUint8(view.baseObj.Arr[view.start+i])
@@ -489,9 +492,15 @@ func (vm *VM) handleByteParseUint64Token(frame *Frame, call *mir.CallInstr, writ
 				i++
 			}
 			if i < end {
-				value, next, ok, vmErr = vm.parseUint64DigitsInByteView(view, i, end)
+				var parsedNext int
+				value, parsedNext, ok, vmErr = vm.parseUint64DigitsInByteView(view, i, end)
 				if vmErr != nil {
 					return vmErr
+				}
+				if ok {
+					next = uint64(parsedNext) //nolint:gosec // parsedNext comes from a checked slice index.
+				} else {
+					next = uint64(start) //nolint:gosec // start is non-negative after uintValueToInt.
 				}
 			}
 		}
@@ -506,7 +515,7 @@ func (vm *VM) handleByteParseUint64Token(frame *Frame, call *mir.CallInstr, writ
 	if vmErr := vm.storeLocation(valueRef.Loc, MakeInt(asInt64(value), vm.refElemType(valueRef.TypeID))); vmErr != nil {
 		return vmErr
 	}
-	if vmErr := vm.storeLocation(nextRef.Loc, MakeInt(int64(next), vm.refElemType(nextRef.TypeID))); vmErr != nil {
+	if vmErr := vm.storeLocation(nextRef.Loc, MakeInt(asInt64(next), vm.refElemType(nextRef.TypeID))); vmErr != nil {
 		return vmErr
 	}
 	if call.HasDst {

--- a/internal/vm/intrinsic_array.go
+++ b/internal/vm/intrinsic_array.go
@@ -422,6 +422,151 @@ func (vm *VM) handleByteArrayDropPrefix(frame *Frame, call *mir.CallInstr, write
 	return nil
 }
 
+func (vm *VM) handleByteParseUint64Token(frame *Frame, call *mir.CallInstr, writes *[]LocalWrite) *VMError {
+	if len(call.Args) != 5 {
+		return vm.eb.makeError(PanicTypeMismatch, "rt_byte_parse_uint64_token requires 5 arguments")
+	}
+	dataVal, vmErr := vm.evalOperand(frame, &call.Args[0])
+	if vmErr != nil {
+		return vmErr
+	}
+	defer vm.dropValue(dataVal)
+	startVal, vmErr := vm.evalOperand(frame, &call.Args[1])
+	if vmErr != nil {
+		return vmErr
+	}
+	defer vm.dropValue(startVal)
+	endVal, vmErr := vm.evalOperand(frame, &call.Args[2])
+	if vmErr != nil {
+		return vmErr
+	}
+	defer vm.dropValue(endVal)
+	valueRef, vmErr := vm.evalOperand(frame, &call.Args[3])
+	if vmErr != nil {
+		return vmErr
+	}
+	defer vm.dropValue(valueRef)
+	nextRef, vmErr := vm.evalOperand(frame, &call.Args[4])
+	if vmErr != nil {
+		return vmErr
+	}
+	defer vm.dropValue(nextRef)
+
+	ok := false
+	var value uint64
+	next := 0
+	start, startErr := vm.uintValueToInt(startVal, "byte parse start out of range")
+	end, endErr := vm.uintValueToInt(endVal, "byte parse end out of range")
+	if startErr != nil || endErr != nil {
+		ok = false
+	} else {
+		next = start
+		if dataVal.Kind == VKRef || dataVal.Kind == VKRefMut {
+			loaded, loadErr := vm.loadLocationRaw(dataVal.Loc)
+			if loadErr != nil {
+				return loadErr
+			}
+			dataVal = loaded
+		}
+		if dataVal.Kind != VKHandleArray {
+			return vm.eb.typeMismatch("byte[]", dataVal.Kind.String())
+		}
+		view, viewErr := vm.arrayViewFromHandle(dataVal.H)
+		if viewErr != nil {
+			return viewErr
+		}
+		if start <= end && start <= view.length && end <= view.length {
+			next = end
+			i := start
+			for i < end {
+				b, convErr := vm.valueToUint8(view.baseObj.Arr[view.start+i])
+				if convErr != nil {
+					return convErr
+				}
+				if b != 32 && b != 9 && b != 10 && b != 13 {
+					break
+				}
+				i++
+			}
+			if i < end {
+				value, next, ok, vmErr = vm.parseUint64DigitsInByteView(view, i, end)
+				if vmErr != nil {
+					return vmErr
+				}
+			}
+		}
+	}
+
+	if valueRef.Kind != VKRefMut {
+		return vm.eb.typeMismatch("&mut uint64", valueRef.Kind.String())
+	}
+	if nextRef.Kind != VKRefMut {
+		return vm.eb.typeMismatch("&mut uint64", nextRef.Kind.String())
+	}
+	if vmErr := vm.storeLocation(valueRef.Loc, MakeInt(asInt64(value), vm.refElemType(valueRef.TypeID))); vmErr != nil {
+		return vmErr
+	}
+	if vmErr := vm.storeLocation(nextRef.Loc, MakeInt(int64(next), vm.refElemType(nextRef.TypeID))); vmErr != nil {
+		return vmErr
+	}
+	if call.HasDst {
+		dstLocal := call.Dst.Local
+		res := MakeBool(ok, frame.Locals[dstLocal].TypeID)
+		if vmErr := vm.writeLocal(frame, dstLocal, res); vmErr != nil {
+			return vmErr
+		}
+		if writes != nil {
+			*writes = append(*writes, LocalWrite{
+				LocalID: dstLocal,
+				Name:    frame.Locals[dstLocal].Name,
+				Value:   res,
+			})
+		}
+	}
+	return nil
+}
+
+func (vm *VM) parseUint64DigitsInByteView(view arrayView, start, end int) (value uint64, next int, ok bool, vmErr *VMError) {
+	const maxUint64 = ^uint64(0)
+	sawDigit := false
+	i := start
+	for i < end {
+		b, vmErr := vm.valueToUint8(view.baseObj.Arr[view.start+i])
+		if vmErr != nil {
+			return 0, start, false, vmErr
+		}
+		if b >= '0' && b <= '9' {
+			digit := uint64(b - '0')
+			if value > maxUint64/10 || (value == maxUint64/10 && digit > maxUint64%10) {
+				return 0, start, false, nil
+			}
+			value = value*10 + digit
+			sawDigit = true
+			i++
+			continue
+		}
+		if b == 32 || b == 9 || b == 10 || b == 13 {
+			break
+		}
+		return 0, start, false, nil
+	}
+	if !sawDigit {
+		return 0, start, false, nil
+	}
+	return value, i, true, nil
+}
+
+func (vm *VM) refElemType(typeID types.TypeID) types.TypeID {
+	if vm == nil || vm.Types == nil || typeID == types.NoTypeID {
+		return types.NoTypeID
+	}
+	tt, ok := vm.Types.Lookup(vm.valueType(typeID))
+	if !ok || tt.Kind != types.KindReference {
+		return types.NoTypeID
+	}
+	return tt.Elem
+}
+
 func (vm *VM) makeOptionSome(typeID types.TypeID, elem Value) (Value, *VMError) {
 	if typeID == types.NoTypeID {
 		return Value{}, vm.eb.makeError(PanicTypeMismatch, "invalid Option<T> type")

--- a/internal/vm/llvm_parity_test.go
+++ b/internal/vm/llvm_parity_test.go
@@ -41,6 +41,7 @@ func TestLLVMParity(t *testing.T) {
 		{name: "exit_code", file: "exit_code.sg"},
 		{name: "panic", file: "panic.sg"},
 		{name: "string_concat", file: "string_concat.sg"},
+		{name: "from_str_fixed_width", file: "from_str_fixed_width.sg"},
 		{name: "array_range_indexing", file: "array_range_indexing.sg"},
 		{name: "byte_array_append_string", file: "byte_array_append_string.sg"},
 		{name: "stdlib_bytes", file: "stdlib_bytes.sg"},

--- a/runtime/native/rt.h
+++ b/runtime/native/rt.h
@@ -25,6 +25,8 @@ void rt_byte_array_append_range(void* dst_slot,
                                 uint64_t start,
                                 uint64_t len);
 void rt_byte_array_drop_prefix(void* array_slot, uint64_t count);
+bool rt_byte_parse_uint64_token(
+    const void* array, uint64_t start, uint64_t end, uint64_t* value_out, uint64_t* next_out);
 size_t rt_tag_payload_offset(size_t payload_align);
 void* rt_tag_alloc(uint32_t tag, size_t payload_align, size_t payload_size);
 

--- a/runtime/native/rt_array.c
+++ b/runtime/native/rt_array.c
@@ -389,3 +389,67 @@ void rt_byte_array_drop_prefix(void* array_slot, uint64_t count) {
     rt_memmove((uint8_t*)header->data, (uint8_t*)header->data + count, new_len);
     header->len = new_len;
 }
+
+bool rt_byte_parse_uint64_token(
+    const void* array, uint64_t start, uint64_t end, uint64_t* value_out, uint64_t* next_out) {
+    if (value_out != NULL) {
+        *value_out = 0;
+    }
+    if (next_out != NULL) {
+        *next_out = start;
+    }
+    if (array == NULL || value_out == NULL || next_out == NULL) {
+        return false;
+    }
+
+    const SurgeArrayHeader* header = (const SurgeArrayHeader*)array;
+    if (start > end || end > header->len) {
+        return false;
+    }
+    if (start == end) {
+        return false;
+    }
+    if (header->data == NULL) {
+        return false;
+    }
+
+    const uint8_t* data = (const uint8_t*)header->data;
+    uint64_t i = start;
+    while (i < end) {
+        uint8_t b = data[i];
+        if (b != 32 && b != 9 && b != 10 && b != 13) {
+            break;
+        }
+        i++;
+    }
+    if (i == end) {
+        *next_out = i;
+        return false;
+    }
+
+    uint64_t value = 0;
+    bool saw_digit = false;
+    while (i < end) {
+        uint8_t b = data[i];
+        if (b >= '0' && b <= '9') {
+            uint64_t digit = (uint64_t)(b - '0');
+            if (value > UINT64_MAX / 10 || (value == UINT64_MAX / 10 && digit > UINT64_MAX % 10)) {
+                return false;
+            }
+            value = value * 10 + digit;
+            saw_digit = true;
+            i++;
+            continue;
+        }
+        if (b == 32 || b == 9 || b == 10 || b == 13) {
+            break;
+        }
+        return false;
+    }
+    if (!saw_digit) {
+        return false;
+    }
+    *value_out = value;
+    *next_out = i;
+    return true;
+}

--- a/scripts/bench_native_byte_lines.sh
+++ b/scripts/bench_native_byte_lines.sh
@@ -45,8 +45,10 @@ for i in $(seq 1 "$repeats"); do
 	echo "$out"
 	string_us="$(sed -n 's/^string_line_us=\([0-9][0-9]*\).*/\1/p' <<<"$out")"
 	byte_us="$(sed -n 's/^byte_line_us=\([0-9][0-9]*\).*/\1/p' <<<"$out")"
-	[[ -n "$string_us" && -n "$byte_us" ]] || fail "cannot parse benchmark output"
-	printf '%s %s %s\n' "$i" "$string_us" "$byte_us" >>"$rows"
+	token_string_us="$(sed -n 's/^token_string_us=\([0-9][0-9]*\).*/\1/p' <<<"$out")"
+	token_byte_us="$(sed -n 's/^token_byte_us=\([0-9][0-9]*\).*/\1/p' <<<"$out")"
+	[[ -n "$string_us" && -n "$byte_us" && -n "$token_string_us" && -n "$token_byte_us" ]] || fail "cannot parse benchmark output"
+	printf '%s %s %s %s %s\n' "$i" "$string_us" "$byte_us" "$token_string_us" "$token_byte_us" >>"$rows"
 done
 
 mkdir -p "$(dirname "$report")"
@@ -59,14 +61,19 @@ rows_path, report_path, surge_version, repeats = sys.argv[1:5]
 rows = []
 with open(rows_path, "r", encoding="utf-8") as f:
     for line in f:
-        run, string_us, byte_us = line.split()
-        rows.append((int(run), int(string_us), int(byte_us)))
+        run, string_us, byte_us, token_string_us, token_byte_us = line.split()
+        rows.append((int(run), int(string_us), int(byte_us), int(token_string_us), int(token_byte_us)))
 
 string_vals = [r[1] for r in rows]
 byte_vals = [r[2] for r in rows]
+token_string_vals = [r[3] for r in rows]
+token_byte_vals = [r[4] for r in rows]
 median_string = statistics.median(string_vals)
 median_byte = statistics.median(byte_vals)
+median_token_string = statistics.median(token_string_vals)
+median_token_byte = statistics.median(token_byte_vals)
 speedup = median_string / median_byte if median_byte else 0.0
+token_speedup = median_token_string / median_token_byte if median_token_byte else 0.0
 
 with open(report_path, "w", encoding="utf-8") as f:
     generated = dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -79,11 +86,18 @@ with open(report_path, "w", encoding="utf-8") as f:
     f.write("## Results\n\n")
     f.write("| run | string line us | byte line us | speedup |\n")
     f.write("| ---: | ---: | ---: | ---: |\n")
-    for run, string_us, byte_us in rows:
+    for run, string_us, byte_us, _, _ in rows:
         run_speedup = string_us / byte_us if byte_us else 0.0
         f.write(f"| {run} | {string_us} | {byte_us} | {run_speedup:.2f}x |\n")
     f.write("\n")
-    f.write(f"Median speedup: {speedup:.2f}x\n")
+    f.write(f"Median line speedup: {speedup:.2f}x\n\n")
+    f.write("| run | string token us | byte token us | speedup |\n")
+    f.write("| ---: | ---: | ---: | ---: |\n")
+    for run, _, _, token_string_us, token_byte_us in rows:
+        run_speedup = token_string_us / token_byte_us if token_byte_us else 0.0
+        f.write(f"| {run} | {token_string_us} | {token_byte_us} | {run_speedup:.2f}x |\n")
+    f.write("\n")
+    f.write(f"Median token speedup: {token_speedup:.2f}x\n")
 
-print(f"median_string_line_us={median_string:.0f} median_byte_line_us={median_byte:.0f} speedup={speedup:.2f}x report={report_path}")
+print(f"median_string_line_us={median_string:.0f} median_byte_line_us={median_byte:.0f} line_speedup={speedup:.2f}x median_string_token_us={median_token_string:.0f} median_byte_token_us={median_token_byte:.0f} token_speedup={token_speedup:.2f}x report={report_path}")
 PY

--- a/scripts/bench_native_byte_lines.sh
+++ b/scripts/bench_native_byte_lines.sh
@@ -12,6 +12,8 @@ fail() {
 	exit 1
 }
 
+[[ "$repeats" =~ ^[1-9][0-9]*$ ]] || fail "SURGE_BYTES_LINE_BENCH_REPEATS must be a positive integer"
+
 if [[ ! -x "$surge" ]]; then
 	surge="$(command -v surge || true)"
 fi

--- a/scripts/bench_native_byte_lines.sh
+++ b/scripts/bench_native_byte_lines.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fixture="$root/benchmarks/native/byte_lines"
+report="${SURGE_BYTES_LINE_BENCH_REPORT:-$root/build/benchmarks/native-byte-lines.md}"
+repeats="${SURGE_BYTES_LINE_BENCH_REPEATS:-5}"
+surge="${SURGE:-$root/surge}"
+
+fail() {
+	echo "bench_native_byte_lines: $*" >&2
+	exit 1
+}
+
+if [[ ! -x "$surge" ]]; then
+	surge="$(command -v surge || true)"
+fi
+[[ -n "$surge" && -x "$surge" ]] || fail "surge binary not found; run 'make build' or set SURGE=/path/to/surge"
+command -v python3 >/dev/null || fail "python3 not found"
+
+export SURGE_STDLIB="${SURGE_BYTES_LINE_BENCH_STDLIB:-$root}"
+
+build_log="$(mktemp)"
+rows="$(mktemp)"
+trap 'rm -f "$build_log" "$rows"' EXIT
+
+if ! "$surge" build --release "$fixture" >"$build_log" 2>&1; then
+	cat "$build_log" >&2
+	fail "failed to build $fixture"
+fi
+
+built_path="$(awk '/^built / { print $2 }' "$build_log" | tail -n 1)"
+[[ -n "$built_path" ]] || fail "cannot find built binary in surge output"
+if [[ "$built_path" != /* ]]; then
+	if [[ -x "$root/$built_path" ]]; then
+		built_path="$root/$built_path"
+	else
+		built_path="$fixture/$built_path"
+	fi
+fi
+[[ -x "$built_path" ]] || fail "built binary not executable: $built_path"
+
+for i in $(seq 1 "$repeats"); do
+	out="$("$built_path")"
+	echo "$out"
+	string_us="$(sed -n 's/^string_line_us=\([0-9][0-9]*\).*/\1/p' <<<"$out")"
+	byte_us="$(sed -n 's/^byte_line_us=\([0-9][0-9]*\).*/\1/p' <<<"$out")"
+	[[ -n "$string_us" && -n "$byte_us" ]] || fail "cannot parse benchmark output"
+	printf '%s %s %s\n' "$i" "$string_us" "$byte_us" >>"$rows"
+done
+
+mkdir -p "$(dirname "$report")"
+python3 - "$rows" "$report" "$("$surge" version --full | tr '\n' ' ' | sed 's/[[:space:]]*$//')" "$repeats" <<'PY'
+import datetime as dt
+import statistics
+import sys
+
+rows_path, report_path, surge_version, repeats = sys.argv[1:5]
+rows = []
+with open(rows_path, "r", encoding="utf-8") as f:
+    for line in f:
+        run, string_us, byte_us = line.split()
+        rows.append((int(run), int(string_us), int(byte_us)))
+
+string_vals = [r[1] for r in rows]
+byte_vals = [r[2] for r in rows]
+median_string = statistics.median(string_vals)
+median_byte = statistics.median(byte_vals)
+speedup = median_string / median_byte if median_byte else 0.0
+
+with open(report_path, "w", encoding="utf-8") as f:
+    generated = dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    f.write("# Native byte line benchmark\n\n")
+    f.write(f"Generated: {generated}\n\n")
+    f.write("## Environment\n\n")
+    f.write(f"- surge: {surge_version}\n")
+    f.write("- fixture: benchmarks/native/byte_lines\n")
+    f.write(f"- repeats: {repeats}\n\n")
+    f.write("## Results\n\n")
+    f.write("| run | string line us | byte line us | speedup |\n")
+    f.write("| ---: | ---: | ---: | ---: |\n")
+    for run, string_us, byte_us in rows:
+        run_speedup = string_us / byte_us if byte_us else 0.0
+        f.write(f"| {run} | {string_us} | {byte_us} | {run_speedup:.2f}x |\n")
+    f.write("\n")
+    f.write(f"Median speedup: {speedup:.2f}x\n")
+
+print(f"median_string_line_us={median_string:.0f} median_byte_line_us={median_byte:.0f} speedup={speedup:.2f}x report={report_path}")
+PY

--- a/scripts/bench_native_byte_lines.sh
+++ b/scripts/bench_native_byte_lines.sh
@@ -47,8 +47,10 @@ for i in $(seq 1 "$repeats"); do
 	byte_us="$(sed -n 's/^byte_line_us=\([0-9][0-9]*\).*/\1/p' <<<"$out")"
 	token_string_us="$(sed -n 's/^token_string_us=\([0-9][0-9]*\).*/\1/p' <<<"$out")"
 	token_byte_us="$(sed -n 's/^token_byte_us=\([0-9][0-9]*\).*/\1/p' <<<"$out")"
-	[[ -n "$string_us" && -n "$byte_us" && -n "$token_string_us" && -n "$token_byte_us" ]] || fail "cannot parse benchmark output"
-	printf '%s %s %s %s %s\n' "$i" "$string_us" "$byte_us" "$token_string_us" "$token_byte_us" >>"$rows"
+	dispatch_string_us="$(sed -n 's/^dispatch_string_us=\([0-9][0-9]*\).*/\1/p' <<<"$out")"
+	dispatch_byte_us="$(sed -n 's/^dispatch_byte_us=\([0-9][0-9]*\).*/\1/p' <<<"$out")"
+	[[ -n "$string_us" && -n "$byte_us" && -n "$token_string_us" && -n "$token_byte_us" && -n "$dispatch_string_us" && -n "$dispatch_byte_us" ]] || fail "cannot parse benchmark output"
+	printf '%s %s %s %s %s %s %s\n' "$i" "$string_us" "$byte_us" "$token_string_us" "$token_byte_us" "$dispatch_string_us" "$dispatch_byte_us" >>"$rows"
 done
 
 mkdir -p "$(dirname "$report")"
@@ -61,19 +63,24 @@ rows_path, report_path, surge_version, repeats = sys.argv[1:5]
 rows = []
 with open(rows_path, "r", encoding="utf-8") as f:
     for line in f:
-        run, string_us, byte_us, token_string_us, token_byte_us = line.split()
-        rows.append((int(run), int(string_us), int(byte_us), int(token_string_us), int(token_byte_us)))
+        run, string_us, byte_us, token_string_us, token_byte_us, dispatch_string_us, dispatch_byte_us = line.split()
+        rows.append((int(run), int(string_us), int(byte_us), int(token_string_us), int(token_byte_us), int(dispatch_string_us), int(dispatch_byte_us)))
 
 string_vals = [r[1] for r in rows]
 byte_vals = [r[2] for r in rows]
 token_string_vals = [r[3] for r in rows]
 token_byte_vals = [r[4] for r in rows]
+dispatch_string_vals = [r[5] for r in rows]
+dispatch_byte_vals = [r[6] for r in rows]
 median_string = statistics.median(string_vals)
 median_byte = statistics.median(byte_vals)
 median_token_string = statistics.median(token_string_vals)
 median_token_byte = statistics.median(token_byte_vals)
+median_dispatch_string = statistics.median(dispatch_string_vals)
+median_dispatch_byte = statistics.median(dispatch_byte_vals)
 speedup = median_string / median_byte if median_byte else 0.0
 token_speedup = median_token_string / median_token_byte if median_token_byte else 0.0
+dispatch_speedup = median_dispatch_string / median_dispatch_byte if median_dispatch_byte else 0.0
 
 with open(report_path, "w", encoding="utf-8") as f:
     generated = dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -86,18 +93,25 @@ with open(report_path, "w", encoding="utf-8") as f:
     f.write("## Results\n\n")
     f.write("| run | string line us | byte line us | speedup |\n")
     f.write("| ---: | ---: | ---: | ---: |\n")
-    for run, string_us, byte_us, _, _ in rows:
+    for run, string_us, byte_us, _, _, _, _ in rows:
         run_speedup = string_us / byte_us if byte_us else 0.0
         f.write(f"| {run} | {string_us} | {byte_us} | {run_speedup:.2f}x |\n")
     f.write("\n")
     f.write(f"Median line speedup: {speedup:.2f}x\n\n")
     f.write("| run | string token us | byte token us | speedup |\n")
     f.write("| ---: | ---: | ---: | ---: |\n")
-    for run, _, _, token_string_us, token_byte_us in rows:
+    for run, _, _, token_string_us, token_byte_us, _, _ in rows:
         run_speedup = token_string_us / token_byte_us if token_byte_us else 0.0
         f.write(f"| {run} | {token_string_us} | {token_byte_us} | {run_speedup:.2f}x |\n")
     f.write("\n")
-    f.write(f"Median token speedup: {token_speedup:.2f}x\n")
+    f.write(f"Median token speedup: {token_speedup:.2f}x\n\n")
+    f.write("| run | string dispatch us | byte dispatch us | speedup |\n")
+    f.write("| ---: | ---: | ---: | ---: |\n")
+    for run, _, _, _, _, dispatch_string_us, dispatch_byte_us in rows:
+        run_speedup = dispatch_string_us / dispatch_byte_us if dispatch_byte_us else 0.0
+        f.write(f"| {run} | {dispatch_string_us} | {dispatch_byte_us} | {run_speedup:.2f}x |\n")
+    f.write("\n")
+    f.write(f"Median dispatch speedup: {dispatch_speedup:.2f}x\n")
 
-print(f"median_string_line_us={median_string:.0f} median_byte_line_us={median_byte:.0f} line_speedup={speedup:.2f}x median_string_token_us={median_token_string:.0f} median_byte_token_us={median_token_byte:.0f} token_speedup={token_speedup:.2f}x report={report_path}")
+print(f"median_string_line_us={median_string:.0f} median_byte_line_us={median_byte:.0f} line_speedup={speedup:.2f}x median_string_token_us={median_token_string:.0f} median_byte_token_us={median_token_byte:.0f} token_speedup={token_speedup:.2f}x median_string_dispatch_us={median_dispatch_string:.0f} median_byte_dispatch_us={median_dispatch_byte:.0f} dispatch_speedup={dispatch_speedup:.2f}x report={report_path}")
 PY

--- a/scripts/bench_native_byte_lines.sh
+++ b/scripts/bench_native_byte_lines.sh
@@ -49,8 +49,10 @@ for i in $(seq 1 "$repeats"); do
 	token_byte_us="$(sed -n 's/^token_byte_us=\([0-9][0-9]*\).*/\1/p' <<<"$out")"
 	dispatch_string_us="$(sed -n 's/^dispatch_string_us=\([0-9][0-9]*\).*/\1/p' <<<"$out")"
 	dispatch_byte_us="$(sed -n 's/^dispatch_byte_us=\([0-9][0-9]*\).*/\1/p' <<<"$out")"
-	[[ -n "$string_us" && -n "$byte_us" && -n "$token_string_us" && -n "$token_byte_us" && -n "$dispatch_string_us" && -n "$dispatch_byte_us" ]] || fail "cannot parse benchmark output"
-	printf '%s %s %s %s %s %s %s\n' "$i" "$string_us" "$byte_us" "$token_string_us" "$token_byte_us" "$dispatch_string_us" "$dispatch_byte_us" >>"$rows"
+	number_string_us="$(sed -n 's/^number_string_us=\([0-9][0-9]*\).*/\1/p' <<<"$out")"
+	number_byte_us="$(sed -n 's/^number_byte_us=\([0-9][0-9]*\).*/\1/p' <<<"$out")"
+	[[ -n "$string_us" && -n "$byte_us" && -n "$token_string_us" && -n "$token_byte_us" && -n "$dispatch_string_us" && -n "$dispatch_byte_us" && -n "$number_string_us" && -n "$number_byte_us" ]] || fail "cannot parse benchmark output"
+	printf '%s %s %s %s %s %s %s %s %s\n' "$i" "$string_us" "$byte_us" "$token_string_us" "$token_byte_us" "$dispatch_string_us" "$dispatch_byte_us" "$number_string_us" "$number_byte_us" >>"$rows"
 done
 
 mkdir -p "$(dirname "$report")"
@@ -63,8 +65,8 @@ rows_path, report_path, surge_version, repeats = sys.argv[1:5]
 rows = []
 with open(rows_path, "r", encoding="utf-8") as f:
     for line in f:
-        run, string_us, byte_us, token_string_us, token_byte_us, dispatch_string_us, dispatch_byte_us = line.split()
-        rows.append((int(run), int(string_us), int(byte_us), int(token_string_us), int(token_byte_us), int(dispatch_string_us), int(dispatch_byte_us)))
+        run, string_us, byte_us, token_string_us, token_byte_us, dispatch_string_us, dispatch_byte_us, number_string_us, number_byte_us = line.split()
+        rows.append((int(run), int(string_us), int(byte_us), int(token_string_us), int(token_byte_us), int(dispatch_string_us), int(dispatch_byte_us), int(number_string_us), int(number_byte_us)))
 
 string_vals = [r[1] for r in rows]
 byte_vals = [r[2] for r in rows]
@@ -72,15 +74,20 @@ token_string_vals = [r[3] for r in rows]
 token_byte_vals = [r[4] for r in rows]
 dispatch_string_vals = [r[5] for r in rows]
 dispatch_byte_vals = [r[6] for r in rows]
+number_string_vals = [r[7] for r in rows]
+number_byte_vals = [r[8] for r in rows]
 median_string = statistics.median(string_vals)
 median_byte = statistics.median(byte_vals)
 median_token_string = statistics.median(token_string_vals)
 median_token_byte = statistics.median(token_byte_vals)
 median_dispatch_string = statistics.median(dispatch_string_vals)
 median_dispatch_byte = statistics.median(dispatch_byte_vals)
+median_number_string = statistics.median(number_string_vals)
+median_number_byte = statistics.median(number_byte_vals)
 speedup = median_string / median_byte if median_byte else 0.0
 token_speedup = median_token_string / median_token_byte if median_token_byte else 0.0
 dispatch_speedup = median_dispatch_string / median_dispatch_byte if median_dispatch_byte else 0.0
+number_speedup = median_number_string / median_number_byte if median_number_byte else 0.0
 
 with open(report_path, "w", encoding="utf-8") as f:
     generated = dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -93,25 +100,33 @@ with open(report_path, "w", encoding="utf-8") as f:
     f.write("## Results\n\n")
     f.write("| run | string line us | byte line us | speedup |\n")
     f.write("| ---: | ---: | ---: | ---: |\n")
-    for run, string_us, byte_us, _, _, _, _ in rows:
+    for run, string_us, byte_us, _, _, _, _, _, _ in rows:
         run_speedup = string_us / byte_us if byte_us else 0.0
         f.write(f"| {run} | {string_us} | {byte_us} | {run_speedup:.2f}x |\n")
     f.write("\n")
     f.write(f"Median line speedup: {speedup:.2f}x\n\n")
     f.write("| run | string token us | byte token us | speedup |\n")
     f.write("| ---: | ---: | ---: | ---: |\n")
-    for run, _, _, token_string_us, token_byte_us, _, _ in rows:
+    for run, _, _, token_string_us, token_byte_us, _, _, _, _ in rows:
         run_speedup = token_string_us / token_byte_us if token_byte_us else 0.0
         f.write(f"| {run} | {token_string_us} | {token_byte_us} | {run_speedup:.2f}x |\n")
     f.write("\n")
     f.write(f"Median token speedup: {token_speedup:.2f}x\n\n")
     f.write("| run | string dispatch us | byte dispatch us | speedup |\n")
     f.write("| ---: | ---: | ---: | ---: |\n")
-    for run, _, _, _, _, dispatch_string_us, dispatch_byte_us in rows:
+    for run, _, _, _, _, dispatch_string_us, dispatch_byte_us, _, _ in rows:
         run_speedup = dispatch_string_us / dispatch_byte_us if dispatch_byte_us else 0.0
         f.write(f"| {run} | {dispatch_string_us} | {dispatch_byte_us} | {run_speedup:.2f}x |\n")
     f.write("\n")
     f.write(f"Median dispatch speedup: {dispatch_speedup:.2f}x\n")
+    f.write("\n")
+    f.write("| run | string number us | byte fused number us | speedup |\n")
+    f.write("| ---: | ---: | ---: | ---: |\n")
+    for run, _, _, _, _, _, _, number_string_us, number_byte_us in rows:
+        run_speedup = number_string_us / number_byte_us if number_byte_us else 0.0
+        f.write(f"| {run} | {number_string_us} | {number_byte_us} | {run_speedup:.2f}x |\n")
+    f.write("\n")
+    f.write(f"Median numeric speedup: {number_speedup:.2f}x\n")
 
-print(f"median_string_line_us={median_string:.0f} median_byte_line_us={median_byte:.0f} line_speedup={speedup:.2f}x median_string_token_us={median_token_string:.0f} median_byte_token_us={median_token_byte:.0f} token_speedup={token_speedup:.2f}x median_string_dispatch_us={median_dispatch_string:.0f} median_byte_dispatch_us={median_dispatch_byte:.0f} dispatch_speedup={dispatch_speedup:.2f}x report={report_path}")
+print(f"median_string_line_us={median_string:.0f} median_byte_line_us={median_byte:.0f} line_speedup={speedup:.2f}x median_string_token_us={median_token_string:.0f} median_byte_token_us={median_token_byte:.0f} token_speedup={token_speedup:.2f}x median_string_dispatch_us={median_dispatch_string:.0f} median_byte_dispatch_us={median_dispatch_byte:.0f} dispatch_speedup={dispatch_speedup:.2f}x median_string_number_us={median_number_string:.0f} median_byte_number_us={median_number_byte:.0f} number_speedup={number_speedup:.2f}x report={report_path}")
 PY

--- a/stats.md
+++ b/stats.md
@@ -13,22 +13,24 @@ Standalone native benchmark:
 - script: `scripts/bench_native_byte_lines.sh`
 - payload: 256 lines, width 32, 200 rounds
 - comparison: `string.from_bytes + string_find_from` vs `ByteBuffer.peek_line_lf`
+- token/dispatch byte paths use borrowed `&byte[]` input directly; they do not
+  clone the source buffer before scanning.
 
 | run | string line us | byte line us | speedup |
 | ---: | ---: | ---: | ---: |
-| 1 | 29621981 | 3894710 | 7.61x |
-| 2 | 29734725 | 3901463 | 7.62x |
-| 3 | 29780974 | 3865089 | 7.71x |
+| 1 | 29722587 | 3909676 | 7.60x |
+| 2 | 29769492 | 3883913 | 7.66x |
+| 3 | 29756330 | 3899171 | 7.63x |
 
 Median line speedup: `7.63x`.
 
 | run | string token us | byte token us | speedup |
 | ---: | ---: | ---: | ---: |
-| 1 | 1934959 | 938871 | 2.06x |
-| 2 | 1941273 | 931750 | 2.08x |
-| 3 | 1910853 | 931912 | 2.05x |
+| 1 | 1928207 | 816197 | 2.36x |
+| 2 | 1922004 | 814096 | 2.36x |
+| 3 | 1910900 | 807574 | 2.37x |
 
-Median token speedup: `2.08x`.
+Median token speedup: `2.36x`.
 
 - dispatch payload: 128 repetitions of `PING GET UNKNOWN PING GET MISSING`,
   100 rounds
@@ -37,11 +39,11 @@ Median token speedup: `2.08x`.
 
 | run | string dispatch us | byte dispatch us | speedup |
 | ---: | ---: | ---: | ---: |
-| 1 | 9093948 | 4927065 | 1.85x |
-| 2 | 9203605 | 4983947 | 1.85x |
-| 3 | 9146101 | 4951927 | 1.85x |
+| 1 | 8214641 | 3380800 | 2.43x |
+| 2 | 8229399 | 3404902 | 2.42x |
+| 3 | 8205971 | 3390101 | 2.42x |
 
-Median dispatch speedup: `1.85x`.
+Median dispatch speedup: `2.42x`.
 
 Conclusion: pure Surge byte scanning is enough for line, token, and small
 literal dispatch helpers. Do not add `rt_byte_find` until numeric parsing,

--- a/stats.md
+++ b/stats.md
@@ -4,7 +4,8 @@
 
 Change: `stdlib/bytes` now exposes `find_byte`, `find_lf`, `find_crlf`,
 `ByteBuffer.peek_line_lf/peek_line_crlf`, ASCII trimming, `split_once_byte`,
-and `next_ascii_token` for protocol input buffers.
+`next_ascii_token`, and byte-range literal compare helpers for protocol input
+buffers.
 
 Standalone native benchmark:
 
@@ -15,23 +16,36 @@ Standalone native benchmark:
 
 | run | string line us | byte line us | speedup |
 | ---: | ---: | ---: | ---: |
-| 1 | 29832954 | 3789231 | 7.87x |
-| 2 | 29810199 | 3801625 | 7.84x |
-| 3 | 29863476 | 3802133 | 7.85x |
+| 1 | 29621981 | 3894710 | 7.61x |
+| 2 | 29734725 | 3901463 | 7.62x |
+| 3 | 29780974 | 3865089 | 7.71x |
 
-Median line speedup: `7.85x`.
+Median line speedup: `7.63x`.
 
 | run | string token us | byte token us | speedup |
 | ---: | ---: | ---: | ---: |
-| 1 | 1914966 | 923478 | 2.07x |
-| 2 | 1912159 | 924952 | 2.07x |
-| 3 | 1927346 | 925550 | 2.08x |
+| 1 | 1934959 | 938871 | 2.06x |
+| 2 | 1941273 | 931750 | 2.08x |
+| 3 | 1910853 | 931912 | 2.05x |
 
-Median token speedup: `2.07x`.
+Median token speedup: `2.08x`.
 
-Conclusion: pure Surge byte scanning is enough for line and token helpers. Do
-not add `rt_byte_find` until literal dispatch or parser benchmarks show a
-specific gap.
+- dispatch payload: 128 repetitions of `PING GET UNKNOWN PING GET MISSING`,
+  100 rounds
+- dispatch comparison: `string.from_bytes + split + string ==` vs
+  `next_ascii_token + range_eq_ascii`
+
+| run | string dispatch us | byte dispatch us | speedup |
+| ---: | ---: | ---: | ---: |
+| 1 | 9093948 | 4927065 | 1.85x |
+| 2 | 9203605 | 4983947 | 1.85x |
+| 3 | 9146101 | 4951927 | 1.85x |
+
+Median dispatch speedup: `1.85x`.
+
+Conclusion: pure Surge byte scanning is enough for line, token, and small
+literal dispatch helpers. Do not add `rt_byte_find` until numeric parsing,
+response building, or larger parser benchmarks show a specific gap.
 
 ## 2026-06-23 - Direct network readiness wait
 

--- a/stats.md
+++ b/stats.md
@@ -2,8 +2,9 @@
 
 ## 2026-06-24 - `stdlib/bytes` LF line scanning
 
-Change: `stdlib/bytes` now exposes `find_byte`, `find_lf`, `find_crlf`, and
-`ByteBuffer.peek_line_lf/peek_line_crlf` for protocol input buffers.
+Change: `stdlib/bytes` now exposes `find_byte`, `find_lf`, `find_crlf`,
+`ByteBuffer.peek_line_lf/peek_line_crlf`, ASCII trimming, `split_once_byte`,
+and `next_ascii_token` for protocol input buffers.
 
 Standalone native benchmark:
 
@@ -14,14 +15,23 @@ Standalone native benchmark:
 
 | run | string line us | byte line us | speedup |
 | ---: | ---: | ---: | ---: |
-| 1 | 29891498 | 3900029 | 7.66x |
-| 2 | 29921010 | 3902029 | 7.67x |
-| 3 | 29922786 | 3894605 | 7.68x |
+| 1 | 29832954 | 3789231 | 7.87x |
+| 2 | 29810199 | 3801625 | 7.84x |
+| 3 | 29863476 | 3802133 | 7.85x |
 
-Median speedup: `7.67x`.
+Median line speedup: `7.85x`.
 
-Conclusion: pure Surge byte scanning is already enough for this slice. Do not
-add `rt_byte_find` until token/dispatch benchmarks show a specific gap.
+| run | string token us | byte token us | speedup |
+| ---: | ---: | ---: | ---: |
+| 1 | 1914966 | 923478 | 2.07x |
+| 2 | 1912159 | 924952 | 2.07x |
+| 3 | 1927346 | 925550 | 2.08x |
+
+Median token speedup: `2.07x`.
+
+Conclusion: pure Surge byte scanning is enough for line and token helpers. Do
+not add `rt_byte_find` until literal dispatch or parser benchmarks show a
+specific gap.
 
 ## 2026-06-23 - Direct network readiness wait
 

--- a/stats.md
+++ b/stats.md
@@ -1,5 +1,28 @@
 # Runtime Performance Notes
 
+## 2026-06-24 - `stdlib/bytes` LF line scanning
+
+Change: `stdlib/bytes` now exposes `find_byte`, `find_lf`, `find_crlf`, and
+`ByteBuffer.peek_line_lf/peek_line_crlf` for protocol input buffers.
+
+Standalone native benchmark:
+
+- fixture: `benchmarks/native/byte_lines`
+- script: `scripts/bench_native_byte_lines.sh`
+- payload: 256 lines, width 32, 200 rounds
+- comparison: `string.from_bytes + string_find_from` vs `ByteBuffer.peek_line_lf`
+
+| run | string line us | byte line us | speedup |
+| ---: | ---: | ---: | ---: |
+| 1 | 29891498 | 3900029 | 7.66x |
+| 2 | 29921010 | 3902029 | 7.67x |
+| 3 | 29922786 | 3894605 | 7.68x |
+
+Median speedup: `7.67x`.
+
+Conclusion: pure Surge byte scanning is already enough for this slice. Do not
+add `rt_byte_find` until token/dispatch benchmarks show a specific gap.
+
 ## 2026-06-23 - Direct network readiness wait
 
 Change: `stdlib/net` no longer awaits a spawned `Task<nothing>` for socket

--- a/stats.md
+++ b/stats.md
@@ -45,9 +45,28 @@ Median token speedup: `2.36x`.
 
 Median dispatch speedup: `2.42x`.
 
+Numeric parsing follow-up:
+
+- change: add `bytes.next_uint64_ascii_token`, backed by
+  `rt_byte_parse_uint64_token`
+- comparison: `string.from_bytes + split + uint64.from_str` vs fused byte
+  token parse
+- script: `SURGE_BYTES_LINE_BENCH_REPEATS=5 ./scripts/bench_native_byte_lines.sh`
+
+| run | string number us | byte number us | speedup |
+| ---: | ---: | ---: | ---: |
+| 1 | 6739289 | 30231 | 222.93x |
+| 2 | 6705169 | 29801 | 225.00x |
+| 3 | 6717633 | 29553 | 227.31x |
+| 4 | 6725390 | 29863 | 225.21x |
+| 5 | 6698135 | 29412 | 227.73x |
+
+Median numeric speedup: `225.42x`.
+
 Conclusion: pure Surge byte scanning is enough for line, token, and small
-literal dispatch helpers. Do not add `rt_byte_find` until numeric parsing,
-response building, or larger parser benchmarks show a specific gap.
+literal dispatch helpers. Numeric protocol parsing is the first measured case
+that needs a narrow runtime fused helper, because the string path materializes a
+string, splits it, and then parses through `uint64.from_str`.
 
 ## 2026-06-23 - Direct network readiness wait
 

--- a/stdlib/bytes/bytes.sg
+++ b/stdlib/bytes/bytes.sg
@@ -9,10 +9,19 @@ pub type ByteRange = {
     end: uint,
 };
 
+@copy
+pub type ByteLine = {
+    body: ByteRange,
+    next: uint,
+};
+
 pub type ByteBuffer = {
     data: byte[],
     start: uint,
 };
+
+const BYTE_CR: byte = 13:byte;
+const BYTE_LF: byte = 10:byte;
 
 fn invalid_range_bytes() -> Erring<byte[], Error> {
     return Error { message = "bytes: invalid range", code = BYTES_ERR_INVALID_RANGE };
@@ -39,6 +48,40 @@ pub fn range_len(r: ByteRange) -> uint {
 
 pub fn is_valid_range(data: &byte[], r: ByteRange) -> bool {
     return r.start <= r.end && r.end <= data.__len();
+}
+
+pub fn find_byte(data: &byte[], r: ByteRange, needle: byte) -> Option<uint> {
+    if !is_valid_range(data, r) {
+        return nothing;
+    }
+    let mut i: int = r.start to int;
+    let end: int = r.end to int;
+    while i < end {
+        if data[i] == needle {
+            return Some(i to uint);
+        }
+        i = i + 1;
+    }
+    return nothing;
+}
+
+pub fn find_lf(data: &byte[], r: ByteRange) -> Option<uint> {
+    return find_byte(data, r, BYTE_LF);
+}
+
+pub fn find_crlf(data: &byte[], r: ByteRange) -> Option<uint> {
+    if !is_valid_range(data, r) || range_len(r) < 2:uint {
+        return nothing;
+    }
+    let mut i: int = r.start to int;
+    let last: int = (r.end - 1:uint) to int;
+    while i < last {
+        if data[i] == BYTE_CR && data[i + 1] == BYTE_LF {
+            return Some(i to uint);
+        }
+        i = i + 1;
+    }
+    return nothing;
 }
 
 pub fn copy_range(data: &byte[], r: ByteRange) -> Erring<byte[], Error> {
@@ -93,6 +136,34 @@ extern<ByteBuffer> {
 
     pub fn append_range(self: &mut ByteBuffer, data: &byte[], r: ByteRange) -> Erring<nothing, Error> {
         return self.data.append_bytes_range(data, r);
+    }
+
+    pub fn peek_line_lf(self: &ByteBuffer) -> Option<ByteLine> {
+        let found: Option<uint> = find_lf(self.data, self.range());
+        return compare found {
+            Some(pos) => {
+                let mut end: uint = pos;
+                if pos > self.start && self.data[(pos - 1:uint) to int] == BYTE_CR {
+                    end = pos - 1:uint;
+                }
+                ret Some(ByteLine {
+                    body = { start = self.start, end = end },
+                    next = pos + 1:uint
+                });
+            }
+            nothing => nothing;
+        };
+    }
+
+    pub fn peek_line_crlf(self: &ByteBuffer) -> Option<ByteLine> {
+        let found: Option<uint> = find_crlf(self.data, self.range());
+        return compare found {
+            Some(pos) => Some(ByteLine {
+                body = { start = self.start, end = pos },
+                next = pos + 2:uint
+            });
+            nothing => nothing;
+        };
     }
 
     pub fn consume(self: &mut ByteBuffer, count: uint) -> Erring<nothing, Error> {

--- a/stdlib/bytes/bytes.sg
+++ b/stdlib/bytes/bytes.sg
@@ -204,6 +204,76 @@ pub fn next_ascii_token(data: &byte[], r: ByteRange) -> Option<ByteSplit> {
     });
 }
 
+pub fn range_eq(data: &byte[], r: ByteRange, expected: &byte[]) -> bool {
+    if !is_valid_range(data, r) || range_len(r) != expected.__len() {
+        return false;
+    }
+    let start: int = r.start to int;
+    let length: int = expected.__len() to int;
+    let mut i: int = 0;
+    while i < length {
+        if data[start + i] != expected[i] {
+            return false;
+        }
+        i = i + 1;
+    }
+    return true;
+}
+
+fn range_eq_view(data: &byte[], r: ByteRange, expected: &BytesView) -> bool {
+    if !is_valid_range(data, r) || range_len(r) != expected.__len() {
+        return false;
+    }
+    let start: int = r.start to int;
+    let length: int = expected.__len() to int;
+    let mut i: int = 0;
+    while i < length {
+        if data[start + i] != (expected[i] to byte) {
+            return false;
+        }
+        i = i + 1;
+    }
+    return true;
+}
+
+pub fn range_eq_ascii(data: &byte[], r: ByteRange, expected: &string) -> bool {
+    let view: BytesView = expected.bytes();
+    return range_eq_view(data, r, &view);
+}
+
+fn range_eq_view_ascii_ci(data: &byte[], r: ByteRange, expected: &BytesView) -> bool {
+    if !is_valid_range(data, r) || range_len(r) != expected.__len() {
+        return false;
+    }
+    let start: int = r.start to int;
+    let length: int = expected.__len() to int;
+    let mut i: int = 0;
+    while i < length {
+        if ascii_to_lower(data[start + i]) != ascii_to_lower(expected[i] to byte) {
+            return false;
+        }
+        i = i + 1;
+    }
+    return true;
+}
+
+pub fn range_eq_ascii_ci(data: &byte[], r: ByteRange, expected: &string) -> bool {
+    let view: BytesView = expected.bytes();
+    return range_eq_view_ascii_ci(data, r, &view);
+}
+
+pub fn starts_with_ascii(data: &byte[], r: ByteRange, expected: &string) -> bool {
+    if !is_valid_range(data, r) {
+        return false;
+    }
+    let view: BytesView = expected.bytes();
+    if view.__len() > range_len(r) {
+        return false;
+    }
+    let prefix: ByteRange = { start = r.start, end = r.start + view.__len() };
+    return range_eq_view(data, prefix, &view);
+}
+
 pub fn copy_range(data: &byte[], r: ByteRange) -> Erring<byte[], Error> {
     if !is_valid_range(data, r) {
         return invalid_range_bytes();

--- a/stdlib/bytes/bytes.sg
+++ b/stdlib/bytes/bytes.sg
@@ -15,13 +15,21 @@ pub type ByteLine = {
     next: uint,
 };
 
+@copy
+pub type ByteSplit = {
+    head: ByteRange,
+    tail: ByteRange,
+};
+
 pub type ByteBuffer = {
     data: byte[],
     start: uint,
 };
 
+const BYTE_TAB: byte = 9:byte;
 const BYTE_CR: byte = 13:byte;
 const BYTE_LF: byte = 10:byte;
+const BYTE_SPACE: byte = 32:byte;
 
 fn invalid_range_bytes() -> Erring<byte[], Error> {
     return Error { message = "bytes: invalid range", code = BYTES_ERR_INVALID_RANGE };
@@ -48,6 +56,59 @@ pub fn range_len(r: ByteRange) -> uint {
 
 pub fn is_valid_range(data: &byte[], r: ByteRange) -> bool {
     return r.start <= r.end && r.end <= data.__len();
+}
+
+pub fn is_ascii_ws(b: byte) -> bool {
+    return b == BYTE_SPACE || b == BYTE_TAB || b == BYTE_LF || b == BYTE_CR;
+}
+
+pub fn is_ascii_digit(b: byte) -> bool {
+    let v: uint = b to uint;
+    return v >= 48:uint && v <= 57:uint;
+}
+
+pub fn is_ascii_alpha(b: byte) -> bool {
+    let v: uint = b to uint;
+    return (v >= 65:uint && v <= 90:uint) || (v >= 97:uint && v <= 122:uint);
+}
+
+pub fn is_ascii_alnum(b: byte) -> bool {
+    return is_ascii_alpha(b) || is_ascii_digit(b);
+}
+
+pub fn is_ascii_hex_digit(b: byte) -> bool {
+    let v: uint = b to uint;
+    return is_ascii_digit(b) || (v >= 65:uint && v <= 70:uint) || (v >= 97:uint && v <= 102:uint);
+}
+
+pub fn ascii_to_lower(b: byte) -> byte {
+    let v: uint = b to uint;
+    if v >= 65:uint && v <= 90:uint {
+        return (v + 32:uint) to byte;
+    }
+    return b;
+}
+
+pub fn ascii_to_upper(b: byte) -> byte {
+    let v: uint = b to uint;
+    if v >= 97:uint && v <= 122:uint {
+        return (v - 32:uint) to byte;
+    }
+    return b;
+}
+
+pub fn ascii_hex_value(b: byte) -> int {
+    let v: uint = b to uint;
+    if v >= 48:uint && v <= 57:uint {
+        return (v - 48:uint) to int;
+    }
+    if v >= 65:uint && v <= 70:uint {
+        return (v - 65:uint + 10:uint) to int;
+    }
+    if v >= 97:uint && v <= 102:uint {
+        return (v - 97:uint + 10:uint) to int;
+    }
+    return -1;
 }
 
 pub fn find_byte(data: &byte[], r: ByteRange, needle: byte) -> Option<uint> {
@@ -82,6 +143,65 @@ pub fn find_crlf(data: &byte[], r: ByteRange) -> Option<uint> {
         i = i + 1;
     }
     return nothing;
+}
+
+pub fn trim_ascii_start(data: &byte[], r: ByteRange) -> ByteRange {
+    if !is_valid_range(data, r) {
+        return { start = 0:uint, end = 0:uint };
+    }
+    let mut start: int = r.start to int;
+    let end: int = r.end to int;
+    while start < end && is_ascii_ws(data[start]) {
+        start = start + 1;
+    }
+    return { start = start to uint, end = r.end };
+}
+
+pub fn trim_ascii_end(data: &byte[], r: ByteRange) -> ByteRange {
+    if !is_valid_range(data, r) {
+        return { start = 0:uint, end = 0:uint };
+    }
+    let start: int = r.start to int;
+    let mut end: int = r.end to int;
+    while end > start && is_ascii_ws(data[end - 1]) {
+        end = end - 1;
+    }
+    return { start = r.start, end = end to uint };
+}
+
+pub fn trim_ascii(data: &byte[], r: ByteRange) -> ByteRange {
+    let left: ByteRange = trim_ascii_start(data, r);
+    return trim_ascii_end(data, left);
+}
+
+pub fn split_once_byte(data: &byte[], r: ByteRange, sep: byte) -> Option<ByteSplit> {
+    if !is_valid_range(data, r) {
+        return nothing;
+    }
+    let found: Option<uint> = find_byte(data, r, sep);
+    return compare found {
+        Some(pos) => Some(ByteSplit {
+            head = { start = r.start, end = pos },
+            tail = { start = pos + 1:uint, end = r.end }
+        });
+        nothing => nothing;
+    };
+}
+
+pub fn next_ascii_token(data: &byte[], r: ByteRange) -> Option<ByteSplit> {
+    let trimmed: ByteRange = trim_ascii_start(data, r);
+    if range_len(trimmed) == 0:uint {
+        return nothing;
+    }
+    let mut end: int = trimmed.start to int;
+    let limit: int = trimmed.end to int;
+    while end < limit && !is_ascii_ws(data[end]) {
+        end = end + 1;
+    }
+    return Some(ByteSplit {
+        head = { start = trimmed.start, end = end to uint },
+        tail = { start = end to uint, end = trimmed.end }
+    });
 }
 
 pub fn copy_range(data: &byte[], r: ByteRange) -> Erring<byte[], Error> {

--- a/stdlib/bytes/bytes.sg
+++ b/stdlib/bytes/bytes.sg
@@ -21,6 +21,12 @@ pub type ByteSplit = {
     tail: ByteRange,
 };
 
+@copy
+pub type ByteUint64 = {
+    value: uint64,
+    tail: ByteRange,
+};
+
 pub type ByteBuffer = {
     data: byte[],
     start: uint,
@@ -201,6 +207,21 @@ pub fn next_ascii_token(data: &byte[], r: ByteRange) -> Option<ByteSplit> {
     return Some(ByteSplit {
         head = { start = trimmed.start, end = end to uint },
         tail = { start = end to uint, end = trimmed.end }
+    });
+}
+
+pub fn next_uint64_ascii_token(data: &byte[], r: ByteRange) -> Option<ByteUint64> {
+    if !is_valid_range(data, r) {
+        return nothing;
+    }
+    let mut value: uint64 = 0:uint64;
+    let mut next: uint64 = 0:uint64;
+    if !rt_byte_parse_uint64_token(data, r.start to uint64, r.end to uint64, &mut value, &mut next) {
+        return nothing;
+    }
+    return Some(ByteUint64 {
+        value = value,
+        tail = { start = next to uint, end = r.end }
     });
 }
 

--- a/testdata/golden/core_stdlib/intrinsics.ast
+++ b/testdata/golden/core_stdlib/intrinsics.ast
@@ -1,4 +1,4 @@
-intrinsics.sg (span: 1:1-869:1)
+intrinsics.sg (span: 1:1-870:1)
 ├─ Item[0]: Type (span: 3:1-3:23)
 │  ├─ Name: byte
 │  ├─ Kind: Alias
@@ -388,60 +388,65 @@ intrinsics.sg (span: 1:1-869:1)
 │  ├─ Params: (a: &mut byte[], count: uint64)
 │  ├─ Return: nothing
 │  └─ Body: <none>
-├─ Item[73]: Fn (span: 137:1-137:47)
+├─ Item[73]: Fn (span: 135:1-135:132)
+│  ├─ Name: rt_byte_parse_uint64_token
+│  ├─ Params: (data: &byte[], start: uint64, end: uint64, value: &mut uint64, next: &mut uint64)
+│  ├─ Return: bool
+│  └─ Body: <none>
+├─ Item[74]: Fn (span: 138:1-138:47)
 │  ├─ Name: rt_map_new
 │  ├─ Generics: <K, V>
 │  ├─ Params: ()
 │  ├─ Return: Map<K, V>
 │  └─ Body: <none>
-├─ Item[74]: Fn (span: 138:1-138:55)
+├─ Item[75]: Fn (span: 139:1-139:55)
 │  ├─ Name: rt_map_len
 │  ├─ Generics: <K, V>
 │  ├─ Params: (m: &Map<K, V>)
 │  ├─ Return: uint
 │  └─ Body: <none>
-├─ Item[75]: Fn (span: 139:1-139:69)
+├─ Item[76]: Fn (span: 140:1-140:69)
 │  ├─ Name: rt_map_contains
 │  ├─ Generics: <K, V>
 │  ├─ Params: (m: &Map<K, V>, key: &K)
 │  ├─ Return: bool
 │  └─ Body: <none>
-├─ Item[76]: Fn (span: 140:1-140:74)
+├─ Item[77]: Fn (span: 141:1-141:74)
 │  ├─ Name: rt_map_get_ref
 │  ├─ Generics: <K, V>
 │  ├─ Params: (m: &Map<K, V>, key: &K)
 │  ├─ Return: Option<&V>
 │  └─ Body: <none>
-├─ Item[77]: Fn (span: 141:1-141:82)
+├─ Item[78]: Fn (span: 142:1-142:82)
 │  ├─ Name: rt_map_get_mut
 │  ├─ Generics: <K, V>
 │  ├─ Params: (m: &mut Map<K, V>, key: &K)
 │  ├─ Return: Option<&mut V>
 │  └─ Body: <none>
-├─ Item[78]: Fn (span: 142:1-142:85)
+├─ Item[79]: Fn (span: 143:1-143:85)
 │  ├─ Name: rt_map_insert
 │  ├─ Generics: <K, V>
 │  ├─ Params: (m: &mut Map<K, V>, key: K, value: V)
 │  ├─ Return: Option<V>
 │  └─ Body: <none>
-├─ Item[79]: Fn (span: 143:1-143:76)
+├─ Item[80]: Fn (span: 144:1-144:76)
 │  ├─ Name: rt_map_remove
 │  ├─ Generics: <K, V>
 │  ├─ Params: (m: &mut Map<K, V>, key: &K)
 │  ├─ Return: Option<V>
 │  └─ Body: <none>
-├─ Item[80]: Fn (span: 144:1-144:55)
+├─ Item[81]: Fn (span: 145:1-145:55)
 │  ├─ Name: rt_map_keys
 │  ├─ Generics: <K, V>
 │  ├─ Params: (m: &Map<K, V>)
 │  ├─ Return: K[]
 │  └─ Body: <none>
-├─ Item[81]: Fn (span: 147:1-148:29)
+├─ Item[82]: Fn (span: 148:1-149:29)
 │  ├─ Name: readline
 │  ├─ Params: ()
 │  ├─ Return: string
 │  └─ Body: <none>
-├─ Item[82]: Type (span: 150:1-153:3)
+├─ Item[83]: Type (span: 151:1-154:3)
 │  ├─ Name: Range
 │  ├─ Kind: Struct
 │  ├─ Visibility: public
@@ -449,34 +454,34 @@ intrinsics.sg (span: 1:1-869:1)
 │  ├─ Attributes: @intrinsic
 │  └─ Struct:
 │     └─ Field[0]: __state: *byte
-├─ Item[83]: Fn (span: 156:1-156:89)
+├─ Item[84]: Fn (span: 157:1-157:89)
 │  ├─ Name: rt_range_int_new
 │  ├─ Params: (start: int, end: int, inclusive: bool)
 │  ├─ Return: Range<int>
 │  └─ Body: <none>
-├─ Item[84]: Fn (span: 157:1-157:86)
+├─ Item[85]: Fn (span: 158:1-158:86)
 │  ├─ Name: rt_range_int_from_start
 │  ├─ Params: (start: int, inclusive: bool)
 │  ├─ Return: Range<int>
 │  └─ Body: <none>
-├─ Item[85]: Fn (span: 158:1-158:80)
+├─ Item[86]: Fn (span: 159:1-159:80)
 │  ├─ Name: rt_range_int_to_end
 │  ├─ Params: (end: int, inclusive: bool)
 │  ├─ Return: Range<int>
 │  └─ Body: <none>
-├─ Item[86]: Fn (span: 159:1-159:68)
+├─ Item[87]: Fn (span: 160:1-160:68)
 │  ├─ Name: rt_range_int_full
 │  ├─ Params: (inclusive: bool)
 │  ├─ Return: Range<int>
 │  └─ Body: <none>
-├─ Item[87]: Extern (span: 161:1-163:2)
+├─ Item[88]: Extern (span: 162:1-164:2)
 │  ├─ Target: Range<T>
 │  ├─ Members:
 │  │  └─ Fn[0]: next
 │  │     ├─ Params: (self: &mut Range<T>)
 │  │     ├─ Return: Option<T>
 │  │     └─ Attributes: @intrinsic
-├─ Item[88]: Type (span: 165:1-172:3)
+├─ Item[89]: Type (span: 166:1-173:3)
 │  ├─ Name: HeapStats
 │  ├─ Kind: Struct
 │  ├─ Visibility: public
@@ -487,32 +492,32 @@ intrinsics.sg (span: 1:1-869:1)
 │     ├─ Field[3]: live_bytes: uint
 │     ├─ Field[4]: rc_increments: uint
 │     └─ Field[5]: rc_decrements: uint
-├─ Item[89]: Fn (span: 178:1-178:48)
+├─ Item[90]: Fn (span: 179:1-179:48)
 │  ├─ Name: rt_heap_stats
 │  ├─ Params: ()
 │  ├─ Return: HeapStats
 │  └─ Body: <none>
-├─ Item[90]: Fn (span: 180:1-180:44)
+├─ Item[91]: Fn (span: 181:1-181:44)
 │  ├─ Name: rt_heap_dump
 │  ├─ Params: ()
 │  ├─ Return: string
 │  └─ Body: <none>
-├─ Item[91]: Fn (span: 182:1-182:45)
+├─ Item[92]: Fn (span: 183:1-183:45)
 │  ├─ Name: rt_worker_count
 │  ├─ Params: ()
 │  ├─ Return: uint
 │  └─ Body: <none>
-├─ Item[92]: Type (span: 184:1-186:3)
+├─ Item[93]: Type (span: 185:1-187:3)
 │  ├─ Name: Task
 │  ├─ Kind: Struct
 │  ├─ Visibility: public
 │  ├─ Generics: <T>
 │  └─ Struct:
 │     └─ Field[0]: __opaque: int
-├─ Item[93]: Tag (span: 188:1-188:21)
+├─ Item[94]: Tag (span: 189:1-189:21)
 │  ├─ Name: Cancelled
 │  └─ Visibility: public
-├─ Item[94]: Type (span: 189:1-189:49)
+├─ Item[95]: Type (span: 190:1-190:49)
 │  ├─ Name: TaskResult
 │  ├─ Kind: Union
 │  ├─ Visibility: public
@@ -520,33 +525,33 @@ intrinsics.sg (span: 1:1-869:1)
 │  └─ Union:
 │     ├─ Member[0]: Success(T)
 │     └─ Member[1]: Cancelled
-├─ Item[95]: Fn (span: 191:1-191:54)
+├─ Item[96]: Fn (span: 192:1-192:54)
 │  ├─ Name: rt_scope_enter
 │  ├─ Params: (failfast: bool)
 │  ├─ Return: uint
 │  └─ Body: <none>
-├─ Item[96]: Fn (span: 192:1-192:82)
+├─ Item[97]: Fn (span: 193:1-193:82)
 │  ├─ Name: rt_scope_register_child
 │  ├─ Generics: <T>
 │  ├─ Params: (scope: uint, child: Task<T>)
 │  ├─ Return: nothing
 │  └─ Body: <none>
-├─ Item[97]: Fn (span: 193:1-193:59)
+├─ Item[98]: Fn (span: 194:1-194:59)
 │  ├─ Name: rt_scope_cancel_all
 │  ├─ Params: (scope: uint)
 │  ├─ Return: nothing
 │  └─ Body: <none>
-├─ Item[98]: Fn (span: 194:1-194:54)
+├─ Item[99]: Fn (span: 195:1-195:54)
 │  ├─ Name: rt_scope_join_all
 │  ├─ Params: (scope: uint)
 │  ├─ Return: bool
 │  └─ Body: <none>
-├─ Item[99]: Fn (span: 195:1-195:53)
+├─ Item[100]: Fn (span: 196:1-196:53)
 │  ├─ Name: rt_scope_exit
 │  ├─ Params: (scope: uint)
 │  ├─ Return: nothing
 │  └─ Body: <none>
-├─ Item[100]: Extern (span: 197:1-201:2)
+├─ Item[101]: Extern (span: 198:1-202:2)
 │  ├─ Target: Task<T>
 │  ├─ Members:
 │  │  ├─ Fn[0]: clone
@@ -561,23 +566,23 @@ intrinsics.sg (span: 1:1-869:1)
 │  │     ├─ Params: (self: own Task<T>)
 │  │     ├─ Return: TaskResult<T>
 │  │     └─ Attributes: @intrinsic
-├─ Item[101]: Fn (span: 205:1-206:38)
+├─ Item[102]: Fn (span: 206:1-207:38)
 │  ├─ Name: checkpoint
 │  ├─ Params: ()
 │  ├─ Return: Task<nothing>
 │  └─ Body: <none>
-├─ Item[102]: Fn (span: 209:1-209:52)
+├─ Item[103]: Fn (span: 210:1-210:52)
 │  ├─ Name: sleep
 │  ├─ Params: (ms: uint)
 │  ├─ Return: Task<nothing>
 │  └─ Body: <none>
-├─ Item[103]: Fn (span: 213:1-213:69)
+├─ Item[104]: Fn (span: 214:1-214:69)
 │  ├─ Name: timeout
 │  ├─ Generics: <T>
 │  ├─ Params: (t: Task<T>, ms: uint)
 │  ├─ Return: TaskResult<T>
 │  └─ Body: <none>
-├─ Item[104]: Type (span: 216:1-220:3)
+├─ Item[105]: Type (span: 217:1-221:3)
 │  ├─ Name: Channel
 │  ├─ Kind: Struct
 │  ├─ Visibility: public
@@ -585,7 +590,7 @@ intrinsics.sg (span: 1:1-869:1)
 │  ├─ Attributes: @copy, @intrinsic
 │  └─ Struct:
 │     └─ Field[0]: __opaque: *byte
-├─ Item[105]: Extern (span: 222:1-235:2)
+├─ Item[106]: Extern (span: 223:1-236:2)
 │  ├─ Target: Channel<T>
 │  ├─ Members:
 │  │  ├─ Fn[0]: new
@@ -612,34 +617,34 @@ intrinsics.sg (span: 1:1-869:1)
 │  │     ├─ Params: (self: &Channel<T>)
 │  │     ├─ Return: nothing
 │  │     └─ Attributes: @intrinsic
-├─ Item[106]: Fn (span: 237:1-238:54)
+├─ Item[107]: Fn (span: 238:1-239:54)
 │  ├─ Name: make_channel
 │  ├─ Generics: <T>
 │  ├─ Params: (capacity: uint)
 │  ├─ Return: own Channel<T>
 │  └─ Body: <none>
-├─ Item[107]: Contract (span: 240:1-243:2)
-├─ Item[108]: Contract (span: 245:1-247:2)
-├─ Item[109]: Contract (span: 249:1-251:2)
-├─ Item[110]: Fn (span: 253:1-255:2)
+├─ Item[108]: Contract (span: 241:1-244:2)
+├─ Item[109]: Contract (span: 246:1-248:2)
+├─ Item[110]: Contract (span: 250:1-252:2)
+├─ Item[111]: Fn (span: 254:1-256:2)
 │  ├─ Name: max_value
 │  ├─ Generics: <T>
 │  ├─ Params: ()
 │  ├─ Return: T
 │  └─ Body:
-│     └─ Stmt[0]: Block (span: 253:40-255:2)
-│        └─ Stmt[0]: Return (span: 254:5-254:28)
+│     └─ Stmt[0]: Block (span: 254:40-256:2)
+│        └─ Stmt[0]: Return (span: 255:5-255:28)
 │           └─ Expr: expr#11: T.__max_value()
-├─ Item[111]: Fn (span: 257:1-259:2)
+├─ Item[112]: Fn (span: 258:1-260:2)
 │  ├─ Name: min_value
 │  ├─ Generics: <T>
 │  ├─ Params: ()
 │  ├─ Return: T
 │  └─ Body:
-│     └─ Stmt[0]: Block (span: 257:40-259:2)
-│        └─ Stmt[0]: Return (span: 258:5-258:28)
+│     └─ Stmt[0]: Block (span: 258:40-260:2)
+│        └─ Stmt[0]: Return (span: 259:5-259:28)
 │           └─ Expr: expr#14: T.__min_value()
-├─ Item[112]: Extern (span: 261:1-300:2)
+├─ Item[113]: Extern (span: 262:1-301:2)
 │  ├─ Target: int
 │  ├─ Members:
 │  │  ├─ Fn[0]: __add
@@ -727,8 +732,8 @@ intrinsics.sg (span: 1:1-869:1)
 │  │  │  ├─ Return: string
 │  │  │  ├─ Attributes: @overload
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 282:60-284:6)
-│  │  │     └─ Stmt[0]: Return (span: 283:9-283:34)
+│  │  │     Stmt[0]: Block (span: 283:60-285:6)
+│  │  │     └─ Stmt[0]: Return (span: 284:9-284:34)
 │  │  │        └─ Expr: expr#18: (*self) to string
 │  │  ├─ Fn[21]: __to
 │  │  │  ├─ Params: (self: int, target: float)
@@ -786,7 +791,7 @@ intrinsics.sg (span: 1:1-869:1)
 │  │     ├─ Params: (s: &string)
 │  │     ├─ Return: Erring<int, Error>
 │  │     └─ Attributes: @intrinsic
-├─ Item[113]: Extern (span: 302:1-340:2)
+├─ Item[114]: Extern (span: 303:1-341:2)
 │  ├─ Target: uint
 │  ├─ Members:
 │  │  ├─ Fn[0]: __add
@@ -870,8 +875,8 @@ intrinsics.sg (span: 1:1-869:1)
 │  │  │  ├─ Return: string
 │  │  │  ├─ Attributes: @overload
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 322:61-324:6)
-│  │  │     └─ Stmt[0]: Return (span: 323:9-323:34)
+│  │  │     Stmt[0]: Block (span: 323:61-325:6)
+│  │  │     └─ Stmt[0]: Return (span: 324:9-324:34)
 │  │  │        └─ Expr: expr#22: (*self) to string
 │  │  ├─ Fn[20]: __to
 │  │  │  ├─ Params: (self: uint, target: int)
@@ -929,22 +934,22 @@ intrinsics.sg (span: 1:1-869:1)
 │  │     ├─ Params: (s: &string)
 │  │     ├─ Return: Erring<uint, Error>
 │  │     └─ Attributes: @intrinsic
-├─ Item[114]: Extern (span: 342:1-369:2)
+├─ Item[115]: Extern (span: 343:1-370:2)
 │  ├─ Target: int8
 │  ├─ Members:
 │  │  ├─ Fn[0]: __min_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: int8
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 343:34-343:57)
-│  │  │     └─ Stmt[0]: Return (span: 343:36-343:55)
+│  │  │     Stmt[0]: Block (span: 344:34-344:57)
+│  │  │     └─ Stmt[0]: Return (span: 344:36-344:55)
 │  │  │        └─ Expr: expr#26: (-128) to int8
 │  │  ├─ Fn[1]: __max_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: int8
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 344:34-344:56)
-│  │  │     └─ Stmt[0]: Return (span: 344:36-344:54)
+│  │  │     Stmt[0]: Block (span: 345:34-345:56)
+│  │  │     └─ Stmt[0]: Return (span: 345:36-345:54)
 │  │  │        └─ Expr: expr#29: (127) to int8
 │  │  ├─ Fn[2]: __add
 │  │  │  ├─ Params: (self: int8, other: int8)
@@ -1042,22 +1047,22 @@ intrinsics.sg (span: 1:1-869:1)
 │  │     ├─ Params: (s: &string)
 │  │     ├─ Return: Erring<int8, Error>
 │  │     └─ Attributes: @intrinsic
-├─ Item[115]: Extern (span: 371:1-398:2)
+├─ Item[116]: Extern (span: 372:1-399:2)
 │  ├─ Target: int16
 │  ├─ Members:
 │  │  ├─ Fn[0]: __min_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: int16
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 372:35-372:62)
-│  │  │     └─ Stmt[0]: Return (span: 372:37-372:60)
+│  │  │     Stmt[0]: Block (span: 373:35-373:62)
+│  │  │     └─ Stmt[0]: Return (span: 373:37-373:60)
 │  │  │        └─ Expr: expr#33: (-32_768) to int16
 │  │  ├─ Fn[1]: __max_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: int16
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 373:35-373:61)
-│  │  │     └─ Stmt[0]: Return (span: 373:37-373:59)
+│  │  │     Stmt[0]: Block (span: 374:35-374:61)
+│  │  │     └─ Stmt[0]: Return (span: 374:37-374:59)
 │  │  │        └─ Expr: expr#36: (32_767) to int16
 │  │  ├─ Fn[2]: __add
 │  │  │  ├─ Params: (self: int16, other: int16)
@@ -1155,22 +1160,22 @@ intrinsics.sg (span: 1:1-869:1)
 │  │     ├─ Params: (s: &string)
 │  │     ├─ Return: Erring<int16, Error>
 │  │     └─ Attributes: @intrinsic
-├─ Item[116]: Extern (span: 400:1-427:2)
+├─ Item[117]: Extern (span: 401:1-428:2)
 │  ├─ Target: int32
 │  ├─ Members:
 │  │  ├─ Fn[0]: __min_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: int32
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 401:35-401:69)
-│  │  │     └─ Stmt[0]: Return (span: 401:37-401:67)
+│  │  │     Stmt[0]: Block (span: 402:35-402:69)
+│  │  │     └─ Stmt[0]: Return (span: 402:37-402:67)
 │  │  │        └─ Expr: expr#40: (-2_147_483_648) to int32
 │  │  ├─ Fn[1]: __max_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: int32
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 402:35-402:68)
-│  │  │     └─ Stmt[0]: Return (span: 402:37-402:66)
+│  │  │     Stmt[0]: Block (span: 403:35-403:68)
+│  │  │     └─ Stmt[0]: Return (span: 403:37-403:66)
 │  │  │        └─ Expr: expr#43: (2_147_483_647) to int32
 │  │  ├─ Fn[2]: __add
 │  │  │  ├─ Params: (self: int32, other: int32)
@@ -1268,22 +1273,22 @@ intrinsics.sg (span: 1:1-869:1)
 │  │     ├─ Params: (s: &string)
 │  │     ├─ Return: Erring<int32, Error>
 │  │     └─ Attributes: @intrinsic
-├─ Item[117]: Extern (span: 429:1-456:2)
+├─ Item[118]: Extern (span: 430:1-457:2)
 │  ├─ Target: int64
 │  ├─ Members:
 │  │  ├─ Fn[0]: __min_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: int64
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 430:35-430:81)
-│  │  │     └─ Stmt[0]: Return (span: 430:37-430:79)
+│  │  │     Stmt[0]: Block (span: 431:35-431:81)
+│  │  │     └─ Stmt[0]: Return (span: 431:37-431:79)
 │  │  │        └─ Expr: expr#47: (-9_223_372_036_854_775_808) to int64
 │  │  ├─ Fn[1]: __max_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: int64
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 431:35-431:80)
-│  │  │     └─ Stmt[0]: Return (span: 431:37-431:78)
+│  │  │     Stmt[0]: Block (span: 432:35-432:80)
+│  │  │     └─ Stmt[0]: Return (span: 432:37-432:78)
 │  │  │        └─ Expr: expr#50: (9_223_372_036_854_775_807) to int64
 │  │  ├─ Fn[2]: __add
 │  │  │  ├─ Params: (self: int64, other: int64)
@@ -1381,22 +1386,22 @@ intrinsics.sg (span: 1:1-869:1)
 │  │     ├─ Params: (s: &string)
 │  │     ├─ Return: Erring<int64, Error>
 │  │     └─ Attributes: @intrinsic
-├─ Item[118]: Extern (span: 458:1-484:2)
+├─ Item[119]: Extern (span: 459:1-485:2)
 │  ├─ Target: uint8
 │  ├─ Members:
 │  │  ├─ Fn[0]: __min_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: uint8
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 459:35-459:56)
-│  │  │     └─ Stmt[0]: Return (span: 459:37-459:54)
+│  │  │     Stmt[0]: Block (span: 460:35-460:56)
+│  │  │     └─ Stmt[0]: Return (span: 460:37-460:54)
 │  │  │        └─ Expr: expr#53: (0) to uint8
 │  │  ├─ Fn[1]: __max_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: uint8
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 460:35-460:58)
-│  │  │     └─ Stmt[0]: Return (span: 460:37-460:56)
+│  │  │     Stmt[0]: Block (span: 461:35-461:58)
+│  │  │     └─ Stmt[0]: Return (span: 461:37-461:56)
 │  │  │        └─ Expr: expr#56: (255) to uint8
 │  │  ├─ Fn[2]: __add
 │  │  │  ├─ Params: (self: uint8, other: uint8)
@@ -1490,22 +1495,22 @@ intrinsics.sg (span: 1:1-869:1)
 │  │     ├─ Params: (s: &string)
 │  │     ├─ Return: Erring<uint8, Error>
 │  │     └─ Attributes: @intrinsic
-├─ Item[119]: Extern (span: 486:1-512:2)
+├─ Item[120]: Extern (span: 487:1-513:2)
 │  ├─ Target: uint16
 │  ├─ Members:
 │  │  ├─ Fn[0]: __min_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: uint16
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 487:36-487:58)
-│  │  │     └─ Stmt[0]: Return (span: 487:38-487:56)
+│  │  │     Stmt[0]: Block (span: 488:36-488:58)
+│  │  │     └─ Stmt[0]: Return (span: 488:38-488:56)
 │  │  │        └─ Expr: expr#59: (0) to uint16
 │  │  ├─ Fn[1]: __max_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: uint16
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 488:36-488:63)
-│  │  │     └─ Stmt[0]: Return (span: 488:38-488:61)
+│  │  │     Stmt[0]: Block (span: 489:36-489:63)
+│  │  │     └─ Stmt[0]: Return (span: 489:38-489:61)
 │  │  │        └─ Expr: expr#62: (65_535) to uint16
 │  │  ├─ Fn[2]: __add
 │  │  │  ├─ Params: (self: uint16, other: uint16)
@@ -1599,22 +1604,22 @@ intrinsics.sg (span: 1:1-869:1)
 │  │     ├─ Params: (s: &string)
 │  │     ├─ Return: Erring<uint16, Error>
 │  │     └─ Attributes: @intrinsic
-├─ Item[120]: Extern (span: 514:1-540:2)
+├─ Item[121]: Extern (span: 515:1-541:2)
 │  ├─ Target: uint32
 │  ├─ Members:
 │  │  ├─ Fn[0]: __min_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: uint32
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 515:36-515:58)
-│  │  │     └─ Stmt[0]: Return (span: 515:38-515:56)
+│  │  │     Stmt[0]: Block (span: 516:36-516:58)
+│  │  │     └─ Stmt[0]: Return (span: 516:38-516:56)
 │  │  │        └─ Expr: expr#65: (0) to uint32
 │  │  ├─ Fn[1]: __max_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: uint32
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 516:36-516:70)
-│  │  │     └─ Stmt[0]: Return (span: 516:38-516:68)
+│  │  │     Stmt[0]: Block (span: 517:36-517:70)
+│  │  │     └─ Stmt[0]: Return (span: 517:38-517:68)
 │  │  │        └─ Expr: expr#68: (4_294_967_295) to uint32
 │  │  ├─ Fn[2]: __add
 │  │  │  ├─ Params: (self: uint32, other: uint32)
@@ -1708,22 +1713,22 @@ intrinsics.sg (span: 1:1-869:1)
 │  │     ├─ Params: (s: &string)
 │  │     ├─ Return: Erring<uint32, Error>
 │  │     └─ Attributes: @intrinsic
-├─ Item[121]: Extern (span: 542:1-568:2)
+├─ Item[122]: Extern (span: 543:1-569:2)
 │  ├─ Target: uint64
 │  ├─ Members:
 │  │  ├─ Fn[0]: __min_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: uint64
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 543:36-543:58)
-│  │  │     └─ Stmt[0]: Return (span: 543:38-543:56)
+│  │  │     Stmt[0]: Block (span: 544:36-544:58)
+│  │  │     └─ Stmt[0]: Return (span: 544:38-544:56)
 │  │  │        └─ Expr: expr#71: (0) to uint64
 │  │  ├─ Fn[1]: __max_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: uint64
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 544:36-544:83)
-│  │  │     └─ Stmt[0]: Return (span: 544:38-544:81)
+│  │  │     Stmt[0]: Block (span: 545:36-545:83)
+│  │  │     └─ Stmt[0]: Return (span: 545:38-545:81)
 │  │  │        └─ Expr: expr#74: (18_446_744_073_709_551_615) to uint64
 │  │  ├─ Fn[2]: __add
 │  │  │  ├─ Params: (self: uint64, other: uint64)
@@ -1817,22 +1822,22 @@ intrinsics.sg (span: 1:1-869:1)
 │  │     ├─ Params: (s: &string)
 │  │     ├─ Return: Erring<uint64, Error>
 │  │     └─ Attributes: @intrinsic
-├─ Item[122]: Extern (span: 570:1-591:2)
+├─ Item[123]: Extern (span: 571:1-592:2)
 │  ├─ Target: float16
 │  ├─ Members:
 │  │  ├─ Fn[0]: __min_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: float16
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 571:37-571:67)
-│  │  │     └─ Stmt[0]: Return (span: 571:39-571:65)
+│  │  │     Stmt[0]: Block (span: 572:37-572:67)
+│  │  │     └─ Stmt[0]: Return (span: 572:39-572:65)
 │  │  │        └─ Expr: expr#78: (-65504.0) to float16
 │  │  ├─ Fn[1]: __max_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: float16
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 572:37-572:66)
-│  │  │     └─ Stmt[0]: Return (span: 572:39-572:64)
+│  │  │     Stmt[0]: Block (span: 573:37-573:66)
+│  │  │     └─ Stmt[0]: Return (span: 573:39-573:64)
 │  │  │        └─ Expr: expr#81: (65504.0) to float16
 │  │  ├─ Fn[2]: __add
 │  │  │  ├─ Params: (self: float16, other: float16)
@@ -1906,22 +1911,22 @@ intrinsics.sg (span: 1:1-869:1)
 │  │     ├─ Params: (s: &string)
 │  │     ├─ Return: Erring<float16, Error>
 │  │     └─ Attributes: @intrinsic
-├─ Item[123]: Extern (span: 593:1-614:2)
+├─ Item[124]: Extern (span: 594:1-615:2)
 │  ├─ Target: float32
 │  ├─ Members:
 │  │  ├─ Fn[0]: __min_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: float32
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 594:37-594:86)
-│  │  │     └─ Stmt[0]: Return (span: 594:39-594:84)
+│  │  │     Stmt[0]: Block (span: 595:37-595:86)
+│  │  │     └─ Stmt[0]: Return (span: 595:39-595:84)
 │  │  │        └─ Expr: expr#85: (-3.402_823_466_385_2886e+38) to float32
 │  │  ├─ Fn[1]: __max_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: float32
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 595:37-595:85)
-│  │  │     └─ Stmt[0]: Return (span: 595:39-595:83)
+│  │  │     Stmt[0]: Block (span: 596:37-596:85)
+│  │  │     └─ Stmt[0]: Return (span: 596:39-596:83)
 │  │  │        └─ Expr: expr#88: (3.402_823_466_385_2886e+38) to float32
 │  │  ├─ Fn[2]: __add
 │  │  │  ├─ Params: (self: float32, other: float32)
@@ -1995,22 +2000,22 @@ intrinsics.sg (span: 1:1-869:1)
 │  │     ├─ Params: (s: &string)
 │  │     ├─ Return: Erring<float32, Error>
 │  │     └─ Attributes: @intrinsic
-├─ Item[124]: Extern (span: 616:1-637:2)
+├─ Item[125]: Extern (span: 617:1-638:2)
 │  ├─ Target: float64
 │  ├─ Members:
 │  │  ├─ Fn[0]: __min_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: float64
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 617:37-617:87)
-│  │  │     └─ Stmt[0]: Return (span: 617:39-617:85)
+│  │  │     Stmt[0]: Block (span: 618:37-618:87)
+│  │  │     └─ Stmt[0]: Return (span: 618:39-618:85)
 │  │  │        └─ Expr: expr#92: (-1.797_693_134_862_3157e+308) to float64
 │  │  ├─ Fn[1]: __max_value
 │  │  │  ├─ Params: ()
 │  │  │  ├─ Return: float64
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 618:37-618:86)
-│  │  │     └─ Stmt[0]: Return (span: 618:39-618:84)
+│  │  │     Stmt[0]: Block (span: 619:37-619:86)
+│  │  │     └─ Stmt[0]: Return (span: 619:39-619:84)
 │  │  │        └─ Expr: expr#95: (1.797_693_134_862_3157e+308) to float64
 │  │  ├─ Fn[2]: __add
 │  │  │  ├─ Params: (self: float64, other: float64)
@@ -2084,7 +2089,7 @@ intrinsics.sg (span: 1:1-869:1)
 │  │     ├─ Params: (s: &string)
 │  │     ├─ Return: Erring<float64, Error>
 │  │     └─ Attributes: @intrinsic
-├─ Item[125]: Extern (span: 639:1-673:2)
+├─ Item[126]: Extern (span: 640:1-674:2)
 │  ├─ Target: float
 │  ├─ Members:
 │  │  ├─ Fn[0]: __add
@@ -2152,8 +2157,8 @@ intrinsics.sg (span: 1:1-869:1)
 │  │  │  ├─ Return: string
 │  │  │  ├─ Attributes: @overload
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 655:62-657:6)
-│  │  │     └─ Stmt[0]: Return (span: 656:9-656:34)
+│  │  │     Stmt[0]: Block (span: 656:62-658:6)
+│  │  │     └─ Stmt[0]: Return (span: 657:9-657:34)
 │  │  │        └─ Expr: expr#99: (*self) to string
 │  │  ├─ Fn[16]: __to
 │  │  │  ├─ Params: (self: float, target: int)
@@ -2211,7 +2216,7 @@ intrinsics.sg (span: 1:1-869:1)
 │  │     ├─ Params: (s: &string)
 │  │     ├─ Return: Erring<float, Error>
 │  │     └─ Attributes: @intrinsic
-├─ Item[126]: Extern (span: 675:1-699:2)
+├─ Item[127]: Extern (span: 676:1-700:2)
 │  ├─ Target: string
 │  ├─ Members:
 │  │  ├─ Fn[0]: __add
@@ -2227,8 +2232,8 @@ intrinsics.sg (span: 1:1-869:1)
 │  │  │  ├─ Return: string
 │  │  │  ├─ Attributes: @overload
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 678:66-680:6)
-│  │  │     └─ Stmt[0]: Return (span: 679:9-679:38)
+│  │  │     Stmt[0]: Block (span: 679:66-681:6)
+│  │  │     └─ Stmt[0]: Return (span: 680:9-680:38)
 │  │  │        └─ Expr: expr#104: (self * (other to int))
 │  │  ├─ Fn[3]: __eq
 │  │  │  ├─ Params: (self: &string, other: &string)
@@ -2255,23 +2260,23 @@ intrinsics.sg (span: 1:1-869:1)
 │  │  │  ├─ Return: string
 │  │  │  ├─ Attributes: @overload
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 686:63-688:6)
-│  │  │     └─ Stmt[0]: Return (span: 687:9-687:31)
+│  │  │     Stmt[0]: Block (span: 687:63-689:6)
+│  │  │     └─ Stmt[0]: Return (span: 688:9-688:31)
 │  │  │        └─ Expr: expr#107: self.__clone()
 │  │  ├─ Fn[9]: __to
 │  │  │  ├─ Params: (self: &string, _: byte[])
 │  │  │  ├─ Return: byte[]
 │  │  │  ├─ Attributes: @overload
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 690:53-694:6)
-│  │  │     ├─ Stmt[0]: Let (span: 691:9-691:34)
+│  │  │     Stmt[0]: Block (span: 691:53-695:6)
+│  │  │     ├─ Stmt[0]: Let (span: 692:9-692:34)
 │  │  │     │  ├─ Name: out
 │  │  │     │  ├─ Mutable: true
 │  │  │     │  ├─ Type: byte[]
 │  │  │     │  └─ Value: expr#108: <ExprKind(8)>
-│  │  │     ├─ Stmt[1]: Expr (span: 692:9-692:103)
+│  │  │     ├─ Stmt[1]: Expr (span: 693:9-693:103)
 │  │  │     │  └─ Expr: expr#119: rt_array_append_raw_bytes(&mut out, rt_string_ptr(self), rt_string_len_bytes(self) to uint64)
-│  │  │     └─ Stmt[2]: Return (span: 693:9-693:20)
+│  │  │     └─ Stmt[2]: Return (span: 694:9-694:20)
 │  │  │        └─ Expr: expr#120: out
 │  │  ├─ Fn[10]: __len
 │  │  │  ├─ Params: (self: &string)
@@ -2289,7 +2294,7 @@ intrinsics.sg (span: 1:1-869:1)
 │  │     ├─ Params: (self: &string, index: Range<int>)
 │  │     ├─ Return: string
 │  │     └─ Attributes: @intrinsic, @overload
-├─ Item[127]: Type (span: 701:1-706:3)
+├─ Item[128]: Type (span: 702:1-707:3)
 │  ├─ Name: BytesView
 │  ├─ Kind: Struct
 │  ├─ Visibility: public
@@ -2298,7 +2303,7 @@ intrinsics.sg (span: 1:1-869:1)
 │     ├─ Field[0]: owner: string
 │     ├─ Field[1]: ptr: *byte
 │     └─ Field[2]: len: uint
-├─ Item[128]: Extern (span: 708:1-712:2)
+├─ Item[129]: Extern (span: 709:1-713:2)
 │  ├─ Target: BytesView
 │  ├─ Members:
 │  │  ├─ Fn[0]: __len
@@ -2313,7 +2318,7 @@ intrinsics.sg (span: 1:1-869:1)
 │  │     ├─ Params: (self: &BytesView, index: int64)
 │  │     ├─ Return: uint8
 │  │     └─ Attributes: @intrinsic, @overload
-├─ Item[129]: Extern (span: 714:1-725:2)
+├─ Item[130]: Extern (span: 715:1-726:2)
 │  ├─ Target: bool
 │  ├─ Members:
 │  │  ├─ Fn[0]: __eq
@@ -2337,8 +2342,8 @@ intrinsics.sg (span: 1:1-869:1)
 │  │  │  ├─ Return: string
 │  │  │  ├─ Attributes: @overload
 │  │  │  └─ Body:
-│  │  │     Stmt[0]: Block (span: 719:61-721:6)
-│  │  │     └─ Stmt[0]: Return (span: 720:9-720:34)
+│  │  │     Stmt[0]: Block (span: 720:61-722:6)
+│  │  │     └─ Stmt[0]: Return (span: 721:9-721:34)
 │  │  │        └─ Expr: expr#124: (*self) to string
 │  │  ├─ Fn[5]: __to
 │  │  │  ├─ Params: (self: bool, target: int)
@@ -2348,7 +2353,7 @@ intrinsics.sg (span: 1:1-869:1)
 │  │     ├─ Params: (s: &string)
 │  │     ├─ Return: Erring<bool, Error>
 │  │     └─ Attributes: @intrinsic
-├─ Item[130]: Extern (span: 727:1-734:2)
+├─ Item[131]: Extern (span: 728:1-735:2)
 │  ├─ Target: Array<T>
 │  ├─ Members:
 │  │  ├─ Fn[0]: __add
@@ -2375,7 +2380,7 @@ intrinsics.sg (span: 1:1-869:1)
 │  │     ├─ Params: (self: &Array<T>)
 │  │     ├─ Return: uint
 │  │     └─ Attributes: @intrinsic
-├─ Item[131]: Extern (span: 736:1-743:2)
+├─ Item[132]: Extern (span: 737:1-744:2)
 │  ├─ Target: ArrayFixed<T, N>
 │  ├─ Members:
 │  │  ├─ Fn[0]: __add
@@ -2402,62 +2407,62 @@ intrinsics.sg (span: 1:1-869:1)
 │  │     ├─ Params: (self: &ArrayFixed<T, N>)
 │  │     ├─ Return: uint
 │  │     └─ Attributes: @intrinsic
-├─ Item[132]: Fn (span: 745:1-746:26)
+├─ Item[133]: Fn (span: 746:1-747:26)
 │  ├─ Name: default
 │  ├─ Generics: <T>
 │  ├─ Params: ()
 │  ├─ Return: T
 │  └─ Body: <none>
-├─ Item[133]: Fn (span: 748:1-749:29)
+├─ Item[134]: Fn (span: 749:1-750:29)
 │  ├─ Name: size_of
 │  ├─ Generics: <T>
 │  ├─ Params: ()
 │  ├─ Return: uint
 │  └─ Body: <none>
-├─ Item[134]: Fn (span: 751:1-752:30)
+├─ Item[135]: Fn (span: 752:1-753:30)
 │  ├─ Name: align_of
 │  ├─ Generics: <T>
 │  ├─ Params: ()
 │  ├─ Return: uint
 │  └─ Body: <none>
-├─ Item[135]: Contract (span: 754:1-757:2)
-├─ Item[136]: Fn (span: 759:1-760:44)
+├─ Item[136]: Contract (span: 755:1-758:2)
+├─ Item[137]: Fn (span: 760:1-761:44)
 │  ├─ Name: exit
 │  ├─ Generics: <E>
 │  ├─ Params: (e: E)
 │  ├─ Return: nothing
 │  └─ Body: <none>
-├─ Item[137]: Fn (span: 762:1-763:54)
+├─ Item[138]: Fn (span: 763:1-764:54)
 │  ├─ Name: rt_panic
 │  ├─ Params: (ptr: *byte, length: uint)
 │  ├─ Return: nothing
 │  └─ Body: <none>
-├─ Item[138]: Fn (span: 765:1-769:2)
+├─ Item[139]: Fn (span: 766:1-770:2)
 │  ├─ Name: panic
 │  ├─ Params: (msg: string)
 │  ├─ Return: nothing
 │  └─ Body:
-│     └─ Stmt[0]: Block (span: 765:38-769:2)
-│        ├─ Stmt[0]: Let (span: 766:5-766:35)
+│     └─ Stmt[0]: Block (span: 766:38-770:2)
+│        ├─ Stmt[0]: Let (span: 767:5-767:35)
 │        │  ├─ Name: ptr
 │        │  ├─ Mutable: false
 │        │  ├─ Type: <inferred>
 │        │  └─ Value: expr#128: rt_string_ptr(&msg)
-│        ├─ Stmt[1]: Let (span: 767:5-767:44)
+│        ├─ Stmt[1]: Let (span: 768:5-768:44)
 │        │  ├─ Name: length
 │        │  ├─ Mutable: false
 │        │  ├─ Type: <inferred>
 │        │  └─ Value: expr#132: rt_string_len_bytes(&msg)
-│        └─ Stmt[2]: Expr (span: 768:5-768:27)
+│        └─ Stmt[2]: Expr (span: 769:5-769:27)
 │           └─ Expr: expr#136: rt_panic(ptr, length)
-├─ Item[139]: Type (span: 771:1-774:3)
+├─ Item[140]: Type (span: 772:1-775:3)
 │  ├─ Name: RwLock
 │  ├─ Kind: Struct
 │  ├─ Visibility: public
 │  ├─ Attributes: @intrinsic
 │  └─ Struct:
 │     └─ Field[0]: __opaque: *byte
-├─ Item[140]: Extern (span: 776:1-784:2)
+├─ Item[141]: Extern (span: 777:1-785:2)
 │  ├─ Target: RwLock
 │  ├─ Members:
 │  │  ├─ Fn[0]: new
@@ -2488,97 +2493,97 @@ intrinsics.sg (span: 1:1-869:1)
 │  │     ├─ Params: (self: &mut RwLock)
 │  │     ├─ Return: bool
 │  │     └─ Attributes: @intrinsic
-├─ Item[141]: Fn (span: 792:1-793:38)
+├─ Item[142]: Fn (span: 793:1-794:38)
 │  ├─ Name: atomic_load
 │  ├─ Params: (ptr: &int)
 │  ├─ Return: int
 │  └─ Body: <none>
-├─ Item[142]: Fn (span: 795:1-797:40)
+├─ Item[143]: Fn (span: 796:1-798:40)
 │  ├─ Name: atomic_load
 │  ├─ Params: (ptr: &uint)
 │  ├─ Return: uint
 │  └─ Body: <none>
-├─ Item[143]: Fn (span: 799:1-801:40)
+├─ Item[144]: Fn (span: 800:1-802:40)
 │  ├─ Name: atomic_load
 │  ├─ Params: (ptr: &bool)
 │  ├─ Return: bool
 │  └─ Body: <none>
-├─ Item[144]: Fn (span: 804:1-805:59)
+├─ Item[145]: Fn (span: 805:1-806:59)
 │  ├─ Name: atomic_store
 │  ├─ Params: (ptr: &mut int, value: int)
 │  ├─ Return: nothing
 │  └─ Body: <none>
-├─ Item[145]: Fn (span: 807:1-809:61)
+├─ Item[146]: Fn (span: 808:1-810:61)
 │  ├─ Name: atomic_store
 │  ├─ Params: (ptr: &mut uint, value: uint)
 │  ├─ Return: nothing
 │  └─ Body: <none>
-├─ Item[146]: Fn (span: 811:1-813:61)
+├─ Item[147]: Fn (span: 812:1-814:61)
 │  ├─ Name: atomic_store
 │  ├─ Params: (ptr: &mut bool, value: bool)
 │  ├─ Return: nothing
 │  └─ Body: <none>
-├─ Item[147]: Fn (span: 816:1-817:60)
+├─ Item[148]: Fn (span: 817:1-818:60)
 │  ├─ Name: atomic_exchange
 │  ├─ Params: (ptr: &mut int, new_val: int)
 │  ├─ Return: int
 │  └─ Body: <none>
-├─ Item[148]: Fn (span: 819:1-821:63)
+├─ Item[149]: Fn (span: 820:1-822:63)
 │  ├─ Name: atomic_exchange
 │  ├─ Params: (ptr: &mut uint, new_val: uint)
 │  ├─ Return: uint
 │  └─ Body: <none>
-├─ Item[149]: Fn (span: 823:1-825:63)
+├─ Item[150]: Fn (span: 824:1-826:63)
 │  ├─ Name: atomic_exchange
 │  ├─ Params: (ptr: &mut bool, new_val: bool)
 │  ├─ Return: bool
 │  └─ Body: <none>
-├─ Item[150]: Fn (span: 829:1-830:84)
+├─ Item[151]: Fn (span: 830:1-831:84)
 │  ├─ Name: atomic_compare_exchange
 │  ├─ Params: (ptr: &mut int, expected: int, desired: int)
 │  ├─ Return: bool
 │  └─ Body: <none>
-├─ Item[151]: Fn (span: 832:1-834:87)
+├─ Item[152]: Fn (span: 833:1-835:87)
 │  ├─ Name: atomic_compare_exchange
 │  ├─ Params: (ptr: &mut uint, expected: uint, desired: uint)
 │  ├─ Return: bool
 │  └─ Body: <none>
-├─ Item[152]: Fn (span: 836:1-838:87)
+├─ Item[153]: Fn (span: 837:1-839:87)
 │  ├─ Name: atomic_compare_exchange
 │  ├─ Params: (ptr: &mut bool, expected: bool, desired: bool)
 │  ├─ Return: bool
 │  └─ Body: <none>
-├─ Item[153]: Fn (span: 841:1-842:59)
+├─ Item[154]: Fn (span: 842:1-843:59)
 │  ├─ Name: atomic_fetch_add
 │  ├─ Params: (ptr: &mut int, delta: int)
 │  ├─ Return: int
 │  └─ Body: <none>
-├─ Item[154]: Fn (span: 844:1-846:62)
+├─ Item[155]: Fn (span: 845:1-847:62)
 │  ├─ Name: atomic_fetch_add
 │  ├─ Params: (ptr: &mut uint, delta: uint)
 │  ├─ Return: uint
 │  └─ Body: <none>
-├─ Item[155]: Fn (span: 849:1-850:59)
+├─ Item[156]: Fn (span: 850:1-851:59)
 │  ├─ Name: atomic_fetch_sub
 │  ├─ Params: (ptr: &mut int, delta: int)
 │  ├─ Return: int
 │  └─ Body: <none>
-├─ Item[156]: Fn (span: 852:1-854:62)
+├─ Item[157]: Fn (span: 853:1-855:62)
 │  ├─ Name: atomic_fetch_sub
 │  ├─ Params: (ptr: &mut uint, delta: uint)
 │  ├─ Return: uint
 │  └─ Body: <none>
-├─ Item[157]: Fn (span: 859:1-860:30)
+├─ Item[158]: Fn (span: 860:1-861:30)
 │  ├─ Name: rt_argv
 │  ├─ Params: ()
 │  ├─ Return: string[]
 │  └─ Body: <none>
-├─ Item[158]: Fn (span: 863:1-864:38)
+├─ Item[159]: Fn (span: 864:1-865:38)
 │  ├─ Name: rt_stdin_read_all
 │  ├─ Params: ()
 │  ├─ Return: string
 │  └─ Body: <none>
-└─ Item[159]: Fn (span: 867:1-868:38)
+└─ Item[160]: Fn (span: 868:1-869:38)
    ├─ Name: rt_exit
    ├─ Params: (code: int)
    ├─ Return: nothing

--- a/testdata/golden/core_stdlib/intrinsics.fmt
+++ b/testdata/golden/core_stdlib/intrinsics.fmt
@@ -132,6 +132,7 @@ extern<TcpConn> {
 @intrinsic fn rt_array_append_raw_bytes(a: &mut byte[], ptr: *byte, length: uint64) -> nothing;
 @intrinsic fn rt_byte_array_append_range(dst: &mut byte[], src: &byte[], start: uint64, length: uint64) -> nothing;
 @intrinsic fn rt_byte_array_drop_prefix(a: &mut byte[], count: uint64) -> nothing;
+@intrinsic fn rt_byte_parse_uint64_token(data: &byte[], start: uint64, end: uint64, value: &mut uint64, next: &mut uint64) -> bool;
 
 // Map access intrinsics
 @intrinsic fn rt_map_new<K, V>() -> Map<K, V>;

--- a/testdata/golden/core_stdlib/intrinsics.sg
+++ b/testdata/golden/core_stdlib/intrinsics.sg
@@ -132,6 +132,7 @@ extern<TcpConn> {
 @intrinsic fn rt_array_append_raw_bytes(a: &mut byte[], ptr: *byte, length: uint64) -> nothing;
 @intrinsic fn rt_byte_array_append_range(dst: &mut byte[], src: &byte[], start: uint64, length: uint64) -> nothing;
 @intrinsic fn rt_byte_array_drop_prefix(a: &mut byte[], count: uint64) -> nothing;
+@intrinsic fn rt_byte_parse_uint64_token(data: &byte[], start: uint64, end: uint64, value: &mut uint64, next: &mut uint64) -> bool;
 
 // Map access intrinsics
 @intrinsic fn rt_map_new<K, V>() -> Map<K, V>;

--- a/testdata/golden/core_stdlib/intrinsics.tokens
+++ b/testdata/golden/core_stdlib/intrinsics.tokens
@@ -1374,181 +1374,181 @@
 1374: Arrow           "->" at 134:72-134:74 (leading: Space)
 1375: NothingLit      "nothing" at 134:75-134:82 (leading: Space)
 1376: Semicolon       ";" at 134:82-134:83
-1377: At              "@" at 137:1-137:2 (leading: Newline, LineComment, Newline)
-1378: Ident           "intrinsic" at 137:2-137:11
-1379: KwFn            "fn" at 137:12-137:14 (leading: Space)
-1380: Ident           "rt_map_new" at 137:15-137:25 (leading: Space)
-1381: Lt              "<" at 137:25-137:26
-1382: Ident           "K" at 137:26-137:27
-1383: Comma           "," at 137:27-137:28
-1384: Ident           "V" at 137:29-137:30 (leading: Space)
-1385: Gt              ">" at 137:30-137:31
-1386: LParen          "(" at 137:31-137:32
-1387: RParen          ")" at 137:32-137:33
-1388: Arrow           "->" at 137:34-137:36 (leading: Space)
-1389: Ident           "Map" at 137:37-137:40 (leading: Space)
-1390: Lt              "<" at 137:40-137:41
-1391: Ident           "K" at 137:41-137:42
-1392: Comma           "," at 137:42-137:43
-1393: Ident           "V" at 137:44-137:45 (leading: Space)
-1394: Gt              ">" at 137:45-137:46
-1395: Semicolon       ";" at 137:46-137:47
-1396: At              "@" at 138:1-138:2 (leading: Newline)
-1397: Ident           "intrinsic" at 138:2-138:11
-1398: KwFn            "fn" at 138:12-138:14 (leading: Space)
-1399: Ident           "rt_map_len" at 138:15-138:25 (leading: Space)
-1400: Lt              "<" at 138:25-138:26
-1401: Ident           "K" at 138:26-138:27
-1402: Comma           "," at 138:27-138:28
-1403: Ident           "V" at 138:29-138:30 (leading: Space)
-1404: Gt              ">" at 138:30-138:31
-1405: LParen          "(" at 138:31-138:32
-1406: Ident           "m" at 138:32-138:33
-1407: Colon           ":" at 138:33-138:34
-1408: Amp             "&" at 138:35-138:36 (leading: Space)
-1409: Ident           "Map" at 138:36-138:39
-1410: Lt              "<" at 138:39-138:40
-1411: Ident           "K" at 138:40-138:41
-1412: Comma           "," at 138:41-138:42
-1413: Ident           "V" at 138:43-138:44 (leading: Space)
-1414: Gt              ">" at 138:44-138:45
-1415: RParen          ")" at 138:45-138:46
-1416: Arrow           "->" at 138:47-138:49 (leading: Space)
-1417: Ident           "uint" at 138:50-138:54 (leading: Space)
-1418: Semicolon       ";" at 138:54-138:55
-1419: At              "@" at 139:1-139:2 (leading: Newline)
-1420: Ident           "intrinsic" at 139:2-139:11
-1421: KwFn            "fn" at 139:12-139:14 (leading: Space)
-1422: Ident           "rt_map_contains" at 139:15-139:30 (leading: Space)
-1423: Lt              "<" at 139:30-139:31
-1424: Ident           "K" at 139:31-139:32
-1425: Comma           "," at 139:32-139:33
-1426: Ident           "V" at 139:34-139:35 (leading: Space)
-1427: Gt              ">" at 139:35-139:36
-1428: LParen          "(" at 139:36-139:37
-1429: Ident           "m" at 139:37-139:38
-1430: Colon           ":" at 139:38-139:39
-1431: Amp             "&" at 139:40-139:41 (leading: Space)
-1432: Ident           "Map" at 139:41-139:44
-1433: Lt              "<" at 139:44-139:45
-1434: Ident           "K" at 139:45-139:46
-1435: Comma           "," at 139:46-139:47
-1436: Ident           "V" at 139:48-139:49 (leading: Space)
-1437: Gt              ">" at 139:49-139:50
-1438: Comma           "," at 139:50-139:51
-1439: Ident           "key" at 139:52-139:55 (leading: Space)
-1440: Colon           ":" at 139:55-139:56
-1441: Amp             "&" at 139:57-139:58 (leading: Space)
-1442: Ident           "K" at 139:58-139:59
-1443: RParen          ")" at 139:59-139:60
-1444: Arrow           "->" at 139:61-139:63 (leading: Space)
-1445: Ident           "bool" at 139:64-139:68 (leading: Space)
-1446: Semicolon       ";" at 139:68-139:69
-1447: At              "@" at 140:1-140:2 (leading: Newline)
-1448: Ident           "intrinsic" at 140:2-140:11
-1449: KwFn            "fn" at 140:12-140:14 (leading: Space)
-1450: Ident           "rt_map_get_ref" at 140:15-140:29 (leading: Space)
-1451: Lt              "<" at 140:29-140:30
-1452: Ident           "K" at 140:30-140:31
-1453: Comma           "," at 140:31-140:32
-1454: Ident           "V" at 140:33-140:34 (leading: Space)
-1455: Gt              ">" at 140:34-140:35
-1456: LParen          "(" at 140:35-140:36
-1457: Ident           "m" at 140:36-140:37
-1458: Colon           ":" at 140:37-140:38
-1459: Amp             "&" at 140:39-140:40 (leading: Space)
-1460: Ident           "Map" at 140:40-140:43
-1461: Lt              "<" at 140:43-140:44
-1462: Ident           "K" at 140:44-140:45
-1463: Comma           "," at 140:45-140:46
-1464: Ident           "V" at 140:47-140:48 (leading: Space)
-1465: Gt              ">" at 140:48-140:49
-1466: Comma           "," at 140:49-140:50
-1467: Ident           "key" at 140:51-140:54 (leading: Space)
-1468: Colon           ":" at 140:54-140:55
-1469: Amp             "&" at 140:56-140:57 (leading: Space)
-1470: Ident           "K" at 140:57-140:58
-1471: RParen          ")" at 140:58-140:59
-1472: Arrow           "->" at 140:60-140:62 (leading: Space)
-1473: Ident           "Option" at 140:63-140:69 (leading: Space)
-1474: Lt              "<" at 140:69-140:70
-1475: Amp             "&" at 140:70-140:71
-1476: Ident           "V" at 140:71-140:72
-1477: Gt              ">" at 140:72-140:73
-1478: Semicolon       ";" at 140:73-140:74
-1479: At              "@" at 141:1-141:2 (leading: Newline)
-1480: Ident           "intrinsic" at 141:2-141:11
-1481: KwFn            "fn" at 141:12-141:14 (leading: Space)
-1482: Ident           "rt_map_get_mut" at 141:15-141:29 (leading: Space)
-1483: Lt              "<" at 141:29-141:30
-1484: Ident           "K" at 141:30-141:31
-1485: Comma           "," at 141:31-141:32
-1486: Ident           "V" at 141:33-141:34 (leading: Space)
-1487: Gt              ">" at 141:34-141:35
-1488: LParen          "(" at 141:35-141:36
-1489: Ident           "m" at 141:36-141:37
-1490: Colon           ":" at 141:37-141:38
-1491: Amp             "&" at 141:39-141:40 (leading: Space)
-1492: KwMut           "mut" at 141:40-141:43
-1493: Ident           "Map" at 141:44-141:47 (leading: Space)
-1494: Lt              "<" at 141:47-141:48
-1495: Ident           "K" at 141:48-141:49
-1496: Comma           "," at 141:49-141:50
-1497: Ident           "V" at 141:51-141:52 (leading: Space)
-1498: Gt              ">" at 141:52-141:53
-1499: Comma           "," at 141:53-141:54
-1500: Ident           "key" at 141:55-141:58 (leading: Space)
-1501: Colon           ":" at 141:58-141:59
-1502: Amp             "&" at 141:60-141:61 (leading: Space)
-1503: Ident           "K" at 141:61-141:62
-1504: RParen          ")" at 141:62-141:63
-1505: Arrow           "->" at 141:64-141:66 (leading: Space)
-1506: Ident           "Option" at 141:67-141:73 (leading: Space)
-1507: Lt              "<" at 141:73-141:74
-1508: Amp             "&" at 141:74-141:75
-1509: KwMut           "mut" at 141:75-141:78
-1510: Ident           "V" at 141:79-141:80 (leading: Space)
-1511: Gt              ">" at 141:80-141:81
-1512: Semicolon       ";" at 141:81-141:82
-1513: At              "@" at 142:1-142:2 (leading: Newline)
-1514: Ident           "intrinsic" at 142:2-142:11
-1515: KwFn            "fn" at 142:12-142:14 (leading: Space)
-1516: Ident           "rt_map_insert" at 142:15-142:28 (leading: Space)
-1517: Lt              "<" at 142:28-142:29
-1518: Ident           "K" at 142:29-142:30
-1519: Comma           "," at 142:30-142:31
-1520: Ident           "V" at 142:32-142:33 (leading: Space)
-1521: Gt              ">" at 142:33-142:34
-1522: LParen          "(" at 142:34-142:35
-1523: Ident           "m" at 142:35-142:36
-1524: Colon           ":" at 142:36-142:37
-1525: Amp             "&" at 142:38-142:39 (leading: Space)
-1526: KwMut           "mut" at 142:39-142:42
-1527: Ident           "Map" at 142:43-142:46 (leading: Space)
-1528: Lt              "<" at 142:46-142:47
-1529: Ident           "K" at 142:47-142:48
-1530: Comma           "," at 142:48-142:49
-1531: Ident           "V" at 142:50-142:51 (leading: Space)
-1532: Gt              ">" at 142:51-142:52
-1533: Comma           "," at 142:52-142:53
-1534: Ident           "key" at 142:54-142:57 (leading: Space)
-1535: Colon           ":" at 142:57-142:58
-1536: Ident           "K" at 142:59-142:60 (leading: Space)
-1537: Comma           "," at 142:60-142:61
-1538: Ident           "value" at 142:62-142:67 (leading: Space)
-1539: Colon           ":" at 142:67-142:68
-1540: Ident           "V" at 142:69-142:70 (leading: Space)
-1541: RParen          ")" at 142:70-142:71
-1542: Arrow           "->" at 142:72-142:74 (leading: Space)
-1543: Ident           "Option" at 142:75-142:81 (leading: Space)
-1544: Lt              "<" at 142:81-142:82
-1545: Ident           "V" at 142:82-142:83
-1546: Gt              ">" at 142:83-142:84
-1547: Semicolon       ";" at 142:84-142:85
+1377: At              "@" at 135:1-135:2 (leading: Newline)
+1378: Ident           "intrinsic" at 135:2-135:11
+1379: KwFn            "fn" at 135:12-135:14 (leading: Space)
+1380: Ident           "rt_byte_parse_uint64_token" at 135:15-135:41 (leading: Space)
+1381: LParen          "(" at 135:41-135:42
+1382: Ident           "data" at 135:42-135:46
+1383: Colon           ":" at 135:46-135:47
+1384: Amp             "&" at 135:48-135:49 (leading: Space)
+1385: Ident           "byte" at 135:49-135:53
+1386: LBracket        "[" at 135:53-135:54
+1387: RBracket        "]" at 135:54-135:55
+1388: Comma           "," at 135:55-135:56
+1389: Ident           "start" at 135:57-135:62 (leading: Space)
+1390: Colon           ":" at 135:62-135:63
+1391: Ident           "uint64" at 135:64-135:70 (leading: Space)
+1392: Comma           "," at 135:70-135:71
+1393: Ident           "end" at 135:72-135:75 (leading: Space)
+1394: Colon           ":" at 135:75-135:76
+1395: Ident           "uint64" at 135:77-135:83 (leading: Space)
+1396: Comma           "," at 135:83-135:84
+1397: Ident           "value" at 135:85-135:90 (leading: Space)
+1398: Colon           ":" at 135:90-135:91
+1399: Amp             "&" at 135:92-135:93 (leading: Space)
+1400: KwMut           "mut" at 135:93-135:96
+1401: Ident           "uint64" at 135:97-135:103 (leading: Space)
+1402: Comma           "," at 135:103-135:104
+1403: Ident           "next" at 135:105-135:109 (leading: Space)
+1404: Colon           ":" at 135:109-135:110
+1405: Amp             "&" at 135:111-135:112 (leading: Space)
+1406: KwMut           "mut" at 135:112-135:115
+1407: Ident           "uint64" at 135:116-135:122 (leading: Space)
+1408: RParen          ")" at 135:122-135:123
+1409: Arrow           "->" at 135:124-135:126 (leading: Space)
+1410: Ident           "bool" at 135:127-135:131 (leading: Space)
+1411: Semicolon       ";" at 135:131-135:132
+1412: At              "@" at 138:1-138:2 (leading: Newline, LineComment, Newline)
+1413: Ident           "intrinsic" at 138:2-138:11
+1414: KwFn            "fn" at 138:12-138:14 (leading: Space)
+1415: Ident           "rt_map_new" at 138:15-138:25 (leading: Space)
+1416: Lt              "<" at 138:25-138:26
+1417: Ident           "K" at 138:26-138:27
+1418: Comma           "," at 138:27-138:28
+1419: Ident           "V" at 138:29-138:30 (leading: Space)
+1420: Gt              ">" at 138:30-138:31
+1421: LParen          "(" at 138:31-138:32
+1422: RParen          ")" at 138:32-138:33
+1423: Arrow           "->" at 138:34-138:36 (leading: Space)
+1424: Ident           "Map" at 138:37-138:40 (leading: Space)
+1425: Lt              "<" at 138:40-138:41
+1426: Ident           "K" at 138:41-138:42
+1427: Comma           "," at 138:42-138:43
+1428: Ident           "V" at 138:44-138:45 (leading: Space)
+1429: Gt              ">" at 138:45-138:46
+1430: Semicolon       ";" at 138:46-138:47
+1431: At              "@" at 139:1-139:2 (leading: Newline)
+1432: Ident           "intrinsic" at 139:2-139:11
+1433: KwFn            "fn" at 139:12-139:14 (leading: Space)
+1434: Ident           "rt_map_len" at 139:15-139:25 (leading: Space)
+1435: Lt              "<" at 139:25-139:26
+1436: Ident           "K" at 139:26-139:27
+1437: Comma           "," at 139:27-139:28
+1438: Ident           "V" at 139:29-139:30 (leading: Space)
+1439: Gt              ">" at 139:30-139:31
+1440: LParen          "(" at 139:31-139:32
+1441: Ident           "m" at 139:32-139:33
+1442: Colon           ":" at 139:33-139:34
+1443: Amp             "&" at 139:35-139:36 (leading: Space)
+1444: Ident           "Map" at 139:36-139:39
+1445: Lt              "<" at 139:39-139:40
+1446: Ident           "K" at 139:40-139:41
+1447: Comma           "," at 139:41-139:42
+1448: Ident           "V" at 139:43-139:44 (leading: Space)
+1449: Gt              ">" at 139:44-139:45
+1450: RParen          ")" at 139:45-139:46
+1451: Arrow           "->" at 139:47-139:49 (leading: Space)
+1452: Ident           "uint" at 139:50-139:54 (leading: Space)
+1453: Semicolon       ";" at 139:54-139:55
+1454: At              "@" at 140:1-140:2 (leading: Newline)
+1455: Ident           "intrinsic" at 140:2-140:11
+1456: KwFn            "fn" at 140:12-140:14 (leading: Space)
+1457: Ident           "rt_map_contains" at 140:15-140:30 (leading: Space)
+1458: Lt              "<" at 140:30-140:31
+1459: Ident           "K" at 140:31-140:32
+1460: Comma           "," at 140:32-140:33
+1461: Ident           "V" at 140:34-140:35 (leading: Space)
+1462: Gt              ">" at 140:35-140:36
+1463: LParen          "(" at 140:36-140:37
+1464: Ident           "m" at 140:37-140:38
+1465: Colon           ":" at 140:38-140:39
+1466: Amp             "&" at 140:40-140:41 (leading: Space)
+1467: Ident           "Map" at 140:41-140:44
+1468: Lt              "<" at 140:44-140:45
+1469: Ident           "K" at 140:45-140:46
+1470: Comma           "," at 140:46-140:47
+1471: Ident           "V" at 140:48-140:49 (leading: Space)
+1472: Gt              ">" at 140:49-140:50
+1473: Comma           "," at 140:50-140:51
+1474: Ident           "key" at 140:52-140:55 (leading: Space)
+1475: Colon           ":" at 140:55-140:56
+1476: Amp             "&" at 140:57-140:58 (leading: Space)
+1477: Ident           "K" at 140:58-140:59
+1478: RParen          ")" at 140:59-140:60
+1479: Arrow           "->" at 140:61-140:63 (leading: Space)
+1480: Ident           "bool" at 140:64-140:68 (leading: Space)
+1481: Semicolon       ";" at 140:68-140:69
+1482: At              "@" at 141:1-141:2 (leading: Newline)
+1483: Ident           "intrinsic" at 141:2-141:11
+1484: KwFn            "fn" at 141:12-141:14 (leading: Space)
+1485: Ident           "rt_map_get_ref" at 141:15-141:29 (leading: Space)
+1486: Lt              "<" at 141:29-141:30
+1487: Ident           "K" at 141:30-141:31
+1488: Comma           "," at 141:31-141:32
+1489: Ident           "V" at 141:33-141:34 (leading: Space)
+1490: Gt              ">" at 141:34-141:35
+1491: LParen          "(" at 141:35-141:36
+1492: Ident           "m" at 141:36-141:37
+1493: Colon           ":" at 141:37-141:38
+1494: Amp             "&" at 141:39-141:40 (leading: Space)
+1495: Ident           "Map" at 141:40-141:43
+1496: Lt              "<" at 141:43-141:44
+1497: Ident           "K" at 141:44-141:45
+1498: Comma           "," at 141:45-141:46
+1499: Ident           "V" at 141:47-141:48 (leading: Space)
+1500: Gt              ">" at 141:48-141:49
+1501: Comma           "," at 141:49-141:50
+1502: Ident           "key" at 141:51-141:54 (leading: Space)
+1503: Colon           ":" at 141:54-141:55
+1504: Amp             "&" at 141:56-141:57 (leading: Space)
+1505: Ident           "K" at 141:57-141:58
+1506: RParen          ")" at 141:58-141:59
+1507: Arrow           "->" at 141:60-141:62 (leading: Space)
+1508: Ident           "Option" at 141:63-141:69 (leading: Space)
+1509: Lt              "<" at 141:69-141:70
+1510: Amp             "&" at 141:70-141:71
+1511: Ident           "V" at 141:71-141:72
+1512: Gt              ">" at 141:72-141:73
+1513: Semicolon       ";" at 141:73-141:74
+1514: At              "@" at 142:1-142:2 (leading: Newline)
+1515: Ident           "intrinsic" at 142:2-142:11
+1516: KwFn            "fn" at 142:12-142:14 (leading: Space)
+1517: Ident           "rt_map_get_mut" at 142:15-142:29 (leading: Space)
+1518: Lt              "<" at 142:29-142:30
+1519: Ident           "K" at 142:30-142:31
+1520: Comma           "," at 142:31-142:32
+1521: Ident           "V" at 142:33-142:34 (leading: Space)
+1522: Gt              ">" at 142:34-142:35
+1523: LParen          "(" at 142:35-142:36
+1524: Ident           "m" at 142:36-142:37
+1525: Colon           ":" at 142:37-142:38
+1526: Amp             "&" at 142:39-142:40 (leading: Space)
+1527: KwMut           "mut" at 142:40-142:43
+1528: Ident           "Map" at 142:44-142:47 (leading: Space)
+1529: Lt              "<" at 142:47-142:48
+1530: Ident           "K" at 142:48-142:49
+1531: Comma           "," at 142:49-142:50
+1532: Ident           "V" at 142:51-142:52 (leading: Space)
+1533: Gt              ">" at 142:52-142:53
+1534: Comma           "," at 142:53-142:54
+1535: Ident           "key" at 142:55-142:58 (leading: Space)
+1536: Colon           ":" at 142:58-142:59
+1537: Amp             "&" at 142:60-142:61 (leading: Space)
+1538: Ident           "K" at 142:61-142:62
+1539: RParen          ")" at 142:62-142:63
+1540: Arrow           "->" at 142:64-142:66 (leading: Space)
+1541: Ident           "Option" at 142:67-142:73 (leading: Space)
+1542: Lt              "<" at 142:73-142:74
+1543: Amp             "&" at 142:74-142:75
+1544: KwMut           "mut" at 142:75-142:78
+1545: Ident           "V" at 142:79-142:80 (leading: Space)
+1546: Gt              ">" at 142:80-142:81
+1547: Semicolon       ";" at 142:81-142:82
 1548: At              "@" at 143:1-143:2 (leading: Newline)
 1549: Ident           "intrinsic" at 143:2-143:11
 1550: KwFn            "fn" at 143:12-143:14 (leading: Space)
-1551: Ident           "rt_map_remove" at 143:15-143:28 (leading: Space)
+1551: Ident           "rt_map_insert" at 143:15-143:28 (leading: Space)
 1552: Lt              "<" at 143:28-143:29
 1553: Ident           "K" at 143:29-143:30
 1554: Comma           "," at 143:30-143:31
@@ -1568,8122 +1568,8157 @@
 1568: Comma           "," at 143:52-143:53
 1569: Ident           "key" at 143:54-143:57 (leading: Space)
 1570: Colon           ":" at 143:57-143:58
-1571: Amp             "&" at 143:59-143:60 (leading: Space)
-1572: Ident           "K" at 143:60-143:61
-1573: RParen          ")" at 143:61-143:62
-1574: Arrow           "->" at 143:63-143:65 (leading: Space)
-1575: Ident           "Option" at 143:66-143:72 (leading: Space)
-1576: Lt              "<" at 143:72-143:73
-1577: Ident           "V" at 143:73-143:74
-1578: Gt              ">" at 143:74-143:75
-1579: Semicolon       ";" at 143:75-143:76
-1580: At              "@" at 144:1-144:2 (leading: Newline)
-1581: Ident           "intrinsic" at 144:2-144:11
-1582: KwFn            "fn" at 144:12-144:14 (leading: Space)
-1583: Ident           "rt_map_keys" at 144:15-144:26 (leading: Space)
-1584: Lt              "<" at 144:26-144:27
-1585: Ident           "K" at 144:27-144:28
-1586: Comma           "," at 144:28-144:29
-1587: Ident           "V" at 144:30-144:31 (leading: Space)
-1588: Gt              ">" at 144:31-144:32
-1589: LParen          "(" at 144:32-144:33
-1590: Ident           "m" at 144:33-144:34
-1591: Colon           ":" at 144:34-144:35
-1592: Amp             "&" at 144:36-144:37 (leading: Space)
-1593: Ident           "Map" at 144:37-144:40
-1594: Lt              "<" at 144:40-144:41
-1595: Ident           "K" at 144:41-144:42
-1596: Comma           "," at 144:42-144:43
-1597: Ident           "V" at 144:44-144:45 (leading: Space)
-1598: Gt              ">" at 144:45-144:46
-1599: RParen          ")" at 144:46-144:47
-1600: Arrow           "->" at 144:48-144:50 (leading: Space)
-1601: Ident           "K" at 144:51-144:52 (leading: Space)
-1602: LBracket        "[" at 144:52-144:53
-1603: RBracket        "]" at 144:53-144:54
-1604: Semicolon       ";" at 144:54-144:55
-1605: At              "@" at 147:1-147:2 (leading: Newline, LineComment, Newline)
-1606: Ident           "intrinsic" at 147:2-147:11
-1607: KwPub           "pub" at 148:1-148:4 (leading: Newline)
-1608: KwFn            "fn" at 148:5-148:7 (leading: Space)
-1609: Ident           "readline" at 148:8-148:16 (leading: Space)
-1610: LParen          "(" at 148:16-148:17
-1611: RParen          ")" at 148:17-148:18
-1612: Arrow           "->" at 148:19-148:21 (leading: Space)
-1613: Ident           "string" at 148:22-148:28 (leading: Space)
-1614: Semicolon       ";" at 148:28-148:29
-1615: At              "@" at 150:1-150:2 (leading: Newline)
-1616: Ident           "intrinsic" at 150:2-150:11
-1617: KwPub           "pub" at 151:1-151:4 (leading: Newline)
-1618: KwType          "type" at 151:5-151:9 (leading: Space)
-1619: Ident           "Range" at 151:10-151:15 (leading: Space)
-1620: Lt              "<" at 151:15-151:16
-1621: Ident           "T" at 151:16-151:17
-1622: Gt              ">" at 151:17-151:18
-1623: Assign          "=" at 151:19-151:20 (leading: Space)
-1624: LBrace          "{" at 151:21-151:22 (leading: Space)
-1625: Ident           "__state" at 152:5-152:12 (leading: Newline, Space)
-1626: Colon           ":" at 152:12-152:13
-1627: Star            "*" at 152:14-152:15 (leading: Space)
-1628: Ident           "byte" at 152:15-152:19
-1629: Comma           "," at 152:19-152:20
-1630: RBrace          "}" at 153:1-153:2 (leading: Newline)
-1631: Semicolon       ";" at 153:2-153:3
-1632: At              "@" at 156:1-156:2 (leading: Newline, LineComment, Newline)
-1633: Ident           "intrinsic" at 156:2-156:11
-1634: KwPub           "pub" at 156:12-156:15 (leading: Space)
-1635: KwFn            "fn" at 156:16-156:18 (leading: Space)
-1636: Ident           "rt_range_int_new" at 156:19-156:35 (leading: Space)
-1637: LParen          "(" at 156:35-156:36
-1638: Ident           "start" at 156:36-156:41
-1639: Colon           ":" at 156:41-156:42
-1640: Ident           "int" at 156:43-156:46 (leading: Space)
-1641: Comma           "," at 156:46-156:47
-1642: Ident           "end" at 156:48-156:51 (leading: Space)
-1643: Colon           ":" at 156:51-156:52
-1644: Ident           "int" at 156:53-156:56 (leading: Space)
-1645: Comma           "," at 156:56-156:57
-1646: Ident           "inclusive" at 156:58-156:67 (leading: Space)
-1647: Colon           ":" at 156:67-156:68
-1648: Ident           "bool" at 156:69-156:73 (leading: Space)
-1649: RParen          ")" at 156:73-156:74
-1650: Arrow           "->" at 156:75-156:77 (leading: Space)
-1651: Ident           "Range" at 156:78-156:83 (leading: Space)
-1652: Lt              "<" at 156:83-156:84
-1653: Ident           "int" at 156:84-156:87
-1654: Gt              ">" at 156:87-156:88
-1655: Semicolon       ";" at 156:88-156:89
-1656: At              "@" at 157:1-157:2 (leading: Newline)
-1657: Ident           "intrinsic" at 157:2-157:11
-1658: KwPub           "pub" at 157:12-157:15 (leading: Space)
-1659: KwFn            "fn" at 157:16-157:18 (leading: Space)
-1660: Ident           "rt_range_int_from_start" at 157:19-157:42 (leading: Space)
-1661: LParen          "(" at 157:42-157:43
-1662: Ident           "start" at 157:43-157:48
-1663: Colon           ":" at 157:48-157:49
-1664: Ident           "int" at 157:50-157:53 (leading: Space)
-1665: Comma           "," at 157:53-157:54
-1666: Ident           "inclusive" at 157:55-157:64 (leading: Space)
-1667: Colon           ":" at 157:64-157:65
-1668: Ident           "bool" at 157:66-157:70 (leading: Space)
-1669: RParen          ")" at 157:70-157:71
-1670: Arrow           "->" at 157:72-157:74 (leading: Space)
-1671: Ident           "Range" at 157:75-157:80 (leading: Space)
-1672: Lt              "<" at 157:80-157:81
-1673: Ident           "int" at 157:81-157:84
-1674: Gt              ">" at 157:84-157:85
-1675: Semicolon       ";" at 157:85-157:86
-1676: At              "@" at 158:1-158:2 (leading: Newline)
-1677: Ident           "intrinsic" at 158:2-158:11
-1678: KwPub           "pub" at 158:12-158:15 (leading: Space)
-1679: KwFn            "fn" at 158:16-158:18 (leading: Space)
-1680: Ident           "rt_range_int_to_end" at 158:19-158:38 (leading: Space)
-1681: LParen          "(" at 158:38-158:39
-1682: Ident           "end" at 158:39-158:42
-1683: Colon           ":" at 158:42-158:43
-1684: Ident           "int" at 158:44-158:47 (leading: Space)
-1685: Comma           "," at 158:47-158:48
-1686: Ident           "inclusive" at 158:49-158:58 (leading: Space)
-1687: Colon           ":" at 158:58-158:59
-1688: Ident           "bool" at 158:60-158:64 (leading: Space)
-1689: RParen          ")" at 158:64-158:65
-1690: Arrow           "->" at 158:66-158:68 (leading: Space)
-1691: Ident           "Range" at 158:69-158:74 (leading: Space)
-1692: Lt              "<" at 158:74-158:75
-1693: Ident           "int" at 158:75-158:78
-1694: Gt              ">" at 158:78-158:79
-1695: Semicolon       ";" at 158:79-158:80
-1696: At              "@" at 159:1-159:2 (leading: Newline)
-1697: Ident           "intrinsic" at 159:2-159:11
-1698: KwPub           "pub" at 159:12-159:15 (leading: Space)
-1699: KwFn            "fn" at 159:16-159:18 (leading: Space)
-1700: Ident           "rt_range_int_full" at 159:19-159:36 (leading: Space)
-1701: LParen          "(" at 159:36-159:37
-1702: Ident           "inclusive" at 159:37-159:46
-1703: Colon           ":" at 159:46-159:47
-1704: Ident           "bool" at 159:48-159:52 (leading: Space)
-1705: RParen          ")" at 159:52-159:53
-1706: Arrow           "->" at 159:54-159:56 (leading: Space)
-1707: Ident           "Range" at 159:57-159:62 (leading: Space)
-1708: Lt              "<" at 159:62-159:63
-1709: Ident           "int" at 159:63-159:66
-1710: Gt              ">" at 159:66-159:67
-1711: Semicolon       ";" at 159:67-159:68
-1712: KwExtern        "extern" at 161:1-161:7 (leading: Newline)
-1713: Lt              "<" at 161:7-161:8
-1714: Ident           "Range" at 161:8-161:13
-1715: Lt              "<" at 161:13-161:14
-1716: Ident           "T" at 161:14-161:15
-1717: Shr             ">>" at 161:15-161:17
-1718: LBrace          "{" at 161:18-161:19 (leading: Space)
-1719: At              "@" at 162:5-162:6 (leading: Newline, Space)
-1720: Ident           "intrinsic" at 162:6-162:15
-1721: KwPub           "pub" at 162:16-162:19 (leading: Space)
-1722: KwFn            "fn" at 162:20-162:22 (leading: Space)
-1723: Ident           "next" at 162:23-162:27 (leading: Space)
-1724: LParen          "(" at 162:27-162:28
-1725: Ident           "self" at 162:28-162:32
-1726: Colon           ":" at 162:32-162:33
-1727: Amp             "&" at 162:34-162:35 (leading: Space)
-1728: KwMut           "mut" at 162:35-162:38
-1729: Ident           "Range" at 162:39-162:44 (leading: Space)
-1730: Lt              "<" at 162:44-162:45
-1731: Ident           "T" at 162:45-162:46
-1732: Gt              ">" at 162:46-162:47
-1733: RParen          ")" at 162:47-162:48
-1734: Arrow           "->" at 162:49-162:51 (leading: Space)
-1735: Ident           "Option" at 162:52-162:58 (leading: Space)
-1736: Lt              "<" at 162:58-162:59
-1737: Ident           "T" at 162:59-162:60
-1738: Gt              ">" at 162:60-162:61
-1739: Semicolon       ";" at 162:61-162:62
-1740: RBrace          "}" at 163:1-163:2 (leading: Newline)
-1741: KwPub           "pub" at 165:1-165:4 (leading: Newline)
-1742: KwType          "type" at 165:5-165:9 (leading: Space)
-1743: Ident           "HeapStats" at 165:10-165:19 (leading: Space)
-1744: Assign          "=" at 165:20-165:21 (leading: Space)
-1745: LBrace          "{" at 165:22-165:23 (leading: Space)
-1746: Ident           "alloc_count" at 166:5-166:16 (leading: Newline, Space)
-1747: Colon           ":" at 166:16-166:17
-1748: Ident           "uint" at 166:18-166:22 (leading: Space)
-1749: Comma           "," at 166:22-166:23
-1750: Ident           "free_count" at 167:5-167:15 (leading: Newline, Space)
-1751: Colon           ":" at 167:15-167:16
-1752: Ident           "uint" at 167:17-167:21 (leading: Space)
-1753: Comma           "," at 167:21-167:22
-1754: Ident           "live_blocks" at 168:5-168:16 (leading: Newline, Space)
-1755: Colon           ":" at 168:16-168:17
-1756: Ident           "uint" at 168:18-168:22 (leading: Space)
-1757: Comma           "," at 168:22-168:23
-1758: Ident           "live_bytes" at 169:5-169:15 (leading: Newline, Space)
-1759: Colon           ":" at 169:15-169:16
-1760: Ident           "uint" at 169:17-169:21 (leading: Space)
-1761: Comma           "," at 169:21-169:22
-1762: Ident           "rc_increments" at 170:5-170:18 (leading: Newline, Space)
-1763: Colon           ":" at 170:18-170:19
-1764: Ident           "uint" at 170:20-170:24 (leading: Space)
-1765: Comma           "," at 170:24-170:25
-1766: Ident           "rc_decrements" at 171:5-171:18 (leading: Newline, Space)
-1767: Colon           ":" at 171:18-171:19
-1768: Ident           "uint" at 171:20-171:24 (leading: Space)
-1769: Comma           "," at 171:24-171:25
-1770: RBrace          "}" at 172:1-172:2 (leading: Newline)
-1771: Semicolon       ";" at 172:2-172:3
-1772: At              "@" at 178:1-178:2 (leading: Newline, LineComment, Newline, LineComment, Newline, LineComment, Newline, LineComment, Newline)
-1773: Ident           "intrinsic" at 178:2-178:11
-1774: KwPub           "pub" at 178:12-178:15 (leading: Space)
-1775: KwFn            "fn" at 178:16-178:18 (leading: Space)
-1776: Ident           "rt_heap_stats" at 178:19-178:32 (leading: Space)
-1777: LParen          "(" at 178:32-178:33
-1778: RParen          ")" at 178:33-178:34
-1779: Arrow           "->" at 178:35-178:37 (leading: Space)
-1780: Ident           "HeapStats" at 178:38-178:47 (leading: Space)
-1781: Semicolon       ";" at 178:47-178:48
-1782: At              "@" at 180:1-180:2 (leading: Newline, LineComment, Newline)
-1783: Ident           "intrinsic" at 180:2-180:11
-1784: KwPub           "pub" at 180:12-180:15 (leading: Space)
-1785: KwFn            "fn" at 180:16-180:18 (leading: Space)
-1786: Ident           "rt_heap_dump" at 180:19-180:31 (leading: Space)
-1787: LParen          "(" at 180:31-180:32
-1788: RParen          ")" at 180:32-180:33
-1789: Arrow           "->" at 180:34-180:36 (leading: Space)
-1790: Ident           "string" at 180:37-180:43 (leading: Space)
-1791: Semicolon       ";" at 180:43-180:44
-1792: At              "@" at 182:1-182:2 (leading: Newline, LineComment, Newline)
-1793: Ident           "intrinsic" at 182:2-182:11
-1794: KwPub           "pub" at 182:12-182:15 (leading: Space)
-1795: KwFn            "fn" at 182:16-182:18 (leading: Space)
-1796: Ident           "rt_worker_count" at 182:19-182:34 (leading: Space)
-1797: LParen          "(" at 182:34-182:35
-1798: RParen          ")" at 182:35-182:36
-1799: Arrow           "->" at 182:37-182:39 (leading: Space)
-1800: Ident           "uint" at 182:40-182:44 (leading: Space)
-1801: Semicolon       ";" at 182:44-182:45
-1802: KwPub           "pub" at 184:1-184:4 (leading: Newline)
-1803: KwType          "type" at 184:5-184:9 (leading: Space)
-1804: Ident           "Task" at 184:10-184:14 (leading: Space)
-1805: Lt              "<" at 184:14-184:15
-1806: Ident           "T" at 184:15-184:16
-1807: Gt              ">" at 184:16-184:17
-1808: Assign          "=" at 184:18-184:19 (leading: Space)
-1809: LBrace          "{" at 184:20-184:21 (leading: Space)
-1810: Ident           "__opaque" at 185:5-185:13 (leading: Newline, Space)
-1811: Colon           ":" at 185:13-185:14
-1812: Ident           "int" at 185:15-185:18 (leading: Space)
-1813: Comma           "," at 185:18-185:19
-1814: RBrace          "}" at 186:1-186:2 (leading: Newline)
-1815: Semicolon       ";" at 186:2-186:3
-1816: KwPub           "pub" at 188:1-188:4 (leading: Newline)
-1817: KwTag           "tag" at 188:5-188:8 (leading: Space)
-1818: Ident           "Cancelled" at 188:9-188:18 (leading: Space)
-1819: LParen          "(" at 188:18-188:19
-1820: RParen          ")" at 188:19-188:20
-1821: Semicolon       ";" at 188:20-188:21
-1822: KwPub           "pub" at 189:1-189:4 (leading: Newline)
-1823: KwType          "type" at 189:5-189:9 (leading: Space)
-1824: Ident           "TaskResult" at 189:10-189:20 (leading: Space)
-1825: Lt              "<" at 189:20-189:21
-1826: Ident           "T" at 189:21-189:22
-1827: Gt              ">" at 189:22-189:23
-1828: Assign          "=" at 189:24-189:25 (leading: Space)
-1829: Ident           "Success" at 189:26-189:33 (leading: Space)
-1830: LParen          "(" at 189:33-189:34
-1831: Ident           "T" at 189:34-189:35
-1832: RParen          ")" at 189:35-189:36
-1833: Pipe            "|" at 189:37-189:38 (leading: Space)
-1834: Ident           "Cancelled" at 189:39-189:48 (leading: Space)
-1835: Semicolon       ";" at 189:48-189:49
-1836: At              "@" at 191:1-191:2 (leading: Newline)
-1837: Ident           "intrinsic" at 191:2-191:11
-1838: KwFn            "fn" at 191:12-191:14 (leading: Space)
-1839: Ident           "rt_scope_enter" at 191:15-191:29 (leading: Space)
-1840: LParen          "(" at 191:29-191:30
-1841: Ident           "failfast" at 191:30-191:38
-1842: Colon           ":" at 191:38-191:39
-1843: Ident           "bool" at 191:40-191:44 (leading: Space)
-1844: RParen          ")" at 191:44-191:45
-1845: Arrow           "->" at 191:46-191:48 (leading: Space)
-1846: Ident           "uint" at 191:49-191:53 (leading: Space)
-1847: Semicolon       ";" at 191:53-191:54
-1848: At              "@" at 192:1-192:2 (leading: Newline)
-1849: Ident           "intrinsic" at 192:2-192:11
-1850: KwFn            "fn" at 192:12-192:14 (leading: Space)
-1851: Ident           "rt_scope_register_child" at 192:15-192:38 (leading: Space)
-1852: Lt              "<" at 192:38-192:39
-1853: Ident           "T" at 192:39-192:40
-1854: Gt              ">" at 192:40-192:41
-1855: LParen          "(" at 192:41-192:42
-1856: Ident           "scope" at 192:42-192:47
-1857: Colon           ":" at 192:47-192:48
-1858: Ident           "uint" at 192:49-192:53 (leading: Space)
-1859: Comma           "," at 192:53-192:54
-1860: Ident           "child" at 192:55-192:60 (leading: Space)
-1861: Colon           ":" at 192:60-192:61
-1862: Ident           "Task" at 192:62-192:66 (leading: Space)
-1863: Lt              "<" at 192:66-192:67
-1864: Ident           "T" at 192:67-192:68
-1865: Gt              ">" at 192:68-192:69
-1866: RParen          ")" at 192:69-192:70
-1867: Arrow           "->" at 192:71-192:73 (leading: Space)
-1868: NothingLit      "nothing" at 192:74-192:81 (leading: Space)
-1869: Semicolon       ";" at 192:81-192:82
-1870: At              "@" at 193:1-193:2 (leading: Newline)
-1871: Ident           "intrinsic" at 193:2-193:11
-1872: KwFn            "fn" at 193:12-193:14 (leading: Space)
-1873: Ident           "rt_scope_cancel_all" at 193:15-193:34 (leading: Space)
-1874: LParen          "(" at 193:34-193:35
-1875: Ident           "scope" at 193:35-193:40
-1876: Colon           ":" at 193:40-193:41
-1877: Ident           "uint" at 193:42-193:46 (leading: Space)
-1878: RParen          ")" at 193:46-193:47
-1879: Arrow           "->" at 193:48-193:50 (leading: Space)
-1880: NothingLit      "nothing" at 193:51-193:58 (leading: Space)
-1881: Semicolon       ";" at 193:58-193:59
-1882: At              "@" at 194:1-194:2 (leading: Newline)
-1883: Ident           "intrinsic" at 194:2-194:11
-1884: KwFn            "fn" at 194:12-194:14 (leading: Space)
-1885: Ident           "rt_scope_join_all" at 194:15-194:32 (leading: Space)
-1886: LParen          "(" at 194:32-194:33
-1887: Ident           "scope" at 194:33-194:38
-1888: Colon           ":" at 194:38-194:39
-1889: Ident           "uint" at 194:40-194:44 (leading: Space)
-1890: RParen          ")" at 194:44-194:45
-1891: Arrow           "->" at 194:46-194:48 (leading: Space)
-1892: Ident           "bool" at 194:49-194:53 (leading: Space)
-1893: Semicolon       ";" at 194:53-194:54
-1894: At              "@" at 195:1-195:2 (leading: Newline)
-1895: Ident           "intrinsic" at 195:2-195:11
-1896: KwFn            "fn" at 195:12-195:14 (leading: Space)
-1897: Ident           "rt_scope_exit" at 195:15-195:28 (leading: Space)
-1898: LParen          "(" at 195:28-195:29
-1899: Ident           "scope" at 195:29-195:34
-1900: Colon           ":" at 195:34-195:35
-1901: Ident           "uint" at 195:36-195:40 (leading: Space)
-1902: RParen          ")" at 195:40-195:41
-1903: Arrow           "->" at 195:42-195:44 (leading: Space)
-1904: NothingLit      "nothing" at 195:45-195:52 (leading: Space)
-1905: Semicolon       ";" at 195:52-195:53
-1906: KwExtern        "extern" at 197:1-197:7 (leading: Newline)
-1907: Lt              "<" at 197:7-197:8
-1908: Ident           "Task" at 197:8-197:12
-1909: Lt              "<" at 197:12-197:13
-1910: Ident           "T" at 197:13-197:14
-1911: Shr             ">>" at 197:14-197:16
-1912: LBrace          "{" at 197:17-197:18 (leading: Space)
-1913: At              "@" at 198:5-198:6 (leading: Newline, Space)
-1914: Ident           "intrinsic" at 198:6-198:15
-1915: KwPub           "pub" at 198:16-198:19 (leading: Space)
-1916: KwFn            "fn" at 198:20-198:22 (leading: Space)
-1917: Ident           "clone" at 198:23-198:28 (leading: Space)
-1918: LParen          "(" at 198:28-198:29
-1919: Ident           "self" at 198:29-198:33
-1920: Colon           ":" at 198:33-198:34
-1921: Amp             "&" at 198:35-198:36 (leading: Space)
-1922: Ident           "Task" at 198:36-198:40
-1923: Lt              "<" at 198:40-198:41
-1924: Ident           "T" at 198:41-198:42
-1925: Gt              ">" at 198:42-198:43
-1926: RParen          ")" at 198:43-198:44
-1927: Arrow           "->" at 198:45-198:47 (leading: Space)
-1928: Ident           "Task" at 198:48-198:52 (leading: Space)
-1929: Lt              "<" at 198:52-198:53
-1930: Ident           "T" at 198:53-198:54
-1931: Gt              ">" at 198:54-198:55
-1932: Semicolon       ";" at 198:55-198:56
-1933: At              "@" at 199:5-199:6 (leading: Newline, Space)
-1934: Ident           "intrinsic" at 199:6-199:15
-1935: KwPub           "pub" at 199:16-199:19 (leading: Space)
-1936: KwFn            "fn" at 199:20-199:22 (leading: Space)
-1937: Ident           "cancel" at 199:23-199:29 (leading: Space)
-1938: LParen          "(" at 199:29-199:30
-1939: Ident           "self" at 199:30-199:34
-1940: Colon           ":" at 199:34-199:35
-1941: Amp             "&" at 199:36-199:37 (leading: Space)
-1942: Ident           "Task" at 199:37-199:41
-1943: Lt              "<" at 199:41-199:42
-1944: Ident           "T" at 199:42-199:43
-1945: Gt              ">" at 199:43-199:44
-1946: RParen          ")" at 199:44-199:45
-1947: Arrow           "->" at 199:46-199:48 (leading: Space)
-1948: NothingLit      "nothing" at 199:49-199:56 (leading: Space)
-1949: Semicolon       ";" at 199:56-199:57
-1950: At              "@" at 200:5-200:6 (leading: Newline, Space)
-1951: Ident           "intrinsic" at 200:6-200:15
-1952: KwPub           "pub" at 200:16-200:19 (leading: Space)
-1953: KwFn            "fn" at 200:20-200:22 (leading: Space)
-1954: Ident           "await" at 200:23-200:28 (leading: Space)
-1955: LParen          "(" at 200:28-200:29
-1956: Ident           "self" at 200:29-200:33
-1957: Colon           ":" at 200:33-200:34
-1958: KwOwn           "own" at 200:35-200:38 (leading: Space)
-1959: Ident           "Task" at 200:39-200:43 (leading: Space)
-1960: Lt              "<" at 200:43-200:44
-1961: Ident           "T" at 200:44-200:45
-1962: Gt              ">" at 200:45-200:46
-1963: RParen          ")" at 200:46-200:47
-1964: Arrow           "->" at 200:48-200:50 (leading: Space)
-1965: Ident           "TaskResult" at 200:51-200:61 (leading: Space)
-1966: Lt              "<" at 200:61-200:62
-1967: Ident           "T" at 200:62-200:63
-1968: Gt              ">" at 200:63-200:64
-1969: Semicolon       ";" at 200:64-200:65
-1970: RBrace          "}" at 201:1-201:2 (leading: Newline)
-1971: At              "@" at 205:1-205:2 (leading: Newline, LineComment, Newline, LineComment, Newline)
-1972: Ident           "intrinsic" at 205:2-205:11
-1973: KwPub           "pub" at 206:1-206:4 (leading: Newline)
-1974: KwFn            "fn" at 206:5-206:7 (leading: Space)
-1975: Ident           "checkpoint" at 206:8-206:18 (leading: Space)
-1976: LParen          "(" at 206:18-206:19
-1977: RParen          ")" at 206:19-206:20
-1978: Arrow           "->" at 206:21-206:23 (leading: Space)
-1979: Ident           "Task" at 206:24-206:28 (leading: Space)
-1980: Lt              "<" at 206:28-206:29
-1981: NothingLit      "nothing" at 206:29-206:36
-1982: Gt              ">" at 206:36-206:37
-1983: Semicolon       ";" at 206:37-206:38
-1984: At              "@" at 209:1-209:2 (leading: Newline, LineComment, Newline)
-1985: Ident           "intrinsic" at 209:2-209:11
-1986: KwPub           "pub" at 209:12-209:15 (leading: Space)
-1987: KwFn            "fn" at 209:16-209:18 (leading: Space)
-1988: Ident           "sleep" at 209:19-209:24 (leading: Space)
-1989: LParen          "(" at 209:24-209:25
-1990: Ident           "ms" at 209:25-209:27
-1991: Colon           ":" at 209:27-209:28
-1992: Ident           "uint" at 209:29-209:33 (leading: Space)
-1993: RParen          ")" at 209:33-209:34
-1994: Arrow           "->" at 209:35-209:37 (leading: Space)
-1995: Ident           "Task" at 209:38-209:42 (leading: Space)
-1996: Lt              "<" at 209:42-209:43
-1997: NothingLit      "nothing" at 209:43-209:50
-1998: Gt              ">" at 209:50-209:51
-1999: Semicolon       ";" at 209:51-209:52
-2000: At              "@" at 213:1-213:2 (leading: Newline, LineComment, Newline, LineComment, Newline)
-2001: Ident           "intrinsic" at 213:2-213:11
-2002: KwPub           "pub" at 213:12-213:15 (leading: Space)
-2003: KwFn            "fn" at 213:16-213:18 (leading: Space)
-2004: Ident           "timeout" at 213:19-213:26 (leading: Space)
-2005: Lt              "<" at 213:26-213:27
-2006: Ident           "T" at 213:27-213:28
-2007: Gt              ">" at 213:28-213:29
-2008: LParen          "(" at 213:29-213:30
-2009: Ident           "t" at 213:30-213:31
-2010: Colon           ":" at 213:31-213:32
-2011: Ident           "Task" at 213:33-213:37 (leading: Space)
-2012: Lt              "<" at 213:37-213:38
-2013: Ident           "T" at 213:38-213:39
-2014: Gt              ">" at 213:39-213:40
-2015: Comma           "," at 213:40-213:41
-2016: Ident           "ms" at 213:42-213:44 (leading: Space)
-2017: Colon           ":" at 213:44-213:45
-2018: Ident           "uint" at 213:46-213:50 (leading: Space)
-2019: RParen          ")" at 213:50-213:51
-2020: Arrow           "->" at 213:52-213:54 (leading: Space)
-2021: Ident           "TaskResult" at 213:55-213:65 (leading: Space)
-2022: Lt              "<" at 213:65-213:66
-2023: Ident           "T" at 213:66-213:67
-2024: Gt              ">" at 213:67-213:68
-2025: Semicolon       ";" at 213:68-213:69
-2026: At              "@" at 216:1-216:2 (leading: Newline, LineComment, Newline)
-2027: Ident           "copy" at 216:2-216:6
-2028: At              "@" at 217:1-217:2 (leading: Newline)
-2029: Ident           "intrinsic" at 217:2-217:11
-2030: KwPub           "pub" at 218:1-218:4 (leading: Newline)
-2031: KwType          "type" at 218:5-218:9 (leading: Space)
-2032: Ident           "Channel" at 218:10-218:17 (leading: Space)
-2033: Lt              "<" at 218:17-218:18
-2034: Ident           "T" at 218:18-218:19
-2035: Gt              ">" at 218:19-218:20
-2036: Assign          "=" at 218:21-218:22 (leading: Space)
-2037: LBrace          "{" at 218:23-218:24 (leading: Space)
-2038: Ident           "__opaque" at 219:5-219:13 (leading: Newline, Space)
-2039: Colon           ":" at 219:13-219:14
-2040: Star            "*" at 219:15-219:16 (leading: Space)
-2041: Ident           "byte" at 219:16-219:20
-2042: Comma           "," at 219:20-219:21
-2043: RBrace          "}" at 220:1-220:2 (leading: Newline)
-2044: Semicolon       ";" at 220:2-220:3
-2045: KwExtern        "extern" at 222:1-222:7 (leading: Newline)
-2046: Lt              "<" at 222:7-222:8
-2047: Ident           "Channel" at 222:8-222:15
-2048: Lt              "<" at 222:15-222:16
-2049: Ident           "T" at 222:16-222:17
-2050: Shr             ">>" at 222:17-222:19
-2051: LBrace          "{" at 222:20-222:21 (leading: Space)
-2052: At              "@" at 224:5-224:6 (leading: Newline, Space, LineComment, Newline, Space)
-2053: Ident           "intrinsic" at 224:6-224:15
-2054: KwPub           "pub" at 224:16-224:19 (leading: Space)
-2055: KwFn            "fn" at 224:20-224:22 (leading: Space)
-2056: Ident           "new" at 224:23-224:26 (leading: Space)
-2057: LParen          "(" at 224:26-224:27
-2058: Ident           "capacity" at 224:27-224:35
-2059: Colon           ":" at 224:35-224:36
-2060: Ident           "uint" at 224:37-224:41 (leading: Space)
-2061: RParen          ")" at 224:41-224:42
-2062: Arrow           "->" at 224:43-224:45 (leading: Space)
-2063: KwOwn           "own" at 224:46-224:49 (leading: Space)
-2064: Ident           "Channel" at 224:50-224:57 (leading: Space)
-2065: Lt              "<" at 224:57-224:58
-2066: Ident           "T" at 224:58-224:59
-2067: Gt              ">" at 224:59-224:60
-2068: Semicolon       ";" at 224:60-224:61
-2069: At              "@" at 226:5-226:6 (leading: Newline, Space, LineComment, Newline, Space)
-2070: Ident           "intrinsic" at 226:6-226:15
-2071: KwPub           "pub" at 226:16-226:19 (leading: Space)
-2072: KwFn            "fn" at 226:20-226:22 (leading: Space)
-2073: Ident           "send" at 226:23-226:27 (leading: Space)
-2074: LParen          "(" at 226:27-226:28
-2075: Ident           "self" at 226:28-226:32
-2076: Colon           ":" at 226:32-226:33
-2077: Amp             "&" at 226:34-226:35 (leading: Space)
-2078: Ident           "Channel" at 226:35-226:42
-2079: Lt              "<" at 226:42-226:43
-2080: Ident           "T" at 226:43-226:44
-2081: Gt              ">" at 226:44-226:45
-2082: Comma           "," at 226:45-226:46
-2083: Ident           "value" at 226:47-226:52 (leading: Space)
-2084: Colon           ":" at 226:52-226:53
-2085: KwOwn           "own" at 226:54-226:57 (leading: Space)
-2086: Ident           "T" at 226:58-226:59 (leading: Space)
-2087: RParen          ")" at 226:59-226:60
-2088: Arrow           "->" at 226:61-226:63 (leading: Space)
-2089: NothingLit      "nothing" at 226:64-226:71 (leading: Space)
-2090: Semicolon       ";" at 226:71-226:72
-2091: At              "@" at 228:5-228:6 (leading: Newline, Space, LineComment, Newline, Space)
-2092: Ident           "intrinsic" at 228:6-228:15
-2093: KwPub           "pub" at 228:16-228:19 (leading: Space)
-2094: KwFn            "fn" at 228:20-228:22 (leading: Space)
-2095: Ident           "recv" at 228:23-228:27 (leading: Space)
-2096: LParen          "(" at 228:27-228:28
-2097: Ident           "self" at 228:28-228:32
-2098: Colon           ":" at 228:32-228:33
-2099: Amp             "&" at 228:34-228:35 (leading: Space)
-2100: Ident           "Channel" at 228:35-228:42
-2101: Lt              "<" at 228:42-228:43
-2102: Ident           "T" at 228:43-228:44
-2103: Gt              ">" at 228:44-228:45
-2104: RParen          ")" at 228:45-228:46
-2105: Arrow           "->" at 228:47-228:49 (leading: Space)
-2106: Ident           "Option" at 228:50-228:56 (leading: Space)
-2107: Lt              "<" at 228:56-228:57
-2108: Ident           "T" at 228:57-228:58
-2109: Gt              ">" at 228:58-228:59
-2110: Semicolon       ";" at 228:59-228:60
-2111: At              "@" at 230:5-230:6 (leading: Newline, Space, LineComment, Newline, Space)
-2112: Ident           "intrinsic" at 230:6-230:15
-2113: KwPub           "pub" at 230:16-230:19 (leading: Space)
-2114: KwFn            "fn" at 230:20-230:22 (leading: Space)
-2115: Ident           "try_send" at 230:23-230:31 (leading: Space)
-2116: LParen          "(" at 230:31-230:32
-2117: Ident           "self" at 230:32-230:36
-2118: Colon           ":" at 230:36-230:37
-2119: Amp             "&" at 230:38-230:39 (leading: Space)
-2120: Ident           "Channel" at 230:39-230:46
-2121: Lt              "<" at 230:46-230:47
-2122: Ident           "T" at 230:47-230:48
-2123: Gt              ">" at 230:48-230:49
-2124: Comma           "," at 230:49-230:50
-2125: Ident           "value" at 230:51-230:56 (leading: Space)
-2126: Colon           ":" at 230:56-230:57
-2127: KwOwn           "own" at 230:58-230:61 (leading: Space)
-2128: Ident           "T" at 230:62-230:63 (leading: Space)
-2129: RParen          ")" at 230:63-230:64
-2130: Arrow           "->" at 230:65-230:67 (leading: Space)
-2131: Ident           "bool" at 230:68-230:72 (leading: Space)
-2132: Semicolon       ";" at 230:72-230:73
-2133: At              "@" at 232:5-232:6 (leading: Newline, Space, LineComment, Newline, Space)
-2134: Ident           "intrinsic" at 232:6-232:15
-2135: KwPub           "pub" at 232:16-232:19 (leading: Space)
-2136: KwFn            "fn" at 232:20-232:22 (leading: Space)
-2137: Ident           "try_recv" at 232:23-232:31 (leading: Space)
-2138: LParen          "(" at 232:31-232:32
-2139: Ident           "self" at 232:32-232:36
-2140: Colon           ":" at 232:36-232:37
-2141: Amp             "&" at 232:38-232:39 (leading: Space)
-2142: Ident           "Channel" at 232:39-232:46
-2143: Lt              "<" at 232:46-232:47
-2144: Ident           "T" at 232:47-232:48
-2145: Gt              ">" at 232:48-232:49
-2146: RParen          ")" at 232:49-232:50
-2147: Arrow           "->" at 232:51-232:53 (leading: Space)
-2148: Ident           "Option" at 232:54-232:60 (leading: Space)
-2149: Lt              "<" at 232:60-232:61
-2150: Ident           "T" at 232:61-232:62
-2151: Gt              ">" at 232:62-232:63
-2152: Semicolon       ";" at 232:63-232:64
-2153: At              "@" at 234:5-234:6 (leading: Newline, Space, LineComment, Newline, Space)
-2154: Ident           "intrinsic" at 234:6-234:15
-2155: KwPub           "pub" at 234:16-234:19 (leading: Space)
-2156: KwFn            "fn" at 234:20-234:22 (leading: Space)
-2157: Ident           "close" at 234:23-234:28 (leading: Space)
-2158: LParen          "(" at 234:28-234:29
-2159: Ident           "self" at 234:29-234:33
-2160: Colon           ":" at 234:33-234:34
-2161: Amp             "&" at 234:35-234:36 (leading: Space)
-2162: Ident           "Channel" at 234:36-234:43
-2163: Lt              "<" at 234:43-234:44
-2164: Ident           "T" at 234:44-234:45
-2165: Gt              ">" at 234:45-234:46
-2166: RParen          ")" at 234:46-234:47
-2167: Arrow           "->" at 234:48-234:50 (leading: Space)
-2168: NothingLit      "nothing" at 234:51-234:58 (leading: Space)
-2169: Semicolon       ";" at 234:58-234:59
-2170: RBrace          "}" at 235:1-235:2 (leading: Newline)
-2171: At              "@" at 237:1-237:2 (leading: Newline)
-2172: Ident           "intrinsic" at 237:2-237:11
-2173: KwFn            "fn" at 238:1-238:3 (leading: Newline)
-2174: Ident           "make_channel" at 238:4-238:16 (leading: Space)
-2175: Lt              "<" at 238:16-238:17
-2176: Ident           "T" at 238:17-238:18
-2177: Gt              ">" at 238:18-238:19
-2178: LParen          "(" at 238:19-238:20
-2179: Ident           "capacity" at 238:20-238:28
-2180: Colon           ":" at 238:28-238:29
-2181: Ident           "uint" at 238:30-238:34 (leading: Space)
-2182: RParen          ")" at 238:34-238:35
-2183: Arrow           "->" at 238:36-238:38 (leading: Space)
-2184: KwOwn           "own" at 238:39-238:42 (leading: Space)
-2185: Ident           "Channel" at 238:43-238:50 (leading: Space)
-2186: Lt              "<" at 238:50-238:51
-2187: Ident           "T" at 238:51-238:52
-2188: Gt              ">" at 238:52-238:53
-2189: Semicolon       ";" at 238:53-238:54
-2190: KwPub           "pub" at 240:1-240:4 (leading: Newline)
-2191: KwContract      "contract" at 240:5-240:13 (leading: Space)
-2192: Ident           "Bounded" at 240:14-240:21 (leading: Space)
-2193: Lt              "<" at 240:21-240:22
-2194: Ident           "T" at 240:22-240:23
-2195: Gt              ">" at 240:23-240:24
-2196: LBrace          "{" at 240:25-240:26 (leading: Space)
-2197: KwFn            "fn" at 241:5-241:7 (leading: Newline, Space)
-2198: Ident           "__min_value" at 241:8-241:19 (leading: Space)
-2199: LParen          "(" at 241:19-241:20
-2200: RParen          ")" at 241:20-241:21
-2201: Arrow           "->" at 241:22-241:24 (leading: Space)
-2202: Ident           "T" at 241:25-241:26 (leading: Space)
-2203: Semicolon       ";" at 241:26-241:27
-2204: KwFn            "fn" at 242:5-242:7 (leading: Newline, Space)
-2205: Ident           "__max_value" at 242:8-242:19 (leading: Space)
-2206: LParen          "(" at 242:19-242:20
-2207: RParen          ")" at 242:20-242:21
-2208: Arrow           "->" at 242:22-242:24 (leading: Space)
-2209: Ident           "T" at 242:25-242:26 (leading: Space)
-2210: Semicolon       ";" at 242:26-242:27
-2211: RBrace          "}" at 243:1-243:2 (leading: Newline)
-2212: KwPub           "pub" at 245:1-245:4 (leading: Newline)
-2213: KwContract      "contract" at 245:5-245:13 (leading: Space)
-2214: Ident           "HasLength" at 245:14-245:23 (leading: Space)
-2215: Lt              "<" at 245:23-245:24
-2216: Ident           "T" at 245:24-245:25
-2217: Gt              ">" at 245:25-245:26
-2218: LBrace          "{" at 245:27-245:28 (leading: Space)
-2219: KwFn            "fn" at 246:5-246:7 (leading: Newline, Space)
-2220: Ident           "__len" at 246:8-246:13 (leading: Space)
-2221: LParen          "(" at 246:13-246:14
-2222: Ident           "self" at 246:14-246:18
-2223: Colon           ":" at 246:18-246:19
-2224: Amp             "&" at 246:20-246:21 (leading: Space)
-2225: Ident           "T" at 246:21-246:22
-2226: RParen          ")" at 246:22-246:23
-2227: Arrow           "->" at 246:24-246:26 (leading: Space)
-2228: Ident           "uint" at 246:27-246:31 (leading: Space)
-2229: Semicolon       ";" at 246:31-246:32
-2230: RBrace          "}" at 247:1-247:2 (leading: Newline)
-2231: KwPub           "pub" at 249:1-249:4 (leading: Newline)
-2232: KwContract      "contract" at 249:5-249:13 (leading: Space)
-2233: Ident           "Printable" at 249:14-249:23 (leading: Space)
-2234: Lt              "<" at 249:23-249:24
-2235: Ident           "T" at 249:24-249:25
-2236: Gt              ">" at 249:25-249:26
-2237: LBrace          "{" at 249:27-249:28 (leading: Space)
-2238: KwFn            "fn" at 250:5-250:7 (leading: Newline, Space)
-2239: Ident           "__to" at 250:8-250:12 (leading: Space)
-2240: LParen          "(" at 250:12-250:13
-2241: Ident           "self" at 250:13-250:17
-2242: Colon           ":" at 250:17-250:18
-2243: Amp             "&" at 250:19-250:20 (leading: Space)
-2244: Ident           "T" at 250:20-250:21
-2245: Comma           "," at 250:21-250:22
-2246: Ident           "target" at 250:23-250:29 (leading: Space)
-2247: Colon           ":" at 250:29-250:30
-2248: Ident           "string" at 250:31-250:37 (leading: Space)
-2249: RParen          ")" at 250:37-250:38
-2250: Arrow           "->" at 250:39-250:41 (leading: Space)
-2251: Ident           "string" at 250:42-250:48 (leading: Space)
-2252: Semicolon       ";" at 250:48-250:49
-2253: RBrace          "}" at 251:1-251:2 (leading: Newline)
-2254: KwPub           "pub" at 253:1-253:4 (leading: Newline)
-2255: KwFn            "fn" at 253:5-253:7 (leading: Space)
-2256: Ident           "max_value" at 253:8-253:17 (leading: Space)
-2257: Lt              "<" at 253:17-253:18
-2258: Ident           "T" at 253:18-253:19
-2259: Colon           ":" at 253:19-253:20
-2260: Ident           "Bounded" at 253:21-253:28 (leading: Space)
-2261: Lt              "<" at 253:28-253:29
-2262: Ident           "T" at 253:29-253:30
-2263: Shr             ">>" at 253:30-253:32
-2264: LParen          "(" at 253:32-253:33
-2265: RParen          ")" at 253:33-253:34
-2266: Arrow           "->" at 253:35-253:37 (leading: Space)
-2267: Ident           "T" at 253:38-253:39 (leading: Space)
-2268: LBrace          "{" at 253:40-253:41 (leading: Space)
-2269: KwReturn        "return" at 254:5-254:11 (leading: Newline, Space)
-2270: Ident           "T" at 254:12-254:13 (leading: Space)
-2271: Dot             "." at 254:13-254:14
-2272: Ident           "__max_value" at 254:14-254:25
-2273: LParen          "(" at 254:25-254:26
-2274: RParen          ")" at 254:26-254:27
-2275: Semicolon       ";" at 254:27-254:28
-2276: RBrace          "}" at 255:1-255:2 (leading: Newline)
-2277: KwPub           "pub" at 257:1-257:4 (leading: Newline)
-2278: KwFn            "fn" at 257:5-257:7 (leading: Space)
-2279: Ident           "min_value" at 257:8-257:17 (leading: Space)
-2280: Lt              "<" at 257:17-257:18
-2281: Ident           "T" at 257:18-257:19
-2282: Colon           ":" at 257:19-257:20
-2283: Ident           "Bounded" at 257:21-257:28 (leading: Space)
-2284: Lt              "<" at 257:28-257:29
-2285: Ident           "T" at 257:29-257:30
-2286: Shr             ">>" at 257:30-257:32
-2287: LParen          "(" at 257:32-257:33
-2288: RParen          ")" at 257:33-257:34
-2289: Arrow           "->" at 257:35-257:37 (leading: Space)
-2290: Ident           "T" at 257:38-257:39 (leading: Space)
-2291: LBrace          "{" at 257:40-257:41 (leading: Space)
-2292: KwReturn        "return" at 258:5-258:11 (leading: Newline, Space)
-2293: Ident           "T" at 258:12-258:13 (leading: Space)
-2294: Dot             "." at 258:13-258:14
-2295: Ident           "__min_value" at 258:14-258:25
-2296: LParen          "(" at 258:25-258:26
-2297: RParen          ")" at 258:26-258:27
-2298: Semicolon       ";" at 258:27-258:28
-2299: RBrace          "}" at 259:1-259:2 (leading: Newline)
-2300: KwExtern        "extern" at 261:1-261:7 (leading: Newline)
-2301: Lt              "<" at 261:7-261:8
-2302: Ident           "int" at 261:8-261:11
-2303: Gt              ">" at 261:11-261:12
-2304: LBrace          "{" at 261:13-261:14 (leading: Space)
-2305: At              "@" at 262:5-262:6 (leading: Newline, Space)
-2306: Ident           "intrinsic" at 262:6-262:15
-2307: KwFn            "fn" at 262:16-262:18 (leading: Space)
-2308: Ident           "__add" at 262:19-262:24 (leading: Space)
-2309: LParen          "(" at 262:24-262:25
-2310: Ident           "self" at 262:25-262:29
-2311: Colon           ":" at 262:29-262:30
-2312: Ident           "int" at 262:31-262:34 (leading: Space)
-2313: Comma           "," at 262:34-262:35
-2314: Ident           "other" at 262:36-262:41 (leading: Space)
-2315: Colon           ":" at 262:41-262:42
-2316: Ident           "int" at 262:43-262:46 (leading: Space)
-2317: RParen          ")" at 262:46-262:47
-2318: Arrow           "->" at 262:48-262:50 (leading: Space)
-2319: Ident           "int" at 262:51-262:54 (leading: Space)
-2320: Semicolon       ";" at 262:54-262:55
-2321: At              "@" at 263:5-263:6 (leading: Newline, Space)
-2322: Ident           "intrinsic" at 263:6-263:15
-2323: KwFn            "fn" at 263:16-263:18 (leading: Space)
-2324: Ident           "__sub" at 263:19-263:24 (leading: Space)
-2325: LParen          "(" at 263:24-263:25
-2326: Ident           "self" at 263:25-263:29
-2327: Colon           ":" at 263:29-263:30
-2328: Ident           "int" at 263:31-263:34 (leading: Space)
-2329: Comma           "," at 263:34-263:35
-2330: Ident           "other" at 263:36-263:41 (leading: Space)
-2331: Colon           ":" at 263:41-263:42
-2332: Ident           "int" at 263:43-263:46 (leading: Space)
-2333: RParen          ")" at 263:46-263:47
-2334: Arrow           "->" at 263:48-263:50 (leading: Space)
-2335: Ident           "int" at 263:51-263:54 (leading: Space)
-2336: Semicolon       ";" at 263:54-263:55
-2337: At              "@" at 264:5-264:6 (leading: Newline, Space)
-2338: Ident           "intrinsic" at 264:6-264:15
-2339: KwFn            "fn" at 264:16-264:18 (leading: Space)
-2340: Ident           "__mul" at 264:19-264:24 (leading: Space)
-2341: LParen          "(" at 264:24-264:25
-2342: Ident           "self" at 264:25-264:29
-2343: Colon           ":" at 264:29-264:30
-2344: Ident           "int" at 264:31-264:34 (leading: Space)
-2345: Comma           "," at 264:34-264:35
-2346: Ident           "other" at 264:36-264:41 (leading: Space)
-2347: Colon           ":" at 264:41-264:42
-2348: Ident           "int" at 264:43-264:46 (leading: Space)
-2349: RParen          ")" at 264:46-264:47
-2350: Arrow           "->" at 264:48-264:50 (leading: Space)
-2351: Ident           "int" at 264:51-264:54 (leading: Space)
-2352: Semicolon       ";" at 264:54-264:55
-2353: At              "@" at 265:5-265:6 (leading: Newline, Space)
-2354: Ident           "intrinsic" at 265:6-265:15
-2355: KwFn            "fn" at 265:16-265:18 (leading: Space)
-2356: Ident           "__div" at 265:19-265:24 (leading: Space)
-2357: LParen          "(" at 265:24-265:25
-2358: Ident           "self" at 265:25-265:29
-2359: Colon           ":" at 265:29-265:30
-2360: Ident           "int" at 265:31-265:34 (leading: Space)
-2361: Comma           "," at 265:34-265:35
-2362: Ident           "other" at 265:36-265:41 (leading: Space)
-2363: Colon           ":" at 265:41-265:42
-2364: Ident           "int" at 265:43-265:46 (leading: Space)
-2365: RParen          ")" at 265:46-265:47
-2366: Arrow           "->" at 265:48-265:50 (leading: Space)
-2367: Ident           "int" at 265:51-265:54 (leading: Space)
-2368: Semicolon       ";" at 265:54-265:55
-2369: At              "@" at 266:5-266:6 (leading: Newline, Space)
-2370: Ident           "intrinsic" at 266:6-266:15
-2371: KwFn            "fn" at 266:16-266:18 (leading: Space)
-2372: Ident           "__mod" at 266:19-266:24 (leading: Space)
-2373: LParen          "(" at 266:24-266:25
-2374: Ident           "self" at 266:25-266:29
-2375: Colon           ":" at 266:29-266:30
-2376: Ident           "int" at 266:31-266:34 (leading: Space)
-2377: Comma           "," at 266:34-266:35
-2378: Ident           "other" at 266:36-266:41 (leading: Space)
-2379: Colon           ":" at 266:41-266:42
-2380: Ident           "int" at 266:43-266:46 (leading: Space)
-2381: RParen          ")" at 266:46-266:47
-2382: Arrow           "->" at 266:48-266:50 (leading: Space)
-2383: Ident           "int" at 266:51-266:54 (leading: Space)
-2384: Semicolon       ";" at 266:54-266:55
-2385: At              "@" at 267:5-267:6 (leading: Newline, Space)
-2386: Ident           "intrinsic" at 267:6-267:15
-2387: KwFn            "fn" at 267:16-267:18 (leading: Space)
-2388: Ident           "__bit_and" at 267:19-267:28 (leading: Space)
-2389: LParen          "(" at 267:28-267:29
-2390: Ident           "self" at 267:29-267:33
-2391: Colon           ":" at 267:33-267:34
-2392: Ident           "int" at 267:35-267:38 (leading: Space)
-2393: Comma           "," at 267:38-267:39
-2394: Ident           "other" at 267:40-267:45 (leading: Space)
-2395: Colon           ":" at 267:45-267:46
-2396: Ident           "int" at 267:47-267:50 (leading: Space)
-2397: RParen          ")" at 267:50-267:51
-2398: Arrow           "->" at 267:52-267:54 (leading: Space)
-2399: Ident           "int" at 267:55-267:58 (leading: Space)
-2400: Semicolon       ";" at 267:58-267:59
-2401: At              "@" at 268:5-268:6 (leading: Newline, Space)
-2402: Ident           "intrinsic" at 268:6-268:15
-2403: KwFn            "fn" at 268:16-268:18 (leading: Space)
-2404: Ident           "__bit_or" at 268:19-268:27 (leading: Space)
-2405: LParen          "(" at 268:27-268:28
-2406: Ident           "self" at 268:28-268:32
-2407: Colon           ":" at 268:32-268:33
-2408: Ident           "int" at 268:34-268:37 (leading: Space)
-2409: Comma           "," at 268:37-268:38
-2410: Ident           "other" at 268:39-268:44 (leading: Space)
-2411: Colon           ":" at 268:44-268:45
-2412: Ident           "int" at 268:46-268:49 (leading: Space)
-2413: RParen          ")" at 268:49-268:50
-2414: Arrow           "->" at 268:51-268:53 (leading: Space)
-2415: Ident           "int" at 268:54-268:57 (leading: Space)
-2416: Semicolon       ";" at 268:57-268:58
-2417: At              "@" at 269:5-269:6 (leading: Newline, Space)
-2418: Ident           "intrinsic" at 269:6-269:15
-2419: KwFn            "fn" at 269:16-269:18 (leading: Space)
-2420: Ident           "__bit_xor" at 269:19-269:28 (leading: Space)
-2421: LParen          "(" at 269:28-269:29
-2422: Ident           "self" at 269:29-269:33
-2423: Colon           ":" at 269:33-269:34
-2424: Ident           "int" at 269:35-269:38 (leading: Space)
-2425: Comma           "," at 269:38-269:39
-2426: Ident           "other" at 269:40-269:45 (leading: Space)
-2427: Colon           ":" at 269:45-269:46
-2428: Ident           "int" at 269:47-269:50 (leading: Space)
-2429: RParen          ")" at 269:50-269:51
-2430: Arrow           "->" at 269:52-269:54 (leading: Space)
-2431: Ident           "int" at 269:55-269:58 (leading: Space)
-2432: Semicolon       ";" at 269:58-269:59
-2433: At              "@" at 270:5-270:6 (leading: Newline, Space)
-2434: Ident           "intrinsic" at 270:6-270:15
-2435: KwFn            "fn" at 270:16-270:18 (leading: Space)
-2436: Ident           "__shl" at 270:19-270:24 (leading: Space)
-2437: LParen          "(" at 270:24-270:25
-2438: Ident           "self" at 270:25-270:29
-2439: Colon           ":" at 270:29-270:30
-2440: Ident           "int" at 270:31-270:34 (leading: Space)
-2441: Comma           "," at 270:34-270:35
-2442: Ident           "other" at 270:36-270:41 (leading: Space)
-2443: Colon           ":" at 270:41-270:42
-2444: Ident           "int" at 270:43-270:46 (leading: Space)
-2445: RParen          ")" at 270:46-270:47
-2446: Arrow           "->" at 270:48-270:50 (leading: Space)
-2447: Ident           "int" at 270:51-270:54 (leading: Space)
-2448: Semicolon       ";" at 270:54-270:55
-2449: At              "@" at 271:5-271:6 (leading: Newline, Space)
-2450: Ident           "intrinsic" at 271:6-271:15
-2451: KwFn            "fn" at 271:16-271:18 (leading: Space)
-2452: Ident           "__shr" at 271:19-271:24 (leading: Space)
-2453: LParen          "(" at 271:24-271:25
-2454: Ident           "self" at 271:25-271:29
-2455: Colon           ":" at 271:29-271:30
-2456: Ident           "int" at 271:31-271:34 (leading: Space)
-2457: Comma           "," at 271:34-271:35
-2458: Ident           "other" at 271:36-271:41 (leading: Space)
-2459: Colon           ":" at 271:41-271:42
-2460: Ident           "int" at 271:43-271:46 (leading: Space)
-2461: RParen          ")" at 271:46-271:47
-2462: Arrow           "->" at 271:48-271:50 (leading: Space)
-2463: Ident           "int" at 271:51-271:54 (leading: Space)
-2464: Semicolon       ";" at 271:54-271:55
-2465: At              "@" at 272:5-272:6 (leading: Newline, Space)
-2466: Ident           "intrinsic" at 272:6-272:15
-2467: KwFn            "fn" at 272:16-272:18 (leading: Space)
-2468: Ident           "__lt" at 272:19-272:23 (leading: Space)
-2469: LParen          "(" at 272:23-272:24
-2470: Ident           "self" at 272:24-272:28
-2471: Colon           ":" at 272:28-272:29
-2472: Ident           "int" at 272:30-272:33 (leading: Space)
-2473: Comma           "," at 272:33-272:34
-2474: Ident           "other" at 272:35-272:40 (leading: Space)
-2475: Colon           ":" at 272:40-272:41
-2476: Ident           "int" at 272:42-272:45 (leading: Space)
-2477: RParen          ")" at 272:45-272:46
-2478: Arrow           "->" at 272:47-272:49 (leading: Space)
-2479: Ident           "bool" at 272:50-272:54 (leading: Space)
-2480: Semicolon       ";" at 272:54-272:55
-2481: At              "@" at 273:5-273:6 (leading: Newline, Space)
-2482: Ident           "intrinsic" at 273:6-273:15
-2483: KwFn            "fn" at 273:16-273:18 (leading: Space)
-2484: Ident           "__le" at 273:19-273:23 (leading: Space)
-2485: LParen          "(" at 273:23-273:24
-2486: Ident           "self" at 273:24-273:28
-2487: Colon           ":" at 273:28-273:29
-2488: Ident           "int" at 273:30-273:33 (leading: Space)
-2489: Comma           "," at 273:33-273:34
-2490: Ident           "other" at 273:35-273:40 (leading: Space)
-2491: Colon           ":" at 273:40-273:41
-2492: Ident           "int" at 273:42-273:45 (leading: Space)
-2493: RParen          ")" at 273:45-273:46
-2494: Arrow           "->" at 273:47-273:49 (leading: Space)
-2495: Ident           "bool" at 273:50-273:54 (leading: Space)
-2496: Semicolon       ";" at 273:54-273:55
-2497: At              "@" at 274:5-274:6 (leading: Newline, Space)
-2498: Ident           "intrinsic" at 274:6-274:15
-2499: KwFn            "fn" at 274:16-274:18 (leading: Space)
-2500: Ident           "__eq" at 274:19-274:23 (leading: Space)
-2501: LParen          "(" at 274:23-274:24
-2502: Ident           "self" at 274:24-274:28
-2503: Colon           ":" at 274:28-274:29
-2504: Ident           "int" at 274:30-274:33 (leading: Space)
-2505: Comma           "," at 274:33-274:34
-2506: Ident           "other" at 274:35-274:40 (leading: Space)
-2507: Colon           ":" at 274:40-274:41
-2508: Ident           "int" at 274:42-274:45 (leading: Space)
-2509: RParen          ")" at 274:45-274:46
-2510: Arrow           "->" at 274:47-274:49 (leading: Space)
-2511: Ident           "bool" at 274:50-274:54 (leading: Space)
-2512: Semicolon       ";" at 274:54-274:55
-2513: At              "@" at 275:5-275:6 (leading: Newline, Space)
-2514: Ident           "intrinsic" at 275:6-275:15
-2515: KwFn            "fn" at 275:16-275:18 (leading: Space)
-2516: Ident           "__ne" at 275:19-275:23 (leading: Space)
-2517: LParen          "(" at 275:23-275:24
-2518: Ident           "self" at 275:24-275:28
-2519: Colon           ":" at 275:28-275:29
-2520: Ident           "int" at 275:30-275:33 (leading: Space)
-2521: Comma           "," at 275:33-275:34
-2522: Ident           "other" at 275:35-275:40 (leading: Space)
-2523: Colon           ":" at 275:40-275:41
-2524: Ident           "int" at 275:42-275:45 (leading: Space)
-2525: RParen          ")" at 275:45-275:46
-2526: Arrow           "->" at 275:47-275:49 (leading: Space)
-2527: Ident           "bool" at 275:50-275:54 (leading: Space)
-2528: Semicolon       ";" at 275:54-275:55
-2529: At              "@" at 276:5-276:6 (leading: Newline, Space)
-2530: Ident           "intrinsic" at 276:6-276:15
-2531: KwFn            "fn" at 276:16-276:18 (leading: Space)
-2532: Ident           "__ge" at 276:19-276:23 (leading: Space)
-2533: LParen          "(" at 276:23-276:24
-2534: Ident           "self" at 276:24-276:28
-2535: Colon           ":" at 276:28-276:29
-2536: Ident           "int" at 276:30-276:33 (leading: Space)
-2537: Comma           "," at 276:33-276:34
-2538: Ident           "other" at 276:35-276:40 (leading: Space)
-2539: Colon           ":" at 276:40-276:41
-2540: Ident           "int" at 276:42-276:45 (leading: Space)
-2541: RParen          ")" at 276:45-276:46
-2542: Arrow           "->" at 276:47-276:49 (leading: Space)
-2543: Ident           "bool" at 276:50-276:54 (leading: Space)
-2544: Semicolon       ";" at 276:54-276:55
-2545: At              "@" at 277:5-277:6 (leading: Newline, Space)
-2546: Ident           "intrinsic" at 277:6-277:15
-2547: KwFn            "fn" at 277:16-277:18 (leading: Space)
-2548: Ident           "__gt" at 277:19-277:23 (leading: Space)
-2549: LParen          "(" at 277:23-277:24
-2550: Ident           "self" at 277:24-277:28
-2551: Colon           ":" at 277:28-277:29
-2552: Ident           "int" at 277:30-277:33 (leading: Space)
-2553: Comma           "," at 277:33-277:34
-2554: Ident           "other" at 277:35-277:40 (leading: Space)
-2555: Colon           ":" at 277:40-277:41
-2556: Ident           "int" at 277:42-277:45 (leading: Space)
-2557: RParen          ")" at 277:45-277:46
-2558: Arrow           "->" at 277:47-277:49 (leading: Space)
-2559: Ident           "bool" at 277:50-277:54 (leading: Space)
-2560: Semicolon       ";" at 277:54-277:55
-2561: At              "@" at 278:5-278:6 (leading: Newline, Space)
-2562: Ident           "intrinsic" at 278:6-278:15
-2563: KwFn            "fn" at 278:16-278:18 (leading: Space)
-2564: Ident           "__pos" at 278:19-278:24 (leading: Space)
-2565: LParen          "(" at 278:24-278:25
-2566: Ident           "self" at 278:25-278:29
-2567: Colon           ":" at 278:29-278:30
-2568: Ident           "int" at 278:31-278:34 (leading: Space)
-2569: RParen          ")" at 278:34-278:35
-2570: Arrow           "->" at 278:36-278:38 (leading: Space)
-2571: Ident           "int" at 278:39-278:42 (leading: Space)
-2572: Semicolon       ";" at 278:42-278:43
-2573: At              "@" at 279:5-279:6 (leading: Newline, Space)
-2574: Ident           "intrinsic" at 279:6-279:15
-2575: KwFn            "fn" at 279:16-279:18 (leading: Space)
-2576: Ident           "__neg" at 279:19-279:24 (leading: Space)
-2577: LParen          "(" at 279:24-279:25
-2578: Ident           "self" at 279:25-279:29
-2579: Colon           ":" at 279:29-279:30
-2580: Ident           "int" at 279:31-279:34 (leading: Space)
-2581: RParen          ")" at 279:34-279:35
-2582: Arrow           "->" at 279:36-279:38 (leading: Space)
-2583: Ident           "int" at 279:39-279:42 (leading: Space)
-2584: Semicolon       ";" at 279:42-279:43
-2585: At              "@" at 280:5-280:6 (leading: Newline, Space)
-2586: Ident           "intrinsic" at 280:6-280:15
-2587: KwFn            "fn" at 280:16-280:18 (leading: Space)
-2588: Ident           "__abs" at 280:19-280:24 (leading: Space)
-2589: LParen          "(" at 280:24-280:25
-2590: Ident           "self" at 280:25-280:29
-2591: Colon           ":" at 280:29-280:30
-2592: Ident           "int" at 280:31-280:34 (leading: Space)
-2593: RParen          ")" at 280:34-280:35
-2594: Arrow           "->" at 280:36-280:38 (leading: Space)
-2595: Ident           "int" at 280:39-280:42 (leading: Space)
-2596: Semicolon       ";" at 280:42-280:43
-2597: At              "@" at 281:5-281:6 (leading: Newline, Space)
-2598: Ident           "intrinsic" at 281:6-281:15
-2599: KwFn            "fn" at 281:16-281:18 (leading: Space)
-2600: Ident           "__to" at 281:19-281:23 (leading: Space)
-2601: LParen          "(" at 281:23-281:24
-2602: Ident           "self" at 281:24-281:28
-2603: Colon           ":" at 281:28-281:29
-2604: Ident           "int" at 281:30-281:33 (leading: Space)
-2605: Comma           "," at 281:33-281:34
-2606: Ident           "target" at 281:35-281:41 (leading: Space)
-2607: Colon           ":" at 281:41-281:42
-2608: Ident           "string" at 281:43-281:49 (leading: Space)
-2609: RParen          ")" at 281:49-281:50
-2610: Arrow           "->" at 281:51-281:53 (leading: Space)
-2611: Ident           "string" at 281:54-281:60 (leading: Space)
-2612: Semicolon       ";" at 281:60-281:61
-2613: At              "@" at 282:5-282:6 (leading: Newline, Space)
-2614: Ident           "overload" at 282:6-282:14
-2615: KwPub           "pub" at 282:15-282:18 (leading: Space)
-2616: KwFn            "fn" at 282:19-282:21 (leading: Space)
-2617: Ident           "__to" at 282:22-282:26 (leading: Space)
-2618: LParen          "(" at 282:26-282:27
-2619: Ident           "self" at 282:27-282:31
-2620: Colon           ":" at 282:31-282:32
-2621: Amp             "&" at 282:33-282:34 (leading: Space)
-2622: Ident           "int" at 282:34-282:37
-2623: Comma           "," at 282:37-282:38
-2624: Underscore      "_" at 282:39-282:40 (leading: Space)
-2625: Colon           ":" at 282:40-282:41
-2626: Ident           "string" at 282:42-282:48 (leading: Space)
-2627: RParen          ")" at 282:48-282:49
-2628: Arrow           "->" at 282:50-282:52 (leading: Space)
-2629: Ident           "string" at 282:53-282:59 (leading: Space)
-2630: LBrace          "{" at 282:60-282:61 (leading: Space)
-2631: KwReturn        "return" at 283:9-283:15 (leading: Newline, Space)
-2632: LParen          "(" at 283:16-283:17 (leading: Space)
-2633: Star            "*" at 283:17-283:18
-2634: Ident           "self" at 283:18-283:22
-2635: RParen          ")" at 283:22-283:23
-2636: KwTo            "to" at 283:24-283:26 (leading: Space)
-2637: Ident           "string" at 283:27-283:33 (leading: Space)
-2638: Semicolon       ";" at 283:33-283:34
-2639: RBrace          "}" at 284:5-284:6 (leading: Newline, Space)
-2640: At              "@" at 285:5-285:6 (leading: Newline, Space)
-2641: Ident           "intrinsic" at 285:6-285:15
-2642: At              "@" at 285:16-285:17 (leading: Space)
-2643: Ident           "overload" at 285:17-285:25
-2644: KwFn            "fn" at 285:26-285:28 (leading: Space)
-2645: Ident           "__to" at 285:29-285:33 (leading: Space)
-2646: LParen          "(" at 285:33-285:34
-2647: Ident           "self" at 285:34-285:38
-2648: Colon           ":" at 285:38-285:39
-2649: Ident           "int" at 285:40-285:43 (leading: Space)
-2650: Comma           "," at 285:43-285:44
-2651: Ident           "target" at 285:45-285:51 (leading: Space)
-2652: Colon           ":" at 285:51-285:52
-2653: Ident           "float" at 285:53-285:58 (leading: Space)
-2654: RParen          ")" at 285:58-285:59
-2655: Arrow           "->" at 285:60-285:62 (leading: Space)
-2656: Ident           "float" at 285:63-285:68 (leading: Space)
-2657: Semicolon       ";" at 285:68-285:69
-2658: At              "@" at 286:5-286:6 (leading: Newline, Space)
-2659: Ident           "intrinsic" at 286:6-286:15
-2660: At              "@" at 286:16-286:17 (leading: Space)
-2661: Ident           "overload" at 286:17-286:25
-2662: KwFn            "fn" at 286:26-286:28 (leading: Space)
-2663: Ident           "__to" at 286:29-286:33 (leading: Space)
-2664: LParen          "(" at 286:33-286:34
-2665: Ident           "self" at 286:34-286:38
-2666: Colon           ":" at 286:38-286:39
-2667: Ident           "int" at 286:40-286:43 (leading: Space)
-2668: Comma           "," at 286:43-286:44
-2669: Ident           "target" at 286:45-286:51 (leading: Space)
-2670: Colon           ":" at 286:51-286:52
-2671: Ident           "uint" at 286:53-286:57 (leading: Space)
-2672: RParen          ")" at 286:57-286:58
-2673: Arrow           "->" at 286:59-286:61 (leading: Space)
-2674: Ident           "uint" at 286:62-286:66 (leading: Space)
-2675: Semicolon       ";" at 286:66-286:67
-2676: At              "@" at 287:5-287:6 (leading: Newline, Space)
-2677: Ident           "intrinsic" at 287:6-287:15
-2678: At              "@" at 287:16-287:17 (leading: Space)
-2679: Ident           "overload" at 287:17-287:25
-2680: KwFn            "fn" at 287:26-287:28 (leading: Space)
-2681: Ident           "__to" at 287:29-287:33 (leading: Space)
-2682: LParen          "(" at 287:33-287:34
-2683: Ident           "self" at 287:34-287:38
-2684: Colon           ":" at 287:38-287:39
-2685: Ident           "int" at 287:40-287:43 (leading: Space)
-2686: Comma           "," at 287:43-287:44
-2687: Ident           "target" at 287:45-287:51 (leading: Space)
-2688: Colon           ":" at 287:51-287:52
-2689: Ident           "int8" at 287:53-287:57 (leading: Space)
-2690: RParen          ")" at 287:57-287:58
-2691: Arrow           "->" at 287:59-287:61 (leading: Space)
-2692: Ident           "int8" at 287:62-287:66 (leading: Space)
-2693: Semicolon       ";" at 287:66-287:67
-2694: At              "@" at 288:5-288:6 (leading: Newline, Space)
-2695: Ident           "intrinsic" at 288:6-288:15
-2696: At              "@" at 288:16-288:17 (leading: Space)
-2697: Ident           "overload" at 288:17-288:25
-2698: KwFn            "fn" at 288:26-288:28 (leading: Space)
-2699: Ident           "__to" at 288:29-288:33 (leading: Space)
-2700: LParen          "(" at 288:33-288:34
-2701: Ident           "self" at 288:34-288:38
-2702: Colon           ":" at 288:38-288:39
-2703: Ident           "int" at 288:40-288:43 (leading: Space)
-2704: Comma           "," at 288:43-288:44
-2705: Ident           "target" at 288:45-288:51 (leading: Space)
-2706: Colon           ":" at 288:51-288:52
-2707: Ident           "int16" at 288:53-288:58 (leading: Space)
-2708: RParen          ")" at 288:58-288:59
-2709: Arrow           "->" at 288:60-288:62 (leading: Space)
-2710: Ident           "int16" at 288:63-288:68 (leading: Space)
-2711: Semicolon       ";" at 288:68-288:69
-2712: At              "@" at 289:5-289:6 (leading: Newline, Space)
-2713: Ident           "intrinsic" at 289:6-289:15
-2714: At              "@" at 289:16-289:17 (leading: Space)
-2715: Ident           "overload" at 289:17-289:25
-2716: KwFn            "fn" at 289:26-289:28 (leading: Space)
-2717: Ident           "__to" at 289:29-289:33 (leading: Space)
-2718: LParen          "(" at 289:33-289:34
-2719: Ident           "self" at 289:34-289:38
-2720: Colon           ":" at 289:38-289:39
-2721: Ident           "int" at 289:40-289:43 (leading: Space)
-2722: Comma           "," at 289:43-289:44
-2723: Ident           "target" at 289:45-289:51 (leading: Space)
-2724: Colon           ":" at 289:51-289:52
-2725: Ident           "int32" at 289:53-289:58 (leading: Space)
-2726: RParen          ")" at 289:58-289:59
-2727: Arrow           "->" at 289:60-289:62 (leading: Space)
-2728: Ident           "int32" at 289:63-289:68 (leading: Space)
-2729: Semicolon       ";" at 289:68-289:69
-2730: At              "@" at 290:5-290:6 (leading: Newline, Space)
-2731: Ident           "intrinsic" at 290:6-290:15
-2732: At              "@" at 290:16-290:17 (leading: Space)
-2733: Ident           "overload" at 290:17-290:25
-2734: KwFn            "fn" at 290:26-290:28 (leading: Space)
-2735: Ident           "__to" at 290:29-290:33 (leading: Space)
-2736: LParen          "(" at 290:33-290:34
-2737: Ident           "self" at 290:34-290:38
-2738: Colon           ":" at 290:38-290:39
-2739: Ident           "int" at 290:40-290:43 (leading: Space)
-2740: Comma           "," at 290:43-290:44
-2741: Ident           "target" at 290:45-290:51 (leading: Space)
-2742: Colon           ":" at 290:51-290:52
-2743: Ident           "int64" at 290:53-290:58 (leading: Space)
-2744: RParen          ")" at 290:58-290:59
-2745: Arrow           "->" at 290:60-290:62 (leading: Space)
-2746: Ident           "int64" at 290:63-290:68 (leading: Space)
-2747: Semicolon       ";" at 290:68-290:69
-2748: At              "@" at 291:5-291:6 (leading: Newline, Space)
-2749: Ident           "intrinsic" at 291:6-291:15
-2750: At              "@" at 291:16-291:17 (leading: Space)
-2751: Ident           "overload" at 291:17-291:25
-2752: KwFn            "fn" at 291:26-291:28 (leading: Space)
-2753: Ident           "__to" at 291:29-291:33 (leading: Space)
-2754: LParen          "(" at 291:33-291:34
-2755: Ident           "self" at 291:34-291:38
-2756: Colon           ":" at 291:38-291:39
-2757: Ident           "int" at 291:40-291:43 (leading: Space)
-2758: Comma           "," at 291:43-291:44
-2759: Ident           "target" at 291:45-291:51 (leading: Space)
-2760: Colon           ":" at 291:51-291:52
-2761: Ident           "uint8" at 291:53-291:58 (leading: Space)
-2762: RParen          ")" at 291:58-291:59
-2763: Arrow           "->" at 291:60-291:62 (leading: Space)
-2764: Ident           "uint8" at 291:63-291:68 (leading: Space)
-2765: Semicolon       ";" at 291:68-291:69
-2766: At              "@" at 292:5-292:6 (leading: Newline, Space)
-2767: Ident           "intrinsic" at 292:6-292:15
-2768: At              "@" at 292:16-292:17 (leading: Space)
-2769: Ident           "overload" at 292:17-292:25
-2770: KwFn            "fn" at 292:26-292:28 (leading: Space)
-2771: Ident           "__to" at 292:29-292:33 (leading: Space)
-2772: LParen          "(" at 292:33-292:34
-2773: Ident           "self" at 292:34-292:38
-2774: Colon           ":" at 292:38-292:39
-2775: Ident           "int" at 292:40-292:43 (leading: Space)
-2776: Comma           "," at 292:43-292:44
-2777: Ident           "target" at 292:45-292:51 (leading: Space)
-2778: Colon           ":" at 292:51-292:52
-2779: Ident           "uint16" at 292:53-292:59 (leading: Space)
-2780: RParen          ")" at 292:59-292:60
-2781: Arrow           "->" at 292:61-292:63 (leading: Space)
-2782: Ident           "uint16" at 292:64-292:70 (leading: Space)
-2783: Semicolon       ";" at 292:70-292:71
-2784: At              "@" at 293:5-293:6 (leading: Newline, Space)
-2785: Ident           "intrinsic" at 293:6-293:15
-2786: At              "@" at 293:16-293:17 (leading: Space)
-2787: Ident           "overload" at 293:17-293:25
-2788: KwFn            "fn" at 293:26-293:28 (leading: Space)
-2789: Ident           "__to" at 293:29-293:33 (leading: Space)
-2790: LParen          "(" at 293:33-293:34
-2791: Ident           "self" at 293:34-293:38
-2792: Colon           ":" at 293:38-293:39
-2793: Ident           "int" at 293:40-293:43 (leading: Space)
-2794: Comma           "," at 293:43-293:44
-2795: Ident           "target" at 293:45-293:51 (leading: Space)
-2796: Colon           ":" at 293:51-293:52
-2797: Ident           "uint32" at 293:53-293:59 (leading: Space)
-2798: RParen          ")" at 293:59-293:60
-2799: Arrow           "->" at 293:61-293:63 (leading: Space)
-2800: Ident           "uint32" at 293:64-293:70 (leading: Space)
-2801: Semicolon       ";" at 293:70-293:71
-2802: At              "@" at 294:5-294:6 (leading: Newline, Space)
-2803: Ident           "intrinsic" at 294:6-294:15
-2804: At              "@" at 294:16-294:17 (leading: Space)
-2805: Ident           "overload" at 294:17-294:25
-2806: KwFn            "fn" at 294:26-294:28 (leading: Space)
-2807: Ident           "__to" at 294:29-294:33 (leading: Space)
-2808: LParen          "(" at 294:33-294:34
-2809: Ident           "self" at 294:34-294:38
-2810: Colon           ":" at 294:38-294:39
-2811: Ident           "int" at 294:40-294:43 (leading: Space)
-2812: Comma           "," at 294:43-294:44
-2813: Ident           "target" at 294:45-294:51 (leading: Space)
-2814: Colon           ":" at 294:51-294:52
-2815: Ident           "uint64" at 294:53-294:59 (leading: Space)
-2816: RParen          ")" at 294:59-294:60
-2817: Arrow           "->" at 294:61-294:63 (leading: Space)
-2818: Ident           "uint64" at 294:64-294:70 (leading: Space)
-2819: Semicolon       ";" at 294:70-294:71
-2820: At              "@" at 295:5-295:6 (leading: Newline, Space)
-2821: Ident           "intrinsic" at 295:6-295:15
-2822: At              "@" at 295:16-295:17 (leading: Space)
-2823: Ident           "overload" at 295:17-295:25
-2824: KwFn            "fn" at 295:26-295:28 (leading: Space)
-2825: Ident           "__to" at 295:29-295:33 (leading: Space)
-2826: LParen          "(" at 295:33-295:34
-2827: Ident           "self" at 295:34-295:38
-2828: Colon           ":" at 295:38-295:39
-2829: Ident           "int" at 295:40-295:43 (leading: Space)
-2830: Comma           "," at 295:43-295:44
-2831: Ident           "target" at 295:45-295:51 (leading: Space)
-2832: Colon           ":" at 295:51-295:52
-2833: Ident           "float16" at 295:53-295:60 (leading: Space)
-2834: RParen          ")" at 295:60-295:61
-2835: Arrow           "->" at 295:62-295:64 (leading: Space)
-2836: Ident           "float16" at 295:65-295:72 (leading: Space)
-2837: Semicolon       ";" at 295:72-295:73
-2838: At              "@" at 296:5-296:6 (leading: Newline, Space)
-2839: Ident           "intrinsic" at 296:6-296:15
-2840: At              "@" at 296:16-296:17 (leading: Space)
-2841: Ident           "overload" at 296:17-296:25
-2842: KwFn            "fn" at 296:26-296:28 (leading: Space)
-2843: Ident           "__to" at 296:29-296:33 (leading: Space)
-2844: LParen          "(" at 296:33-296:34
-2845: Ident           "self" at 296:34-296:38
-2846: Colon           ":" at 296:38-296:39
-2847: Ident           "int" at 296:40-296:43 (leading: Space)
-2848: Comma           "," at 296:43-296:44
-2849: Ident           "target" at 296:45-296:51 (leading: Space)
-2850: Colon           ":" at 296:51-296:52
-2851: Ident           "float32" at 296:53-296:60 (leading: Space)
-2852: RParen          ")" at 296:60-296:61
-2853: Arrow           "->" at 296:62-296:64 (leading: Space)
-2854: Ident           "float32" at 296:65-296:72 (leading: Space)
-2855: Semicolon       ";" at 296:72-296:73
-2856: At              "@" at 297:5-297:6 (leading: Newline, Space)
-2857: Ident           "intrinsic" at 297:6-297:15
-2858: At              "@" at 297:16-297:17 (leading: Space)
-2859: Ident           "overload" at 297:17-297:25
-2860: KwFn            "fn" at 297:26-297:28 (leading: Space)
-2861: Ident           "__to" at 297:29-297:33 (leading: Space)
-2862: LParen          "(" at 297:33-297:34
-2863: Ident           "self" at 297:34-297:38
-2864: Colon           ":" at 297:38-297:39
-2865: Ident           "int" at 297:40-297:43 (leading: Space)
-2866: Comma           "," at 297:43-297:44
-2867: Ident           "target" at 297:45-297:51 (leading: Space)
-2868: Colon           ":" at 297:51-297:52
-2869: Ident           "float64" at 297:53-297:60 (leading: Space)
-2870: RParen          ")" at 297:60-297:61
-2871: Arrow           "->" at 297:62-297:64 (leading: Space)
-2872: Ident           "float64" at 297:65-297:72 (leading: Space)
-2873: Semicolon       ";" at 297:72-297:73
-2874: At              "@" at 299:5-299:6 (leading: Newline, Space, LineComment, Newline, Space)
-2875: Ident           "intrinsic" at 299:6-299:15
-2876: KwPub           "pub" at 299:16-299:19 (leading: Space)
-2877: KwFn            "fn" at 299:20-299:22 (leading: Space)
-2878: Ident           "from_str" at 299:23-299:31 (leading: Space)
-2879: LParen          "(" at 299:31-299:32
-2880: Ident           "s" at 299:32-299:33
-2881: Colon           ":" at 299:33-299:34
-2882: Amp             "&" at 299:35-299:36 (leading: Space)
-2883: Ident           "string" at 299:36-299:42
-2884: RParen          ")" at 299:42-299:43
-2885: Arrow           "->" at 299:44-299:46 (leading: Space)
-2886: Ident           "Erring" at 299:47-299:53 (leading: Space)
-2887: Lt              "<" at 299:53-299:54
-2888: Ident           "int" at 299:54-299:57
-2889: Comma           "," at 299:57-299:58
-2890: Ident           "Error" at 299:59-299:64 (leading: Space)
-2891: Gt              ">" at 299:64-299:65
-2892: Semicolon       ";" at 299:65-299:66
-2893: RBrace          "}" at 300:1-300:2 (leading: Newline)
-2894: KwExtern        "extern" at 302:1-302:7 (leading: Newline)
-2895: Lt              "<" at 302:7-302:8
-2896: Ident           "uint" at 302:8-302:12
-2897: Gt              ">" at 302:12-302:13
-2898: LBrace          "{" at 302:14-302:15 (leading: Space)
-2899: At              "@" at 303:5-303:6 (leading: Newline, Space)
-2900: Ident           "intrinsic" at 303:6-303:15
-2901: KwFn            "fn" at 303:16-303:18 (leading: Space)
-2902: Ident           "__add" at 303:19-303:24 (leading: Space)
-2903: LParen          "(" at 303:24-303:25
-2904: Ident           "self" at 303:25-303:29
-2905: Colon           ":" at 303:29-303:30
-2906: Ident           "uint" at 303:31-303:35 (leading: Space)
-2907: Comma           "," at 303:35-303:36
-2908: Ident           "other" at 303:37-303:42 (leading: Space)
-2909: Colon           ":" at 303:42-303:43
-2910: Ident           "uint" at 303:44-303:48 (leading: Space)
-2911: RParen          ")" at 303:48-303:49
-2912: Arrow           "->" at 303:50-303:52 (leading: Space)
-2913: Ident           "uint" at 303:53-303:57 (leading: Space)
-2914: Semicolon       ";" at 303:57-303:58
-2915: At              "@" at 304:5-304:6 (leading: Newline, Space)
-2916: Ident           "intrinsic" at 304:6-304:15
-2917: KwFn            "fn" at 304:16-304:18 (leading: Space)
-2918: Ident           "__sub" at 304:19-304:24 (leading: Space)
-2919: LParen          "(" at 304:24-304:25
-2920: Ident           "self" at 304:25-304:29
-2921: Colon           ":" at 304:29-304:30
-2922: Ident           "uint" at 304:31-304:35 (leading: Space)
-2923: Comma           "," at 304:35-304:36
-2924: Ident           "other" at 304:37-304:42 (leading: Space)
-2925: Colon           ":" at 304:42-304:43
-2926: Ident           "uint" at 304:44-304:48 (leading: Space)
-2927: RParen          ")" at 304:48-304:49
-2928: Arrow           "->" at 304:50-304:52 (leading: Space)
-2929: Ident           "uint" at 304:53-304:57 (leading: Space)
-2930: Semicolon       ";" at 304:57-304:58
-2931: At              "@" at 305:5-305:6 (leading: Newline, Space)
-2932: Ident           "intrinsic" at 305:6-305:15
-2933: KwFn            "fn" at 305:16-305:18 (leading: Space)
-2934: Ident           "__mul" at 305:19-305:24 (leading: Space)
-2935: LParen          "(" at 305:24-305:25
-2936: Ident           "self" at 305:25-305:29
-2937: Colon           ":" at 305:29-305:30
-2938: Ident           "uint" at 305:31-305:35 (leading: Space)
-2939: Comma           "," at 305:35-305:36
-2940: Ident           "other" at 305:37-305:42 (leading: Space)
-2941: Colon           ":" at 305:42-305:43
-2942: Ident           "uint" at 305:44-305:48 (leading: Space)
-2943: RParen          ")" at 305:48-305:49
-2944: Arrow           "->" at 305:50-305:52 (leading: Space)
-2945: Ident           "uint" at 305:53-305:57 (leading: Space)
-2946: Semicolon       ";" at 305:57-305:58
-2947: At              "@" at 306:5-306:6 (leading: Newline, Space)
-2948: Ident           "intrinsic" at 306:6-306:15
-2949: KwFn            "fn" at 306:16-306:18 (leading: Space)
-2950: Ident           "__div" at 306:19-306:24 (leading: Space)
-2951: LParen          "(" at 306:24-306:25
-2952: Ident           "self" at 306:25-306:29
-2953: Colon           ":" at 306:29-306:30
-2954: Ident           "uint" at 306:31-306:35 (leading: Space)
-2955: Comma           "," at 306:35-306:36
-2956: Ident           "other" at 306:37-306:42 (leading: Space)
-2957: Colon           ":" at 306:42-306:43
-2958: Ident           "uint" at 306:44-306:48 (leading: Space)
-2959: RParen          ")" at 306:48-306:49
-2960: Arrow           "->" at 306:50-306:52 (leading: Space)
-2961: Ident           "uint" at 306:53-306:57 (leading: Space)
-2962: Semicolon       ";" at 306:57-306:58
-2963: At              "@" at 307:5-307:6 (leading: Newline, Space)
-2964: Ident           "intrinsic" at 307:6-307:15
-2965: KwFn            "fn" at 307:16-307:18 (leading: Space)
-2966: Ident           "__mod" at 307:19-307:24 (leading: Space)
-2967: LParen          "(" at 307:24-307:25
-2968: Ident           "self" at 307:25-307:29
-2969: Colon           ":" at 307:29-307:30
-2970: Ident           "uint" at 307:31-307:35 (leading: Space)
-2971: Comma           "," at 307:35-307:36
-2972: Ident           "other" at 307:37-307:42 (leading: Space)
-2973: Colon           ":" at 307:42-307:43
-2974: Ident           "uint" at 307:44-307:48 (leading: Space)
-2975: RParen          ")" at 307:48-307:49
-2976: Arrow           "->" at 307:50-307:52 (leading: Space)
-2977: Ident           "uint" at 307:53-307:57 (leading: Space)
-2978: Semicolon       ";" at 307:57-307:58
-2979: At              "@" at 308:5-308:6 (leading: Newline, Space)
-2980: Ident           "intrinsic" at 308:6-308:15
-2981: KwFn            "fn" at 308:16-308:18 (leading: Space)
-2982: Ident           "__bit_and" at 308:19-308:28 (leading: Space)
-2983: LParen          "(" at 308:28-308:29
-2984: Ident           "self" at 308:29-308:33
-2985: Colon           ":" at 308:33-308:34
-2986: Ident           "uint" at 308:35-308:39 (leading: Space)
-2987: Comma           "," at 308:39-308:40
-2988: Ident           "other" at 308:41-308:46 (leading: Space)
-2989: Colon           ":" at 308:46-308:47
-2990: Ident           "uint" at 308:48-308:52 (leading: Space)
-2991: RParen          ")" at 308:52-308:53
-2992: Arrow           "->" at 308:54-308:56 (leading: Space)
-2993: Ident           "uint" at 308:57-308:61 (leading: Space)
-2994: Semicolon       ";" at 308:61-308:62
-2995: At              "@" at 309:5-309:6 (leading: Newline, Space)
-2996: Ident           "intrinsic" at 309:6-309:15
-2997: KwFn            "fn" at 309:16-309:18 (leading: Space)
-2998: Ident           "__bit_or" at 309:19-309:27 (leading: Space)
-2999: LParen          "(" at 309:27-309:28
-3000: Ident           "self" at 309:28-309:32
-3001: Colon           ":" at 309:32-309:33
-3002: Ident           "uint" at 309:34-309:38 (leading: Space)
-3003: Comma           "," at 309:38-309:39
-3004: Ident           "other" at 309:40-309:45 (leading: Space)
-3005: Colon           ":" at 309:45-309:46
-3006: Ident           "uint" at 309:47-309:51 (leading: Space)
-3007: RParen          ")" at 309:51-309:52
-3008: Arrow           "->" at 309:53-309:55 (leading: Space)
-3009: Ident           "uint" at 309:56-309:60 (leading: Space)
-3010: Semicolon       ";" at 309:60-309:61
-3011: At              "@" at 310:5-310:6 (leading: Newline, Space)
-3012: Ident           "intrinsic" at 310:6-310:15
-3013: KwFn            "fn" at 310:16-310:18 (leading: Space)
-3014: Ident           "__bit_xor" at 310:19-310:28 (leading: Space)
-3015: LParen          "(" at 310:28-310:29
-3016: Ident           "self" at 310:29-310:33
-3017: Colon           ":" at 310:33-310:34
-3018: Ident           "uint" at 310:35-310:39 (leading: Space)
-3019: Comma           "," at 310:39-310:40
-3020: Ident           "other" at 310:41-310:46 (leading: Space)
-3021: Colon           ":" at 310:46-310:47
-3022: Ident           "uint" at 310:48-310:52 (leading: Space)
-3023: RParen          ")" at 310:52-310:53
-3024: Arrow           "->" at 310:54-310:56 (leading: Space)
-3025: Ident           "uint" at 310:57-310:61 (leading: Space)
-3026: Semicolon       ";" at 310:61-310:62
-3027: At              "@" at 311:5-311:6 (leading: Newline, Space)
-3028: Ident           "intrinsic" at 311:6-311:15
-3029: KwFn            "fn" at 311:16-311:18 (leading: Space)
-3030: Ident           "__shl" at 311:19-311:24 (leading: Space)
-3031: LParen          "(" at 311:24-311:25
-3032: Ident           "self" at 311:25-311:29
-3033: Colon           ":" at 311:29-311:30
-3034: Ident           "uint" at 311:31-311:35 (leading: Space)
-3035: Comma           "," at 311:35-311:36
-3036: Ident           "other" at 311:37-311:42 (leading: Space)
-3037: Colon           ":" at 311:42-311:43
-3038: Ident           "uint" at 311:44-311:48 (leading: Space)
-3039: RParen          ")" at 311:48-311:49
-3040: Arrow           "->" at 311:50-311:52 (leading: Space)
-3041: Ident           "uint" at 311:53-311:57 (leading: Space)
-3042: Semicolon       ";" at 311:57-311:58
-3043: At              "@" at 312:5-312:6 (leading: Newline, Space)
-3044: Ident           "intrinsic" at 312:6-312:15
-3045: KwFn            "fn" at 312:16-312:18 (leading: Space)
-3046: Ident           "__shr" at 312:19-312:24 (leading: Space)
-3047: LParen          "(" at 312:24-312:25
-3048: Ident           "self" at 312:25-312:29
-3049: Colon           ":" at 312:29-312:30
-3050: Ident           "uint" at 312:31-312:35 (leading: Space)
-3051: Comma           "," at 312:35-312:36
-3052: Ident           "other" at 312:37-312:42 (leading: Space)
-3053: Colon           ":" at 312:42-312:43
-3054: Ident           "uint" at 312:44-312:48 (leading: Space)
-3055: RParen          ")" at 312:48-312:49
-3056: Arrow           "->" at 312:50-312:52 (leading: Space)
-3057: Ident           "uint" at 312:53-312:57 (leading: Space)
-3058: Semicolon       ";" at 312:57-312:58
-3059: At              "@" at 313:5-313:6 (leading: Newline, Space)
-3060: Ident           "intrinsic" at 313:6-313:15
-3061: KwFn            "fn" at 313:16-313:18 (leading: Space)
-3062: Ident           "__lt" at 313:19-313:23 (leading: Space)
-3063: LParen          "(" at 313:23-313:24
-3064: Ident           "self" at 313:24-313:28
-3065: Colon           ":" at 313:28-313:29
-3066: Ident           "uint" at 313:30-313:34 (leading: Space)
-3067: Comma           "," at 313:34-313:35
-3068: Ident           "other" at 313:36-313:41 (leading: Space)
-3069: Colon           ":" at 313:41-313:42
-3070: Ident           "uint" at 313:43-313:47 (leading: Space)
-3071: RParen          ")" at 313:47-313:48
-3072: Arrow           "->" at 313:49-313:51 (leading: Space)
-3073: Ident           "bool" at 313:52-313:56 (leading: Space)
-3074: Semicolon       ";" at 313:56-313:57
-3075: At              "@" at 314:5-314:6 (leading: Newline, Space)
-3076: Ident           "intrinsic" at 314:6-314:15
-3077: KwFn            "fn" at 314:16-314:18 (leading: Space)
-3078: Ident           "__le" at 314:19-314:23 (leading: Space)
-3079: LParen          "(" at 314:23-314:24
-3080: Ident           "self" at 314:24-314:28
-3081: Colon           ":" at 314:28-314:29
-3082: Ident           "uint" at 314:30-314:34 (leading: Space)
-3083: Comma           "," at 314:34-314:35
-3084: Ident           "other" at 314:36-314:41 (leading: Space)
-3085: Colon           ":" at 314:41-314:42
-3086: Ident           "uint" at 314:43-314:47 (leading: Space)
-3087: RParen          ")" at 314:47-314:48
-3088: Arrow           "->" at 314:49-314:51 (leading: Space)
-3089: Ident           "bool" at 314:52-314:56 (leading: Space)
-3090: Semicolon       ";" at 314:56-314:57
-3091: At              "@" at 315:5-315:6 (leading: Newline, Space)
-3092: Ident           "intrinsic" at 315:6-315:15
-3093: KwFn            "fn" at 315:16-315:18 (leading: Space)
-3094: Ident           "__eq" at 315:19-315:23 (leading: Space)
-3095: LParen          "(" at 315:23-315:24
-3096: Ident           "self" at 315:24-315:28
-3097: Colon           ":" at 315:28-315:29
-3098: Ident           "uint" at 315:30-315:34 (leading: Space)
-3099: Comma           "," at 315:34-315:35
-3100: Ident           "other" at 315:36-315:41 (leading: Space)
-3101: Colon           ":" at 315:41-315:42
-3102: Ident           "uint" at 315:43-315:47 (leading: Space)
-3103: RParen          ")" at 315:47-315:48
-3104: Arrow           "->" at 315:49-315:51 (leading: Space)
-3105: Ident           "bool" at 315:52-315:56 (leading: Space)
-3106: Semicolon       ";" at 315:56-315:57
-3107: At              "@" at 316:5-316:6 (leading: Newline, Space)
-3108: Ident           "intrinsic" at 316:6-316:15
-3109: KwFn            "fn" at 316:16-316:18 (leading: Space)
-3110: Ident           "__ne" at 316:19-316:23 (leading: Space)
-3111: LParen          "(" at 316:23-316:24
-3112: Ident           "self" at 316:24-316:28
-3113: Colon           ":" at 316:28-316:29
-3114: Ident           "uint" at 316:30-316:34 (leading: Space)
-3115: Comma           "," at 316:34-316:35
-3116: Ident           "other" at 316:36-316:41 (leading: Space)
-3117: Colon           ":" at 316:41-316:42
-3118: Ident           "uint" at 316:43-316:47 (leading: Space)
-3119: RParen          ")" at 316:47-316:48
-3120: Arrow           "->" at 316:49-316:51 (leading: Space)
-3121: Ident           "bool" at 316:52-316:56 (leading: Space)
-3122: Semicolon       ";" at 316:56-316:57
-3123: At              "@" at 317:5-317:6 (leading: Newline, Space)
-3124: Ident           "intrinsic" at 317:6-317:15
-3125: KwFn            "fn" at 317:16-317:18 (leading: Space)
-3126: Ident           "__ge" at 317:19-317:23 (leading: Space)
-3127: LParen          "(" at 317:23-317:24
-3128: Ident           "self" at 317:24-317:28
-3129: Colon           ":" at 317:28-317:29
-3130: Ident           "uint" at 317:30-317:34 (leading: Space)
-3131: Comma           "," at 317:34-317:35
-3132: Ident           "other" at 317:36-317:41 (leading: Space)
-3133: Colon           ":" at 317:41-317:42
-3134: Ident           "uint" at 317:43-317:47 (leading: Space)
-3135: RParen          ")" at 317:47-317:48
-3136: Arrow           "->" at 317:49-317:51 (leading: Space)
-3137: Ident           "bool" at 317:52-317:56 (leading: Space)
-3138: Semicolon       ";" at 317:56-317:57
-3139: At              "@" at 318:5-318:6 (leading: Newline, Space)
-3140: Ident           "intrinsic" at 318:6-318:15
-3141: KwFn            "fn" at 318:16-318:18 (leading: Space)
-3142: Ident           "__gt" at 318:19-318:23 (leading: Space)
-3143: LParen          "(" at 318:23-318:24
-3144: Ident           "self" at 318:24-318:28
-3145: Colon           ":" at 318:28-318:29
-3146: Ident           "uint" at 318:30-318:34 (leading: Space)
-3147: Comma           "," at 318:34-318:35
-3148: Ident           "other" at 318:36-318:41 (leading: Space)
-3149: Colon           ":" at 318:41-318:42
-3150: Ident           "uint" at 318:43-318:47 (leading: Space)
-3151: RParen          ")" at 318:47-318:48
-3152: Arrow           "->" at 318:49-318:51 (leading: Space)
-3153: Ident           "bool" at 318:52-318:56 (leading: Space)
-3154: Semicolon       ";" at 318:56-318:57
-3155: At              "@" at 319:5-319:6 (leading: Newline, Space)
-3156: Ident           "intrinsic" at 319:6-319:15
-3157: KwFn            "fn" at 319:16-319:18 (leading: Space)
-3158: Ident           "__pos" at 319:19-319:24 (leading: Space)
-3159: LParen          "(" at 319:24-319:25
-3160: Ident           "self" at 319:25-319:29
-3161: Colon           ":" at 319:29-319:30
-3162: Ident           "uint" at 319:31-319:35 (leading: Space)
-3163: RParen          ")" at 319:35-319:36
-3164: Arrow           "->" at 319:37-319:39 (leading: Space)
-3165: Ident           "uint" at 319:40-319:44 (leading: Space)
-3166: Semicolon       ";" at 319:44-319:45
-3167: At              "@" at 320:5-320:6 (leading: Newline, Space)
-3168: Ident           "intrinsic" at 320:6-320:15
-3169: KwFn            "fn" at 320:16-320:18 (leading: Space)
-3170: Ident           "__abs" at 320:19-320:24 (leading: Space)
-3171: LParen          "(" at 320:24-320:25
-3172: Ident           "self" at 320:25-320:29
-3173: Colon           ":" at 320:29-320:30
-3174: Ident           "uint" at 320:31-320:35 (leading: Space)
-3175: RParen          ")" at 320:35-320:36
-3176: Arrow           "->" at 320:37-320:39 (leading: Space)
-3177: Ident           "uint" at 320:40-320:44 (leading: Space)
-3178: Semicolon       ";" at 320:44-320:45
-3179: At              "@" at 321:5-321:6 (leading: Newline, Space)
-3180: Ident           "intrinsic" at 321:6-321:15
-3181: KwFn            "fn" at 321:16-321:18 (leading: Space)
-3182: Ident           "__to" at 321:19-321:23 (leading: Space)
-3183: LParen          "(" at 321:23-321:24
-3184: Ident           "self" at 321:24-321:28
-3185: Colon           ":" at 321:28-321:29
-3186: Ident           "uint" at 321:30-321:34 (leading: Space)
-3187: Comma           "," at 321:34-321:35
-3188: Ident           "target" at 321:36-321:42 (leading: Space)
-3189: Colon           ":" at 321:42-321:43
-3190: Ident           "string" at 321:44-321:50 (leading: Space)
-3191: RParen          ")" at 321:50-321:51
-3192: Arrow           "->" at 321:52-321:54 (leading: Space)
-3193: Ident           "string" at 321:55-321:61 (leading: Space)
-3194: Semicolon       ";" at 321:61-321:62
-3195: At              "@" at 322:5-322:6 (leading: Newline, Space)
-3196: Ident           "overload" at 322:6-322:14
-3197: KwPub           "pub" at 322:15-322:18 (leading: Space)
-3198: KwFn            "fn" at 322:19-322:21 (leading: Space)
-3199: Ident           "__to" at 322:22-322:26 (leading: Space)
-3200: LParen          "(" at 322:26-322:27
-3201: Ident           "self" at 322:27-322:31
-3202: Colon           ":" at 322:31-322:32
-3203: Amp             "&" at 322:33-322:34 (leading: Space)
-3204: Ident           "uint" at 322:34-322:38
-3205: Comma           "," at 322:38-322:39
-3206: Underscore      "_" at 322:40-322:41 (leading: Space)
-3207: Colon           ":" at 322:41-322:42
-3208: Ident           "string" at 322:43-322:49 (leading: Space)
-3209: RParen          ")" at 322:49-322:50
-3210: Arrow           "->" at 322:51-322:53 (leading: Space)
-3211: Ident           "string" at 322:54-322:60 (leading: Space)
-3212: LBrace          "{" at 322:61-322:62 (leading: Space)
-3213: KwReturn        "return" at 323:9-323:15 (leading: Newline, Space)
-3214: LParen          "(" at 323:16-323:17 (leading: Space)
-3215: Star            "*" at 323:17-323:18
-3216: Ident           "self" at 323:18-323:22
-3217: RParen          ")" at 323:22-323:23
-3218: KwTo            "to" at 323:24-323:26 (leading: Space)
-3219: Ident           "string" at 323:27-323:33 (leading: Space)
-3220: Semicolon       ";" at 323:33-323:34
-3221: RBrace          "}" at 324:5-324:6 (leading: Newline, Space)
-3222: At              "@" at 325:5-325:6 (leading: Newline, Space)
-3223: Ident           "intrinsic" at 325:6-325:15
-3224: At              "@" at 325:16-325:17 (leading: Space)
-3225: Ident           "overload" at 325:17-325:25
-3226: KwFn            "fn" at 325:26-325:28 (leading: Space)
-3227: Ident           "__to" at 325:29-325:33 (leading: Space)
-3228: LParen          "(" at 325:33-325:34
-3229: Ident           "self" at 325:34-325:38
-3230: Colon           ":" at 325:38-325:39
-3231: Ident           "uint" at 325:40-325:44 (leading: Space)
-3232: Comma           "," at 325:44-325:45
-3233: Ident           "target" at 325:46-325:52 (leading: Space)
-3234: Colon           ":" at 325:52-325:53
-3235: Ident           "int" at 325:54-325:57 (leading: Space)
-3236: RParen          ")" at 325:57-325:58
-3237: Arrow           "->" at 325:59-325:61 (leading: Space)
-3238: Ident           "int" at 325:62-325:65 (leading: Space)
-3239: Semicolon       ";" at 325:65-325:66
-3240: At              "@" at 326:5-326:6 (leading: Newline, Space)
-3241: Ident           "intrinsic" at 326:6-326:15
-3242: At              "@" at 326:16-326:17 (leading: Space)
-3243: Ident           "overload" at 326:17-326:25
-3244: KwFn            "fn" at 326:26-326:28 (leading: Space)
-3245: Ident           "__to" at 326:29-326:33 (leading: Space)
-3246: LParen          "(" at 326:33-326:34
-3247: Ident           "self" at 326:34-326:38
-3248: Colon           ":" at 326:38-326:39
-3249: Ident           "uint" at 326:40-326:44 (leading: Space)
-3250: Comma           "," at 326:44-326:45
-3251: Ident           "target" at 326:46-326:52 (leading: Space)
-3252: Colon           ":" at 326:52-326:53
-3253: Ident           "float" at 326:54-326:59 (leading: Space)
-3254: RParen          ")" at 326:59-326:60
-3255: Arrow           "->" at 326:61-326:63 (leading: Space)
-3256: Ident           "float" at 326:64-326:69 (leading: Space)
-3257: Semicolon       ";" at 326:69-326:70
-3258: At              "@" at 327:5-327:6 (leading: Newline, Space)
-3259: Ident           "intrinsic" at 327:6-327:15
-3260: At              "@" at 327:16-327:17 (leading: Space)
-3261: Ident           "overload" at 327:17-327:25
-3262: KwFn            "fn" at 327:26-327:28 (leading: Space)
-3263: Ident           "__to" at 327:29-327:33 (leading: Space)
-3264: LParen          "(" at 327:33-327:34
-3265: Ident           "self" at 327:34-327:38
-3266: Colon           ":" at 327:38-327:39
-3267: Ident           "uint" at 327:40-327:44 (leading: Space)
-3268: Comma           "," at 327:44-327:45
-3269: Ident           "target" at 327:46-327:52 (leading: Space)
-3270: Colon           ":" at 327:52-327:53
-3271: Ident           "int8" at 327:54-327:58 (leading: Space)
-3272: RParen          ")" at 327:58-327:59
-3273: Arrow           "->" at 327:60-327:62 (leading: Space)
-3274: Ident           "int8" at 327:63-327:67 (leading: Space)
-3275: Semicolon       ";" at 327:67-327:68
-3276: At              "@" at 328:5-328:6 (leading: Newline, Space)
-3277: Ident           "intrinsic" at 328:6-328:15
-3278: At              "@" at 328:16-328:17 (leading: Space)
-3279: Ident           "overload" at 328:17-328:25
-3280: KwFn            "fn" at 328:26-328:28 (leading: Space)
-3281: Ident           "__to" at 328:29-328:33 (leading: Space)
-3282: LParen          "(" at 328:33-328:34
-3283: Ident           "self" at 328:34-328:38
-3284: Colon           ":" at 328:38-328:39
-3285: Ident           "uint" at 328:40-328:44 (leading: Space)
-3286: Comma           "," at 328:44-328:45
-3287: Ident           "target" at 328:46-328:52 (leading: Space)
-3288: Colon           ":" at 328:52-328:53
-3289: Ident           "int16" at 328:54-328:59 (leading: Space)
-3290: RParen          ")" at 328:59-328:60
-3291: Arrow           "->" at 328:61-328:63 (leading: Space)
-3292: Ident           "int16" at 328:64-328:69 (leading: Space)
-3293: Semicolon       ";" at 328:69-328:70
-3294: At              "@" at 329:5-329:6 (leading: Newline, Space)
-3295: Ident           "intrinsic" at 329:6-329:15
-3296: At              "@" at 329:16-329:17 (leading: Space)
-3297: Ident           "overload" at 329:17-329:25
-3298: KwFn            "fn" at 329:26-329:28 (leading: Space)
-3299: Ident           "__to" at 329:29-329:33 (leading: Space)
-3300: LParen          "(" at 329:33-329:34
-3301: Ident           "self" at 329:34-329:38
-3302: Colon           ":" at 329:38-329:39
-3303: Ident           "uint" at 329:40-329:44 (leading: Space)
-3304: Comma           "," at 329:44-329:45
-3305: Ident           "target" at 329:46-329:52 (leading: Space)
-3306: Colon           ":" at 329:52-329:53
-3307: Ident           "int32" at 329:54-329:59 (leading: Space)
-3308: RParen          ")" at 329:59-329:60
-3309: Arrow           "->" at 329:61-329:63 (leading: Space)
-3310: Ident           "int32" at 329:64-329:69 (leading: Space)
-3311: Semicolon       ";" at 329:69-329:70
-3312: At              "@" at 330:5-330:6 (leading: Newline, Space)
-3313: Ident           "intrinsic" at 330:6-330:15
-3314: At              "@" at 330:16-330:17 (leading: Space)
-3315: Ident           "overload" at 330:17-330:25
-3316: KwFn            "fn" at 330:26-330:28 (leading: Space)
-3317: Ident           "__to" at 330:29-330:33 (leading: Space)
-3318: LParen          "(" at 330:33-330:34
-3319: Ident           "self" at 330:34-330:38
-3320: Colon           ":" at 330:38-330:39
-3321: Ident           "uint" at 330:40-330:44 (leading: Space)
-3322: Comma           "," at 330:44-330:45
-3323: Ident           "target" at 330:46-330:52 (leading: Space)
-3324: Colon           ":" at 330:52-330:53
-3325: Ident           "int64" at 330:54-330:59 (leading: Space)
-3326: RParen          ")" at 330:59-330:60
-3327: Arrow           "->" at 330:61-330:63 (leading: Space)
-3328: Ident           "int64" at 330:64-330:69 (leading: Space)
-3329: Semicolon       ";" at 330:69-330:70
-3330: At              "@" at 331:5-331:6 (leading: Newline, Space)
-3331: Ident           "intrinsic" at 331:6-331:15
-3332: At              "@" at 331:16-331:17 (leading: Space)
-3333: Ident           "overload" at 331:17-331:25
-3334: KwFn            "fn" at 331:26-331:28 (leading: Space)
-3335: Ident           "__to" at 331:29-331:33 (leading: Space)
-3336: LParen          "(" at 331:33-331:34
-3337: Ident           "self" at 331:34-331:38
-3338: Colon           ":" at 331:38-331:39
-3339: Ident           "uint" at 331:40-331:44 (leading: Space)
-3340: Comma           "," at 331:44-331:45
-3341: Ident           "target" at 331:46-331:52 (leading: Space)
-3342: Colon           ":" at 331:52-331:53
-3343: Ident           "uint8" at 331:54-331:59 (leading: Space)
-3344: RParen          ")" at 331:59-331:60
-3345: Arrow           "->" at 331:61-331:63 (leading: Space)
-3346: Ident           "uint8" at 331:64-331:69 (leading: Space)
-3347: Semicolon       ";" at 331:69-331:70
-3348: At              "@" at 332:5-332:6 (leading: Newline, Space)
-3349: Ident           "intrinsic" at 332:6-332:15
-3350: At              "@" at 332:16-332:17 (leading: Space)
-3351: Ident           "overload" at 332:17-332:25
-3352: KwFn            "fn" at 332:26-332:28 (leading: Space)
-3353: Ident           "__to" at 332:29-332:33 (leading: Space)
-3354: LParen          "(" at 332:33-332:34
-3355: Ident           "self" at 332:34-332:38
-3356: Colon           ":" at 332:38-332:39
-3357: Ident           "uint" at 332:40-332:44 (leading: Space)
-3358: Comma           "," at 332:44-332:45
-3359: Ident           "target" at 332:46-332:52 (leading: Space)
-3360: Colon           ":" at 332:52-332:53
-3361: Ident           "uint16" at 332:54-332:60 (leading: Space)
-3362: RParen          ")" at 332:60-332:61
-3363: Arrow           "->" at 332:62-332:64 (leading: Space)
-3364: Ident           "uint16" at 332:65-332:71 (leading: Space)
-3365: Semicolon       ";" at 332:71-332:72
-3366: At              "@" at 333:5-333:6 (leading: Newline, Space)
-3367: Ident           "intrinsic" at 333:6-333:15
-3368: At              "@" at 333:16-333:17 (leading: Space)
-3369: Ident           "overload" at 333:17-333:25
-3370: KwFn            "fn" at 333:26-333:28 (leading: Space)
-3371: Ident           "__to" at 333:29-333:33 (leading: Space)
-3372: LParen          "(" at 333:33-333:34
-3373: Ident           "self" at 333:34-333:38
-3374: Colon           ":" at 333:38-333:39
-3375: Ident           "uint" at 333:40-333:44 (leading: Space)
-3376: Comma           "," at 333:44-333:45
-3377: Ident           "target" at 333:46-333:52 (leading: Space)
-3378: Colon           ":" at 333:52-333:53
-3379: Ident           "uint32" at 333:54-333:60 (leading: Space)
-3380: RParen          ")" at 333:60-333:61
-3381: Arrow           "->" at 333:62-333:64 (leading: Space)
-3382: Ident           "uint32" at 333:65-333:71 (leading: Space)
-3383: Semicolon       ";" at 333:71-333:72
-3384: At              "@" at 334:5-334:6 (leading: Newline, Space)
-3385: Ident           "intrinsic" at 334:6-334:15
-3386: At              "@" at 334:16-334:17 (leading: Space)
-3387: Ident           "overload" at 334:17-334:25
-3388: KwFn            "fn" at 334:26-334:28 (leading: Space)
-3389: Ident           "__to" at 334:29-334:33 (leading: Space)
-3390: LParen          "(" at 334:33-334:34
-3391: Ident           "self" at 334:34-334:38
-3392: Colon           ":" at 334:38-334:39
-3393: Ident           "uint" at 334:40-334:44 (leading: Space)
-3394: Comma           "," at 334:44-334:45
-3395: Ident           "target" at 334:46-334:52 (leading: Space)
-3396: Colon           ":" at 334:52-334:53
-3397: Ident           "uint64" at 334:54-334:60 (leading: Space)
-3398: RParen          ")" at 334:60-334:61
-3399: Arrow           "->" at 334:62-334:64 (leading: Space)
-3400: Ident           "uint64" at 334:65-334:71 (leading: Space)
-3401: Semicolon       ";" at 334:71-334:72
-3402: At              "@" at 335:5-335:6 (leading: Newline, Space)
-3403: Ident           "intrinsic" at 335:6-335:15
-3404: At              "@" at 335:16-335:17 (leading: Space)
-3405: Ident           "overload" at 335:17-335:25
-3406: KwFn            "fn" at 335:26-335:28 (leading: Space)
-3407: Ident           "__to" at 335:29-335:33 (leading: Space)
-3408: LParen          "(" at 335:33-335:34
-3409: Ident           "self" at 335:34-335:38
-3410: Colon           ":" at 335:38-335:39
-3411: Ident           "uint" at 335:40-335:44 (leading: Space)
-3412: Comma           "," at 335:44-335:45
-3413: Ident           "target" at 335:46-335:52 (leading: Space)
-3414: Colon           ":" at 335:52-335:53
-3415: Ident           "float16" at 335:54-335:61 (leading: Space)
-3416: RParen          ")" at 335:61-335:62
-3417: Arrow           "->" at 335:63-335:65 (leading: Space)
-3418: Ident           "float16" at 335:66-335:73 (leading: Space)
-3419: Semicolon       ";" at 335:73-335:74
-3420: At              "@" at 336:5-336:6 (leading: Newline, Space)
-3421: Ident           "intrinsic" at 336:6-336:15
-3422: At              "@" at 336:16-336:17 (leading: Space)
-3423: Ident           "overload" at 336:17-336:25
-3424: KwFn            "fn" at 336:26-336:28 (leading: Space)
-3425: Ident           "__to" at 336:29-336:33 (leading: Space)
-3426: LParen          "(" at 336:33-336:34
-3427: Ident           "self" at 336:34-336:38
-3428: Colon           ":" at 336:38-336:39
-3429: Ident           "uint" at 336:40-336:44 (leading: Space)
-3430: Comma           "," at 336:44-336:45
-3431: Ident           "target" at 336:46-336:52 (leading: Space)
-3432: Colon           ":" at 336:52-336:53
-3433: Ident           "float32" at 336:54-336:61 (leading: Space)
-3434: RParen          ")" at 336:61-336:62
-3435: Arrow           "->" at 336:63-336:65 (leading: Space)
-3436: Ident           "float32" at 336:66-336:73 (leading: Space)
-3437: Semicolon       ";" at 336:73-336:74
-3438: At              "@" at 337:5-337:6 (leading: Newline, Space)
-3439: Ident           "intrinsic" at 337:6-337:15
-3440: At              "@" at 337:16-337:17 (leading: Space)
-3441: Ident           "overload" at 337:17-337:25
-3442: KwFn            "fn" at 337:26-337:28 (leading: Space)
-3443: Ident           "__to" at 337:29-337:33 (leading: Space)
-3444: LParen          "(" at 337:33-337:34
-3445: Ident           "self" at 337:34-337:38
-3446: Colon           ":" at 337:38-337:39
-3447: Ident           "uint" at 337:40-337:44 (leading: Space)
-3448: Comma           "," at 337:44-337:45
-3449: Ident           "target" at 337:46-337:52 (leading: Space)
-3450: Colon           ":" at 337:52-337:53
-3451: Ident           "float64" at 337:54-337:61 (leading: Space)
-3452: RParen          ")" at 337:61-337:62
-3453: Arrow           "->" at 337:63-337:65 (leading: Space)
-3454: Ident           "float64" at 337:66-337:73 (leading: Space)
-3455: Semicolon       ";" at 337:73-337:74
-3456: At              "@" at 339:5-339:6 (leading: Newline, Space, LineComment, Newline, Space)
-3457: Ident           "intrinsic" at 339:6-339:15
-3458: KwPub           "pub" at 339:16-339:19 (leading: Space)
-3459: KwFn            "fn" at 339:20-339:22 (leading: Space)
-3460: Ident           "from_str" at 339:23-339:31 (leading: Space)
-3461: LParen          "(" at 339:31-339:32
-3462: Ident           "s" at 339:32-339:33
-3463: Colon           ":" at 339:33-339:34
-3464: Amp             "&" at 339:35-339:36 (leading: Space)
-3465: Ident           "string" at 339:36-339:42
-3466: RParen          ")" at 339:42-339:43
-3467: Arrow           "->" at 339:44-339:46 (leading: Space)
-3468: Ident           "Erring" at 339:47-339:53 (leading: Space)
-3469: Lt              "<" at 339:53-339:54
-3470: Ident           "uint" at 339:54-339:58
-3471: Comma           "," at 339:58-339:59
-3472: Ident           "Error" at 339:60-339:65 (leading: Space)
-3473: Gt              ">" at 339:65-339:66
-3474: Semicolon       ";" at 339:66-339:67
-3475: RBrace          "}" at 340:1-340:2 (leading: Newline)
-3476: KwExtern        "extern" at 342:1-342:7 (leading: Newline)
-3477: Lt              "<" at 342:7-342:8
-3478: Ident           "int8" at 342:8-342:12
-3479: Gt              ">" at 342:12-342:13
-3480: LBrace          "{" at 342:14-342:15 (leading: Space)
-3481: KwPub           "pub" at 343:5-343:8 (leading: Newline, Space)
-3482: KwFn            "fn" at 343:9-343:11 (leading: Space)
-3483: Ident           "__min_value" at 343:12-343:23 (leading: Space)
-3484: LParen          "(" at 343:23-343:24
-3485: RParen          ")" at 343:24-343:25
-3486: Arrow           "->" at 343:26-343:28 (leading: Space)
-3487: Ident           "int8" at 343:29-343:33 (leading: Space)
-3488: LBrace          "{" at 343:34-343:35 (leading: Space)
-3489: KwReturn        "return" at 343:36-343:42 (leading: Space)
-3490: LParen          "(" at 343:43-343:44 (leading: Space)
-3491: Minus           "-" at 343:44-343:45
-3492: IntLit          "128" at 343:45-343:48
-3493: RParen          ")" at 343:48-343:49
-3494: Colon           ":" at 343:49-343:50
-3495: Ident           "int8" at 343:50-343:54
-3496: Semicolon       ";" at 343:54-343:55
-3497: RBrace          "}" at 343:56-343:57 (leading: Space)
-3498: KwPub           "pub" at 344:5-344:8 (leading: Newline, Space)
-3499: KwFn            "fn" at 344:9-344:11 (leading: Space)
-3500: Ident           "__max_value" at 344:12-344:23 (leading: Space)
-3501: LParen          "(" at 344:23-344:24
-3502: RParen          ")" at 344:24-344:25
-3503: Arrow           "->" at 344:26-344:28 (leading: Space)
-3504: Ident           "int8" at 344:29-344:33 (leading: Space)
-3505: LBrace          "{" at 344:34-344:35 (leading: Space)
-3506: KwReturn        "return" at 344:36-344:42 (leading: Space)
-3507: LParen          "(" at 344:43-344:44 (leading: Space)
-3508: IntLit          "127" at 344:44-344:47
-3509: RParen          ")" at 344:47-344:48
-3510: Colon           ":" at 344:48-344:49
-3511: Ident           "int8" at 344:49-344:53
-3512: Semicolon       ";" at 344:53-344:54
-3513: RBrace          "}" at 344:55-344:56 (leading: Space)
-3514: At              "@" at 345:5-345:6 (leading: Newline, Space)
-3515: Ident           "intrinsic" at 345:6-345:15
-3516: KwFn            "fn" at 345:16-345:18 (leading: Space)
-3517: Ident           "__add" at 345:19-345:24 (leading: Space)
-3518: LParen          "(" at 345:24-345:25
-3519: Ident           "self" at 345:25-345:29
-3520: Colon           ":" at 345:29-345:30
-3521: Ident           "int8" at 345:31-345:35 (leading: Space)
-3522: Comma           "," at 345:35-345:36
-3523: Ident           "other" at 345:37-345:42 (leading: Space)
-3524: Colon           ":" at 345:42-345:43
-3525: Ident           "int8" at 345:44-345:48 (leading: Space)
-3526: RParen          ")" at 345:48-345:49
-3527: Arrow           "->" at 345:50-345:52 (leading: Space)
-3528: Ident           "int8" at 345:53-345:57 (leading: Space)
-3529: Semicolon       ";" at 345:57-345:58
-3530: At              "@" at 346:5-346:6 (leading: Newline, Space)
-3531: Ident           "intrinsic" at 346:6-346:15
-3532: KwFn            "fn" at 346:16-346:18 (leading: Space)
-3533: Ident           "__sub" at 346:19-346:24 (leading: Space)
-3534: LParen          "(" at 346:24-346:25
-3535: Ident           "self" at 346:25-346:29
-3536: Colon           ":" at 346:29-346:30
-3537: Ident           "int8" at 346:31-346:35 (leading: Space)
-3538: Comma           "," at 346:35-346:36
-3539: Ident           "other" at 346:37-346:42 (leading: Space)
-3540: Colon           ":" at 346:42-346:43
-3541: Ident           "int8" at 346:44-346:48 (leading: Space)
-3542: RParen          ")" at 346:48-346:49
-3543: Arrow           "->" at 346:50-346:52 (leading: Space)
-3544: Ident           "int8" at 346:53-346:57 (leading: Space)
-3545: Semicolon       ";" at 346:57-346:58
-3546: At              "@" at 347:5-347:6 (leading: Newline, Space)
-3547: Ident           "intrinsic" at 347:6-347:15
-3548: KwFn            "fn" at 347:16-347:18 (leading: Space)
-3549: Ident           "__mul" at 347:19-347:24 (leading: Space)
-3550: LParen          "(" at 347:24-347:25
-3551: Ident           "self" at 347:25-347:29
-3552: Colon           ":" at 347:29-347:30
-3553: Ident           "int8" at 347:31-347:35 (leading: Space)
-3554: Comma           "," at 347:35-347:36
-3555: Ident           "other" at 347:37-347:42 (leading: Space)
-3556: Colon           ":" at 347:42-347:43
-3557: Ident           "int8" at 347:44-347:48 (leading: Space)
-3558: RParen          ")" at 347:48-347:49
-3559: Arrow           "->" at 347:50-347:52 (leading: Space)
-3560: Ident           "int8" at 347:53-347:57 (leading: Space)
-3561: Semicolon       ";" at 347:57-347:58
-3562: At              "@" at 348:5-348:6 (leading: Newline, Space)
-3563: Ident           "intrinsic" at 348:6-348:15
-3564: KwFn            "fn" at 348:16-348:18 (leading: Space)
-3565: Ident           "__div" at 348:19-348:24 (leading: Space)
-3566: LParen          "(" at 348:24-348:25
-3567: Ident           "self" at 348:25-348:29
-3568: Colon           ":" at 348:29-348:30
-3569: Ident           "int8" at 348:31-348:35 (leading: Space)
-3570: Comma           "," at 348:35-348:36
-3571: Ident           "other" at 348:37-348:42 (leading: Space)
-3572: Colon           ":" at 348:42-348:43
-3573: Ident           "int8" at 348:44-348:48 (leading: Space)
-3574: RParen          ")" at 348:48-348:49
-3575: Arrow           "->" at 348:50-348:52 (leading: Space)
-3576: Ident           "int8" at 348:53-348:57 (leading: Space)
-3577: Semicolon       ";" at 348:57-348:58
-3578: At              "@" at 349:5-349:6 (leading: Newline, Space)
-3579: Ident           "intrinsic" at 349:6-349:15
-3580: KwFn            "fn" at 349:16-349:18 (leading: Space)
-3581: Ident           "__mod" at 349:19-349:24 (leading: Space)
-3582: LParen          "(" at 349:24-349:25
-3583: Ident           "self" at 349:25-349:29
-3584: Colon           ":" at 349:29-349:30
-3585: Ident           "int8" at 349:31-349:35 (leading: Space)
-3586: Comma           "," at 349:35-349:36
-3587: Ident           "other" at 349:37-349:42 (leading: Space)
-3588: Colon           ":" at 349:42-349:43
-3589: Ident           "int8" at 349:44-349:48 (leading: Space)
-3590: RParen          ")" at 349:48-349:49
-3591: Arrow           "->" at 349:50-349:52 (leading: Space)
-3592: Ident           "int8" at 349:53-349:57 (leading: Space)
-3593: Semicolon       ";" at 349:57-349:58
-3594: At              "@" at 350:5-350:6 (leading: Newline, Space)
-3595: Ident           "intrinsic" at 350:6-350:15
-3596: KwFn            "fn" at 350:16-350:18 (leading: Space)
-3597: Ident           "__bit_and" at 350:19-350:28 (leading: Space)
-3598: LParen          "(" at 350:28-350:29
-3599: Ident           "self" at 350:29-350:33
-3600: Colon           ":" at 350:33-350:34
-3601: Ident           "int8" at 350:35-350:39 (leading: Space)
-3602: Comma           "," at 350:39-350:40
-3603: Ident           "other" at 350:41-350:46 (leading: Space)
-3604: Colon           ":" at 350:46-350:47
-3605: Ident           "int8" at 350:48-350:52 (leading: Space)
-3606: RParen          ")" at 350:52-350:53
-3607: Arrow           "->" at 350:54-350:56 (leading: Space)
-3608: Ident           "int8" at 350:57-350:61 (leading: Space)
-3609: Semicolon       ";" at 350:61-350:62
-3610: At              "@" at 351:5-351:6 (leading: Newline, Space)
-3611: Ident           "intrinsic" at 351:6-351:15
-3612: KwFn            "fn" at 351:16-351:18 (leading: Space)
-3613: Ident           "__bit_or" at 351:19-351:27 (leading: Space)
-3614: LParen          "(" at 351:27-351:28
-3615: Ident           "self" at 351:28-351:32
-3616: Colon           ":" at 351:32-351:33
-3617: Ident           "int8" at 351:34-351:38 (leading: Space)
-3618: Comma           "," at 351:38-351:39
-3619: Ident           "other" at 351:40-351:45 (leading: Space)
-3620: Colon           ":" at 351:45-351:46
-3621: Ident           "int8" at 351:47-351:51 (leading: Space)
-3622: RParen          ")" at 351:51-351:52
-3623: Arrow           "->" at 351:53-351:55 (leading: Space)
-3624: Ident           "int8" at 351:56-351:60 (leading: Space)
-3625: Semicolon       ";" at 351:60-351:61
-3626: At              "@" at 352:5-352:6 (leading: Newline, Space)
-3627: Ident           "intrinsic" at 352:6-352:15
-3628: KwFn            "fn" at 352:16-352:18 (leading: Space)
-3629: Ident           "__bit_xor" at 352:19-352:28 (leading: Space)
-3630: LParen          "(" at 352:28-352:29
-3631: Ident           "self" at 352:29-352:33
-3632: Colon           ":" at 352:33-352:34
-3633: Ident           "int8" at 352:35-352:39 (leading: Space)
-3634: Comma           "," at 352:39-352:40
-3635: Ident           "other" at 352:41-352:46 (leading: Space)
-3636: Colon           ":" at 352:46-352:47
-3637: Ident           "int8" at 352:48-352:52 (leading: Space)
-3638: RParen          ")" at 352:52-352:53
-3639: Arrow           "->" at 352:54-352:56 (leading: Space)
-3640: Ident           "int8" at 352:57-352:61 (leading: Space)
-3641: Semicolon       ";" at 352:61-352:62
-3642: At              "@" at 353:5-353:6 (leading: Newline, Space)
-3643: Ident           "intrinsic" at 353:6-353:15
-3644: KwFn            "fn" at 353:16-353:18 (leading: Space)
-3645: Ident           "__shl" at 353:19-353:24 (leading: Space)
-3646: LParen          "(" at 353:24-353:25
-3647: Ident           "self" at 353:25-353:29
-3648: Colon           ":" at 353:29-353:30
-3649: Ident           "int8" at 353:31-353:35 (leading: Space)
-3650: Comma           "," at 353:35-353:36
-3651: Ident           "other" at 353:37-353:42 (leading: Space)
-3652: Colon           ":" at 353:42-353:43
-3653: Ident           "int8" at 353:44-353:48 (leading: Space)
-3654: RParen          ")" at 353:48-353:49
-3655: Arrow           "->" at 353:50-353:52 (leading: Space)
-3656: Ident           "int8" at 353:53-353:57 (leading: Space)
-3657: Semicolon       ";" at 353:57-353:58
-3658: At              "@" at 354:5-354:6 (leading: Newline, Space)
-3659: Ident           "intrinsic" at 354:6-354:15
-3660: KwFn            "fn" at 354:16-354:18 (leading: Space)
-3661: Ident           "__shr" at 354:19-354:24 (leading: Space)
-3662: LParen          "(" at 354:24-354:25
-3663: Ident           "self" at 354:25-354:29
-3664: Colon           ":" at 354:29-354:30
-3665: Ident           "int8" at 354:31-354:35 (leading: Space)
-3666: Comma           "," at 354:35-354:36
-3667: Ident           "other" at 354:37-354:42 (leading: Space)
-3668: Colon           ":" at 354:42-354:43
-3669: Ident           "int8" at 354:44-354:48 (leading: Space)
-3670: RParen          ")" at 354:48-354:49
-3671: Arrow           "->" at 354:50-354:52 (leading: Space)
-3672: Ident           "int8" at 354:53-354:57 (leading: Space)
-3673: Semicolon       ";" at 354:57-354:58
-3674: At              "@" at 355:5-355:6 (leading: Newline, Space)
-3675: Ident           "intrinsic" at 355:6-355:15
-3676: KwFn            "fn" at 355:16-355:18 (leading: Space)
-3677: Ident           "__lt" at 355:19-355:23 (leading: Space)
-3678: LParen          "(" at 355:23-355:24
-3679: Ident           "self" at 355:24-355:28
-3680: Colon           ":" at 355:28-355:29
-3681: Ident           "int8" at 355:30-355:34 (leading: Space)
-3682: Comma           "," at 355:34-355:35
-3683: Ident           "other" at 355:36-355:41 (leading: Space)
-3684: Colon           ":" at 355:41-355:42
-3685: Ident           "int8" at 355:43-355:47 (leading: Space)
-3686: RParen          ")" at 355:47-355:48
-3687: Arrow           "->" at 355:49-355:51 (leading: Space)
-3688: Ident           "bool" at 355:52-355:56 (leading: Space)
-3689: Semicolon       ";" at 355:56-355:57
-3690: At              "@" at 356:5-356:6 (leading: Newline, Space)
-3691: Ident           "intrinsic" at 356:6-356:15
-3692: KwFn            "fn" at 356:16-356:18 (leading: Space)
-3693: Ident           "__le" at 356:19-356:23 (leading: Space)
-3694: LParen          "(" at 356:23-356:24
-3695: Ident           "self" at 356:24-356:28
-3696: Colon           ":" at 356:28-356:29
-3697: Ident           "int8" at 356:30-356:34 (leading: Space)
-3698: Comma           "," at 356:34-356:35
-3699: Ident           "other" at 356:36-356:41 (leading: Space)
-3700: Colon           ":" at 356:41-356:42
-3701: Ident           "int8" at 356:43-356:47 (leading: Space)
-3702: RParen          ")" at 356:47-356:48
-3703: Arrow           "->" at 356:49-356:51 (leading: Space)
-3704: Ident           "bool" at 356:52-356:56 (leading: Space)
-3705: Semicolon       ";" at 356:56-356:57
-3706: At              "@" at 357:5-357:6 (leading: Newline, Space)
-3707: Ident           "intrinsic" at 357:6-357:15
-3708: KwFn            "fn" at 357:16-357:18 (leading: Space)
-3709: Ident           "__eq" at 357:19-357:23 (leading: Space)
-3710: LParen          "(" at 357:23-357:24
-3711: Ident           "self" at 357:24-357:28
-3712: Colon           ":" at 357:28-357:29
-3713: Ident           "int8" at 357:30-357:34 (leading: Space)
-3714: Comma           "," at 357:34-357:35
-3715: Ident           "other" at 357:36-357:41 (leading: Space)
-3716: Colon           ":" at 357:41-357:42
-3717: Ident           "int8" at 357:43-357:47 (leading: Space)
-3718: RParen          ")" at 357:47-357:48
-3719: Arrow           "->" at 357:49-357:51 (leading: Space)
-3720: Ident           "bool" at 357:52-357:56 (leading: Space)
-3721: Semicolon       ";" at 357:56-357:57
-3722: At              "@" at 358:5-358:6 (leading: Newline, Space)
-3723: Ident           "intrinsic" at 358:6-358:15
-3724: KwFn            "fn" at 358:16-358:18 (leading: Space)
-3725: Ident           "__ne" at 358:19-358:23 (leading: Space)
-3726: LParen          "(" at 358:23-358:24
-3727: Ident           "self" at 358:24-358:28
-3728: Colon           ":" at 358:28-358:29
-3729: Ident           "int8" at 358:30-358:34 (leading: Space)
-3730: Comma           "," at 358:34-358:35
-3731: Ident           "other" at 358:36-358:41 (leading: Space)
-3732: Colon           ":" at 358:41-358:42
-3733: Ident           "int8" at 358:43-358:47 (leading: Space)
-3734: RParen          ")" at 358:47-358:48
-3735: Arrow           "->" at 358:49-358:51 (leading: Space)
-3736: Ident           "bool" at 358:52-358:56 (leading: Space)
-3737: Semicolon       ";" at 358:56-358:57
-3738: At              "@" at 359:5-359:6 (leading: Newline, Space)
-3739: Ident           "intrinsic" at 359:6-359:15
-3740: KwFn            "fn" at 359:16-359:18 (leading: Space)
-3741: Ident           "__ge" at 359:19-359:23 (leading: Space)
-3742: LParen          "(" at 359:23-359:24
-3743: Ident           "self" at 359:24-359:28
-3744: Colon           ":" at 359:28-359:29
-3745: Ident           "int8" at 359:30-359:34 (leading: Space)
-3746: Comma           "," at 359:34-359:35
-3747: Ident           "other" at 359:36-359:41 (leading: Space)
-3748: Colon           ":" at 359:41-359:42
-3749: Ident           "int8" at 359:43-359:47 (leading: Space)
-3750: RParen          ")" at 359:47-359:48
-3751: Arrow           "->" at 359:49-359:51 (leading: Space)
-3752: Ident           "bool" at 359:52-359:56 (leading: Space)
-3753: Semicolon       ";" at 359:56-359:57
-3754: At              "@" at 360:5-360:6 (leading: Newline, Space)
-3755: Ident           "intrinsic" at 360:6-360:15
-3756: KwFn            "fn" at 360:16-360:18 (leading: Space)
-3757: Ident           "__gt" at 360:19-360:23 (leading: Space)
-3758: LParen          "(" at 360:23-360:24
-3759: Ident           "self" at 360:24-360:28
-3760: Colon           ":" at 360:28-360:29
-3761: Ident           "int8" at 360:30-360:34 (leading: Space)
-3762: Comma           "," at 360:34-360:35
-3763: Ident           "other" at 360:36-360:41 (leading: Space)
-3764: Colon           ":" at 360:41-360:42
-3765: Ident           "int8" at 360:43-360:47 (leading: Space)
-3766: RParen          ")" at 360:47-360:48
-3767: Arrow           "->" at 360:49-360:51 (leading: Space)
-3768: Ident           "bool" at 360:52-360:56 (leading: Space)
-3769: Semicolon       ";" at 360:56-360:57
-3770: At              "@" at 361:5-361:6 (leading: Newline, Space)
-3771: Ident           "intrinsic" at 361:6-361:15
-3772: KwFn            "fn" at 361:16-361:18 (leading: Space)
-3773: Ident           "__pos" at 361:19-361:24 (leading: Space)
-3774: LParen          "(" at 361:24-361:25
-3775: Ident           "self" at 361:25-361:29
-3776: Colon           ":" at 361:29-361:30
-3777: Ident           "int8" at 361:31-361:35 (leading: Space)
-3778: RParen          ")" at 361:35-361:36
-3779: Arrow           "->" at 361:37-361:39 (leading: Space)
-3780: Ident           "int8" at 361:40-361:44 (leading: Space)
-3781: Semicolon       ";" at 361:44-361:45
-3782: At              "@" at 362:5-362:6 (leading: Newline, Space)
-3783: Ident           "intrinsic" at 362:6-362:15
-3784: KwFn            "fn" at 362:16-362:18 (leading: Space)
-3785: Ident           "__neg" at 362:19-362:24 (leading: Space)
-3786: LParen          "(" at 362:24-362:25
-3787: Ident           "self" at 362:25-362:29
-3788: Colon           ":" at 362:29-362:30
-3789: Ident           "int8" at 362:31-362:35 (leading: Space)
-3790: RParen          ")" at 362:35-362:36
-3791: Arrow           "->" at 362:37-362:39 (leading: Space)
-3792: Ident           "int8" at 362:40-362:44 (leading: Space)
-3793: Semicolon       ";" at 362:44-362:45
-3794: At              "@" at 363:5-363:6 (leading: Newline, Space)
-3795: Ident           "intrinsic" at 363:6-363:15
-3796: KwFn            "fn" at 363:16-363:18 (leading: Space)
-3797: Ident           "__abs" at 363:19-363:24 (leading: Space)
-3798: LParen          "(" at 363:24-363:25
-3799: Ident           "self" at 363:25-363:29
-3800: Colon           ":" at 363:29-363:30
-3801: Ident           "int8" at 363:31-363:35 (leading: Space)
-3802: RParen          ")" at 363:35-363:36
-3803: Arrow           "->" at 363:37-363:39 (leading: Space)
-3804: Ident           "int8" at 363:40-363:44 (leading: Space)
-3805: Semicolon       ";" at 363:44-363:45
-3806: At              "@" at 364:5-364:6 (leading: Newline, Space)
-3807: Ident           "intrinsic" at 364:6-364:15
-3808: KwFn            "fn" at 364:16-364:18 (leading: Space)
-3809: Ident           "__to" at 364:19-364:23 (leading: Space)
-3810: LParen          "(" at 364:23-364:24
-3811: Ident           "self" at 364:24-364:28
-3812: Colon           ":" at 364:28-364:29
-3813: Ident           "int8" at 364:30-364:34 (leading: Space)
-3814: Comma           "," at 364:34-364:35
-3815: Ident           "target" at 364:36-364:42 (leading: Space)
-3816: Colon           ":" at 364:42-364:43
-3817: Ident           "int" at 364:44-364:47 (leading: Space)
-3818: RParen          ")" at 364:47-364:48
-3819: Arrow           "->" at 364:49-364:51 (leading: Space)
-3820: Ident           "int" at 364:52-364:55 (leading: Space)
-3821: Semicolon       ";" at 364:55-364:56
-3822: At              "@" at 365:5-365:6 (leading: Newline, Space)
-3823: Ident           "intrinsic" at 365:6-365:15
-3824: At              "@" at 365:16-365:17 (leading: Space)
-3825: Ident           "overload" at 365:17-365:25
-3826: KwFn            "fn" at 365:26-365:28 (leading: Space)
-3827: Ident           "__to" at 365:29-365:33 (leading: Space)
-3828: LParen          "(" at 365:33-365:34
-3829: Ident           "self" at 365:34-365:38
-3830: Colon           ":" at 365:38-365:39
-3831: Ident           "int8" at 365:40-365:44 (leading: Space)
-3832: Comma           "," at 365:44-365:45
-3833: Ident           "target" at 365:46-365:52 (leading: Space)
-3834: Colon           ":" at 365:52-365:53
-3835: Ident           "int16" at 365:54-365:59 (leading: Space)
-3836: RParen          ")" at 365:59-365:60
-3837: Arrow           "->" at 365:61-365:63 (leading: Space)
-3838: Ident           "int16" at 365:64-365:69 (leading: Space)
-3839: Semicolon       ";" at 365:69-365:70
-3840: At              "@" at 366:5-366:6 (leading: Newline, Space)
-3841: Ident           "intrinsic" at 366:6-366:15
-3842: At              "@" at 366:16-366:17 (leading: Space)
-3843: Ident           "overload" at 366:17-366:25
-3844: KwFn            "fn" at 366:26-366:28 (leading: Space)
-3845: Ident           "__to" at 366:29-366:33 (leading: Space)
-3846: LParen          "(" at 366:33-366:34
-3847: Ident           "self" at 366:34-366:38
-3848: Colon           ":" at 366:38-366:39
-3849: Ident           "int8" at 366:40-366:44 (leading: Space)
-3850: Comma           "," at 366:44-366:45
-3851: Ident           "target" at 366:46-366:52 (leading: Space)
-3852: Colon           ":" at 366:52-366:53
-3853: Ident           "int32" at 366:54-366:59 (leading: Space)
-3854: RParen          ")" at 366:59-366:60
-3855: Arrow           "->" at 366:61-366:63 (leading: Space)
-3856: Ident           "int32" at 366:64-366:69 (leading: Space)
-3857: Semicolon       ";" at 366:69-366:70
-3858: At              "@" at 367:5-367:6 (leading: Newline, Space)
-3859: Ident           "intrinsic" at 367:6-367:15
-3860: At              "@" at 367:16-367:17 (leading: Space)
-3861: Ident           "overload" at 367:17-367:25
-3862: KwFn            "fn" at 367:26-367:28 (leading: Space)
-3863: Ident           "__to" at 367:29-367:33 (leading: Space)
-3864: LParen          "(" at 367:33-367:34
-3865: Ident           "self" at 367:34-367:38
-3866: Colon           ":" at 367:38-367:39
-3867: Ident           "int8" at 367:40-367:44 (leading: Space)
-3868: Comma           "," at 367:44-367:45
-3869: Ident           "target" at 367:46-367:52 (leading: Space)
-3870: Colon           ":" at 367:52-367:53
-3871: Ident           "int64" at 367:54-367:59 (leading: Space)
-3872: RParen          ")" at 367:59-367:60
-3873: Arrow           "->" at 367:61-367:63 (leading: Space)
-3874: Ident           "int64" at 367:64-367:69 (leading: Space)
-3875: Semicolon       ";" at 367:69-367:70
-3876: At              "@" at 368:5-368:6 (leading: Newline, Space)
-3877: Ident           "intrinsic" at 368:6-368:15
-3878: KwPub           "pub" at 368:16-368:19 (leading: Space)
-3879: KwFn            "fn" at 368:20-368:22 (leading: Space)
-3880: Ident           "from_str" at 368:23-368:31 (leading: Space)
-3881: LParen          "(" at 368:31-368:32
-3882: Ident           "s" at 368:32-368:33
-3883: Colon           ":" at 368:33-368:34
-3884: Amp             "&" at 368:35-368:36 (leading: Space)
-3885: Ident           "string" at 368:36-368:42
-3886: RParen          ")" at 368:42-368:43
-3887: Arrow           "->" at 368:44-368:46 (leading: Space)
-3888: Ident           "Erring" at 368:47-368:53 (leading: Space)
-3889: Lt              "<" at 368:53-368:54
-3890: Ident           "int8" at 368:54-368:58
-3891: Comma           "," at 368:58-368:59
-3892: Ident           "Error" at 368:60-368:65 (leading: Space)
-3893: Gt              ">" at 368:65-368:66
-3894: Semicolon       ";" at 368:66-368:67
-3895: RBrace          "}" at 369:1-369:2 (leading: Newline)
-3896: KwExtern        "extern" at 371:1-371:7 (leading: Newline)
-3897: Lt              "<" at 371:7-371:8
-3898: Ident           "int16" at 371:8-371:13
-3899: Gt              ">" at 371:13-371:14
-3900: LBrace          "{" at 371:15-371:16 (leading: Space)
-3901: KwPub           "pub" at 372:5-372:8 (leading: Newline, Space)
-3902: KwFn            "fn" at 372:9-372:11 (leading: Space)
-3903: Ident           "__min_value" at 372:12-372:23 (leading: Space)
-3904: LParen          "(" at 372:23-372:24
-3905: RParen          ")" at 372:24-372:25
-3906: Arrow           "->" at 372:26-372:28 (leading: Space)
-3907: Ident           "int16" at 372:29-372:34 (leading: Space)
-3908: LBrace          "{" at 372:35-372:36 (leading: Space)
-3909: KwReturn        "return" at 372:37-372:43 (leading: Space)
-3910: LParen          "(" at 372:44-372:45 (leading: Space)
-3911: Minus           "-" at 372:45-372:46
-3912: IntLit          "32_768" at 372:46-372:52
-3913: RParen          ")" at 372:52-372:53
-3914: Colon           ":" at 372:53-372:54
-3915: Ident           "int16" at 372:54-372:59
-3916: Semicolon       ";" at 372:59-372:60
-3917: RBrace          "}" at 372:61-372:62 (leading: Space)
-3918: KwPub           "pub" at 373:5-373:8 (leading: Newline, Space)
-3919: KwFn            "fn" at 373:9-373:11 (leading: Space)
-3920: Ident           "__max_value" at 373:12-373:23 (leading: Space)
-3921: LParen          "(" at 373:23-373:24
-3922: RParen          ")" at 373:24-373:25
-3923: Arrow           "->" at 373:26-373:28 (leading: Space)
-3924: Ident           "int16" at 373:29-373:34 (leading: Space)
-3925: LBrace          "{" at 373:35-373:36 (leading: Space)
-3926: KwReturn        "return" at 373:37-373:43 (leading: Space)
-3927: LParen          "(" at 373:44-373:45 (leading: Space)
-3928: IntLit          "32_767" at 373:45-373:51
-3929: RParen          ")" at 373:51-373:52
-3930: Colon           ":" at 373:52-373:53
-3931: Ident           "int16" at 373:53-373:58
-3932: Semicolon       ";" at 373:58-373:59
-3933: RBrace          "}" at 373:60-373:61 (leading: Space)
-3934: At              "@" at 374:5-374:6 (leading: Newline, Space)
-3935: Ident           "intrinsic" at 374:6-374:15
-3936: KwFn            "fn" at 374:16-374:18 (leading: Space)
-3937: Ident           "__add" at 374:19-374:24 (leading: Space)
-3938: LParen          "(" at 374:24-374:25
-3939: Ident           "self" at 374:25-374:29
-3940: Colon           ":" at 374:29-374:30
-3941: Ident           "int16" at 374:31-374:36 (leading: Space)
-3942: Comma           "," at 374:36-374:37
-3943: Ident           "other" at 374:38-374:43 (leading: Space)
-3944: Colon           ":" at 374:43-374:44
-3945: Ident           "int16" at 374:45-374:50 (leading: Space)
-3946: RParen          ")" at 374:50-374:51
-3947: Arrow           "->" at 374:52-374:54 (leading: Space)
-3948: Ident           "int16" at 374:55-374:60 (leading: Space)
-3949: Semicolon       ";" at 374:60-374:61
-3950: At              "@" at 375:5-375:6 (leading: Newline, Space)
-3951: Ident           "intrinsic" at 375:6-375:15
-3952: KwFn            "fn" at 375:16-375:18 (leading: Space)
-3953: Ident           "__sub" at 375:19-375:24 (leading: Space)
-3954: LParen          "(" at 375:24-375:25
-3955: Ident           "self" at 375:25-375:29
-3956: Colon           ":" at 375:29-375:30
-3957: Ident           "int16" at 375:31-375:36 (leading: Space)
-3958: Comma           "," at 375:36-375:37
-3959: Ident           "other" at 375:38-375:43 (leading: Space)
-3960: Colon           ":" at 375:43-375:44
-3961: Ident           "int16" at 375:45-375:50 (leading: Space)
-3962: RParen          ")" at 375:50-375:51
-3963: Arrow           "->" at 375:52-375:54 (leading: Space)
-3964: Ident           "int16" at 375:55-375:60 (leading: Space)
-3965: Semicolon       ";" at 375:60-375:61
-3966: At              "@" at 376:5-376:6 (leading: Newline, Space)
-3967: Ident           "intrinsic" at 376:6-376:15
-3968: KwFn            "fn" at 376:16-376:18 (leading: Space)
-3969: Ident           "__mul" at 376:19-376:24 (leading: Space)
-3970: LParen          "(" at 376:24-376:25
-3971: Ident           "self" at 376:25-376:29
-3972: Colon           ":" at 376:29-376:30
-3973: Ident           "int16" at 376:31-376:36 (leading: Space)
-3974: Comma           "," at 376:36-376:37
-3975: Ident           "other" at 376:38-376:43 (leading: Space)
-3976: Colon           ":" at 376:43-376:44
-3977: Ident           "int16" at 376:45-376:50 (leading: Space)
-3978: RParen          ")" at 376:50-376:51
-3979: Arrow           "->" at 376:52-376:54 (leading: Space)
-3980: Ident           "int16" at 376:55-376:60 (leading: Space)
-3981: Semicolon       ";" at 376:60-376:61
-3982: At              "@" at 377:5-377:6 (leading: Newline, Space)
-3983: Ident           "intrinsic" at 377:6-377:15
-3984: KwFn            "fn" at 377:16-377:18 (leading: Space)
-3985: Ident           "__div" at 377:19-377:24 (leading: Space)
-3986: LParen          "(" at 377:24-377:25
-3987: Ident           "self" at 377:25-377:29
-3988: Colon           ":" at 377:29-377:30
-3989: Ident           "int16" at 377:31-377:36 (leading: Space)
-3990: Comma           "," at 377:36-377:37
-3991: Ident           "other" at 377:38-377:43 (leading: Space)
-3992: Colon           ":" at 377:43-377:44
-3993: Ident           "int16" at 377:45-377:50 (leading: Space)
-3994: RParen          ")" at 377:50-377:51
-3995: Arrow           "->" at 377:52-377:54 (leading: Space)
-3996: Ident           "int16" at 377:55-377:60 (leading: Space)
-3997: Semicolon       ";" at 377:60-377:61
-3998: At              "@" at 378:5-378:6 (leading: Newline, Space)
-3999: Ident           "intrinsic" at 378:6-378:15
-4000: KwFn            "fn" at 378:16-378:18 (leading: Space)
-4001: Ident           "__mod" at 378:19-378:24 (leading: Space)
-4002: LParen          "(" at 378:24-378:25
-4003: Ident           "self" at 378:25-378:29
-4004: Colon           ":" at 378:29-378:30
-4005: Ident           "int16" at 378:31-378:36 (leading: Space)
-4006: Comma           "," at 378:36-378:37
-4007: Ident           "other" at 378:38-378:43 (leading: Space)
-4008: Colon           ":" at 378:43-378:44
-4009: Ident           "int16" at 378:45-378:50 (leading: Space)
-4010: RParen          ")" at 378:50-378:51
-4011: Arrow           "->" at 378:52-378:54 (leading: Space)
-4012: Ident           "int16" at 378:55-378:60 (leading: Space)
-4013: Semicolon       ";" at 378:60-378:61
-4014: At              "@" at 379:5-379:6 (leading: Newline, Space)
-4015: Ident           "intrinsic" at 379:6-379:15
-4016: KwFn            "fn" at 379:16-379:18 (leading: Space)
-4017: Ident           "__bit_and" at 379:19-379:28 (leading: Space)
-4018: LParen          "(" at 379:28-379:29
-4019: Ident           "self" at 379:29-379:33
-4020: Colon           ":" at 379:33-379:34
-4021: Ident           "int16" at 379:35-379:40 (leading: Space)
-4022: Comma           "," at 379:40-379:41
-4023: Ident           "other" at 379:42-379:47 (leading: Space)
-4024: Colon           ":" at 379:47-379:48
-4025: Ident           "int16" at 379:49-379:54 (leading: Space)
-4026: RParen          ")" at 379:54-379:55
-4027: Arrow           "->" at 379:56-379:58 (leading: Space)
-4028: Ident           "int16" at 379:59-379:64 (leading: Space)
-4029: Semicolon       ";" at 379:64-379:65
-4030: At              "@" at 380:5-380:6 (leading: Newline, Space)
-4031: Ident           "intrinsic" at 380:6-380:15
-4032: KwFn            "fn" at 380:16-380:18 (leading: Space)
-4033: Ident           "__bit_or" at 380:19-380:27 (leading: Space)
-4034: LParen          "(" at 380:27-380:28
-4035: Ident           "self" at 380:28-380:32
-4036: Colon           ":" at 380:32-380:33
-4037: Ident           "int16" at 380:34-380:39 (leading: Space)
-4038: Comma           "," at 380:39-380:40
-4039: Ident           "other" at 380:41-380:46 (leading: Space)
-4040: Colon           ":" at 380:46-380:47
-4041: Ident           "int16" at 380:48-380:53 (leading: Space)
-4042: RParen          ")" at 380:53-380:54
-4043: Arrow           "->" at 380:55-380:57 (leading: Space)
-4044: Ident           "int16" at 380:58-380:63 (leading: Space)
-4045: Semicolon       ";" at 380:63-380:64
-4046: At              "@" at 381:5-381:6 (leading: Newline, Space)
-4047: Ident           "intrinsic" at 381:6-381:15
-4048: KwFn            "fn" at 381:16-381:18 (leading: Space)
-4049: Ident           "__bit_xor" at 381:19-381:28 (leading: Space)
-4050: LParen          "(" at 381:28-381:29
-4051: Ident           "self" at 381:29-381:33
-4052: Colon           ":" at 381:33-381:34
-4053: Ident           "int16" at 381:35-381:40 (leading: Space)
-4054: Comma           "," at 381:40-381:41
-4055: Ident           "other" at 381:42-381:47 (leading: Space)
-4056: Colon           ":" at 381:47-381:48
-4057: Ident           "int16" at 381:49-381:54 (leading: Space)
-4058: RParen          ")" at 381:54-381:55
-4059: Arrow           "->" at 381:56-381:58 (leading: Space)
-4060: Ident           "int16" at 381:59-381:64 (leading: Space)
-4061: Semicolon       ";" at 381:64-381:65
-4062: At              "@" at 382:5-382:6 (leading: Newline, Space)
-4063: Ident           "intrinsic" at 382:6-382:15
-4064: KwFn            "fn" at 382:16-382:18 (leading: Space)
-4065: Ident           "__shl" at 382:19-382:24 (leading: Space)
-4066: LParen          "(" at 382:24-382:25
-4067: Ident           "self" at 382:25-382:29
-4068: Colon           ":" at 382:29-382:30
-4069: Ident           "int16" at 382:31-382:36 (leading: Space)
-4070: Comma           "," at 382:36-382:37
-4071: Ident           "other" at 382:38-382:43 (leading: Space)
-4072: Colon           ":" at 382:43-382:44
-4073: Ident           "int16" at 382:45-382:50 (leading: Space)
-4074: RParen          ")" at 382:50-382:51
-4075: Arrow           "->" at 382:52-382:54 (leading: Space)
-4076: Ident           "int16" at 382:55-382:60 (leading: Space)
-4077: Semicolon       ";" at 382:60-382:61
-4078: At              "@" at 383:5-383:6 (leading: Newline, Space)
-4079: Ident           "intrinsic" at 383:6-383:15
-4080: KwFn            "fn" at 383:16-383:18 (leading: Space)
-4081: Ident           "__shr" at 383:19-383:24 (leading: Space)
-4082: LParen          "(" at 383:24-383:25
-4083: Ident           "self" at 383:25-383:29
-4084: Colon           ":" at 383:29-383:30
-4085: Ident           "int16" at 383:31-383:36 (leading: Space)
-4086: Comma           "," at 383:36-383:37
-4087: Ident           "other" at 383:38-383:43 (leading: Space)
-4088: Colon           ":" at 383:43-383:44
-4089: Ident           "int16" at 383:45-383:50 (leading: Space)
-4090: RParen          ")" at 383:50-383:51
-4091: Arrow           "->" at 383:52-383:54 (leading: Space)
-4092: Ident           "int16" at 383:55-383:60 (leading: Space)
-4093: Semicolon       ";" at 383:60-383:61
-4094: At              "@" at 384:5-384:6 (leading: Newline, Space)
-4095: Ident           "intrinsic" at 384:6-384:15
-4096: KwFn            "fn" at 384:16-384:18 (leading: Space)
-4097: Ident           "__lt" at 384:19-384:23 (leading: Space)
-4098: LParen          "(" at 384:23-384:24
-4099: Ident           "self" at 384:24-384:28
-4100: Colon           ":" at 384:28-384:29
-4101: Ident           "int16" at 384:30-384:35 (leading: Space)
-4102: Comma           "," at 384:35-384:36
-4103: Ident           "other" at 384:37-384:42 (leading: Space)
-4104: Colon           ":" at 384:42-384:43
-4105: Ident           "int16" at 384:44-384:49 (leading: Space)
-4106: RParen          ")" at 384:49-384:50
-4107: Arrow           "->" at 384:51-384:53 (leading: Space)
-4108: Ident           "bool" at 384:54-384:58 (leading: Space)
-4109: Semicolon       ";" at 384:58-384:59
-4110: At              "@" at 385:5-385:6 (leading: Newline, Space)
-4111: Ident           "intrinsic" at 385:6-385:15
-4112: KwFn            "fn" at 385:16-385:18 (leading: Space)
-4113: Ident           "__le" at 385:19-385:23 (leading: Space)
-4114: LParen          "(" at 385:23-385:24
-4115: Ident           "self" at 385:24-385:28
-4116: Colon           ":" at 385:28-385:29
-4117: Ident           "int16" at 385:30-385:35 (leading: Space)
-4118: Comma           "," at 385:35-385:36
-4119: Ident           "other" at 385:37-385:42 (leading: Space)
-4120: Colon           ":" at 385:42-385:43
-4121: Ident           "int16" at 385:44-385:49 (leading: Space)
-4122: RParen          ")" at 385:49-385:50
-4123: Arrow           "->" at 385:51-385:53 (leading: Space)
-4124: Ident           "bool" at 385:54-385:58 (leading: Space)
-4125: Semicolon       ";" at 385:58-385:59
-4126: At              "@" at 386:5-386:6 (leading: Newline, Space)
-4127: Ident           "intrinsic" at 386:6-386:15
-4128: KwFn            "fn" at 386:16-386:18 (leading: Space)
-4129: Ident           "__eq" at 386:19-386:23 (leading: Space)
-4130: LParen          "(" at 386:23-386:24
-4131: Ident           "self" at 386:24-386:28
-4132: Colon           ":" at 386:28-386:29
-4133: Ident           "int16" at 386:30-386:35 (leading: Space)
-4134: Comma           "," at 386:35-386:36
-4135: Ident           "other" at 386:37-386:42 (leading: Space)
-4136: Colon           ":" at 386:42-386:43
-4137: Ident           "int16" at 386:44-386:49 (leading: Space)
-4138: RParen          ")" at 386:49-386:50
-4139: Arrow           "->" at 386:51-386:53 (leading: Space)
-4140: Ident           "bool" at 386:54-386:58 (leading: Space)
-4141: Semicolon       ";" at 386:58-386:59
-4142: At              "@" at 387:5-387:6 (leading: Newline, Space)
-4143: Ident           "intrinsic" at 387:6-387:15
-4144: KwFn            "fn" at 387:16-387:18 (leading: Space)
-4145: Ident           "__ne" at 387:19-387:23 (leading: Space)
-4146: LParen          "(" at 387:23-387:24
-4147: Ident           "self" at 387:24-387:28
-4148: Colon           ":" at 387:28-387:29
-4149: Ident           "int16" at 387:30-387:35 (leading: Space)
-4150: Comma           "," at 387:35-387:36
-4151: Ident           "other" at 387:37-387:42 (leading: Space)
-4152: Colon           ":" at 387:42-387:43
-4153: Ident           "int16" at 387:44-387:49 (leading: Space)
-4154: RParen          ")" at 387:49-387:50
-4155: Arrow           "->" at 387:51-387:53 (leading: Space)
-4156: Ident           "bool" at 387:54-387:58 (leading: Space)
-4157: Semicolon       ";" at 387:58-387:59
-4158: At              "@" at 388:5-388:6 (leading: Newline, Space)
-4159: Ident           "intrinsic" at 388:6-388:15
-4160: KwFn            "fn" at 388:16-388:18 (leading: Space)
-4161: Ident           "__ge" at 388:19-388:23 (leading: Space)
-4162: LParen          "(" at 388:23-388:24
-4163: Ident           "self" at 388:24-388:28
-4164: Colon           ":" at 388:28-388:29
-4165: Ident           "int16" at 388:30-388:35 (leading: Space)
-4166: Comma           "," at 388:35-388:36
-4167: Ident           "other" at 388:37-388:42 (leading: Space)
-4168: Colon           ":" at 388:42-388:43
-4169: Ident           "int16" at 388:44-388:49 (leading: Space)
-4170: RParen          ")" at 388:49-388:50
-4171: Arrow           "->" at 388:51-388:53 (leading: Space)
-4172: Ident           "bool" at 388:54-388:58 (leading: Space)
-4173: Semicolon       ";" at 388:58-388:59
-4174: At              "@" at 389:5-389:6 (leading: Newline, Space)
-4175: Ident           "intrinsic" at 389:6-389:15
-4176: KwFn            "fn" at 389:16-389:18 (leading: Space)
-4177: Ident           "__gt" at 389:19-389:23 (leading: Space)
-4178: LParen          "(" at 389:23-389:24
-4179: Ident           "self" at 389:24-389:28
-4180: Colon           ":" at 389:28-389:29
-4181: Ident           "int16" at 389:30-389:35 (leading: Space)
-4182: Comma           "," at 389:35-389:36
-4183: Ident           "other" at 389:37-389:42 (leading: Space)
-4184: Colon           ":" at 389:42-389:43
-4185: Ident           "int16" at 389:44-389:49 (leading: Space)
-4186: RParen          ")" at 389:49-389:50
-4187: Arrow           "->" at 389:51-389:53 (leading: Space)
-4188: Ident           "bool" at 389:54-389:58 (leading: Space)
-4189: Semicolon       ";" at 389:58-389:59
-4190: At              "@" at 390:5-390:6 (leading: Newline, Space)
-4191: Ident           "intrinsic" at 390:6-390:15
-4192: KwFn            "fn" at 390:16-390:18 (leading: Space)
-4193: Ident           "__pos" at 390:19-390:24 (leading: Space)
-4194: LParen          "(" at 390:24-390:25
-4195: Ident           "self" at 390:25-390:29
-4196: Colon           ":" at 390:29-390:30
-4197: Ident           "int16" at 390:31-390:36 (leading: Space)
-4198: RParen          ")" at 390:36-390:37
-4199: Arrow           "->" at 390:38-390:40 (leading: Space)
-4200: Ident           "int16" at 390:41-390:46 (leading: Space)
-4201: Semicolon       ";" at 390:46-390:47
-4202: At              "@" at 391:5-391:6 (leading: Newline, Space)
-4203: Ident           "intrinsic" at 391:6-391:15
-4204: KwFn            "fn" at 391:16-391:18 (leading: Space)
-4205: Ident           "__neg" at 391:19-391:24 (leading: Space)
-4206: LParen          "(" at 391:24-391:25
-4207: Ident           "self" at 391:25-391:29
-4208: Colon           ":" at 391:29-391:30
-4209: Ident           "int16" at 391:31-391:36 (leading: Space)
-4210: RParen          ")" at 391:36-391:37
-4211: Arrow           "->" at 391:38-391:40 (leading: Space)
-4212: Ident           "int16" at 391:41-391:46 (leading: Space)
-4213: Semicolon       ";" at 391:46-391:47
-4214: At              "@" at 392:5-392:6 (leading: Newline, Space)
-4215: Ident           "intrinsic" at 392:6-392:15
-4216: KwFn            "fn" at 392:16-392:18 (leading: Space)
-4217: Ident           "__abs" at 392:19-392:24 (leading: Space)
-4218: LParen          "(" at 392:24-392:25
-4219: Ident           "self" at 392:25-392:29
-4220: Colon           ":" at 392:29-392:30
-4221: Ident           "int16" at 392:31-392:36 (leading: Space)
-4222: RParen          ")" at 392:36-392:37
-4223: Arrow           "->" at 392:38-392:40 (leading: Space)
-4224: Ident           "int16" at 392:41-392:46 (leading: Space)
-4225: Semicolon       ";" at 392:46-392:47
-4226: At              "@" at 393:5-393:6 (leading: Newline, Space)
-4227: Ident           "intrinsic" at 393:6-393:15
-4228: KwFn            "fn" at 393:16-393:18 (leading: Space)
-4229: Ident           "__to" at 393:19-393:23 (leading: Space)
-4230: LParen          "(" at 393:23-393:24
-4231: Ident           "self" at 393:24-393:28
-4232: Colon           ":" at 393:28-393:29
-4233: Ident           "int16" at 393:30-393:35 (leading: Space)
-4234: Comma           "," at 393:35-393:36
-4235: Ident           "target" at 393:37-393:43 (leading: Space)
-4236: Colon           ":" at 393:43-393:44
-4237: Ident           "int" at 393:45-393:48 (leading: Space)
-4238: RParen          ")" at 393:48-393:49
-4239: Arrow           "->" at 393:50-393:52 (leading: Space)
-4240: Ident           "int" at 393:53-393:56 (leading: Space)
-4241: Semicolon       ";" at 393:56-393:57
-4242: At              "@" at 394:5-394:6 (leading: Newline, Space)
-4243: Ident           "intrinsic" at 394:6-394:15
-4244: At              "@" at 394:16-394:17 (leading: Space)
-4245: Ident           "overload" at 394:17-394:25
-4246: KwFn            "fn" at 394:26-394:28 (leading: Space)
-4247: Ident           "__to" at 394:29-394:33 (leading: Space)
-4248: LParen          "(" at 394:33-394:34
-4249: Ident           "self" at 394:34-394:38
-4250: Colon           ":" at 394:38-394:39
-4251: Ident           "int16" at 394:40-394:45 (leading: Space)
-4252: Comma           "," at 394:45-394:46
-4253: Ident           "target" at 394:47-394:53 (leading: Space)
-4254: Colon           ":" at 394:53-394:54
-4255: Ident           "int8" at 394:55-394:59 (leading: Space)
-4256: RParen          ")" at 394:59-394:60
-4257: Arrow           "->" at 394:61-394:63 (leading: Space)
-4258: Ident           "int8" at 394:64-394:68 (leading: Space)
-4259: Semicolon       ";" at 394:68-394:69
-4260: At              "@" at 395:5-395:6 (leading: Newline, Space)
-4261: Ident           "intrinsic" at 395:6-395:15
-4262: At              "@" at 395:16-395:17 (leading: Space)
-4263: Ident           "overload" at 395:17-395:25
-4264: KwFn            "fn" at 395:26-395:28 (leading: Space)
-4265: Ident           "__to" at 395:29-395:33 (leading: Space)
-4266: LParen          "(" at 395:33-395:34
-4267: Ident           "self" at 395:34-395:38
-4268: Colon           ":" at 395:38-395:39
-4269: Ident           "int16" at 395:40-395:45 (leading: Space)
-4270: Comma           "," at 395:45-395:46
-4271: Ident           "target" at 395:47-395:53 (leading: Space)
-4272: Colon           ":" at 395:53-395:54
-4273: Ident           "int32" at 395:55-395:60 (leading: Space)
-4274: RParen          ")" at 395:60-395:61
-4275: Arrow           "->" at 395:62-395:64 (leading: Space)
-4276: Ident           "int32" at 395:65-395:70 (leading: Space)
-4277: Semicolon       ";" at 395:70-395:71
-4278: At              "@" at 396:5-396:6 (leading: Newline, Space)
-4279: Ident           "intrinsic" at 396:6-396:15
-4280: At              "@" at 396:16-396:17 (leading: Space)
-4281: Ident           "overload" at 396:17-396:25
-4282: KwFn            "fn" at 396:26-396:28 (leading: Space)
-4283: Ident           "__to" at 396:29-396:33 (leading: Space)
-4284: LParen          "(" at 396:33-396:34
-4285: Ident           "self" at 396:34-396:38
-4286: Colon           ":" at 396:38-396:39
-4287: Ident           "int16" at 396:40-396:45 (leading: Space)
-4288: Comma           "," at 396:45-396:46
-4289: Ident           "target" at 396:47-396:53 (leading: Space)
-4290: Colon           ":" at 396:53-396:54
-4291: Ident           "int64" at 396:55-396:60 (leading: Space)
-4292: RParen          ")" at 396:60-396:61
-4293: Arrow           "->" at 396:62-396:64 (leading: Space)
-4294: Ident           "int64" at 396:65-396:70 (leading: Space)
-4295: Semicolon       ";" at 396:70-396:71
-4296: At              "@" at 397:5-397:6 (leading: Newline, Space)
-4297: Ident           "intrinsic" at 397:6-397:15
-4298: KwPub           "pub" at 397:16-397:19 (leading: Space)
-4299: KwFn            "fn" at 397:20-397:22 (leading: Space)
-4300: Ident           "from_str" at 397:23-397:31 (leading: Space)
-4301: LParen          "(" at 397:31-397:32
-4302: Ident           "s" at 397:32-397:33
-4303: Colon           ":" at 397:33-397:34
-4304: Amp             "&" at 397:35-397:36 (leading: Space)
-4305: Ident           "string" at 397:36-397:42
-4306: RParen          ")" at 397:42-397:43
-4307: Arrow           "->" at 397:44-397:46 (leading: Space)
-4308: Ident           "Erring" at 397:47-397:53 (leading: Space)
-4309: Lt              "<" at 397:53-397:54
-4310: Ident           "int16" at 397:54-397:59
-4311: Comma           "," at 397:59-397:60
-4312: Ident           "Error" at 397:61-397:66 (leading: Space)
-4313: Gt              ">" at 397:66-397:67
-4314: Semicolon       ";" at 397:67-397:68
-4315: RBrace          "}" at 398:1-398:2 (leading: Newline)
-4316: KwExtern        "extern" at 400:1-400:7 (leading: Newline)
-4317: Lt              "<" at 400:7-400:8
-4318: Ident           "int32" at 400:8-400:13
-4319: Gt              ">" at 400:13-400:14
-4320: LBrace          "{" at 400:15-400:16 (leading: Space)
-4321: KwPub           "pub" at 401:5-401:8 (leading: Newline, Space)
-4322: KwFn            "fn" at 401:9-401:11 (leading: Space)
-4323: Ident           "__min_value" at 401:12-401:23 (leading: Space)
-4324: LParen          "(" at 401:23-401:24
-4325: RParen          ")" at 401:24-401:25
-4326: Arrow           "->" at 401:26-401:28 (leading: Space)
-4327: Ident           "int32" at 401:29-401:34 (leading: Space)
-4328: LBrace          "{" at 401:35-401:36 (leading: Space)
-4329: KwReturn        "return" at 401:37-401:43 (leading: Space)
-4330: LParen          "(" at 401:44-401:45 (leading: Space)
-4331: Minus           "-" at 401:45-401:46
-4332: IntLit          "2_147_483_648" at 401:46-401:59
-4333: RParen          ")" at 401:59-401:60
-4334: Colon           ":" at 401:60-401:61
-4335: Ident           "int32" at 401:61-401:66
-4336: Semicolon       ";" at 401:66-401:67
-4337: RBrace          "}" at 401:68-401:69 (leading: Space)
-4338: KwPub           "pub" at 402:5-402:8 (leading: Newline, Space)
-4339: KwFn            "fn" at 402:9-402:11 (leading: Space)
-4340: Ident           "__max_value" at 402:12-402:23 (leading: Space)
-4341: LParen          "(" at 402:23-402:24
-4342: RParen          ")" at 402:24-402:25
-4343: Arrow           "->" at 402:26-402:28 (leading: Space)
-4344: Ident           "int32" at 402:29-402:34 (leading: Space)
-4345: LBrace          "{" at 402:35-402:36 (leading: Space)
-4346: KwReturn        "return" at 402:37-402:43 (leading: Space)
-4347: LParen          "(" at 402:44-402:45 (leading: Space)
-4348: IntLit          "2_147_483_647" at 402:45-402:58
-4349: RParen          ")" at 402:58-402:59
-4350: Colon           ":" at 402:59-402:60
-4351: Ident           "int32" at 402:60-402:65
-4352: Semicolon       ";" at 402:65-402:66
-4353: RBrace          "}" at 402:67-402:68 (leading: Space)
-4354: At              "@" at 403:5-403:6 (leading: Newline, Space)
-4355: Ident           "intrinsic" at 403:6-403:15
-4356: KwFn            "fn" at 403:16-403:18 (leading: Space)
-4357: Ident           "__add" at 403:19-403:24 (leading: Space)
-4358: LParen          "(" at 403:24-403:25
-4359: Ident           "self" at 403:25-403:29
-4360: Colon           ":" at 403:29-403:30
-4361: Ident           "int32" at 403:31-403:36 (leading: Space)
-4362: Comma           "," at 403:36-403:37
-4363: Ident           "other" at 403:38-403:43 (leading: Space)
-4364: Colon           ":" at 403:43-403:44
-4365: Ident           "int32" at 403:45-403:50 (leading: Space)
-4366: RParen          ")" at 403:50-403:51
-4367: Arrow           "->" at 403:52-403:54 (leading: Space)
-4368: Ident           "int32" at 403:55-403:60 (leading: Space)
-4369: Semicolon       ";" at 403:60-403:61
-4370: At              "@" at 404:5-404:6 (leading: Newline, Space)
-4371: Ident           "intrinsic" at 404:6-404:15
-4372: KwFn            "fn" at 404:16-404:18 (leading: Space)
-4373: Ident           "__sub" at 404:19-404:24 (leading: Space)
-4374: LParen          "(" at 404:24-404:25
-4375: Ident           "self" at 404:25-404:29
-4376: Colon           ":" at 404:29-404:30
-4377: Ident           "int32" at 404:31-404:36 (leading: Space)
-4378: Comma           "," at 404:36-404:37
-4379: Ident           "other" at 404:38-404:43 (leading: Space)
-4380: Colon           ":" at 404:43-404:44
-4381: Ident           "int32" at 404:45-404:50 (leading: Space)
-4382: RParen          ")" at 404:50-404:51
-4383: Arrow           "->" at 404:52-404:54 (leading: Space)
-4384: Ident           "int32" at 404:55-404:60 (leading: Space)
-4385: Semicolon       ";" at 404:60-404:61
-4386: At              "@" at 405:5-405:6 (leading: Newline, Space)
-4387: Ident           "intrinsic" at 405:6-405:15
-4388: KwFn            "fn" at 405:16-405:18 (leading: Space)
-4389: Ident           "__mul" at 405:19-405:24 (leading: Space)
-4390: LParen          "(" at 405:24-405:25
-4391: Ident           "self" at 405:25-405:29
-4392: Colon           ":" at 405:29-405:30
-4393: Ident           "int32" at 405:31-405:36 (leading: Space)
-4394: Comma           "," at 405:36-405:37
-4395: Ident           "other" at 405:38-405:43 (leading: Space)
-4396: Colon           ":" at 405:43-405:44
-4397: Ident           "int32" at 405:45-405:50 (leading: Space)
-4398: RParen          ")" at 405:50-405:51
-4399: Arrow           "->" at 405:52-405:54 (leading: Space)
-4400: Ident           "int32" at 405:55-405:60 (leading: Space)
-4401: Semicolon       ";" at 405:60-405:61
-4402: At              "@" at 406:5-406:6 (leading: Newline, Space)
-4403: Ident           "intrinsic" at 406:6-406:15
-4404: KwFn            "fn" at 406:16-406:18 (leading: Space)
-4405: Ident           "__div" at 406:19-406:24 (leading: Space)
-4406: LParen          "(" at 406:24-406:25
-4407: Ident           "self" at 406:25-406:29
-4408: Colon           ":" at 406:29-406:30
-4409: Ident           "int32" at 406:31-406:36 (leading: Space)
-4410: Comma           "," at 406:36-406:37
-4411: Ident           "other" at 406:38-406:43 (leading: Space)
-4412: Colon           ":" at 406:43-406:44
-4413: Ident           "int32" at 406:45-406:50 (leading: Space)
-4414: RParen          ")" at 406:50-406:51
-4415: Arrow           "->" at 406:52-406:54 (leading: Space)
-4416: Ident           "int32" at 406:55-406:60 (leading: Space)
-4417: Semicolon       ";" at 406:60-406:61
-4418: At              "@" at 407:5-407:6 (leading: Newline, Space)
-4419: Ident           "intrinsic" at 407:6-407:15
-4420: KwFn            "fn" at 407:16-407:18 (leading: Space)
-4421: Ident           "__mod" at 407:19-407:24 (leading: Space)
-4422: LParen          "(" at 407:24-407:25
-4423: Ident           "self" at 407:25-407:29
-4424: Colon           ":" at 407:29-407:30
-4425: Ident           "int32" at 407:31-407:36 (leading: Space)
-4426: Comma           "," at 407:36-407:37
-4427: Ident           "other" at 407:38-407:43 (leading: Space)
-4428: Colon           ":" at 407:43-407:44
-4429: Ident           "int32" at 407:45-407:50 (leading: Space)
-4430: RParen          ")" at 407:50-407:51
-4431: Arrow           "->" at 407:52-407:54 (leading: Space)
-4432: Ident           "int32" at 407:55-407:60 (leading: Space)
-4433: Semicolon       ";" at 407:60-407:61
-4434: At              "@" at 408:5-408:6 (leading: Newline, Space)
-4435: Ident           "intrinsic" at 408:6-408:15
-4436: KwFn            "fn" at 408:16-408:18 (leading: Space)
-4437: Ident           "__bit_and" at 408:19-408:28 (leading: Space)
-4438: LParen          "(" at 408:28-408:29
-4439: Ident           "self" at 408:29-408:33
-4440: Colon           ":" at 408:33-408:34
-4441: Ident           "int32" at 408:35-408:40 (leading: Space)
-4442: Comma           "," at 408:40-408:41
-4443: Ident           "other" at 408:42-408:47 (leading: Space)
-4444: Colon           ":" at 408:47-408:48
-4445: Ident           "int32" at 408:49-408:54 (leading: Space)
-4446: RParen          ")" at 408:54-408:55
-4447: Arrow           "->" at 408:56-408:58 (leading: Space)
-4448: Ident           "int32" at 408:59-408:64 (leading: Space)
-4449: Semicolon       ";" at 408:64-408:65
-4450: At              "@" at 409:5-409:6 (leading: Newline, Space)
-4451: Ident           "intrinsic" at 409:6-409:15
-4452: KwFn            "fn" at 409:16-409:18 (leading: Space)
-4453: Ident           "__bit_or" at 409:19-409:27 (leading: Space)
-4454: LParen          "(" at 409:27-409:28
-4455: Ident           "self" at 409:28-409:32
-4456: Colon           ":" at 409:32-409:33
-4457: Ident           "int32" at 409:34-409:39 (leading: Space)
-4458: Comma           "," at 409:39-409:40
-4459: Ident           "other" at 409:41-409:46 (leading: Space)
-4460: Colon           ":" at 409:46-409:47
-4461: Ident           "int32" at 409:48-409:53 (leading: Space)
-4462: RParen          ")" at 409:53-409:54
-4463: Arrow           "->" at 409:55-409:57 (leading: Space)
-4464: Ident           "int32" at 409:58-409:63 (leading: Space)
-4465: Semicolon       ";" at 409:63-409:64
-4466: At              "@" at 410:5-410:6 (leading: Newline, Space)
-4467: Ident           "intrinsic" at 410:6-410:15
-4468: KwFn            "fn" at 410:16-410:18 (leading: Space)
-4469: Ident           "__bit_xor" at 410:19-410:28 (leading: Space)
-4470: LParen          "(" at 410:28-410:29
-4471: Ident           "self" at 410:29-410:33
-4472: Colon           ":" at 410:33-410:34
-4473: Ident           "int32" at 410:35-410:40 (leading: Space)
-4474: Comma           "," at 410:40-410:41
-4475: Ident           "other" at 410:42-410:47 (leading: Space)
-4476: Colon           ":" at 410:47-410:48
-4477: Ident           "int32" at 410:49-410:54 (leading: Space)
-4478: RParen          ")" at 410:54-410:55
-4479: Arrow           "->" at 410:56-410:58 (leading: Space)
-4480: Ident           "int32" at 410:59-410:64 (leading: Space)
-4481: Semicolon       ";" at 410:64-410:65
-4482: At              "@" at 411:5-411:6 (leading: Newline, Space)
-4483: Ident           "intrinsic" at 411:6-411:15
-4484: KwFn            "fn" at 411:16-411:18 (leading: Space)
-4485: Ident           "__shl" at 411:19-411:24 (leading: Space)
-4486: LParen          "(" at 411:24-411:25
-4487: Ident           "self" at 411:25-411:29
-4488: Colon           ":" at 411:29-411:30
-4489: Ident           "int32" at 411:31-411:36 (leading: Space)
-4490: Comma           "," at 411:36-411:37
-4491: Ident           "other" at 411:38-411:43 (leading: Space)
-4492: Colon           ":" at 411:43-411:44
-4493: Ident           "int32" at 411:45-411:50 (leading: Space)
-4494: RParen          ")" at 411:50-411:51
-4495: Arrow           "->" at 411:52-411:54 (leading: Space)
-4496: Ident           "int32" at 411:55-411:60 (leading: Space)
-4497: Semicolon       ";" at 411:60-411:61
-4498: At              "@" at 412:5-412:6 (leading: Newline, Space)
-4499: Ident           "intrinsic" at 412:6-412:15
-4500: KwFn            "fn" at 412:16-412:18 (leading: Space)
-4501: Ident           "__shr" at 412:19-412:24 (leading: Space)
-4502: LParen          "(" at 412:24-412:25
-4503: Ident           "self" at 412:25-412:29
-4504: Colon           ":" at 412:29-412:30
-4505: Ident           "int32" at 412:31-412:36 (leading: Space)
-4506: Comma           "," at 412:36-412:37
-4507: Ident           "other" at 412:38-412:43 (leading: Space)
-4508: Colon           ":" at 412:43-412:44
-4509: Ident           "int32" at 412:45-412:50 (leading: Space)
-4510: RParen          ")" at 412:50-412:51
-4511: Arrow           "->" at 412:52-412:54 (leading: Space)
-4512: Ident           "int32" at 412:55-412:60 (leading: Space)
-4513: Semicolon       ";" at 412:60-412:61
-4514: At              "@" at 413:5-413:6 (leading: Newline, Space)
-4515: Ident           "intrinsic" at 413:6-413:15
-4516: KwFn            "fn" at 413:16-413:18 (leading: Space)
-4517: Ident           "__lt" at 413:19-413:23 (leading: Space)
-4518: LParen          "(" at 413:23-413:24
-4519: Ident           "self" at 413:24-413:28
-4520: Colon           ":" at 413:28-413:29
-4521: Ident           "int32" at 413:30-413:35 (leading: Space)
-4522: Comma           "," at 413:35-413:36
-4523: Ident           "other" at 413:37-413:42 (leading: Space)
-4524: Colon           ":" at 413:42-413:43
-4525: Ident           "int32" at 413:44-413:49 (leading: Space)
-4526: RParen          ")" at 413:49-413:50
-4527: Arrow           "->" at 413:51-413:53 (leading: Space)
-4528: Ident           "bool" at 413:54-413:58 (leading: Space)
-4529: Semicolon       ";" at 413:58-413:59
-4530: At              "@" at 414:5-414:6 (leading: Newline, Space)
-4531: Ident           "intrinsic" at 414:6-414:15
-4532: KwFn            "fn" at 414:16-414:18 (leading: Space)
-4533: Ident           "__le" at 414:19-414:23 (leading: Space)
-4534: LParen          "(" at 414:23-414:24
-4535: Ident           "self" at 414:24-414:28
-4536: Colon           ":" at 414:28-414:29
-4537: Ident           "int32" at 414:30-414:35 (leading: Space)
-4538: Comma           "," at 414:35-414:36
-4539: Ident           "other" at 414:37-414:42 (leading: Space)
-4540: Colon           ":" at 414:42-414:43
-4541: Ident           "int32" at 414:44-414:49 (leading: Space)
-4542: RParen          ")" at 414:49-414:50
-4543: Arrow           "->" at 414:51-414:53 (leading: Space)
-4544: Ident           "bool" at 414:54-414:58 (leading: Space)
-4545: Semicolon       ";" at 414:58-414:59
-4546: At              "@" at 415:5-415:6 (leading: Newline, Space)
-4547: Ident           "intrinsic" at 415:6-415:15
-4548: KwFn            "fn" at 415:16-415:18 (leading: Space)
-4549: Ident           "__eq" at 415:19-415:23 (leading: Space)
-4550: LParen          "(" at 415:23-415:24
-4551: Ident           "self" at 415:24-415:28
-4552: Colon           ":" at 415:28-415:29
-4553: Ident           "int32" at 415:30-415:35 (leading: Space)
-4554: Comma           "," at 415:35-415:36
-4555: Ident           "other" at 415:37-415:42 (leading: Space)
-4556: Colon           ":" at 415:42-415:43
-4557: Ident           "int32" at 415:44-415:49 (leading: Space)
-4558: RParen          ")" at 415:49-415:50
-4559: Arrow           "->" at 415:51-415:53 (leading: Space)
-4560: Ident           "bool" at 415:54-415:58 (leading: Space)
-4561: Semicolon       ";" at 415:58-415:59
-4562: At              "@" at 416:5-416:6 (leading: Newline, Space)
-4563: Ident           "intrinsic" at 416:6-416:15
-4564: KwFn            "fn" at 416:16-416:18 (leading: Space)
-4565: Ident           "__ne" at 416:19-416:23 (leading: Space)
-4566: LParen          "(" at 416:23-416:24
-4567: Ident           "self" at 416:24-416:28
-4568: Colon           ":" at 416:28-416:29
-4569: Ident           "int32" at 416:30-416:35 (leading: Space)
-4570: Comma           "," at 416:35-416:36
-4571: Ident           "other" at 416:37-416:42 (leading: Space)
-4572: Colon           ":" at 416:42-416:43
-4573: Ident           "int32" at 416:44-416:49 (leading: Space)
-4574: RParen          ")" at 416:49-416:50
-4575: Arrow           "->" at 416:51-416:53 (leading: Space)
-4576: Ident           "bool" at 416:54-416:58 (leading: Space)
-4577: Semicolon       ";" at 416:58-416:59
-4578: At              "@" at 417:5-417:6 (leading: Newline, Space)
-4579: Ident           "intrinsic" at 417:6-417:15
-4580: KwFn            "fn" at 417:16-417:18 (leading: Space)
-4581: Ident           "__ge" at 417:19-417:23 (leading: Space)
-4582: LParen          "(" at 417:23-417:24
-4583: Ident           "self" at 417:24-417:28
-4584: Colon           ":" at 417:28-417:29
-4585: Ident           "int32" at 417:30-417:35 (leading: Space)
-4586: Comma           "," at 417:35-417:36
-4587: Ident           "other" at 417:37-417:42 (leading: Space)
-4588: Colon           ":" at 417:42-417:43
-4589: Ident           "int32" at 417:44-417:49 (leading: Space)
-4590: RParen          ")" at 417:49-417:50
-4591: Arrow           "->" at 417:51-417:53 (leading: Space)
-4592: Ident           "bool" at 417:54-417:58 (leading: Space)
-4593: Semicolon       ";" at 417:58-417:59
-4594: At              "@" at 418:5-418:6 (leading: Newline, Space)
-4595: Ident           "intrinsic" at 418:6-418:15
-4596: KwFn            "fn" at 418:16-418:18 (leading: Space)
-4597: Ident           "__gt" at 418:19-418:23 (leading: Space)
-4598: LParen          "(" at 418:23-418:24
-4599: Ident           "self" at 418:24-418:28
-4600: Colon           ":" at 418:28-418:29
-4601: Ident           "int32" at 418:30-418:35 (leading: Space)
-4602: Comma           "," at 418:35-418:36
-4603: Ident           "other" at 418:37-418:42 (leading: Space)
-4604: Colon           ":" at 418:42-418:43
-4605: Ident           "int32" at 418:44-418:49 (leading: Space)
-4606: RParen          ")" at 418:49-418:50
-4607: Arrow           "->" at 418:51-418:53 (leading: Space)
-4608: Ident           "bool" at 418:54-418:58 (leading: Space)
-4609: Semicolon       ";" at 418:58-418:59
-4610: At              "@" at 419:5-419:6 (leading: Newline, Space)
-4611: Ident           "intrinsic" at 419:6-419:15
-4612: KwFn            "fn" at 419:16-419:18 (leading: Space)
-4613: Ident           "__pos" at 419:19-419:24 (leading: Space)
-4614: LParen          "(" at 419:24-419:25
-4615: Ident           "self" at 419:25-419:29
-4616: Colon           ":" at 419:29-419:30
-4617: Ident           "int32" at 419:31-419:36 (leading: Space)
-4618: RParen          ")" at 419:36-419:37
-4619: Arrow           "->" at 419:38-419:40 (leading: Space)
-4620: Ident           "int32" at 419:41-419:46 (leading: Space)
-4621: Semicolon       ";" at 419:46-419:47
-4622: At              "@" at 420:5-420:6 (leading: Newline, Space)
-4623: Ident           "intrinsic" at 420:6-420:15
-4624: KwFn            "fn" at 420:16-420:18 (leading: Space)
-4625: Ident           "__neg" at 420:19-420:24 (leading: Space)
-4626: LParen          "(" at 420:24-420:25
-4627: Ident           "self" at 420:25-420:29
-4628: Colon           ":" at 420:29-420:30
-4629: Ident           "int32" at 420:31-420:36 (leading: Space)
-4630: RParen          ")" at 420:36-420:37
-4631: Arrow           "->" at 420:38-420:40 (leading: Space)
-4632: Ident           "int32" at 420:41-420:46 (leading: Space)
-4633: Semicolon       ";" at 420:46-420:47
-4634: At              "@" at 421:5-421:6 (leading: Newline, Space)
-4635: Ident           "intrinsic" at 421:6-421:15
-4636: KwFn            "fn" at 421:16-421:18 (leading: Space)
-4637: Ident           "__abs" at 421:19-421:24 (leading: Space)
-4638: LParen          "(" at 421:24-421:25
-4639: Ident           "self" at 421:25-421:29
-4640: Colon           ":" at 421:29-421:30
-4641: Ident           "int32" at 421:31-421:36 (leading: Space)
-4642: RParen          ")" at 421:36-421:37
-4643: Arrow           "->" at 421:38-421:40 (leading: Space)
-4644: Ident           "int32" at 421:41-421:46 (leading: Space)
-4645: Semicolon       ";" at 421:46-421:47
-4646: At              "@" at 422:5-422:6 (leading: Newline, Space)
-4647: Ident           "intrinsic" at 422:6-422:15
-4648: KwFn            "fn" at 422:16-422:18 (leading: Space)
-4649: Ident           "__to" at 422:19-422:23 (leading: Space)
-4650: LParen          "(" at 422:23-422:24
-4651: Ident           "self" at 422:24-422:28
-4652: Colon           ":" at 422:28-422:29
-4653: Ident           "int32" at 422:30-422:35 (leading: Space)
-4654: Comma           "," at 422:35-422:36
-4655: Ident           "target" at 422:37-422:43 (leading: Space)
-4656: Colon           ":" at 422:43-422:44
-4657: Ident           "int" at 422:45-422:48 (leading: Space)
-4658: RParen          ")" at 422:48-422:49
-4659: Arrow           "->" at 422:50-422:52 (leading: Space)
-4660: Ident           "int" at 422:53-422:56 (leading: Space)
-4661: Semicolon       ";" at 422:56-422:57
-4662: At              "@" at 423:5-423:6 (leading: Newline, Space)
-4663: Ident           "intrinsic" at 423:6-423:15
-4664: At              "@" at 423:16-423:17 (leading: Space)
-4665: Ident           "overload" at 423:17-423:25
-4666: KwFn            "fn" at 423:26-423:28 (leading: Space)
-4667: Ident           "__to" at 423:29-423:33 (leading: Space)
-4668: LParen          "(" at 423:33-423:34
-4669: Ident           "self" at 423:34-423:38
-4670: Colon           ":" at 423:38-423:39
-4671: Ident           "int32" at 423:40-423:45 (leading: Space)
-4672: Comma           "," at 423:45-423:46
-4673: Ident           "target" at 423:47-423:53 (leading: Space)
-4674: Colon           ":" at 423:53-423:54
-4675: Ident           "int8" at 423:55-423:59 (leading: Space)
-4676: RParen          ")" at 423:59-423:60
-4677: Arrow           "->" at 423:61-423:63 (leading: Space)
-4678: Ident           "int8" at 423:64-423:68 (leading: Space)
-4679: Semicolon       ";" at 423:68-423:69
-4680: At              "@" at 424:5-424:6 (leading: Newline, Space)
-4681: Ident           "intrinsic" at 424:6-424:15
-4682: At              "@" at 424:16-424:17 (leading: Space)
-4683: Ident           "overload" at 424:17-424:25
-4684: KwFn            "fn" at 424:26-424:28 (leading: Space)
-4685: Ident           "__to" at 424:29-424:33 (leading: Space)
-4686: LParen          "(" at 424:33-424:34
-4687: Ident           "self" at 424:34-424:38
-4688: Colon           ":" at 424:38-424:39
-4689: Ident           "int32" at 424:40-424:45 (leading: Space)
-4690: Comma           "," at 424:45-424:46
-4691: Ident           "target" at 424:47-424:53 (leading: Space)
-4692: Colon           ":" at 424:53-424:54
-4693: Ident           "int16" at 424:55-424:60 (leading: Space)
-4694: RParen          ")" at 424:60-424:61
-4695: Arrow           "->" at 424:62-424:64 (leading: Space)
-4696: Ident           "int16" at 424:65-424:70 (leading: Space)
-4697: Semicolon       ";" at 424:70-424:71
-4698: At              "@" at 425:5-425:6 (leading: Newline, Space)
-4699: Ident           "intrinsic" at 425:6-425:15
-4700: At              "@" at 425:16-425:17 (leading: Space)
-4701: Ident           "overload" at 425:17-425:25
-4702: KwFn            "fn" at 425:26-425:28 (leading: Space)
-4703: Ident           "__to" at 425:29-425:33 (leading: Space)
-4704: LParen          "(" at 425:33-425:34
-4705: Ident           "self" at 425:34-425:38
-4706: Colon           ":" at 425:38-425:39
-4707: Ident           "int32" at 425:40-425:45 (leading: Space)
-4708: Comma           "," at 425:45-425:46
-4709: Ident           "target" at 425:47-425:53 (leading: Space)
-4710: Colon           ":" at 425:53-425:54
-4711: Ident           "int64" at 425:55-425:60 (leading: Space)
-4712: RParen          ")" at 425:60-425:61
-4713: Arrow           "->" at 425:62-425:64 (leading: Space)
-4714: Ident           "int64" at 425:65-425:70 (leading: Space)
-4715: Semicolon       ";" at 425:70-425:71
-4716: At              "@" at 426:5-426:6 (leading: Newline, Space)
-4717: Ident           "intrinsic" at 426:6-426:15
-4718: KwPub           "pub" at 426:16-426:19 (leading: Space)
-4719: KwFn            "fn" at 426:20-426:22 (leading: Space)
-4720: Ident           "from_str" at 426:23-426:31 (leading: Space)
-4721: LParen          "(" at 426:31-426:32
-4722: Ident           "s" at 426:32-426:33
-4723: Colon           ":" at 426:33-426:34
-4724: Amp             "&" at 426:35-426:36 (leading: Space)
-4725: Ident           "string" at 426:36-426:42
-4726: RParen          ")" at 426:42-426:43
-4727: Arrow           "->" at 426:44-426:46 (leading: Space)
-4728: Ident           "Erring" at 426:47-426:53 (leading: Space)
-4729: Lt              "<" at 426:53-426:54
-4730: Ident           "int32" at 426:54-426:59
-4731: Comma           "," at 426:59-426:60
-4732: Ident           "Error" at 426:61-426:66 (leading: Space)
-4733: Gt              ">" at 426:66-426:67
-4734: Semicolon       ";" at 426:67-426:68
-4735: RBrace          "}" at 427:1-427:2 (leading: Newline)
-4736: KwExtern        "extern" at 429:1-429:7 (leading: Newline)
-4737: Lt              "<" at 429:7-429:8
-4738: Ident           "int64" at 429:8-429:13
-4739: Gt              ">" at 429:13-429:14
-4740: LBrace          "{" at 429:15-429:16 (leading: Space)
-4741: KwPub           "pub" at 430:5-430:8 (leading: Newline, Space)
-4742: KwFn            "fn" at 430:9-430:11 (leading: Space)
-4743: Ident           "__min_value" at 430:12-430:23 (leading: Space)
-4744: LParen          "(" at 430:23-430:24
-4745: RParen          ")" at 430:24-430:25
-4746: Arrow           "->" at 430:26-430:28 (leading: Space)
-4747: Ident           "int64" at 430:29-430:34 (leading: Space)
-4748: LBrace          "{" at 430:35-430:36 (leading: Space)
-4749: KwReturn        "return" at 430:37-430:43 (leading: Space)
-4750: LParen          "(" at 430:44-430:45 (leading: Space)
-4751: Minus           "-" at 430:45-430:46
-4752: IntLit          "9_223_372_036_854_775_808" at 430:46-430:71
-4753: RParen          ")" at 430:71-430:72
-4754: Colon           ":" at 430:72-430:73
-4755: Ident           "int64" at 430:73-430:78
-4756: Semicolon       ";" at 430:78-430:79
-4757: RBrace          "}" at 430:80-430:81 (leading: Space)
-4758: KwPub           "pub" at 431:5-431:8 (leading: Newline, Space)
-4759: KwFn            "fn" at 431:9-431:11 (leading: Space)
-4760: Ident           "__max_value" at 431:12-431:23 (leading: Space)
-4761: LParen          "(" at 431:23-431:24
-4762: RParen          ")" at 431:24-431:25
-4763: Arrow           "->" at 431:26-431:28 (leading: Space)
-4764: Ident           "int64" at 431:29-431:34 (leading: Space)
-4765: LBrace          "{" at 431:35-431:36 (leading: Space)
-4766: KwReturn        "return" at 431:37-431:43 (leading: Space)
-4767: LParen          "(" at 431:44-431:45 (leading: Space)
-4768: IntLit          "9_223_372_036_854_775_807" at 431:45-431:70
-4769: RParen          ")" at 431:70-431:71
-4770: Colon           ":" at 431:71-431:72
-4771: Ident           "int64" at 431:72-431:77
-4772: Semicolon       ";" at 431:77-431:78
-4773: RBrace          "}" at 431:79-431:80 (leading: Space)
-4774: At              "@" at 432:5-432:6 (leading: Newline, Space)
-4775: Ident           "intrinsic" at 432:6-432:15
-4776: KwFn            "fn" at 432:16-432:18 (leading: Space)
-4777: Ident           "__add" at 432:19-432:24 (leading: Space)
-4778: LParen          "(" at 432:24-432:25
-4779: Ident           "self" at 432:25-432:29
-4780: Colon           ":" at 432:29-432:30
-4781: Ident           "int64" at 432:31-432:36 (leading: Space)
-4782: Comma           "," at 432:36-432:37
-4783: Ident           "other" at 432:38-432:43 (leading: Space)
-4784: Colon           ":" at 432:43-432:44
-4785: Ident           "int64" at 432:45-432:50 (leading: Space)
-4786: RParen          ")" at 432:50-432:51
-4787: Arrow           "->" at 432:52-432:54 (leading: Space)
-4788: Ident           "int64" at 432:55-432:60 (leading: Space)
-4789: Semicolon       ";" at 432:60-432:61
-4790: At              "@" at 433:5-433:6 (leading: Newline, Space)
-4791: Ident           "intrinsic" at 433:6-433:15
-4792: KwFn            "fn" at 433:16-433:18 (leading: Space)
-4793: Ident           "__sub" at 433:19-433:24 (leading: Space)
-4794: LParen          "(" at 433:24-433:25
-4795: Ident           "self" at 433:25-433:29
-4796: Colon           ":" at 433:29-433:30
-4797: Ident           "int64" at 433:31-433:36 (leading: Space)
-4798: Comma           "," at 433:36-433:37
-4799: Ident           "other" at 433:38-433:43 (leading: Space)
-4800: Colon           ":" at 433:43-433:44
-4801: Ident           "int64" at 433:45-433:50 (leading: Space)
-4802: RParen          ")" at 433:50-433:51
-4803: Arrow           "->" at 433:52-433:54 (leading: Space)
-4804: Ident           "int64" at 433:55-433:60 (leading: Space)
-4805: Semicolon       ";" at 433:60-433:61
-4806: At              "@" at 434:5-434:6 (leading: Newline, Space)
-4807: Ident           "intrinsic" at 434:6-434:15
-4808: KwFn            "fn" at 434:16-434:18 (leading: Space)
-4809: Ident           "__mul" at 434:19-434:24 (leading: Space)
-4810: LParen          "(" at 434:24-434:25
-4811: Ident           "self" at 434:25-434:29
-4812: Colon           ":" at 434:29-434:30
-4813: Ident           "int64" at 434:31-434:36 (leading: Space)
-4814: Comma           "," at 434:36-434:37
-4815: Ident           "other" at 434:38-434:43 (leading: Space)
-4816: Colon           ":" at 434:43-434:44
-4817: Ident           "int64" at 434:45-434:50 (leading: Space)
-4818: RParen          ")" at 434:50-434:51
-4819: Arrow           "->" at 434:52-434:54 (leading: Space)
-4820: Ident           "int64" at 434:55-434:60 (leading: Space)
-4821: Semicolon       ";" at 434:60-434:61
-4822: At              "@" at 435:5-435:6 (leading: Newline, Space)
-4823: Ident           "intrinsic" at 435:6-435:15
-4824: KwFn            "fn" at 435:16-435:18 (leading: Space)
-4825: Ident           "__div" at 435:19-435:24 (leading: Space)
-4826: LParen          "(" at 435:24-435:25
-4827: Ident           "self" at 435:25-435:29
-4828: Colon           ":" at 435:29-435:30
-4829: Ident           "int64" at 435:31-435:36 (leading: Space)
-4830: Comma           "," at 435:36-435:37
-4831: Ident           "other" at 435:38-435:43 (leading: Space)
-4832: Colon           ":" at 435:43-435:44
-4833: Ident           "int64" at 435:45-435:50 (leading: Space)
-4834: RParen          ")" at 435:50-435:51
-4835: Arrow           "->" at 435:52-435:54 (leading: Space)
-4836: Ident           "int64" at 435:55-435:60 (leading: Space)
-4837: Semicolon       ";" at 435:60-435:61
-4838: At              "@" at 436:5-436:6 (leading: Newline, Space)
-4839: Ident           "intrinsic" at 436:6-436:15
-4840: KwFn            "fn" at 436:16-436:18 (leading: Space)
-4841: Ident           "__mod" at 436:19-436:24 (leading: Space)
-4842: LParen          "(" at 436:24-436:25
-4843: Ident           "self" at 436:25-436:29
-4844: Colon           ":" at 436:29-436:30
-4845: Ident           "int64" at 436:31-436:36 (leading: Space)
-4846: Comma           "," at 436:36-436:37
-4847: Ident           "other" at 436:38-436:43 (leading: Space)
-4848: Colon           ":" at 436:43-436:44
-4849: Ident           "int64" at 436:45-436:50 (leading: Space)
-4850: RParen          ")" at 436:50-436:51
-4851: Arrow           "->" at 436:52-436:54 (leading: Space)
-4852: Ident           "int64" at 436:55-436:60 (leading: Space)
-4853: Semicolon       ";" at 436:60-436:61
-4854: At              "@" at 437:5-437:6 (leading: Newline, Space)
-4855: Ident           "intrinsic" at 437:6-437:15
-4856: KwFn            "fn" at 437:16-437:18 (leading: Space)
-4857: Ident           "__bit_and" at 437:19-437:28 (leading: Space)
-4858: LParen          "(" at 437:28-437:29
-4859: Ident           "self" at 437:29-437:33
-4860: Colon           ":" at 437:33-437:34
-4861: Ident           "int64" at 437:35-437:40 (leading: Space)
-4862: Comma           "," at 437:40-437:41
-4863: Ident           "other" at 437:42-437:47 (leading: Space)
-4864: Colon           ":" at 437:47-437:48
-4865: Ident           "int64" at 437:49-437:54 (leading: Space)
-4866: RParen          ")" at 437:54-437:55
-4867: Arrow           "->" at 437:56-437:58 (leading: Space)
-4868: Ident           "int64" at 437:59-437:64 (leading: Space)
-4869: Semicolon       ";" at 437:64-437:65
-4870: At              "@" at 438:5-438:6 (leading: Newline, Space)
-4871: Ident           "intrinsic" at 438:6-438:15
-4872: KwFn            "fn" at 438:16-438:18 (leading: Space)
-4873: Ident           "__bit_or" at 438:19-438:27 (leading: Space)
-4874: LParen          "(" at 438:27-438:28
-4875: Ident           "self" at 438:28-438:32
-4876: Colon           ":" at 438:32-438:33
-4877: Ident           "int64" at 438:34-438:39 (leading: Space)
-4878: Comma           "," at 438:39-438:40
-4879: Ident           "other" at 438:41-438:46 (leading: Space)
-4880: Colon           ":" at 438:46-438:47
-4881: Ident           "int64" at 438:48-438:53 (leading: Space)
-4882: RParen          ")" at 438:53-438:54
-4883: Arrow           "->" at 438:55-438:57 (leading: Space)
-4884: Ident           "int64" at 438:58-438:63 (leading: Space)
-4885: Semicolon       ";" at 438:63-438:64
-4886: At              "@" at 439:5-439:6 (leading: Newline, Space)
-4887: Ident           "intrinsic" at 439:6-439:15
-4888: KwFn            "fn" at 439:16-439:18 (leading: Space)
-4889: Ident           "__bit_xor" at 439:19-439:28 (leading: Space)
-4890: LParen          "(" at 439:28-439:29
-4891: Ident           "self" at 439:29-439:33
-4892: Colon           ":" at 439:33-439:34
-4893: Ident           "int64" at 439:35-439:40 (leading: Space)
-4894: Comma           "," at 439:40-439:41
-4895: Ident           "other" at 439:42-439:47 (leading: Space)
-4896: Colon           ":" at 439:47-439:48
-4897: Ident           "int64" at 439:49-439:54 (leading: Space)
-4898: RParen          ")" at 439:54-439:55
-4899: Arrow           "->" at 439:56-439:58 (leading: Space)
-4900: Ident           "int64" at 439:59-439:64 (leading: Space)
-4901: Semicolon       ";" at 439:64-439:65
-4902: At              "@" at 440:5-440:6 (leading: Newline, Space)
-4903: Ident           "intrinsic" at 440:6-440:15
-4904: KwFn            "fn" at 440:16-440:18 (leading: Space)
-4905: Ident           "__shl" at 440:19-440:24 (leading: Space)
-4906: LParen          "(" at 440:24-440:25
-4907: Ident           "self" at 440:25-440:29
-4908: Colon           ":" at 440:29-440:30
-4909: Ident           "int64" at 440:31-440:36 (leading: Space)
-4910: Comma           "," at 440:36-440:37
-4911: Ident           "other" at 440:38-440:43 (leading: Space)
-4912: Colon           ":" at 440:43-440:44
-4913: Ident           "int64" at 440:45-440:50 (leading: Space)
-4914: RParen          ")" at 440:50-440:51
-4915: Arrow           "->" at 440:52-440:54 (leading: Space)
-4916: Ident           "int64" at 440:55-440:60 (leading: Space)
-4917: Semicolon       ";" at 440:60-440:61
-4918: At              "@" at 441:5-441:6 (leading: Newline, Space)
-4919: Ident           "intrinsic" at 441:6-441:15
-4920: KwFn            "fn" at 441:16-441:18 (leading: Space)
-4921: Ident           "__shr" at 441:19-441:24 (leading: Space)
-4922: LParen          "(" at 441:24-441:25
-4923: Ident           "self" at 441:25-441:29
-4924: Colon           ":" at 441:29-441:30
-4925: Ident           "int64" at 441:31-441:36 (leading: Space)
-4926: Comma           "," at 441:36-441:37
-4927: Ident           "other" at 441:38-441:43 (leading: Space)
-4928: Colon           ":" at 441:43-441:44
-4929: Ident           "int64" at 441:45-441:50 (leading: Space)
-4930: RParen          ")" at 441:50-441:51
-4931: Arrow           "->" at 441:52-441:54 (leading: Space)
-4932: Ident           "int64" at 441:55-441:60 (leading: Space)
-4933: Semicolon       ";" at 441:60-441:61
-4934: At              "@" at 442:5-442:6 (leading: Newline, Space)
-4935: Ident           "intrinsic" at 442:6-442:15
-4936: KwFn            "fn" at 442:16-442:18 (leading: Space)
-4937: Ident           "__lt" at 442:19-442:23 (leading: Space)
-4938: LParen          "(" at 442:23-442:24
-4939: Ident           "self" at 442:24-442:28
-4940: Colon           ":" at 442:28-442:29
-4941: Ident           "int64" at 442:30-442:35 (leading: Space)
-4942: Comma           "," at 442:35-442:36
-4943: Ident           "other" at 442:37-442:42 (leading: Space)
-4944: Colon           ":" at 442:42-442:43
-4945: Ident           "int64" at 442:44-442:49 (leading: Space)
-4946: RParen          ")" at 442:49-442:50
-4947: Arrow           "->" at 442:51-442:53 (leading: Space)
-4948: Ident           "bool" at 442:54-442:58 (leading: Space)
-4949: Semicolon       ";" at 442:58-442:59
-4950: At              "@" at 443:5-443:6 (leading: Newline, Space)
-4951: Ident           "intrinsic" at 443:6-443:15
-4952: KwFn            "fn" at 443:16-443:18 (leading: Space)
-4953: Ident           "__le" at 443:19-443:23 (leading: Space)
-4954: LParen          "(" at 443:23-443:24
-4955: Ident           "self" at 443:24-443:28
-4956: Colon           ":" at 443:28-443:29
-4957: Ident           "int64" at 443:30-443:35 (leading: Space)
-4958: Comma           "," at 443:35-443:36
-4959: Ident           "other" at 443:37-443:42 (leading: Space)
-4960: Colon           ":" at 443:42-443:43
-4961: Ident           "int64" at 443:44-443:49 (leading: Space)
-4962: RParen          ")" at 443:49-443:50
-4963: Arrow           "->" at 443:51-443:53 (leading: Space)
-4964: Ident           "bool" at 443:54-443:58 (leading: Space)
-4965: Semicolon       ";" at 443:58-443:59
-4966: At              "@" at 444:5-444:6 (leading: Newline, Space)
-4967: Ident           "intrinsic" at 444:6-444:15
-4968: KwFn            "fn" at 444:16-444:18 (leading: Space)
-4969: Ident           "__eq" at 444:19-444:23 (leading: Space)
-4970: LParen          "(" at 444:23-444:24
-4971: Ident           "self" at 444:24-444:28
-4972: Colon           ":" at 444:28-444:29
-4973: Ident           "int64" at 444:30-444:35 (leading: Space)
-4974: Comma           "," at 444:35-444:36
-4975: Ident           "other" at 444:37-444:42 (leading: Space)
-4976: Colon           ":" at 444:42-444:43
-4977: Ident           "int64" at 444:44-444:49 (leading: Space)
-4978: RParen          ")" at 444:49-444:50
-4979: Arrow           "->" at 444:51-444:53 (leading: Space)
-4980: Ident           "bool" at 444:54-444:58 (leading: Space)
-4981: Semicolon       ";" at 444:58-444:59
-4982: At              "@" at 445:5-445:6 (leading: Newline, Space)
-4983: Ident           "intrinsic" at 445:6-445:15
-4984: KwFn            "fn" at 445:16-445:18 (leading: Space)
-4985: Ident           "__ne" at 445:19-445:23 (leading: Space)
-4986: LParen          "(" at 445:23-445:24
-4987: Ident           "self" at 445:24-445:28
-4988: Colon           ":" at 445:28-445:29
-4989: Ident           "int64" at 445:30-445:35 (leading: Space)
-4990: Comma           "," at 445:35-445:36
-4991: Ident           "other" at 445:37-445:42 (leading: Space)
-4992: Colon           ":" at 445:42-445:43
-4993: Ident           "int64" at 445:44-445:49 (leading: Space)
-4994: RParen          ")" at 445:49-445:50
-4995: Arrow           "->" at 445:51-445:53 (leading: Space)
-4996: Ident           "bool" at 445:54-445:58 (leading: Space)
-4997: Semicolon       ";" at 445:58-445:59
-4998: At              "@" at 446:5-446:6 (leading: Newline, Space)
-4999: Ident           "intrinsic" at 446:6-446:15
-5000: KwFn            "fn" at 446:16-446:18 (leading: Space)
-5001: Ident           "__ge" at 446:19-446:23 (leading: Space)
-5002: LParen          "(" at 446:23-446:24
-5003: Ident           "self" at 446:24-446:28
-5004: Colon           ":" at 446:28-446:29
-5005: Ident           "int64" at 446:30-446:35 (leading: Space)
-5006: Comma           "," at 446:35-446:36
-5007: Ident           "other" at 446:37-446:42 (leading: Space)
-5008: Colon           ":" at 446:42-446:43
-5009: Ident           "int64" at 446:44-446:49 (leading: Space)
-5010: RParen          ")" at 446:49-446:50
-5011: Arrow           "->" at 446:51-446:53 (leading: Space)
-5012: Ident           "bool" at 446:54-446:58 (leading: Space)
-5013: Semicolon       ";" at 446:58-446:59
-5014: At              "@" at 447:5-447:6 (leading: Newline, Space)
-5015: Ident           "intrinsic" at 447:6-447:15
-5016: KwFn            "fn" at 447:16-447:18 (leading: Space)
-5017: Ident           "__gt" at 447:19-447:23 (leading: Space)
-5018: LParen          "(" at 447:23-447:24
-5019: Ident           "self" at 447:24-447:28
-5020: Colon           ":" at 447:28-447:29
-5021: Ident           "int64" at 447:30-447:35 (leading: Space)
-5022: Comma           "," at 447:35-447:36
-5023: Ident           "other" at 447:37-447:42 (leading: Space)
-5024: Colon           ":" at 447:42-447:43
-5025: Ident           "int64" at 447:44-447:49 (leading: Space)
-5026: RParen          ")" at 447:49-447:50
-5027: Arrow           "->" at 447:51-447:53 (leading: Space)
-5028: Ident           "bool" at 447:54-447:58 (leading: Space)
-5029: Semicolon       ";" at 447:58-447:59
-5030: At              "@" at 448:5-448:6 (leading: Newline, Space)
-5031: Ident           "intrinsic" at 448:6-448:15
-5032: KwFn            "fn" at 448:16-448:18 (leading: Space)
-5033: Ident           "__pos" at 448:19-448:24 (leading: Space)
-5034: LParen          "(" at 448:24-448:25
-5035: Ident           "self" at 448:25-448:29
-5036: Colon           ":" at 448:29-448:30
-5037: Ident           "int64" at 448:31-448:36 (leading: Space)
-5038: RParen          ")" at 448:36-448:37
-5039: Arrow           "->" at 448:38-448:40 (leading: Space)
-5040: Ident           "int64" at 448:41-448:46 (leading: Space)
-5041: Semicolon       ";" at 448:46-448:47
-5042: At              "@" at 449:5-449:6 (leading: Newline, Space)
-5043: Ident           "intrinsic" at 449:6-449:15
-5044: KwFn            "fn" at 449:16-449:18 (leading: Space)
-5045: Ident           "__neg" at 449:19-449:24 (leading: Space)
-5046: LParen          "(" at 449:24-449:25
-5047: Ident           "self" at 449:25-449:29
-5048: Colon           ":" at 449:29-449:30
-5049: Ident           "int64" at 449:31-449:36 (leading: Space)
-5050: RParen          ")" at 449:36-449:37
-5051: Arrow           "->" at 449:38-449:40 (leading: Space)
-5052: Ident           "int64" at 449:41-449:46 (leading: Space)
-5053: Semicolon       ";" at 449:46-449:47
-5054: At              "@" at 450:5-450:6 (leading: Newline, Space)
-5055: Ident           "intrinsic" at 450:6-450:15
-5056: KwFn            "fn" at 450:16-450:18 (leading: Space)
-5057: Ident           "__abs" at 450:19-450:24 (leading: Space)
-5058: LParen          "(" at 450:24-450:25
-5059: Ident           "self" at 450:25-450:29
-5060: Colon           ":" at 450:29-450:30
-5061: Ident           "int64" at 450:31-450:36 (leading: Space)
-5062: RParen          ")" at 450:36-450:37
-5063: Arrow           "->" at 450:38-450:40 (leading: Space)
-5064: Ident           "int64" at 450:41-450:46 (leading: Space)
-5065: Semicolon       ";" at 450:46-450:47
-5066: At              "@" at 451:5-451:6 (leading: Newline, Space)
-5067: Ident           "intrinsic" at 451:6-451:15
-5068: KwFn            "fn" at 451:16-451:18 (leading: Space)
-5069: Ident           "__to" at 451:19-451:23 (leading: Space)
-5070: LParen          "(" at 451:23-451:24
-5071: Ident           "self" at 451:24-451:28
-5072: Colon           ":" at 451:28-451:29
-5073: Ident           "int64" at 451:30-451:35 (leading: Space)
-5074: Comma           "," at 451:35-451:36
-5075: Ident           "target" at 451:37-451:43 (leading: Space)
-5076: Colon           ":" at 451:43-451:44
-5077: Ident           "int" at 451:45-451:48 (leading: Space)
-5078: RParen          ")" at 451:48-451:49
-5079: Arrow           "->" at 451:50-451:52 (leading: Space)
-5080: Ident           "int" at 451:53-451:56 (leading: Space)
-5081: Semicolon       ";" at 451:56-451:57
-5082: At              "@" at 452:5-452:6 (leading: Newline, Space)
-5083: Ident           "intrinsic" at 452:6-452:15
-5084: At              "@" at 452:16-452:17 (leading: Space)
-5085: Ident           "overload" at 452:17-452:25
-5086: KwFn            "fn" at 452:26-452:28 (leading: Space)
-5087: Ident           "__to" at 452:29-452:33 (leading: Space)
-5088: LParen          "(" at 452:33-452:34
-5089: Ident           "self" at 452:34-452:38
-5090: Colon           ":" at 452:38-452:39
-5091: Ident           "int64" at 452:40-452:45 (leading: Space)
-5092: Comma           "," at 452:45-452:46
-5093: Ident           "target" at 452:47-452:53 (leading: Space)
-5094: Colon           ":" at 452:53-452:54
-5095: Ident           "int8" at 452:55-452:59 (leading: Space)
-5096: RParen          ")" at 452:59-452:60
-5097: Arrow           "->" at 452:61-452:63 (leading: Space)
-5098: Ident           "int8" at 452:64-452:68 (leading: Space)
-5099: Semicolon       ";" at 452:68-452:69
-5100: At              "@" at 453:5-453:6 (leading: Newline, Space)
-5101: Ident           "intrinsic" at 453:6-453:15
-5102: At              "@" at 453:16-453:17 (leading: Space)
-5103: Ident           "overload" at 453:17-453:25
-5104: KwFn            "fn" at 453:26-453:28 (leading: Space)
-5105: Ident           "__to" at 453:29-453:33 (leading: Space)
-5106: LParen          "(" at 453:33-453:34
-5107: Ident           "self" at 453:34-453:38
-5108: Colon           ":" at 453:38-453:39
-5109: Ident           "int64" at 453:40-453:45 (leading: Space)
-5110: Comma           "," at 453:45-453:46
-5111: Ident           "target" at 453:47-453:53 (leading: Space)
-5112: Colon           ":" at 453:53-453:54
-5113: Ident           "int16" at 453:55-453:60 (leading: Space)
-5114: RParen          ")" at 453:60-453:61
-5115: Arrow           "->" at 453:62-453:64 (leading: Space)
-5116: Ident           "int16" at 453:65-453:70 (leading: Space)
-5117: Semicolon       ";" at 453:70-453:71
-5118: At              "@" at 454:5-454:6 (leading: Newline, Space)
-5119: Ident           "intrinsic" at 454:6-454:15
-5120: At              "@" at 454:16-454:17 (leading: Space)
-5121: Ident           "overload" at 454:17-454:25
-5122: KwFn            "fn" at 454:26-454:28 (leading: Space)
-5123: Ident           "__to" at 454:29-454:33 (leading: Space)
-5124: LParen          "(" at 454:33-454:34
-5125: Ident           "self" at 454:34-454:38
-5126: Colon           ":" at 454:38-454:39
-5127: Ident           "int64" at 454:40-454:45 (leading: Space)
-5128: Comma           "," at 454:45-454:46
-5129: Ident           "target" at 454:47-454:53 (leading: Space)
-5130: Colon           ":" at 454:53-454:54
-5131: Ident           "int32" at 454:55-454:60 (leading: Space)
-5132: RParen          ")" at 454:60-454:61
-5133: Arrow           "->" at 454:62-454:64 (leading: Space)
-5134: Ident           "int32" at 454:65-454:70 (leading: Space)
-5135: Semicolon       ";" at 454:70-454:71
-5136: At              "@" at 455:5-455:6 (leading: Newline, Space)
-5137: Ident           "intrinsic" at 455:6-455:15
-5138: KwPub           "pub" at 455:16-455:19 (leading: Space)
-5139: KwFn            "fn" at 455:20-455:22 (leading: Space)
-5140: Ident           "from_str" at 455:23-455:31 (leading: Space)
-5141: LParen          "(" at 455:31-455:32
-5142: Ident           "s" at 455:32-455:33
-5143: Colon           ":" at 455:33-455:34
-5144: Amp             "&" at 455:35-455:36 (leading: Space)
-5145: Ident           "string" at 455:36-455:42
-5146: RParen          ")" at 455:42-455:43
-5147: Arrow           "->" at 455:44-455:46 (leading: Space)
-5148: Ident           "Erring" at 455:47-455:53 (leading: Space)
-5149: Lt              "<" at 455:53-455:54
-5150: Ident           "int64" at 455:54-455:59
-5151: Comma           "," at 455:59-455:60
-5152: Ident           "Error" at 455:61-455:66 (leading: Space)
-5153: Gt              ">" at 455:66-455:67
-5154: Semicolon       ";" at 455:67-455:68
-5155: RBrace          "}" at 456:1-456:2 (leading: Newline)
-5156: KwExtern        "extern" at 458:1-458:7 (leading: Newline)
-5157: Lt              "<" at 458:7-458:8
-5158: Ident           "uint8" at 458:8-458:13
-5159: Gt              ">" at 458:13-458:14
-5160: LBrace          "{" at 458:15-458:16 (leading: Space)
-5161: KwPub           "pub" at 459:5-459:8 (leading: Newline, Space)
-5162: KwFn            "fn" at 459:9-459:11 (leading: Space)
-5163: Ident           "__min_value" at 459:12-459:23 (leading: Space)
-5164: LParen          "(" at 459:23-459:24
-5165: RParen          ")" at 459:24-459:25
-5166: Arrow           "->" at 459:26-459:28 (leading: Space)
-5167: Ident           "uint8" at 459:29-459:34 (leading: Space)
-5168: LBrace          "{" at 459:35-459:36 (leading: Space)
-5169: KwReturn        "return" at 459:37-459:43 (leading: Space)
-5170: LParen          "(" at 459:44-459:45 (leading: Space)
-5171: IntLit          "0" at 459:45-459:46
-5172: RParen          ")" at 459:46-459:47
-5173: Colon           ":" at 459:47-459:48
-5174: Ident           "uint8" at 459:48-459:53
-5175: Semicolon       ";" at 459:53-459:54
-5176: RBrace          "}" at 459:55-459:56 (leading: Space)
-5177: KwPub           "pub" at 460:5-460:8 (leading: Newline, Space)
-5178: KwFn            "fn" at 460:9-460:11 (leading: Space)
-5179: Ident           "__max_value" at 460:12-460:23 (leading: Space)
-5180: LParen          "(" at 460:23-460:24
-5181: RParen          ")" at 460:24-460:25
-5182: Arrow           "->" at 460:26-460:28 (leading: Space)
-5183: Ident           "uint8" at 460:29-460:34 (leading: Space)
-5184: LBrace          "{" at 460:35-460:36 (leading: Space)
-5185: KwReturn        "return" at 460:37-460:43 (leading: Space)
-5186: LParen          "(" at 460:44-460:45 (leading: Space)
-5187: IntLit          "255" at 460:45-460:48
-5188: RParen          ")" at 460:48-460:49
-5189: Colon           ":" at 460:49-460:50
-5190: Ident           "uint8" at 460:50-460:55
-5191: Semicolon       ";" at 460:55-460:56
-5192: RBrace          "}" at 460:57-460:58 (leading: Space)
-5193: At              "@" at 461:5-461:6 (leading: Newline, Space)
-5194: Ident           "intrinsic" at 461:6-461:15
-5195: KwFn            "fn" at 461:16-461:18 (leading: Space)
-5196: Ident           "__add" at 461:19-461:24 (leading: Space)
-5197: LParen          "(" at 461:24-461:25
-5198: Ident           "self" at 461:25-461:29
-5199: Colon           ":" at 461:29-461:30
-5200: Ident           "uint8" at 461:31-461:36 (leading: Space)
-5201: Comma           "," at 461:36-461:37
-5202: Ident           "other" at 461:38-461:43 (leading: Space)
-5203: Colon           ":" at 461:43-461:44
-5204: Ident           "uint8" at 461:45-461:50 (leading: Space)
-5205: RParen          ")" at 461:50-461:51
-5206: Arrow           "->" at 461:52-461:54 (leading: Space)
-5207: Ident           "uint8" at 461:55-461:60 (leading: Space)
-5208: Semicolon       ";" at 461:60-461:61
-5209: At              "@" at 462:5-462:6 (leading: Newline, Space)
-5210: Ident           "intrinsic" at 462:6-462:15
-5211: KwFn            "fn" at 462:16-462:18 (leading: Space)
-5212: Ident           "__sub" at 462:19-462:24 (leading: Space)
-5213: LParen          "(" at 462:24-462:25
-5214: Ident           "self" at 462:25-462:29
-5215: Colon           ":" at 462:29-462:30
-5216: Ident           "uint8" at 462:31-462:36 (leading: Space)
-5217: Comma           "," at 462:36-462:37
-5218: Ident           "other" at 462:38-462:43 (leading: Space)
-5219: Colon           ":" at 462:43-462:44
-5220: Ident           "uint8" at 462:45-462:50 (leading: Space)
-5221: RParen          ")" at 462:50-462:51
-5222: Arrow           "->" at 462:52-462:54 (leading: Space)
-5223: Ident           "uint8" at 462:55-462:60 (leading: Space)
-5224: Semicolon       ";" at 462:60-462:61
-5225: At              "@" at 463:5-463:6 (leading: Newline, Space)
-5226: Ident           "intrinsic" at 463:6-463:15
-5227: KwFn            "fn" at 463:16-463:18 (leading: Space)
-5228: Ident           "__mul" at 463:19-463:24 (leading: Space)
-5229: LParen          "(" at 463:24-463:25
-5230: Ident           "self" at 463:25-463:29
-5231: Colon           ":" at 463:29-463:30
-5232: Ident           "uint8" at 463:31-463:36 (leading: Space)
-5233: Comma           "," at 463:36-463:37
-5234: Ident           "other" at 463:38-463:43 (leading: Space)
-5235: Colon           ":" at 463:43-463:44
-5236: Ident           "uint8" at 463:45-463:50 (leading: Space)
-5237: RParen          ")" at 463:50-463:51
-5238: Arrow           "->" at 463:52-463:54 (leading: Space)
-5239: Ident           "uint8" at 463:55-463:60 (leading: Space)
-5240: Semicolon       ";" at 463:60-463:61
-5241: At              "@" at 464:5-464:6 (leading: Newline, Space)
-5242: Ident           "intrinsic" at 464:6-464:15
-5243: KwFn            "fn" at 464:16-464:18 (leading: Space)
-5244: Ident           "__div" at 464:19-464:24 (leading: Space)
-5245: LParen          "(" at 464:24-464:25
-5246: Ident           "self" at 464:25-464:29
-5247: Colon           ":" at 464:29-464:30
-5248: Ident           "uint8" at 464:31-464:36 (leading: Space)
-5249: Comma           "," at 464:36-464:37
-5250: Ident           "other" at 464:38-464:43 (leading: Space)
-5251: Colon           ":" at 464:43-464:44
-5252: Ident           "uint8" at 464:45-464:50 (leading: Space)
-5253: RParen          ")" at 464:50-464:51
-5254: Arrow           "->" at 464:52-464:54 (leading: Space)
-5255: Ident           "uint8" at 464:55-464:60 (leading: Space)
-5256: Semicolon       ";" at 464:60-464:61
-5257: At              "@" at 465:5-465:6 (leading: Newline, Space)
-5258: Ident           "intrinsic" at 465:6-465:15
-5259: KwFn            "fn" at 465:16-465:18 (leading: Space)
-5260: Ident           "__mod" at 465:19-465:24 (leading: Space)
-5261: LParen          "(" at 465:24-465:25
-5262: Ident           "self" at 465:25-465:29
-5263: Colon           ":" at 465:29-465:30
-5264: Ident           "uint8" at 465:31-465:36 (leading: Space)
-5265: Comma           "," at 465:36-465:37
-5266: Ident           "other" at 465:38-465:43 (leading: Space)
-5267: Colon           ":" at 465:43-465:44
-5268: Ident           "uint8" at 465:45-465:50 (leading: Space)
-5269: RParen          ")" at 465:50-465:51
-5270: Arrow           "->" at 465:52-465:54 (leading: Space)
-5271: Ident           "uint8" at 465:55-465:60 (leading: Space)
-5272: Semicolon       ";" at 465:60-465:61
-5273: At              "@" at 466:5-466:6 (leading: Newline, Space)
-5274: Ident           "intrinsic" at 466:6-466:15
-5275: KwFn            "fn" at 466:16-466:18 (leading: Space)
-5276: Ident           "__bit_and" at 466:19-466:28 (leading: Space)
-5277: LParen          "(" at 466:28-466:29
-5278: Ident           "self" at 466:29-466:33
-5279: Colon           ":" at 466:33-466:34
-5280: Ident           "uint8" at 466:35-466:40 (leading: Space)
-5281: Comma           "," at 466:40-466:41
-5282: Ident           "other" at 466:42-466:47 (leading: Space)
-5283: Colon           ":" at 466:47-466:48
-5284: Ident           "uint8" at 466:49-466:54 (leading: Space)
-5285: RParen          ")" at 466:54-466:55
-5286: Arrow           "->" at 466:56-466:58 (leading: Space)
-5287: Ident           "uint8" at 466:59-466:64 (leading: Space)
-5288: Semicolon       ";" at 466:64-466:65
-5289: At              "@" at 467:5-467:6 (leading: Newline, Space)
-5290: Ident           "intrinsic" at 467:6-467:15
-5291: KwFn            "fn" at 467:16-467:18 (leading: Space)
-5292: Ident           "__bit_or" at 467:19-467:27 (leading: Space)
-5293: LParen          "(" at 467:27-467:28
-5294: Ident           "self" at 467:28-467:32
-5295: Colon           ":" at 467:32-467:33
-5296: Ident           "uint8" at 467:34-467:39 (leading: Space)
-5297: Comma           "," at 467:39-467:40
-5298: Ident           "other" at 467:41-467:46 (leading: Space)
-5299: Colon           ":" at 467:46-467:47
-5300: Ident           "uint8" at 467:48-467:53 (leading: Space)
-5301: RParen          ")" at 467:53-467:54
-5302: Arrow           "->" at 467:55-467:57 (leading: Space)
-5303: Ident           "uint8" at 467:58-467:63 (leading: Space)
-5304: Semicolon       ";" at 467:63-467:64
-5305: At              "@" at 468:5-468:6 (leading: Newline, Space)
-5306: Ident           "intrinsic" at 468:6-468:15
-5307: KwFn            "fn" at 468:16-468:18 (leading: Space)
-5308: Ident           "__bit_xor" at 468:19-468:28 (leading: Space)
-5309: LParen          "(" at 468:28-468:29
-5310: Ident           "self" at 468:29-468:33
-5311: Colon           ":" at 468:33-468:34
-5312: Ident           "uint8" at 468:35-468:40 (leading: Space)
-5313: Comma           "," at 468:40-468:41
-5314: Ident           "other" at 468:42-468:47 (leading: Space)
-5315: Colon           ":" at 468:47-468:48
-5316: Ident           "uint8" at 468:49-468:54 (leading: Space)
-5317: RParen          ")" at 468:54-468:55
-5318: Arrow           "->" at 468:56-468:58 (leading: Space)
-5319: Ident           "uint8" at 468:59-468:64 (leading: Space)
-5320: Semicolon       ";" at 468:64-468:65
-5321: At              "@" at 469:5-469:6 (leading: Newline, Space)
-5322: Ident           "intrinsic" at 469:6-469:15
-5323: KwFn            "fn" at 469:16-469:18 (leading: Space)
-5324: Ident           "__shl" at 469:19-469:24 (leading: Space)
-5325: LParen          "(" at 469:24-469:25
-5326: Ident           "self" at 469:25-469:29
-5327: Colon           ":" at 469:29-469:30
-5328: Ident           "uint8" at 469:31-469:36 (leading: Space)
-5329: Comma           "," at 469:36-469:37
-5330: Ident           "other" at 469:38-469:43 (leading: Space)
-5331: Colon           ":" at 469:43-469:44
-5332: Ident           "uint8" at 469:45-469:50 (leading: Space)
-5333: RParen          ")" at 469:50-469:51
-5334: Arrow           "->" at 469:52-469:54 (leading: Space)
-5335: Ident           "uint8" at 469:55-469:60 (leading: Space)
-5336: Semicolon       ";" at 469:60-469:61
-5337: At              "@" at 470:5-470:6 (leading: Newline, Space)
-5338: Ident           "intrinsic" at 470:6-470:15
-5339: KwFn            "fn" at 470:16-470:18 (leading: Space)
-5340: Ident           "__shr" at 470:19-470:24 (leading: Space)
-5341: LParen          "(" at 470:24-470:25
-5342: Ident           "self" at 470:25-470:29
-5343: Colon           ":" at 470:29-470:30
-5344: Ident           "uint8" at 470:31-470:36 (leading: Space)
-5345: Comma           "," at 470:36-470:37
-5346: Ident           "other" at 470:38-470:43 (leading: Space)
-5347: Colon           ":" at 470:43-470:44
-5348: Ident           "uint8" at 470:45-470:50 (leading: Space)
-5349: RParen          ")" at 470:50-470:51
-5350: Arrow           "->" at 470:52-470:54 (leading: Space)
-5351: Ident           "uint8" at 470:55-470:60 (leading: Space)
-5352: Semicolon       ";" at 470:60-470:61
-5353: At              "@" at 471:5-471:6 (leading: Newline, Space)
-5354: Ident           "intrinsic" at 471:6-471:15
-5355: KwFn            "fn" at 471:16-471:18 (leading: Space)
-5356: Ident           "__lt" at 471:19-471:23 (leading: Space)
-5357: LParen          "(" at 471:23-471:24
-5358: Ident           "self" at 471:24-471:28
-5359: Colon           ":" at 471:28-471:29
-5360: Ident           "uint8" at 471:30-471:35 (leading: Space)
-5361: Comma           "," at 471:35-471:36
-5362: Ident           "other" at 471:37-471:42 (leading: Space)
-5363: Colon           ":" at 471:42-471:43
-5364: Ident           "uint8" at 471:44-471:49 (leading: Space)
-5365: RParen          ")" at 471:49-471:50
-5366: Arrow           "->" at 471:51-471:53 (leading: Space)
-5367: Ident           "bool" at 471:54-471:58 (leading: Space)
-5368: Semicolon       ";" at 471:58-471:59
-5369: At              "@" at 472:5-472:6 (leading: Newline, Space)
-5370: Ident           "intrinsic" at 472:6-472:15
-5371: KwFn            "fn" at 472:16-472:18 (leading: Space)
-5372: Ident           "__le" at 472:19-472:23 (leading: Space)
-5373: LParen          "(" at 472:23-472:24
-5374: Ident           "self" at 472:24-472:28
-5375: Colon           ":" at 472:28-472:29
-5376: Ident           "uint8" at 472:30-472:35 (leading: Space)
-5377: Comma           "," at 472:35-472:36
-5378: Ident           "other" at 472:37-472:42 (leading: Space)
-5379: Colon           ":" at 472:42-472:43
-5380: Ident           "uint8" at 472:44-472:49 (leading: Space)
-5381: RParen          ")" at 472:49-472:50
-5382: Arrow           "->" at 472:51-472:53 (leading: Space)
-5383: Ident           "bool" at 472:54-472:58 (leading: Space)
-5384: Semicolon       ";" at 472:58-472:59
-5385: At              "@" at 473:5-473:6 (leading: Newline, Space)
-5386: Ident           "intrinsic" at 473:6-473:15
-5387: KwFn            "fn" at 473:16-473:18 (leading: Space)
-5388: Ident           "__eq" at 473:19-473:23 (leading: Space)
-5389: LParen          "(" at 473:23-473:24
-5390: Ident           "self" at 473:24-473:28
-5391: Colon           ":" at 473:28-473:29
-5392: Ident           "uint8" at 473:30-473:35 (leading: Space)
-5393: Comma           "," at 473:35-473:36
-5394: Ident           "other" at 473:37-473:42 (leading: Space)
-5395: Colon           ":" at 473:42-473:43
-5396: Ident           "uint8" at 473:44-473:49 (leading: Space)
-5397: RParen          ")" at 473:49-473:50
-5398: Arrow           "->" at 473:51-473:53 (leading: Space)
-5399: Ident           "bool" at 473:54-473:58 (leading: Space)
-5400: Semicolon       ";" at 473:58-473:59
-5401: At              "@" at 474:5-474:6 (leading: Newline, Space)
-5402: Ident           "intrinsic" at 474:6-474:15
-5403: KwFn            "fn" at 474:16-474:18 (leading: Space)
-5404: Ident           "__ne" at 474:19-474:23 (leading: Space)
-5405: LParen          "(" at 474:23-474:24
-5406: Ident           "self" at 474:24-474:28
-5407: Colon           ":" at 474:28-474:29
-5408: Ident           "uint8" at 474:30-474:35 (leading: Space)
-5409: Comma           "," at 474:35-474:36
-5410: Ident           "other" at 474:37-474:42 (leading: Space)
-5411: Colon           ":" at 474:42-474:43
-5412: Ident           "uint8" at 474:44-474:49 (leading: Space)
-5413: RParen          ")" at 474:49-474:50
-5414: Arrow           "->" at 474:51-474:53 (leading: Space)
-5415: Ident           "bool" at 474:54-474:58 (leading: Space)
-5416: Semicolon       ";" at 474:58-474:59
-5417: At              "@" at 475:5-475:6 (leading: Newline, Space)
-5418: Ident           "intrinsic" at 475:6-475:15
-5419: KwFn            "fn" at 475:16-475:18 (leading: Space)
-5420: Ident           "__ge" at 475:19-475:23 (leading: Space)
-5421: LParen          "(" at 475:23-475:24
-5422: Ident           "self" at 475:24-475:28
-5423: Colon           ":" at 475:28-475:29
-5424: Ident           "uint8" at 475:30-475:35 (leading: Space)
-5425: Comma           "," at 475:35-475:36
-5426: Ident           "other" at 475:37-475:42 (leading: Space)
-5427: Colon           ":" at 475:42-475:43
-5428: Ident           "uint8" at 475:44-475:49 (leading: Space)
-5429: RParen          ")" at 475:49-475:50
-5430: Arrow           "->" at 475:51-475:53 (leading: Space)
-5431: Ident           "bool" at 475:54-475:58 (leading: Space)
-5432: Semicolon       ";" at 475:58-475:59
-5433: At              "@" at 476:5-476:6 (leading: Newline, Space)
-5434: Ident           "intrinsic" at 476:6-476:15
-5435: KwFn            "fn" at 476:16-476:18 (leading: Space)
-5436: Ident           "__gt" at 476:19-476:23 (leading: Space)
-5437: LParen          "(" at 476:23-476:24
-5438: Ident           "self" at 476:24-476:28
-5439: Colon           ":" at 476:28-476:29
-5440: Ident           "uint8" at 476:30-476:35 (leading: Space)
-5441: Comma           "," at 476:35-476:36
-5442: Ident           "other" at 476:37-476:42 (leading: Space)
-5443: Colon           ":" at 476:42-476:43
-5444: Ident           "uint8" at 476:44-476:49 (leading: Space)
-5445: RParen          ")" at 476:49-476:50
-5446: Arrow           "->" at 476:51-476:53 (leading: Space)
-5447: Ident           "bool" at 476:54-476:58 (leading: Space)
-5448: Semicolon       ";" at 476:58-476:59
-5449: At              "@" at 477:5-477:6 (leading: Newline, Space)
-5450: Ident           "intrinsic" at 477:6-477:15
-5451: KwFn            "fn" at 477:16-477:18 (leading: Space)
-5452: Ident           "__pos" at 477:19-477:24 (leading: Space)
-5453: LParen          "(" at 477:24-477:25
-5454: Ident           "self" at 477:25-477:29
-5455: Colon           ":" at 477:29-477:30
-5456: Ident           "uint8" at 477:31-477:36 (leading: Space)
-5457: RParen          ")" at 477:36-477:37
-5458: Arrow           "->" at 477:38-477:40 (leading: Space)
-5459: Ident           "uint8" at 477:41-477:46 (leading: Space)
-5460: Semicolon       ";" at 477:46-477:47
-5461: At              "@" at 478:5-478:6 (leading: Newline, Space)
-5462: Ident           "intrinsic" at 478:6-478:15
-5463: KwFn            "fn" at 478:16-478:18 (leading: Space)
-5464: Ident           "__abs" at 478:19-478:24 (leading: Space)
-5465: LParen          "(" at 478:24-478:25
-5466: Ident           "self" at 478:25-478:29
-5467: Colon           ":" at 478:29-478:30
-5468: Ident           "uint8" at 478:31-478:36 (leading: Space)
-5469: RParen          ")" at 478:36-478:37
-5470: Arrow           "->" at 478:38-478:40 (leading: Space)
-5471: Ident           "uint8" at 478:41-478:46 (leading: Space)
-5472: Semicolon       ";" at 478:46-478:47
-5473: At              "@" at 479:5-479:6 (leading: Newline, Space)
-5474: Ident           "intrinsic" at 479:6-479:15
-5475: KwFn            "fn" at 479:16-479:18 (leading: Space)
-5476: Ident           "__to" at 479:19-479:23 (leading: Space)
-5477: LParen          "(" at 479:23-479:24
-5478: Ident           "self" at 479:24-479:28
-5479: Colon           ":" at 479:28-479:29
-5480: Ident           "uint8" at 479:30-479:35 (leading: Space)
-5481: Comma           "," at 479:35-479:36
-5482: Ident           "target" at 479:37-479:43 (leading: Space)
-5483: Colon           ":" at 479:43-479:44
-5484: Ident           "uint" at 479:45-479:49 (leading: Space)
-5485: RParen          ")" at 479:49-479:50
-5486: Arrow           "->" at 479:51-479:53 (leading: Space)
-5487: Ident           "uint" at 479:54-479:58 (leading: Space)
-5488: Semicolon       ";" at 479:58-479:59
-5489: At              "@" at 480:5-480:6 (leading: Newline, Space)
-5490: Ident           "intrinsic" at 480:6-480:15
-5491: At              "@" at 480:16-480:17 (leading: Space)
-5492: Ident           "overload" at 480:17-480:25
-5493: KwFn            "fn" at 480:26-480:28 (leading: Space)
-5494: Ident           "__to" at 480:29-480:33 (leading: Space)
-5495: LParen          "(" at 480:33-480:34
-5496: Ident           "self" at 480:34-480:38
-5497: Colon           ":" at 480:38-480:39
-5498: Ident           "uint8" at 480:40-480:45 (leading: Space)
-5499: Comma           "," at 480:45-480:46
-5500: Ident           "target" at 480:47-480:53 (leading: Space)
-5501: Colon           ":" at 480:53-480:54
-5502: Ident           "uint16" at 480:55-480:61 (leading: Space)
-5503: RParen          ")" at 480:61-480:62
-5504: Arrow           "->" at 480:63-480:65 (leading: Space)
-5505: Ident           "uint16" at 480:66-480:72 (leading: Space)
-5506: Semicolon       ";" at 480:72-480:73
-5507: At              "@" at 481:5-481:6 (leading: Newline, Space)
-5508: Ident           "intrinsic" at 481:6-481:15
-5509: At              "@" at 481:16-481:17 (leading: Space)
-5510: Ident           "overload" at 481:17-481:25
-5511: KwFn            "fn" at 481:26-481:28 (leading: Space)
-5512: Ident           "__to" at 481:29-481:33 (leading: Space)
-5513: LParen          "(" at 481:33-481:34
-5514: Ident           "self" at 481:34-481:38
-5515: Colon           ":" at 481:38-481:39
-5516: Ident           "uint8" at 481:40-481:45 (leading: Space)
-5517: Comma           "," at 481:45-481:46
-5518: Ident           "target" at 481:47-481:53 (leading: Space)
-5519: Colon           ":" at 481:53-481:54
-5520: Ident           "uint32" at 481:55-481:61 (leading: Space)
-5521: RParen          ")" at 481:61-481:62
-5522: Arrow           "->" at 481:63-481:65 (leading: Space)
-5523: Ident           "uint32" at 481:66-481:72 (leading: Space)
-5524: Semicolon       ";" at 481:72-481:73
-5525: At              "@" at 482:5-482:6 (leading: Newline, Space)
-5526: Ident           "intrinsic" at 482:6-482:15
-5527: At              "@" at 482:16-482:17 (leading: Space)
-5528: Ident           "overload" at 482:17-482:25
-5529: KwFn            "fn" at 482:26-482:28 (leading: Space)
-5530: Ident           "__to" at 482:29-482:33 (leading: Space)
-5531: LParen          "(" at 482:33-482:34
-5532: Ident           "self" at 482:34-482:38
-5533: Colon           ":" at 482:38-482:39
-5534: Ident           "uint8" at 482:40-482:45 (leading: Space)
-5535: Comma           "," at 482:45-482:46
-5536: Ident           "target" at 482:47-482:53 (leading: Space)
-5537: Colon           ":" at 482:53-482:54
-5538: Ident           "uint64" at 482:55-482:61 (leading: Space)
-5539: RParen          ")" at 482:61-482:62
-5540: Arrow           "->" at 482:63-482:65 (leading: Space)
-5541: Ident           "uint64" at 482:66-482:72 (leading: Space)
-5542: Semicolon       ";" at 482:72-482:73
-5543: At              "@" at 483:5-483:6 (leading: Newline, Space)
-5544: Ident           "intrinsic" at 483:6-483:15
-5545: KwPub           "pub" at 483:16-483:19 (leading: Space)
-5546: KwFn            "fn" at 483:20-483:22 (leading: Space)
-5547: Ident           "from_str" at 483:23-483:31 (leading: Space)
-5548: LParen          "(" at 483:31-483:32
-5549: Ident           "s" at 483:32-483:33
-5550: Colon           ":" at 483:33-483:34
-5551: Amp             "&" at 483:35-483:36 (leading: Space)
-5552: Ident           "string" at 483:36-483:42
-5553: RParen          ")" at 483:42-483:43
-5554: Arrow           "->" at 483:44-483:46 (leading: Space)
-5555: Ident           "Erring" at 483:47-483:53 (leading: Space)
-5556: Lt              "<" at 483:53-483:54
-5557: Ident           "uint8" at 483:54-483:59
-5558: Comma           "," at 483:59-483:60
-5559: Ident           "Error" at 483:61-483:66 (leading: Space)
-5560: Gt              ">" at 483:66-483:67
-5561: Semicolon       ";" at 483:67-483:68
-5562: RBrace          "}" at 484:1-484:2 (leading: Newline)
-5563: KwExtern        "extern" at 486:1-486:7 (leading: Newline)
-5564: Lt              "<" at 486:7-486:8
-5565: Ident           "uint16" at 486:8-486:14
-5566: Gt              ">" at 486:14-486:15
-5567: LBrace          "{" at 486:16-486:17 (leading: Space)
-5568: KwPub           "pub" at 487:5-487:8 (leading: Newline, Space)
-5569: KwFn            "fn" at 487:9-487:11 (leading: Space)
-5570: Ident           "__min_value" at 487:12-487:23 (leading: Space)
-5571: LParen          "(" at 487:23-487:24
-5572: RParen          ")" at 487:24-487:25
-5573: Arrow           "->" at 487:26-487:28 (leading: Space)
-5574: Ident           "uint16" at 487:29-487:35 (leading: Space)
-5575: LBrace          "{" at 487:36-487:37 (leading: Space)
-5576: KwReturn        "return" at 487:38-487:44 (leading: Space)
-5577: LParen          "(" at 487:45-487:46 (leading: Space)
-5578: IntLit          "0" at 487:46-487:47
-5579: RParen          ")" at 487:47-487:48
-5580: Colon           ":" at 487:48-487:49
-5581: Ident           "uint16" at 487:49-487:55
-5582: Semicolon       ";" at 487:55-487:56
-5583: RBrace          "}" at 487:57-487:58 (leading: Space)
-5584: KwPub           "pub" at 488:5-488:8 (leading: Newline, Space)
-5585: KwFn            "fn" at 488:9-488:11 (leading: Space)
-5586: Ident           "__max_value" at 488:12-488:23 (leading: Space)
-5587: LParen          "(" at 488:23-488:24
-5588: RParen          ")" at 488:24-488:25
-5589: Arrow           "->" at 488:26-488:28 (leading: Space)
-5590: Ident           "uint16" at 488:29-488:35 (leading: Space)
-5591: LBrace          "{" at 488:36-488:37 (leading: Space)
-5592: KwReturn        "return" at 488:38-488:44 (leading: Space)
-5593: LParen          "(" at 488:45-488:46 (leading: Space)
-5594: IntLit          "65_535" at 488:46-488:52
-5595: RParen          ")" at 488:52-488:53
-5596: Colon           ":" at 488:53-488:54
-5597: Ident           "uint16" at 488:54-488:60
-5598: Semicolon       ";" at 488:60-488:61
-5599: RBrace          "}" at 488:62-488:63 (leading: Space)
-5600: At              "@" at 489:5-489:6 (leading: Newline, Space)
-5601: Ident           "intrinsic" at 489:6-489:15
-5602: KwFn            "fn" at 489:16-489:18 (leading: Space)
-5603: Ident           "__add" at 489:19-489:24 (leading: Space)
-5604: LParen          "(" at 489:24-489:25
-5605: Ident           "self" at 489:25-489:29
-5606: Colon           ":" at 489:29-489:30
-5607: Ident           "uint16" at 489:31-489:37 (leading: Space)
-5608: Comma           "," at 489:37-489:38
-5609: Ident           "other" at 489:39-489:44 (leading: Space)
-5610: Colon           ":" at 489:44-489:45
-5611: Ident           "uint16" at 489:46-489:52 (leading: Space)
-5612: RParen          ")" at 489:52-489:53
-5613: Arrow           "->" at 489:54-489:56 (leading: Space)
-5614: Ident           "uint16" at 489:57-489:63 (leading: Space)
-5615: Semicolon       ";" at 489:63-489:64
-5616: At              "@" at 490:5-490:6 (leading: Newline, Space)
-5617: Ident           "intrinsic" at 490:6-490:15
-5618: KwFn            "fn" at 490:16-490:18 (leading: Space)
-5619: Ident           "__sub" at 490:19-490:24 (leading: Space)
-5620: LParen          "(" at 490:24-490:25
-5621: Ident           "self" at 490:25-490:29
-5622: Colon           ":" at 490:29-490:30
-5623: Ident           "uint16" at 490:31-490:37 (leading: Space)
-5624: Comma           "," at 490:37-490:38
-5625: Ident           "other" at 490:39-490:44 (leading: Space)
-5626: Colon           ":" at 490:44-490:45
-5627: Ident           "uint16" at 490:46-490:52 (leading: Space)
-5628: RParen          ")" at 490:52-490:53
-5629: Arrow           "->" at 490:54-490:56 (leading: Space)
-5630: Ident           "uint16" at 490:57-490:63 (leading: Space)
-5631: Semicolon       ";" at 490:63-490:64
-5632: At              "@" at 491:5-491:6 (leading: Newline, Space)
-5633: Ident           "intrinsic" at 491:6-491:15
-5634: KwFn            "fn" at 491:16-491:18 (leading: Space)
-5635: Ident           "__mul" at 491:19-491:24 (leading: Space)
-5636: LParen          "(" at 491:24-491:25
-5637: Ident           "self" at 491:25-491:29
-5638: Colon           ":" at 491:29-491:30
-5639: Ident           "uint16" at 491:31-491:37 (leading: Space)
-5640: Comma           "," at 491:37-491:38
-5641: Ident           "other" at 491:39-491:44 (leading: Space)
-5642: Colon           ":" at 491:44-491:45
-5643: Ident           "uint16" at 491:46-491:52 (leading: Space)
-5644: RParen          ")" at 491:52-491:53
-5645: Arrow           "->" at 491:54-491:56 (leading: Space)
-5646: Ident           "uint16" at 491:57-491:63 (leading: Space)
-5647: Semicolon       ";" at 491:63-491:64
-5648: At              "@" at 492:5-492:6 (leading: Newline, Space)
-5649: Ident           "intrinsic" at 492:6-492:15
-5650: KwFn            "fn" at 492:16-492:18 (leading: Space)
-5651: Ident           "__div" at 492:19-492:24 (leading: Space)
-5652: LParen          "(" at 492:24-492:25
-5653: Ident           "self" at 492:25-492:29
-5654: Colon           ":" at 492:29-492:30
-5655: Ident           "uint16" at 492:31-492:37 (leading: Space)
-5656: Comma           "," at 492:37-492:38
-5657: Ident           "other" at 492:39-492:44 (leading: Space)
-5658: Colon           ":" at 492:44-492:45
-5659: Ident           "uint16" at 492:46-492:52 (leading: Space)
-5660: RParen          ")" at 492:52-492:53
-5661: Arrow           "->" at 492:54-492:56 (leading: Space)
-5662: Ident           "uint16" at 492:57-492:63 (leading: Space)
-5663: Semicolon       ";" at 492:63-492:64
-5664: At              "@" at 493:5-493:6 (leading: Newline, Space)
-5665: Ident           "intrinsic" at 493:6-493:15
-5666: KwFn            "fn" at 493:16-493:18 (leading: Space)
-5667: Ident           "__mod" at 493:19-493:24 (leading: Space)
-5668: LParen          "(" at 493:24-493:25
-5669: Ident           "self" at 493:25-493:29
-5670: Colon           ":" at 493:29-493:30
-5671: Ident           "uint16" at 493:31-493:37 (leading: Space)
-5672: Comma           "," at 493:37-493:38
-5673: Ident           "other" at 493:39-493:44 (leading: Space)
-5674: Colon           ":" at 493:44-493:45
-5675: Ident           "uint16" at 493:46-493:52 (leading: Space)
-5676: RParen          ")" at 493:52-493:53
-5677: Arrow           "->" at 493:54-493:56 (leading: Space)
-5678: Ident           "uint16" at 493:57-493:63 (leading: Space)
-5679: Semicolon       ";" at 493:63-493:64
-5680: At              "@" at 494:5-494:6 (leading: Newline, Space)
-5681: Ident           "intrinsic" at 494:6-494:15
-5682: KwFn            "fn" at 494:16-494:18 (leading: Space)
-5683: Ident           "__bit_and" at 494:19-494:28 (leading: Space)
-5684: LParen          "(" at 494:28-494:29
-5685: Ident           "self" at 494:29-494:33
-5686: Colon           ":" at 494:33-494:34
-5687: Ident           "uint16" at 494:35-494:41 (leading: Space)
-5688: Comma           "," at 494:41-494:42
-5689: Ident           "other" at 494:43-494:48 (leading: Space)
-5690: Colon           ":" at 494:48-494:49
-5691: Ident           "uint16" at 494:50-494:56 (leading: Space)
-5692: RParen          ")" at 494:56-494:57
-5693: Arrow           "->" at 494:58-494:60 (leading: Space)
-5694: Ident           "uint16" at 494:61-494:67 (leading: Space)
-5695: Semicolon       ";" at 494:67-494:68
-5696: At              "@" at 495:5-495:6 (leading: Newline, Space)
-5697: Ident           "intrinsic" at 495:6-495:15
-5698: KwFn            "fn" at 495:16-495:18 (leading: Space)
-5699: Ident           "__bit_or" at 495:19-495:27 (leading: Space)
-5700: LParen          "(" at 495:27-495:28
-5701: Ident           "self" at 495:28-495:32
-5702: Colon           ":" at 495:32-495:33
-5703: Ident           "uint16" at 495:34-495:40 (leading: Space)
-5704: Comma           "," at 495:40-495:41
-5705: Ident           "other" at 495:42-495:47 (leading: Space)
-5706: Colon           ":" at 495:47-495:48
-5707: Ident           "uint16" at 495:49-495:55 (leading: Space)
-5708: RParen          ")" at 495:55-495:56
-5709: Arrow           "->" at 495:57-495:59 (leading: Space)
-5710: Ident           "uint16" at 495:60-495:66 (leading: Space)
-5711: Semicolon       ";" at 495:66-495:67
-5712: At              "@" at 496:5-496:6 (leading: Newline, Space)
-5713: Ident           "intrinsic" at 496:6-496:15
-5714: KwFn            "fn" at 496:16-496:18 (leading: Space)
-5715: Ident           "__bit_xor" at 496:19-496:28 (leading: Space)
-5716: LParen          "(" at 496:28-496:29
-5717: Ident           "self" at 496:29-496:33
-5718: Colon           ":" at 496:33-496:34
-5719: Ident           "uint16" at 496:35-496:41 (leading: Space)
-5720: Comma           "," at 496:41-496:42
-5721: Ident           "other" at 496:43-496:48 (leading: Space)
-5722: Colon           ":" at 496:48-496:49
-5723: Ident           "uint16" at 496:50-496:56 (leading: Space)
-5724: RParen          ")" at 496:56-496:57
-5725: Arrow           "->" at 496:58-496:60 (leading: Space)
-5726: Ident           "uint16" at 496:61-496:67 (leading: Space)
-5727: Semicolon       ";" at 496:67-496:68
-5728: At              "@" at 497:5-497:6 (leading: Newline, Space)
-5729: Ident           "intrinsic" at 497:6-497:15
-5730: KwFn            "fn" at 497:16-497:18 (leading: Space)
-5731: Ident           "__shl" at 497:19-497:24 (leading: Space)
-5732: LParen          "(" at 497:24-497:25
-5733: Ident           "self" at 497:25-497:29
-5734: Colon           ":" at 497:29-497:30
-5735: Ident           "uint16" at 497:31-497:37 (leading: Space)
-5736: Comma           "," at 497:37-497:38
-5737: Ident           "other" at 497:39-497:44 (leading: Space)
-5738: Colon           ":" at 497:44-497:45
-5739: Ident           "uint16" at 497:46-497:52 (leading: Space)
-5740: RParen          ")" at 497:52-497:53
-5741: Arrow           "->" at 497:54-497:56 (leading: Space)
-5742: Ident           "uint16" at 497:57-497:63 (leading: Space)
-5743: Semicolon       ";" at 497:63-497:64
-5744: At              "@" at 498:5-498:6 (leading: Newline, Space)
-5745: Ident           "intrinsic" at 498:6-498:15
-5746: KwFn            "fn" at 498:16-498:18 (leading: Space)
-5747: Ident           "__shr" at 498:19-498:24 (leading: Space)
-5748: LParen          "(" at 498:24-498:25
-5749: Ident           "self" at 498:25-498:29
-5750: Colon           ":" at 498:29-498:30
-5751: Ident           "uint16" at 498:31-498:37 (leading: Space)
-5752: Comma           "," at 498:37-498:38
-5753: Ident           "other" at 498:39-498:44 (leading: Space)
-5754: Colon           ":" at 498:44-498:45
-5755: Ident           "uint16" at 498:46-498:52 (leading: Space)
-5756: RParen          ")" at 498:52-498:53
-5757: Arrow           "->" at 498:54-498:56 (leading: Space)
-5758: Ident           "uint16" at 498:57-498:63 (leading: Space)
-5759: Semicolon       ";" at 498:63-498:64
-5760: At              "@" at 499:5-499:6 (leading: Newline, Space)
-5761: Ident           "intrinsic" at 499:6-499:15
-5762: KwFn            "fn" at 499:16-499:18 (leading: Space)
-5763: Ident           "__lt" at 499:19-499:23 (leading: Space)
-5764: LParen          "(" at 499:23-499:24
-5765: Ident           "self" at 499:24-499:28
-5766: Colon           ":" at 499:28-499:29
-5767: Ident           "uint16" at 499:30-499:36 (leading: Space)
-5768: Comma           "," at 499:36-499:37
-5769: Ident           "other" at 499:38-499:43 (leading: Space)
-5770: Colon           ":" at 499:43-499:44
-5771: Ident           "uint16" at 499:45-499:51 (leading: Space)
-5772: RParen          ")" at 499:51-499:52
-5773: Arrow           "->" at 499:53-499:55 (leading: Space)
-5774: Ident           "bool" at 499:56-499:60 (leading: Space)
-5775: Semicolon       ";" at 499:60-499:61
-5776: At              "@" at 500:5-500:6 (leading: Newline, Space)
-5777: Ident           "intrinsic" at 500:6-500:15
-5778: KwFn            "fn" at 500:16-500:18 (leading: Space)
-5779: Ident           "__le" at 500:19-500:23 (leading: Space)
-5780: LParen          "(" at 500:23-500:24
-5781: Ident           "self" at 500:24-500:28
-5782: Colon           ":" at 500:28-500:29
-5783: Ident           "uint16" at 500:30-500:36 (leading: Space)
-5784: Comma           "," at 500:36-500:37
-5785: Ident           "other" at 500:38-500:43 (leading: Space)
-5786: Colon           ":" at 500:43-500:44
-5787: Ident           "uint16" at 500:45-500:51 (leading: Space)
-5788: RParen          ")" at 500:51-500:52
-5789: Arrow           "->" at 500:53-500:55 (leading: Space)
-5790: Ident           "bool" at 500:56-500:60 (leading: Space)
-5791: Semicolon       ";" at 500:60-500:61
-5792: At              "@" at 501:5-501:6 (leading: Newline, Space)
-5793: Ident           "intrinsic" at 501:6-501:15
-5794: KwFn            "fn" at 501:16-501:18 (leading: Space)
-5795: Ident           "__eq" at 501:19-501:23 (leading: Space)
-5796: LParen          "(" at 501:23-501:24
-5797: Ident           "self" at 501:24-501:28
-5798: Colon           ":" at 501:28-501:29
-5799: Ident           "uint16" at 501:30-501:36 (leading: Space)
-5800: Comma           "," at 501:36-501:37
-5801: Ident           "other" at 501:38-501:43 (leading: Space)
-5802: Colon           ":" at 501:43-501:44
-5803: Ident           "uint16" at 501:45-501:51 (leading: Space)
-5804: RParen          ")" at 501:51-501:52
-5805: Arrow           "->" at 501:53-501:55 (leading: Space)
-5806: Ident           "bool" at 501:56-501:60 (leading: Space)
-5807: Semicolon       ";" at 501:60-501:61
-5808: At              "@" at 502:5-502:6 (leading: Newline, Space)
-5809: Ident           "intrinsic" at 502:6-502:15
-5810: KwFn            "fn" at 502:16-502:18 (leading: Space)
-5811: Ident           "__ne" at 502:19-502:23 (leading: Space)
-5812: LParen          "(" at 502:23-502:24
-5813: Ident           "self" at 502:24-502:28
-5814: Colon           ":" at 502:28-502:29
-5815: Ident           "uint16" at 502:30-502:36 (leading: Space)
-5816: Comma           "," at 502:36-502:37
-5817: Ident           "other" at 502:38-502:43 (leading: Space)
-5818: Colon           ":" at 502:43-502:44
-5819: Ident           "uint16" at 502:45-502:51 (leading: Space)
-5820: RParen          ")" at 502:51-502:52
-5821: Arrow           "->" at 502:53-502:55 (leading: Space)
-5822: Ident           "bool" at 502:56-502:60 (leading: Space)
-5823: Semicolon       ";" at 502:60-502:61
-5824: At              "@" at 503:5-503:6 (leading: Newline, Space)
-5825: Ident           "intrinsic" at 503:6-503:15
-5826: KwFn            "fn" at 503:16-503:18 (leading: Space)
-5827: Ident           "__ge" at 503:19-503:23 (leading: Space)
-5828: LParen          "(" at 503:23-503:24
-5829: Ident           "self" at 503:24-503:28
-5830: Colon           ":" at 503:28-503:29
-5831: Ident           "uint16" at 503:30-503:36 (leading: Space)
-5832: Comma           "," at 503:36-503:37
-5833: Ident           "other" at 503:38-503:43 (leading: Space)
-5834: Colon           ":" at 503:43-503:44
-5835: Ident           "uint16" at 503:45-503:51 (leading: Space)
-5836: RParen          ")" at 503:51-503:52
-5837: Arrow           "->" at 503:53-503:55 (leading: Space)
-5838: Ident           "bool" at 503:56-503:60 (leading: Space)
-5839: Semicolon       ";" at 503:60-503:61
-5840: At              "@" at 504:5-504:6 (leading: Newline, Space)
-5841: Ident           "intrinsic" at 504:6-504:15
-5842: KwFn            "fn" at 504:16-504:18 (leading: Space)
-5843: Ident           "__gt" at 504:19-504:23 (leading: Space)
-5844: LParen          "(" at 504:23-504:24
-5845: Ident           "self" at 504:24-504:28
-5846: Colon           ":" at 504:28-504:29
-5847: Ident           "uint16" at 504:30-504:36 (leading: Space)
-5848: Comma           "," at 504:36-504:37
-5849: Ident           "other" at 504:38-504:43 (leading: Space)
-5850: Colon           ":" at 504:43-504:44
-5851: Ident           "uint16" at 504:45-504:51 (leading: Space)
-5852: RParen          ")" at 504:51-504:52
-5853: Arrow           "->" at 504:53-504:55 (leading: Space)
-5854: Ident           "bool" at 504:56-504:60 (leading: Space)
-5855: Semicolon       ";" at 504:60-504:61
-5856: At              "@" at 505:5-505:6 (leading: Newline, Space)
-5857: Ident           "intrinsic" at 505:6-505:15
-5858: KwFn            "fn" at 505:16-505:18 (leading: Space)
-5859: Ident           "__pos" at 505:19-505:24 (leading: Space)
-5860: LParen          "(" at 505:24-505:25
-5861: Ident           "self" at 505:25-505:29
-5862: Colon           ":" at 505:29-505:30
-5863: Ident           "uint16" at 505:31-505:37 (leading: Space)
-5864: RParen          ")" at 505:37-505:38
-5865: Arrow           "->" at 505:39-505:41 (leading: Space)
-5866: Ident           "uint16" at 505:42-505:48 (leading: Space)
-5867: Semicolon       ";" at 505:48-505:49
-5868: At              "@" at 506:5-506:6 (leading: Newline, Space)
-5869: Ident           "intrinsic" at 506:6-506:15
-5870: KwFn            "fn" at 506:16-506:18 (leading: Space)
-5871: Ident           "__abs" at 506:19-506:24 (leading: Space)
-5872: LParen          "(" at 506:24-506:25
-5873: Ident           "self" at 506:25-506:29
-5874: Colon           ":" at 506:29-506:30
-5875: Ident           "uint16" at 506:31-506:37 (leading: Space)
-5876: RParen          ")" at 506:37-506:38
-5877: Arrow           "->" at 506:39-506:41 (leading: Space)
-5878: Ident           "uint16" at 506:42-506:48 (leading: Space)
-5879: Semicolon       ";" at 506:48-506:49
-5880: At              "@" at 507:5-507:6 (leading: Newline, Space)
-5881: Ident           "intrinsic" at 507:6-507:15
-5882: KwFn            "fn" at 507:16-507:18 (leading: Space)
-5883: Ident           "__to" at 507:19-507:23 (leading: Space)
-5884: LParen          "(" at 507:23-507:24
-5885: Ident           "self" at 507:24-507:28
-5886: Colon           ":" at 507:28-507:29
-5887: Ident           "uint16" at 507:30-507:36 (leading: Space)
-5888: Comma           "," at 507:36-507:37
-5889: Ident           "target" at 507:38-507:44 (leading: Space)
-5890: Colon           ":" at 507:44-507:45
-5891: Ident           "uint" at 507:46-507:50 (leading: Space)
-5892: RParen          ")" at 507:50-507:51
-5893: Arrow           "->" at 507:52-507:54 (leading: Space)
-5894: Ident           "uint" at 507:55-507:59 (leading: Space)
-5895: Semicolon       ";" at 507:59-507:60
-5896: At              "@" at 508:5-508:6 (leading: Newline, Space)
-5897: Ident           "intrinsic" at 508:6-508:15
-5898: At              "@" at 508:16-508:17 (leading: Space)
-5899: Ident           "overload" at 508:17-508:25
-5900: KwFn            "fn" at 508:26-508:28 (leading: Space)
-5901: Ident           "__to" at 508:29-508:33 (leading: Space)
-5902: LParen          "(" at 508:33-508:34
-5903: Ident           "self" at 508:34-508:38
-5904: Colon           ":" at 508:38-508:39
-5905: Ident           "uint16" at 508:40-508:46 (leading: Space)
-5906: Comma           "," at 508:46-508:47
-5907: Ident           "target" at 508:48-508:54 (leading: Space)
-5908: Colon           ":" at 508:54-508:55
-5909: Ident           "uint8" at 508:56-508:61 (leading: Space)
-5910: RParen          ")" at 508:61-508:62
-5911: Arrow           "->" at 508:63-508:65 (leading: Space)
-5912: Ident           "uint8" at 508:66-508:71 (leading: Space)
-5913: Semicolon       ";" at 508:71-508:72
-5914: At              "@" at 509:5-509:6 (leading: Newline, Space)
-5915: Ident           "intrinsic" at 509:6-509:15
-5916: At              "@" at 509:16-509:17 (leading: Space)
-5917: Ident           "overload" at 509:17-509:25
-5918: KwFn            "fn" at 509:26-509:28 (leading: Space)
-5919: Ident           "__to" at 509:29-509:33 (leading: Space)
-5920: LParen          "(" at 509:33-509:34
-5921: Ident           "self" at 509:34-509:38
-5922: Colon           ":" at 509:38-509:39
-5923: Ident           "uint16" at 509:40-509:46 (leading: Space)
-5924: Comma           "," at 509:46-509:47
-5925: Ident           "target" at 509:48-509:54 (leading: Space)
-5926: Colon           ":" at 509:54-509:55
-5927: Ident           "uint32" at 509:56-509:62 (leading: Space)
-5928: RParen          ")" at 509:62-509:63
-5929: Arrow           "->" at 509:64-509:66 (leading: Space)
-5930: Ident           "uint32" at 509:67-509:73 (leading: Space)
-5931: Semicolon       ";" at 509:73-509:74
-5932: At              "@" at 510:5-510:6 (leading: Newline, Space)
-5933: Ident           "intrinsic" at 510:6-510:15
-5934: At              "@" at 510:16-510:17 (leading: Space)
-5935: Ident           "overload" at 510:17-510:25
-5936: KwFn            "fn" at 510:26-510:28 (leading: Space)
-5937: Ident           "__to" at 510:29-510:33 (leading: Space)
-5938: LParen          "(" at 510:33-510:34
-5939: Ident           "self" at 510:34-510:38
-5940: Colon           ":" at 510:38-510:39
-5941: Ident           "uint16" at 510:40-510:46 (leading: Space)
-5942: Comma           "," at 510:46-510:47
-5943: Ident           "target" at 510:48-510:54 (leading: Space)
-5944: Colon           ":" at 510:54-510:55
-5945: Ident           "uint64" at 510:56-510:62 (leading: Space)
-5946: RParen          ")" at 510:62-510:63
-5947: Arrow           "->" at 510:64-510:66 (leading: Space)
-5948: Ident           "uint64" at 510:67-510:73 (leading: Space)
-5949: Semicolon       ";" at 510:73-510:74
-5950: At              "@" at 511:5-511:6 (leading: Newline, Space)
-5951: Ident           "intrinsic" at 511:6-511:15
-5952: KwPub           "pub" at 511:16-511:19 (leading: Space)
-5953: KwFn            "fn" at 511:20-511:22 (leading: Space)
-5954: Ident           "from_str" at 511:23-511:31 (leading: Space)
-5955: LParen          "(" at 511:31-511:32
-5956: Ident           "s" at 511:32-511:33
-5957: Colon           ":" at 511:33-511:34
-5958: Amp             "&" at 511:35-511:36 (leading: Space)
-5959: Ident           "string" at 511:36-511:42
-5960: RParen          ")" at 511:42-511:43
-5961: Arrow           "->" at 511:44-511:46 (leading: Space)
-5962: Ident           "Erring" at 511:47-511:53 (leading: Space)
-5963: Lt              "<" at 511:53-511:54
-5964: Ident           "uint16" at 511:54-511:60
-5965: Comma           "," at 511:60-511:61
-5966: Ident           "Error" at 511:62-511:67 (leading: Space)
-5967: Gt              ">" at 511:67-511:68
-5968: Semicolon       ";" at 511:68-511:69
-5969: RBrace          "}" at 512:1-512:2 (leading: Newline)
-5970: KwExtern        "extern" at 514:1-514:7 (leading: Newline)
-5971: Lt              "<" at 514:7-514:8
-5972: Ident           "uint32" at 514:8-514:14
-5973: Gt              ">" at 514:14-514:15
-5974: LBrace          "{" at 514:16-514:17 (leading: Space)
-5975: KwPub           "pub" at 515:5-515:8 (leading: Newline, Space)
-5976: KwFn            "fn" at 515:9-515:11 (leading: Space)
-5977: Ident           "__min_value" at 515:12-515:23 (leading: Space)
-5978: LParen          "(" at 515:23-515:24
-5979: RParen          ")" at 515:24-515:25
-5980: Arrow           "->" at 515:26-515:28 (leading: Space)
-5981: Ident           "uint32" at 515:29-515:35 (leading: Space)
-5982: LBrace          "{" at 515:36-515:37 (leading: Space)
-5983: KwReturn        "return" at 515:38-515:44 (leading: Space)
-5984: LParen          "(" at 515:45-515:46 (leading: Space)
-5985: IntLit          "0" at 515:46-515:47
-5986: RParen          ")" at 515:47-515:48
-5987: Colon           ":" at 515:48-515:49
-5988: Ident           "uint32" at 515:49-515:55
-5989: Semicolon       ";" at 515:55-515:56
-5990: RBrace          "}" at 515:57-515:58 (leading: Space)
-5991: KwPub           "pub" at 516:5-516:8 (leading: Newline, Space)
-5992: KwFn            "fn" at 516:9-516:11 (leading: Space)
-5993: Ident           "__max_value" at 516:12-516:23 (leading: Space)
-5994: LParen          "(" at 516:23-516:24
-5995: RParen          ")" at 516:24-516:25
-5996: Arrow           "->" at 516:26-516:28 (leading: Space)
-5997: Ident           "uint32" at 516:29-516:35 (leading: Space)
-5998: LBrace          "{" at 516:36-516:37 (leading: Space)
-5999: KwReturn        "return" at 516:38-516:44 (leading: Space)
-6000: LParen          "(" at 516:45-516:46 (leading: Space)
-6001: IntLit          "4_294_967_295" at 516:46-516:59
-6002: RParen          ")" at 516:59-516:60
-6003: Colon           ":" at 516:60-516:61
-6004: Ident           "uint32" at 516:61-516:67
-6005: Semicolon       ";" at 516:67-516:68
-6006: RBrace          "}" at 516:69-516:70 (leading: Space)
-6007: At              "@" at 517:5-517:6 (leading: Newline, Space)
-6008: Ident           "intrinsic" at 517:6-517:15
-6009: KwFn            "fn" at 517:16-517:18 (leading: Space)
-6010: Ident           "__add" at 517:19-517:24 (leading: Space)
-6011: LParen          "(" at 517:24-517:25
-6012: Ident           "self" at 517:25-517:29
-6013: Colon           ":" at 517:29-517:30
-6014: Ident           "uint32" at 517:31-517:37 (leading: Space)
-6015: Comma           "," at 517:37-517:38
-6016: Ident           "other" at 517:39-517:44 (leading: Space)
-6017: Colon           ":" at 517:44-517:45
-6018: Ident           "uint32" at 517:46-517:52 (leading: Space)
-6019: RParen          ")" at 517:52-517:53
-6020: Arrow           "->" at 517:54-517:56 (leading: Space)
-6021: Ident           "uint32" at 517:57-517:63 (leading: Space)
-6022: Semicolon       ";" at 517:63-517:64
-6023: At              "@" at 518:5-518:6 (leading: Newline, Space)
-6024: Ident           "intrinsic" at 518:6-518:15
-6025: KwFn            "fn" at 518:16-518:18 (leading: Space)
-6026: Ident           "__sub" at 518:19-518:24 (leading: Space)
-6027: LParen          "(" at 518:24-518:25
-6028: Ident           "self" at 518:25-518:29
-6029: Colon           ":" at 518:29-518:30
-6030: Ident           "uint32" at 518:31-518:37 (leading: Space)
-6031: Comma           "," at 518:37-518:38
-6032: Ident           "other" at 518:39-518:44 (leading: Space)
-6033: Colon           ":" at 518:44-518:45
-6034: Ident           "uint32" at 518:46-518:52 (leading: Space)
-6035: RParen          ")" at 518:52-518:53
-6036: Arrow           "->" at 518:54-518:56 (leading: Space)
-6037: Ident           "uint32" at 518:57-518:63 (leading: Space)
-6038: Semicolon       ";" at 518:63-518:64
-6039: At              "@" at 519:5-519:6 (leading: Newline, Space)
-6040: Ident           "intrinsic" at 519:6-519:15
-6041: KwFn            "fn" at 519:16-519:18 (leading: Space)
-6042: Ident           "__mul" at 519:19-519:24 (leading: Space)
-6043: LParen          "(" at 519:24-519:25
-6044: Ident           "self" at 519:25-519:29
-6045: Colon           ":" at 519:29-519:30
-6046: Ident           "uint32" at 519:31-519:37 (leading: Space)
-6047: Comma           "," at 519:37-519:38
-6048: Ident           "other" at 519:39-519:44 (leading: Space)
-6049: Colon           ":" at 519:44-519:45
-6050: Ident           "uint32" at 519:46-519:52 (leading: Space)
-6051: RParen          ")" at 519:52-519:53
-6052: Arrow           "->" at 519:54-519:56 (leading: Space)
-6053: Ident           "uint32" at 519:57-519:63 (leading: Space)
-6054: Semicolon       ";" at 519:63-519:64
-6055: At              "@" at 520:5-520:6 (leading: Newline, Space)
-6056: Ident           "intrinsic" at 520:6-520:15
-6057: KwFn            "fn" at 520:16-520:18 (leading: Space)
-6058: Ident           "__div" at 520:19-520:24 (leading: Space)
-6059: LParen          "(" at 520:24-520:25
-6060: Ident           "self" at 520:25-520:29
-6061: Colon           ":" at 520:29-520:30
-6062: Ident           "uint32" at 520:31-520:37 (leading: Space)
-6063: Comma           "," at 520:37-520:38
-6064: Ident           "other" at 520:39-520:44 (leading: Space)
-6065: Colon           ":" at 520:44-520:45
-6066: Ident           "uint32" at 520:46-520:52 (leading: Space)
-6067: RParen          ")" at 520:52-520:53
-6068: Arrow           "->" at 520:54-520:56 (leading: Space)
-6069: Ident           "uint32" at 520:57-520:63 (leading: Space)
-6070: Semicolon       ";" at 520:63-520:64
-6071: At              "@" at 521:5-521:6 (leading: Newline, Space)
-6072: Ident           "intrinsic" at 521:6-521:15
-6073: KwFn            "fn" at 521:16-521:18 (leading: Space)
-6074: Ident           "__mod" at 521:19-521:24 (leading: Space)
-6075: LParen          "(" at 521:24-521:25
-6076: Ident           "self" at 521:25-521:29
-6077: Colon           ":" at 521:29-521:30
-6078: Ident           "uint32" at 521:31-521:37 (leading: Space)
-6079: Comma           "," at 521:37-521:38
-6080: Ident           "other" at 521:39-521:44 (leading: Space)
-6081: Colon           ":" at 521:44-521:45
-6082: Ident           "uint32" at 521:46-521:52 (leading: Space)
-6083: RParen          ")" at 521:52-521:53
-6084: Arrow           "->" at 521:54-521:56 (leading: Space)
-6085: Ident           "uint32" at 521:57-521:63 (leading: Space)
-6086: Semicolon       ";" at 521:63-521:64
-6087: At              "@" at 522:5-522:6 (leading: Newline, Space)
-6088: Ident           "intrinsic" at 522:6-522:15
-6089: KwFn            "fn" at 522:16-522:18 (leading: Space)
-6090: Ident           "__bit_and" at 522:19-522:28 (leading: Space)
-6091: LParen          "(" at 522:28-522:29
-6092: Ident           "self" at 522:29-522:33
-6093: Colon           ":" at 522:33-522:34
-6094: Ident           "uint32" at 522:35-522:41 (leading: Space)
-6095: Comma           "," at 522:41-522:42
-6096: Ident           "other" at 522:43-522:48 (leading: Space)
-6097: Colon           ":" at 522:48-522:49
-6098: Ident           "uint32" at 522:50-522:56 (leading: Space)
-6099: RParen          ")" at 522:56-522:57
-6100: Arrow           "->" at 522:58-522:60 (leading: Space)
-6101: Ident           "uint32" at 522:61-522:67 (leading: Space)
-6102: Semicolon       ";" at 522:67-522:68
-6103: At              "@" at 523:5-523:6 (leading: Newline, Space)
-6104: Ident           "intrinsic" at 523:6-523:15
-6105: KwFn            "fn" at 523:16-523:18 (leading: Space)
-6106: Ident           "__bit_or" at 523:19-523:27 (leading: Space)
-6107: LParen          "(" at 523:27-523:28
-6108: Ident           "self" at 523:28-523:32
-6109: Colon           ":" at 523:32-523:33
-6110: Ident           "uint32" at 523:34-523:40 (leading: Space)
-6111: Comma           "," at 523:40-523:41
-6112: Ident           "other" at 523:42-523:47 (leading: Space)
-6113: Colon           ":" at 523:47-523:48
-6114: Ident           "uint32" at 523:49-523:55 (leading: Space)
-6115: RParen          ")" at 523:55-523:56
-6116: Arrow           "->" at 523:57-523:59 (leading: Space)
-6117: Ident           "uint32" at 523:60-523:66 (leading: Space)
-6118: Semicolon       ";" at 523:66-523:67
-6119: At              "@" at 524:5-524:6 (leading: Newline, Space)
-6120: Ident           "intrinsic" at 524:6-524:15
-6121: KwFn            "fn" at 524:16-524:18 (leading: Space)
-6122: Ident           "__bit_xor" at 524:19-524:28 (leading: Space)
-6123: LParen          "(" at 524:28-524:29
-6124: Ident           "self" at 524:29-524:33
-6125: Colon           ":" at 524:33-524:34
-6126: Ident           "uint32" at 524:35-524:41 (leading: Space)
-6127: Comma           "," at 524:41-524:42
-6128: Ident           "other" at 524:43-524:48 (leading: Space)
-6129: Colon           ":" at 524:48-524:49
-6130: Ident           "uint32" at 524:50-524:56 (leading: Space)
-6131: RParen          ")" at 524:56-524:57
-6132: Arrow           "->" at 524:58-524:60 (leading: Space)
-6133: Ident           "uint32" at 524:61-524:67 (leading: Space)
-6134: Semicolon       ";" at 524:67-524:68
-6135: At              "@" at 525:5-525:6 (leading: Newline, Space)
-6136: Ident           "intrinsic" at 525:6-525:15
-6137: KwFn            "fn" at 525:16-525:18 (leading: Space)
-6138: Ident           "__shl" at 525:19-525:24 (leading: Space)
-6139: LParen          "(" at 525:24-525:25
-6140: Ident           "self" at 525:25-525:29
-6141: Colon           ":" at 525:29-525:30
-6142: Ident           "uint32" at 525:31-525:37 (leading: Space)
-6143: Comma           "," at 525:37-525:38
-6144: Ident           "other" at 525:39-525:44 (leading: Space)
-6145: Colon           ":" at 525:44-525:45
-6146: Ident           "uint32" at 525:46-525:52 (leading: Space)
-6147: RParen          ")" at 525:52-525:53
-6148: Arrow           "->" at 525:54-525:56 (leading: Space)
-6149: Ident           "uint32" at 525:57-525:63 (leading: Space)
-6150: Semicolon       ";" at 525:63-525:64
-6151: At              "@" at 526:5-526:6 (leading: Newline, Space)
-6152: Ident           "intrinsic" at 526:6-526:15
-6153: KwFn            "fn" at 526:16-526:18 (leading: Space)
-6154: Ident           "__shr" at 526:19-526:24 (leading: Space)
-6155: LParen          "(" at 526:24-526:25
-6156: Ident           "self" at 526:25-526:29
-6157: Colon           ":" at 526:29-526:30
-6158: Ident           "uint32" at 526:31-526:37 (leading: Space)
-6159: Comma           "," at 526:37-526:38
-6160: Ident           "other" at 526:39-526:44 (leading: Space)
-6161: Colon           ":" at 526:44-526:45
-6162: Ident           "uint32" at 526:46-526:52 (leading: Space)
-6163: RParen          ")" at 526:52-526:53
-6164: Arrow           "->" at 526:54-526:56 (leading: Space)
-6165: Ident           "uint32" at 526:57-526:63 (leading: Space)
-6166: Semicolon       ";" at 526:63-526:64
-6167: At              "@" at 527:5-527:6 (leading: Newline, Space)
-6168: Ident           "intrinsic" at 527:6-527:15
-6169: KwFn            "fn" at 527:16-527:18 (leading: Space)
-6170: Ident           "__lt" at 527:19-527:23 (leading: Space)
-6171: LParen          "(" at 527:23-527:24
-6172: Ident           "self" at 527:24-527:28
-6173: Colon           ":" at 527:28-527:29
-6174: Ident           "uint32" at 527:30-527:36 (leading: Space)
-6175: Comma           "," at 527:36-527:37
-6176: Ident           "other" at 527:38-527:43 (leading: Space)
-6177: Colon           ":" at 527:43-527:44
-6178: Ident           "uint32" at 527:45-527:51 (leading: Space)
-6179: RParen          ")" at 527:51-527:52
-6180: Arrow           "->" at 527:53-527:55 (leading: Space)
-6181: Ident           "bool" at 527:56-527:60 (leading: Space)
-6182: Semicolon       ";" at 527:60-527:61
-6183: At              "@" at 528:5-528:6 (leading: Newline, Space)
-6184: Ident           "intrinsic" at 528:6-528:15
-6185: KwFn            "fn" at 528:16-528:18 (leading: Space)
-6186: Ident           "__le" at 528:19-528:23 (leading: Space)
-6187: LParen          "(" at 528:23-528:24
-6188: Ident           "self" at 528:24-528:28
-6189: Colon           ":" at 528:28-528:29
-6190: Ident           "uint32" at 528:30-528:36 (leading: Space)
-6191: Comma           "," at 528:36-528:37
-6192: Ident           "other" at 528:38-528:43 (leading: Space)
-6193: Colon           ":" at 528:43-528:44
-6194: Ident           "uint32" at 528:45-528:51 (leading: Space)
-6195: RParen          ")" at 528:51-528:52
-6196: Arrow           "->" at 528:53-528:55 (leading: Space)
-6197: Ident           "bool" at 528:56-528:60 (leading: Space)
-6198: Semicolon       ";" at 528:60-528:61
-6199: At              "@" at 529:5-529:6 (leading: Newline, Space)
-6200: Ident           "intrinsic" at 529:6-529:15
-6201: KwFn            "fn" at 529:16-529:18 (leading: Space)
-6202: Ident           "__eq" at 529:19-529:23 (leading: Space)
-6203: LParen          "(" at 529:23-529:24
-6204: Ident           "self" at 529:24-529:28
-6205: Colon           ":" at 529:28-529:29
-6206: Ident           "uint32" at 529:30-529:36 (leading: Space)
-6207: Comma           "," at 529:36-529:37
-6208: Ident           "other" at 529:38-529:43 (leading: Space)
-6209: Colon           ":" at 529:43-529:44
-6210: Ident           "uint32" at 529:45-529:51 (leading: Space)
-6211: RParen          ")" at 529:51-529:52
-6212: Arrow           "->" at 529:53-529:55 (leading: Space)
-6213: Ident           "bool" at 529:56-529:60 (leading: Space)
-6214: Semicolon       ";" at 529:60-529:61
-6215: At              "@" at 530:5-530:6 (leading: Newline, Space)
-6216: Ident           "intrinsic" at 530:6-530:15
-6217: KwFn            "fn" at 530:16-530:18 (leading: Space)
-6218: Ident           "__ne" at 530:19-530:23 (leading: Space)
-6219: LParen          "(" at 530:23-530:24
-6220: Ident           "self" at 530:24-530:28
-6221: Colon           ":" at 530:28-530:29
-6222: Ident           "uint32" at 530:30-530:36 (leading: Space)
-6223: Comma           "," at 530:36-530:37
-6224: Ident           "other" at 530:38-530:43 (leading: Space)
-6225: Colon           ":" at 530:43-530:44
-6226: Ident           "uint32" at 530:45-530:51 (leading: Space)
-6227: RParen          ")" at 530:51-530:52
-6228: Arrow           "->" at 530:53-530:55 (leading: Space)
-6229: Ident           "bool" at 530:56-530:60 (leading: Space)
-6230: Semicolon       ";" at 530:60-530:61
-6231: At              "@" at 531:5-531:6 (leading: Newline, Space)
-6232: Ident           "intrinsic" at 531:6-531:15
-6233: KwFn            "fn" at 531:16-531:18 (leading: Space)
-6234: Ident           "__ge" at 531:19-531:23 (leading: Space)
-6235: LParen          "(" at 531:23-531:24
-6236: Ident           "self" at 531:24-531:28
-6237: Colon           ":" at 531:28-531:29
-6238: Ident           "uint32" at 531:30-531:36 (leading: Space)
-6239: Comma           "," at 531:36-531:37
-6240: Ident           "other" at 531:38-531:43 (leading: Space)
-6241: Colon           ":" at 531:43-531:44
-6242: Ident           "uint32" at 531:45-531:51 (leading: Space)
-6243: RParen          ")" at 531:51-531:52
-6244: Arrow           "->" at 531:53-531:55 (leading: Space)
-6245: Ident           "bool" at 531:56-531:60 (leading: Space)
-6246: Semicolon       ";" at 531:60-531:61
-6247: At              "@" at 532:5-532:6 (leading: Newline, Space)
-6248: Ident           "intrinsic" at 532:6-532:15
-6249: KwFn            "fn" at 532:16-532:18 (leading: Space)
-6250: Ident           "__gt" at 532:19-532:23 (leading: Space)
-6251: LParen          "(" at 532:23-532:24
-6252: Ident           "self" at 532:24-532:28
-6253: Colon           ":" at 532:28-532:29
-6254: Ident           "uint32" at 532:30-532:36 (leading: Space)
-6255: Comma           "," at 532:36-532:37
-6256: Ident           "other" at 532:38-532:43 (leading: Space)
-6257: Colon           ":" at 532:43-532:44
-6258: Ident           "uint32" at 532:45-532:51 (leading: Space)
-6259: RParen          ")" at 532:51-532:52
-6260: Arrow           "->" at 532:53-532:55 (leading: Space)
-6261: Ident           "bool" at 532:56-532:60 (leading: Space)
-6262: Semicolon       ";" at 532:60-532:61
-6263: At              "@" at 533:5-533:6 (leading: Newline, Space)
-6264: Ident           "intrinsic" at 533:6-533:15
-6265: KwFn            "fn" at 533:16-533:18 (leading: Space)
-6266: Ident           "__pos" at 533:19-533:24 (leading: Space)
-6267: LParen          "(" at 533:24-533:25
-6268: Ident           "self" at 533:25-533:29
-6269: Colon           ":" at 533:29-533:30
-6270: Ident           "uint32" at 533:31-533:37 (leading: Space)
-6271: RParen          ")" at 533:37-533:38
-6272: Arrow           "->" at 533:39-533:41 (leading: Space)
-6273: Ident           "uint32" at 533:42-533:48 (leading: Space)
-6274: Semicolon       ";" at 533:48-533:49
-6275: At              "@" at 534:5-534:6 (leading: Newline, Space)
-6276: Ident           "intrinsic" at 534:6-534:15
-6277: KwFn            "fn" at 534:16-534:18 (leading: Space)
-6278: Ident           "__abs" at 534:19-534:24 (leading: Space)
-6279: LParen          "(" at 534:24-534:25
-6280: Ident           "self" at 534:25-534:29
-6281: Colon           ":" at 534:29-534:30
-6282: Ident           "uint32" at 534:31-534:37 (leading: Space)
-6283: RParen          ")" at 534:37-534:38
-6284: Arrow           "->" at 534:39-534:41 (leading: Space)
-6285: Ident           "uint32" at 534:42-534:48 (leading: Space)
-6286: Semicolon       ";" at 534:48-534:49
-6287: At              "@" at 535:5-535:6 (leading: Newline, Space)
-6288: Ident           "intrinsic" at 535:6-535:15
-6289: KwFn            "fn" at 535:16-535:18 (leading: Space)
-6290: Ident           "__to" at 535:19-535:23 (leading: Space)
-6291: LParen          "(" at 535:23-535:24
-6292: Ident           "self" at 535:24-535:28
-6293: Colon           ":" at 535:28-535:29
-6294: Ident           "uint32" at 535:30-535:36 (leading: Space)
-6295: Comma           "," at 535:36-535:37
-6296: Ident           "target" at 535:38-535:44 (leading: Space)
-6297: Colon           ":" at 535:44-535:45
-6298: Ident           "uint" at 535:46-535:50 (leading: Space)
-6299: RParen          ")" at 535:50-535:51
-6300: Arrow           "->" at 535:52-535:54 (leading: Space)
-6301: Ident           "uint" at 535:55-535:59 (leading: Space)
-6302: Semicolon       ";" at 535:59-535:60
-6303: At              "@" at 536:5-536:6 (leading: Newline, Space)
-6304: Ident           "intrinsic" at 536:6-536:15
-6305: At              "@" at 536:16-536:17 (leading: Space)
-6306: Ident           "overload" at 536:17-536:25
-6307: KwFn            "fn" at 536:26-536:28 (leading: Space)
-6308: Ident           "__to" at 536:29-536:33 (leading: Space)
-6309: LParen          "(" at 536:33-536:34
-6310: Ident           "self" at 536:34-536:38
-6311: Colon           ":" at 536:38-536:39
-6312: Ident           "uint32" at 536:40-536:46 (leading: Space)
-6313: Comma           "," at 536:46-536:47
-6314: Ident           "target" at 536:48-536:54 (leading: Space)
-6315: Colon           ":" at 536:54-536:55
-6316: Ident           "uint8" at 536:56-536:61 (leading: Space)
-6317: RParen          ")" at 536:61-536:62
-6318: Arrow           "->" at 536:63-536:65 (leading: Space)
-6319: Ident           "uint8" at 536:66-536:71 (leading: Space)
-6320: Semicolon       ";" at 536:71-536:72
-6321: At              "@" at 537:5-537:6 (leading: Newline, Space)
-6322: Ident           "intrinsic" at 537:6-537:15
-6323: At              "@" at 537:16-537:17 (leading: Space)
-6324: Ident           "overload" at 537:17-537:25
-6325: KwFn            "fn" at 537:26-537:28 (leading: Space)
-6326: Ident           "__to" at 537:29-537:33 (leading: Space)
-6327: LParen          "(" at 537:33-537:34
-6328: Ident           "self" at 537:34-537:38
-6329: Colon           ":" at 537:38-537:39
-6330: Ident           "uint32" at 537:40-537:46 (leading: Space)
-6331: Comma           "," at 537:46-537:47
-6332: Ident           "target" at 537:48-537:54 (leading: Space)
-6333: Colon           ":" at 537:54-537:55
-6334: Ident           "uint16" at 537:56-537:62 (leading: Space)
-6335: RParen          ")" at 537:62-537:63
-6336: Arrow           "->" at 537:64-537:66 (leading: Space)
-6337: Ident           "uint16" at 537:67-537:73 (leading: Space)
-6338: Semicolon       ";" at 537:73-537:74
-6339: At              "@" at 538:5-538:6 (leading: Newline, Space)
-6340: Ident           "intrinsic" at 538:6-538:15
-6341: At              "@" at 538:16-538:17 (leading: Space)
-6342: Ident           "overload" at 538:17-538:25
-6343: KwFn            "fn" at 538:26-538:28 (leading: Space)
-6344: Ident           "__to" at 538:29-538:33 (leading: Space)
-6345: LParen          "(" at 538:33-538:34
-6346: Ident           "self" at 538:34-538:38
-6347: Colon           ":" at 538:38-538:39
-6348: Ident           "uint32" at 538:40-538:46 (leading: Space)
-6349: Comma           "," at 538:46-538:47
-6350: Ident           "target" at 538:48-538:54 (leading: Space)
-6351: Colon           ":" at 538:54-538:55
-6352: Ident           "uint64" at 538:56-538:62 (leading: Space)
-6353: RParen          ")" at 538:62-538:63
-6354: Arrow           "->" at 538:64-538:66 (leading: Space)
-6355: Ident           "uint64" at 538:67-538:73 (leading: Space)
-6356: Semicolon       ";" at 538:73-538:74
-6357: At              "@" at 539:5-539:6 (leading: Newline, Space)
-6358: Ident           "intrinsic" at 539:6-539:15
-6359: KwPub           "pub" at 539:16-539:19 (leading: Space)
-6360: KwFn            "fn" at 539:20-539:22 (leading: Space)
-6361: Ident           "from_str" at 539:23-539:31 (leading: Space)
-6362: LParen          "(" at 539:31-539:32
-6363: Ident           "s" at 539:32-539:33
-6364: Colon           ":" at 539:33-539:34
-6365: Amp             "&" at 539:35-539:36 (leading: Space)
-6366: Ident           "string" at 539:36-539:42
-6367: RParen          ")" at 539:42-539:43
-6368: Arrow           "->" at 539:44-539:46 (leading: Space)
-6369: Ident           "Erring" at 539:47-539:53 (leading: Space)
-6370: Lt              "<" at 539:53-539:54
-6371: Ident           "uint32" at 539:54-539:60
-6372: Comma           "," at 539:60-539:61
-6373: Ident           "Error" at 539:62-539:67 (leading: Space)
-6374: Gt              ">" at 539:67-539:68
-6375: Semicolon       ";" at 539:68-539:69
-6376: RBrace          "}" at 540:1-540:2 (leading: Newline)
-6377: KwExtern        "extern" at 542:1-542:7 (leading: Newline)
-6378: Lt              "<" at 542:7-542:8
-6379: Ident           "uint64" at 542:8-542:14
-6380: Gt              ">" at 542:14-542:15
-6381: LBrace          "{" at 542:16-542:17 (leading: Space)
-6382: KwPub           "pub" at 543:5-543:8 (leading: Newline, Space)
-6383: KwFn            "fn" at 543:9-543:11 (leading: Space)
-6384: Ident           "__min_value" at 543:12-543:23 (leading: Space)
-6385: LParen          "(" at 543:23-543:24
-6386: RParen          ")" at 543:24-543:25
-6387: Arrow           "->" at 543:26-543:28 (leading: Space)
-6388: Ident           "uint64" at 543:29-543:35 (leading: Space)
-6389: LBrace          "{" at 543:36-543:37 (leading: Space)
-6390: KwReturn        "return" at 543:38-543:44 (leading: Space)
-6391: LParen          "(" at 543:45-543:46 (leading: Space)
-6392: IntLit          "0" at 543:46-543:47
-6393: RParen          ")" at 543:47-543:48
-6394: Colon           ":" at 543:48-543:49
-6395: Ident           "uint64" at 543:49-543:55
-6396: Semicolon       ";" at 543:55-543:56
-6397: RBrace          "}" at 543:57-543:58 (leading: Space)
-6398: KwPub           "pub" at 544:5-544:8 (leading: Newline, Space)
-6399: KwFn            "fn" at 544:9-544:11 (leading: Space)
-6400: Ident           "__max_value" at 544:12-544:23 (leading: Space)
-6401: LParen          "(" at 544:23-544:24
-6402: RParen          ")" at 544:24-544:25
-6403: Arrow           "->" at 544:26-544:28 (leading: Space)
-6404: Ident           "uint64" at 544:29-544:35 (leading: Space)
-6405: LBrace          "{" at 544:36-544:37 (leading: Space)
-6406: KwReturn        "return" at 544:38-544:44 (leading: Space)
-6407: LParen          "(" at 544:45-544:46 (leading: Space)
-6408: IntLit          "18_446_744_073_709_551_615" at 544:46-544:72
-6409: RParen          ")" at 544:72-544:73
-6410: Colon           ":" at 544:73-544:74
-6411: Ident           "uint64" at 544:74-544:80
-6412: Semicolon       ";" at 544:80-544:81
-6413: RBrace          "}" at 544:82-544:83 (leading: Space)
-6414: At              "@" at 545:5-545:6 (leading: Newline, Space)
-6415: Ident           "intrinsic" at 545:6-545:15
-6416: KwFn            "fn" at 545:16-545:18 (leading: Space)
-6417: Ident           "__add" at 545:19-545:24 (leading: Space)
-6418: LParen          "(" at 545:24-545:25
-6419: Ident           "self" at 545:25-545:29
-6420: Colon           ":" at 545:29-545:30
-6421: Ident           "uint64" at 545:31-545:37 (leading: Space)
-6422: Comma           "," at 545:37-545:38
-6423: Ident           "other" at 545:39-545:44 (leading: Space)
-6424: Colon           ":" at 545:44-545:45
-6425: Ident           "uint64" at 545:46-545:52 (leading: Space)
-6426: RParen          ")" at 545:52-545:53
-6427: Arrow           "->" at 545:54-545:56 (leading: Space)
-6428: Ident           "uint64" at 545:57-545:63 (leading: Space)
-6429: Semicolon       ";" at 545:63-545:64
-6430: At              "@" at 546:5-546:6 (leading: Newline, Space)
-6431: Ident           "intrinsic" at 546:6-546:15
-6432: KwFn            "fn" at 546:16-546:18 (leading: Space)
-6433: Ident           "__sub" at 546:19-546:24 (leading: Space)
-6434: LParen          "(" at 546:24-546:25
-6435: Ident           "self" at 546:25-546:29
-6436: Colon           ":" at 546:29-546:30
-6437: Ident           "uint64" at 546:31-546:37 (leading: Space)
-6438: Comma           "," at 546:37-546:38
-6439: Ident           "other" at 546:39-546:44 (leading: Space)
-6440: Colon           ":" at 546:44-546:45
-6441: Ident           "uint64" at 546:46-546:52 (leading: Space)
-6442: RParen          ")" at 546:52-546:53
-6443: Arrow           "->" at 546:54-546:56 (leading: Space)
-6444: Ident           "uint64" at 546:57-546:63 (leading: Space)
-6445: Semicolon       ";" at 546:63-546:64
-6446: At              "@" at 547:5-547:6 (leading: Newline, Space)
-6447: Ident           "intrinsic" at 547:6-547:15
-6448: KwFn            "fn" at 547:16-547:18 (leading: Space)
-6449: Ident           "__mul" at 547:19-547:24 (leading: Space)
-6450: LParen          "(" at 547:24-547:25
-6451: Ident           "self" at 547:25-547:29
-6452: Colon           ":" at 547:29-547:30
-6453: Ident           "uint64" at 547:31-547:37 (leading: Space)
-6454: Comma           "," at 547:37-547:38
-6455: Ident           "other" at 547:39-547:44 (leading: Space)
-6456: Colon           ":" at 547:44-547:45
-6457: Ident           "uint64" at 547:46-547:52 (leading: Space)
-6458: RParen          ")" at 547:52-547:53
-6459: Arrow           "->" at 547:54-547:56 (leading: Space)
-6460: Ident           "uint64" at 547:57-547:63 (leading: Space)
-6461: Semicolon       ";" at 547:63-547:64
-6462: At              "@" at 548:5-548:6 (leading: Newline, Space)
-6463: Ident           "intrinsic" at 548:6-548:15
-6464: KwFn            "fn" at 548:16-548:18 (leading: Space)
-6465: Ident           "__div" at 548:19-548:24 (leading: Space)
-6466: LParen          "(" at 548:24-548:25
-6467: Ident           "self" at 548:25-548:29
-6468: Colon           ":" at 548:29-548:30
-6469: Ident           "uint64" at 548:31-548:37 (leading: Space)
-6470: Comma           "," at 548:37-548:38
-6471: Ident           "other" at 548:39-548:44 (leading: Space)
-6472: Colon           ":" at 548:44-548:45
-6473: Ident           "uint64" at 548:46-548:52 (leading: Space)
-6474: RParen          ")" at 548:52-548:53
-6475: Arrow           "->" at 548:54-548:56 (leading: Space)
-6476: Ident           "uint64" at 548:57-548:63 (leading: Space)
-6477: Semicolon       ";" at 548:63-548:64
-6478: At              "@" at 549:5-549:6 (leading: Newline, Space)
-6479: Ident           "intrinsic" at 549:6-549:15
-6480: KwFn            "fn" at 549:16-549:18 (leading: Space)
-6481: Ident           "__mod" at 549:19-549:24 (leading: Space)
-6482: LParen          "(" at 549:24-549:25
-6483: Ident           "self" at 549:25-549:29
-6484: Colon           ":" at 549:29-549:30
-6485: Ident           "uint64" at 549:31-549:37 (leading: Space)
-6486: Comma           "," at 549:37-549:38
-6487: Ident           "other" at 549:39-549:44 (leading: Space)
-6488: Colon           ":" at 549:44-549:45
-6489: Ident           "uint64" at 549:46-549:52 (leading: Space)
-6490: RParen          ")" at 549:52-549:53
-6491: Arrow           "->" at 549:54-549:56 (leading: Space)
-6492: Ident           "uint64" at 549:57-549:63 (leading: Space)
-6493: Semicolon       ";" at 549:63-549:64
-6494: At              "@" at 550:5-550:6 (leading: Newline, Space)
-6495: Ident           "intrinsic" at 550:6-550:15
-6496: KwFn            "fn" at 550:16-550:18 (leading: Space)
-6497: Ident           "__bit_and" at 550:19-550:28 (leading: Space)
-6498: LParen          "(" at 550:28-550:29
-6499: Ident           "self" at 550:29-550:33
-6500: Colon           ":" at 550:33-550:34
-6501: Ident           "uint64" at 550:35-550:41 (leading: Space)
-6502: Comma           "," at 550:41-550:42
-6503: Ident           "other" at 550:43-550:48 (leading: Space)
-6504: Colon           ":" at 550:48-550:49
-6505: Ident           "uint64" at 550:50-550:56 (leading: Space)
-6506: RParen          ")" at 550:56-550:57
-6507: Arrow           "->" at 550:58-550:60 (leading: Space)
-6508: Ident           "uint64" at 550:61-550:67 (leading: Space)
-6509: Semicolon       ";" at 550:67-550:68
-6510: At              "@" at 551:5-551:6 (leading: Newline, Space)
-6511: Ident           "intrinsic" at 551:6-551:15
-6512: KwFn            "fn" at 551:16-551:18 (leading: Space)
-6513: Ident           "__bit_or" at 551:19-551:27 (leading: Space)
-6514: LParen          "(" at 551:27-551:28
-6515: Ident           "self" at 551:28-551:32
-6516: Colon           ":" at 551:32-551:33
-6517: Ident           "uint64" at 551:34-551:40 (leading: Space)
-6518: Comma           "," at 551:40-551:41
-6519: Ident           "other" at 551:42-551:47 (leading: Space)
-6520: Colon           ":" at 551:47-551:48
-6521: Ident           "uint64" at 551:49-551:55 (leading: Space)
-6522: RParen          ")" at 551:55-551:56
-6523: Arrow           "->" at 551:57-551:59 (leading: Space)
-6524: Ident           "uint64" at 551:60-551:66 (leading: Space)
-6525: Semicolon       ";" at 551:66-551:67
-6526: At              "@" at 552:5-552:6 (leading: Newline, Space)
-6527: Ident           "intrinsic" at 552:6-552:15
-6528: KwFn            "fn" at 552:16-552:18 (leading: Space)
-6529: Ident           "__bit_xor" at 552:19-552:28 (leading: Space)
-6530: LParen          "(" at 552:28-552:29
-6531: Ident           "self" at 552:29-552:33
-6532: Colon           ":" at 552:33-552:34
-6533: Ident           "uint64" at 552:35-552:41 (leading: Space)
-6534: Comma           "," at 552:41-552:42
-6535: Ident           "other" at 552:43-552:48 (leading: Space)
-6536: Colon           ":" at 552:48-552:49
-6537: Ident           "uint64" at 552:50-552:56 (leading: Space)
-6538: RParen          ")" at 552:56-552:57
-6539: Arrow           "->" at 552:58-552:60 (leading: Space)
-6540: Ident           "uint64" at 552:61-552:67 (leading: Space)
-6541: Semicolon       ";" at 552:67-552:68
-6542: At              "@" at 553:5-553:6 (leading: Newline, Space)
-6543: Ident           "intrinsic" at 553:6-553:15
-6544: KwFn            "fn" at 553:16-553:18 (leading: Space)
-6545: Ident           "__shl" at 553:19-553:24 (leading: Space)
-6546: LParen          "(" at 553:24-553:25
-6547: Ident           "self" at 553:25-553:29
-6548: Colon           ":" at 553:29-553:30
-6549: Ident           "uint64" at 553:31-553:37 (leading: Space)
-6550: Comma           "," at 553:37-553:38
-6551: Ident           "other" at 553:39-553:44 (leading: Space)
-6552: Colon           ":" at 553:44-553:45
-6553: Ident           "uint64" at 553:46-553:52 (leading: Space)
-6554: RParen          ")" at 553:52-553:53
-6555: Arrow           "->" at 553:54-553:56 (leading: Space)
-6556: Ident           "uint64" at 553:57-553:63 (leading: Space)
-6557: Semicolon       ";" at 553:63-553:64
-6558: At              "@" at 554:5-554:6 (leading: Newline, Space)
-6559: Ident           "intrinsic" at 554:6-554:15
-6560: KwFn            "fn" at 554:16-554:18 (leading: Space)
-6561: Ident           "__shr" at 554:19-554:24 (leading: Space)
-6562: LParen          "(" at 554:24-554:25
-6563: Ident           "self" at 554:25-554:29
-6564: Colon           ":" at 554:29-554:30
-6565: Ident           "uint64" at 554:31-554:37 (leading: Space)
-6566: Comma           "," at 554:37-554:38
-6567: Ident           "other" at 554:39-554:44 (leading: Space)
-6568: Colon           ":" at 554:44-554:45
-6569: Ident           "uint64" at 554:46-554:52 (leading: Space)
-6570: RParen          ")" at 554:52-554:53
-6571: Arrow           "->" at 554:54-554:56 (leading: Space)
-6572: Ident           "uint64" at 554:57-554:63 (leading: Space)
-6573: Semicolon       ";" at 554:63-554:64
-6574: At              "@" at 555:5-555:6 (leading: Newline, Space)
-6575: Ident           "intrinsic" at 555:6-555:15
-6576: KwFn            "fn" at 555:16-555:18 (leading: Space)
-6577: Ident           "__lt" at 555:19-555:23 (leading: Space)
-6578: LParen          "(" at 555:23-555:24
-6579: Ident           "self" at 555:24-555:28
-6580: Colon           ":" at 555:28-555:29
-6581: Ident           "uint64" at 555:30-555:36 (leading: Space)
-6582: Comma           "," at 555:36-555:37
-6583: Ident           "other" at 555:38-555:43 (leading: Space)
-6584: Colon           ":" at 555:43-555:44
-6585: Ident           "uint64" at 555:45-555:51 (leading: Space)
-6586: RParen          ")" at 555:51-555:52
-6587: Arrow           "->" at 555:53-555:55 (leading: Space)
-6588: Ident           "bool" at 555:56-555:60 (leading: Space)
-6589: Semicolon       ";" at 555:60-555:61
-6590: At              "@" at 556:5-556:6 (leading: Newline, Space)
-6591: Ident           "intrinsic" at 556:6-556:15
-6592: KwFn            "fn" at 556:16-556:18 (leading: Space)
-6593: Ident           "__le" at 556:19-556:23 (leading: Space)
-6594: LParen          "(" at 556:23-556:24
-6595: Ident           "self" at 556:24-556:28
-6596: Colon           ":" at 556:28-556:29
-6597: Ident           "uint64" at 556:30-556:36 (leading: Space)
-6598: Comma           "," at 556:36-556:37
-6599: Ident           "other" at 556:38-556:43 (leading: Space)
-6600: Colon           ":" at 556:43-556:44
-6601: Ident           "uint64" at 556:45-556:51 (leading: Space)
-6602: RParen          ")" at 556:51-556:52
-6603: Arrow           "->" at 556:53-556:55 (leading: Space)
-6604: Ident           "bool" at 556:56-556:60 (leading: Space)
-6605: Semicolon       ";" at 556:60-556:61
-6606: At              "@" at 557:5-557:6 (leading: Newline, Space)
-6607: Ident           "intrinsic" at 557:6-557:15
-6608: KwFn            "fn" at 557:16-557:18 (leading: Space)
-6609: Ident           "__eq" at 557:19-557:23 (leading: Space)
-6610: LParen          "(" at 557:23-557:24
-6611: Ident           "self" at 557:24-557:28
-6612: Colon           ":" at 557:28-557:29
-6613: Ident           "uint64" at 557:30-557:36 (leading: Space)
-6614: Comma           "," at 557:36-557:37
-6615: Ident           "other" at 557:38-557:43 (leading: Space)
-6616: Colon           ":" at 557:43-557:44
-6617: Ident           "uint64" at 557:45-557:51 (leading: Space)
-6618: RParen          ")" at 557:51-557:52
-6619: Arrow           "->" at 557:53-557:55 (leading: Space)
-6620: Ident           "bool" at 557:56-557:60 (leading: Space)
-6621: Semicolon       ";" at 557:60-557:61
-6622: At              "@" at 558:5-558:6 (leading: Newline, Space)
-6623: Ident           "intrinsic" at 558:6-558:15
-6624: KwFn            "fn" at 558:16-558:18 (leading: Space)
-6625: Ident           "__ne" at 558:19-558:23 (leading: Space)
-6626: LParen          "(" at 558:23-558:24
-6627: Ident           "self" at 558:24-558:28
-6628: Colon           ":" at 558:28-558:29
-6629: Ident           "uint64" at 558:30-558:36 (leading: Space)
-6630: Comma           "," at 558:36-558:37
-6631: Ident           "other" at 558:38-558:43 (leading: Space)
-6632: Colon           ":" at 558:43-558:44
-6633: Ident           "uint64" at 558:45-558:51 (leading: Space)
-6634: RParen          ")" at 558:51-558:52
-6635: Arrow           "->" at 558:53-558:55 (leading: Space)
-6636: Ident           "bool" at 558:56-558:60 (leading: Space)
-6637: Semicolon       ";" at 558:60-558:61
-6638: At              "@" at 559:5-559:6 (leading: Newline, Space)
-6639: Ident           "intrinsic" at 559:6-559:15
-6640: KwFn            "fn" at 559:16-559:18 (leading: Space)
-6641: Ident           "__ge" at 559:19-559:23 (leading: Space)
-6642: LParen          "(" at 559:23-559:24
-6643: Ident           "self" at 559:24-559:28
-6644: Colon           ":" at 559:28-559:29
-6645: Ident           "uint64" at 559:30-559:36 (leading: Space)
-6646: Comma           "," at 559:36-559:37
-6647: Ident           "other" at 559:38-559:43 (leading: Space)
-6648: Colon           ":" at 559:43-559:44
-6649: Ident           "uint64" at 559:45-559:51 (leading: Space)
-6650: RParen          ")" at 559:51-559:52
-6651: Arrow           "->" at 559:53-559:55 (leading: Space)
-6652: Ident           "bool" at 559:56-559:60 (leading: Space)
-6653: Semicolon       ";" at 559:60-559:61
-6654: At              "@" at 560:5-560:6 (leading: Newline, Space)
-6655: Ident           "intrinsic" at 560:6-560:15
-6656: KwFn            "fn" at 560:16-560:18 (leading: Space)
-6657: Ident           "__gt" at 560:19-560:23 (leading: Space)
-6658: LParen          "(" at 560:23-560:24
-6659: Ident           "self" at 560:24-560:28
-6660: Colon           ":" at 560:28-560:29
-6661: Ident           "uint64" at 560:30-560:36 (leading: Space)
-6662: Comma           "," at 560:36-560:37
-6663: Ident           "other" at 560:38-560:43 (leading: Space)
-6664: Colon           ":" at 560:43-560:44
-6665: Ident           "uint64" at 560:45-560:51 (leading: Space)
-6666: RParen          ")" at 560:51-560:52
-6667: Arrow           "->" at 560:53-560:55 (leading: Space)
-6668: Ident           "bool" at 560:56-560:60 (leading: Space)
-6669: Semicolon       ";" at 560:60-560:61
-6670: At              "@" at 561:5-561:6 (leading: Newline, Space)
-6671: Ident           "intrinsic" at 561:6-561:15
-6672: KwFn            "fn" at 561:16-561:18 (leading: Space)
-6673: Ident           "__pos" at 561:19-561:24 (leading: Space)
-6674: LParen          "(" at 561:24-561:25
-6675: Ident           "self" at 561:25-561:29
-6676: Colon           ":" at 561:29-561:30
-6677: Ident           "uint64" at 561:31-561:37 (leading: Space)
-6678: RParen          ")" at 561:37-561:38
-6679: Arrow           "->" at 561:39-561:41 (leading: Space)
-6680: Ident           "uint64" at 561:42-561:48 (leading: Space)
-6681: Semicolon       ";" at 561:48-561:49
-6682: At              "@" at 562:5-562:6 (leading: Newline, Space)
-6683: Ident           "intrinsic" at 562:6-562:15
-6684: KwFn            "fn" at 562:16-562:18 (leading: Space)
-6685: Ident           "__abs" at 562:19-562:24 (leading: Space)
-6686: LParen          "(" at 562:24-562:25
-6687: Ident           "self" at 562:25-562:29
-6688: Colon           ":" at 562:29-562:30
-6689: Ident           "uint64" at 562:31-562:37 (leading: Space)
-6690: RParen          ")" at 562:37-562:38
-6691: Arrow           "->" at 562:39-562:41 (leading: Space)
-6692: Ident           "uint64" at 562:42-562:48 (leading: Space)
-6693: Semicolon       ";" at 562:48-562:49
-6694: At              "@" at 563:5-563:6 (leading: Newline, Space)
-6695: Ident           "intrinsic" at 563:6-563:15
-6696: KwFn            "fn" at 563:16-563:18 (leading: Space)
-6697: Ident           "__to" at 563:19-563:23 (leading: Space)
-6698: LParen          "(" at 563:23-563:24
-6699: Ident           "self" at 563:24-563:28
-6700: Colon           ":" at 563:28-563:29
-6701: Ident           "uint64" at 563:30-563:36 (leading: Space)
-6702: Comma           "," at 563:36-563:37
-6703: Ident           "target" at 563:38-563:44 (leading: Space)
-6704: Colon           ":" at 563:44-563:45
-6705: Ident           "uint" at 563:46-563:50 (leading: Space)
-6706: RParen          ")" at 563:50-563:51
-6707: Arrow           "->" at 563:52-563:54 (leading: Space)
-6708: Ident           "uint" at 563:55-563:59 (leading: Space)
-6709: Semicolon       ";" at 563:59-563:60
-6710: At              "@" at 564:5-564:6 (leading: Newline, Space)
-6711: Ident           "intrinsic" at 564:6-564:15
-6712: At              "@" at 564:16-564:17 (leading: Space)
-6713: Ident           "overload" at 564:17-564:25
-6714: KwFn            "fn" at 564:26-564:28 (leading: Space)
-6715: Ident           "__to" at 564:29-564:33 (leading: Space)
-6716: LParen          "(" at 564:33-564:34
-6717: Ident           "self" at 564:34-564:38
-6718: Colon           ":" at 564:38-564:39
-6719: Ident           "uint64" at 564:40-564:46 (leading: Space)
-6720: Comma           "," at 564:46-564:47
-6721: Ident           "target" at 564:48-564:54 (leading: Space)
-6722: Colon           ":" at 564:54-564:55
-6723: Ident           "uint8" at 564:56-564:61 (leading: Space)
-6724: RParen          ")" at 564:61-564:62
-6725: Arrow           "->" at 564:63-564:65 (leading: Space)
-6726: Ident           "uint8" at 564:66-564:71 (leading: Space)
-6727: Semicolon       ";" at 564:71-564:72
-6728: At              "@" at 565:5-565:6 (leading: Newline, Space)
-6729: Ident           "intrinsic" at 565:6-565:15
-6730: At              "@" at 565:16-565:17 (leading: Space)
-6731: Ident           "overload" at 565:17-565:25
-6732: KwFn            "fn" at 565:26-565:28 (leading: Space)
-6733: Ident           "__to" at 565:29-565:33 (leading: Space)
-6734: LParen          "(" at 565:33-565:34
-6735: Ident           "self" at 565:34-565:38
-6736: Colon           ":" at 565:38-565:39
-6737: Ident           "uint64" at 565:40-565:46 (leading: Space)
-6738: Comma           "," at 565:46-565:47
-6739: Ident           "target" at 565:48-565:54 (leading: Space)
-6740: Colon           ":" at 565:54-565:55
-6741: Ident           "uint16" at 565:56-565:62 (leading: Space)
-6742: RParen          ")" at 565:62-565:63
-6743: Arrow           "->" at 565:64-565:66 (leading: Space)
-6744: Ident           "uint16" at 565:67-565:73 (leading: Space)
-6745: Semicolon       ";" at 565:73-565:74
-6746: At              "@" at 566:5-566:6 (leading: Newline, Space)
-6747: Ident           "intrinsic" at 566:6-566:15
-6748: At              "@" at 566:16-566:17 (leading: Space)
-6749: Ident           "overload" at 566:17-566:25
-6750: KwFn            "fn" at 566:26-566:28 (leading: Space)
-6751: Ident           "__to" at 566:29-566:33 (leading: Space)
-6752: LParen          "(" at 566:33-566:34
-6753: Ident           "self" at 566:34-566:38
-6754: Colon           ":" at 566:38-566:39
-6755: Ident           "uint64" at 566:40-566:46 (leading: Space)
-6756: Comma           "," at 566:46-566:47
-6757: Ident           "target" at 566:48-566:54 (leading: Space)
-6758: Colon           ":" at 566:54-566:55
-6759: Ident           "uint32" at 566:56-566:62 (leading: Space)
-6760: RParen          ")" at 566:62-566:63
-6761: Arrow           "->" at 566:64-566:66 (leading: Space)
-6762: Ident           "uint32" at 566:67-566:73 (leading: Space)
-6763: Semicolon       ";" at 566:73-566:74
-6764: At              "@" at 567:5-567:6 (leading: Newline, Space)
-6765: Ident           "intrinsic" at 567:6-567:15
-6766: KwPub           "pub" at 567:16-567:19 (leading: Space)
-6767: KwFn            "fn" at 567:20-567:22 (leading: Space)
-6768: Ident           "from_str" at 567:23-567:31 (leading: Space)
-6769: LParen          "(" at 567:31-567:32
-6770: Ident           "s" at 567:32-567:33
-6771: Colon           ":" at 567:33-567:34
-6772: Amp             "&" at 567:35-567:36 (leading: Space)
-6773: Ident           "string" at 567:36-567:42
-6774: RParen          ")" at 567:42-567:43
-6775: Arrow           "->" at 567:44-567:46 (leading: Space)
-6776: Ident           "Erring" at 567:47-567:53 (leading: Space)
-6777: Lt              "<" at 567:53-567:54
-6778: Ident           "uint64" at 567:54-567:60
-6779: Comma           "," at 567:60-567:61
-6780: Ident           "Error" at 567:62-567:67 (leading: Space)
-6781: Gt              ">" at 567:67-567:68
-6782: Semicolon       ";" at 567:68-567:69
-6783: RBrace          "}" at 568:1-568:2 (leading: Newline)
-6784: KwExtern        "extern" at 570:1-570:7 (leading: Newline)
-6785: Lt              "<" at 570:7-570:8
-6786: Ident           "float16" at 570:8-570:15
-6787: Gt              ">" at 570:15-570:16
-6788: LBrace          "{" at 570:17-570:18 (leading: Space)
-6789: KwPub           "pub" at 571:5-571:8 (leading: Newline, Space)
-6790: KwFn            "fn" at 571:9-571:11 (leading: Space)
-6791: Ident           "__min_value" at 571:12-571:23 (leading: Space)
-6792: LParen          "(" at 571:23-571:24
-6793: RParen          ")" at 571:24-571:25
-6794: Arrow           "->" at 571:26-571:28 (leading: Space)
-6795: Ident           "float16" at 571:29-571:36 (leading: Space)
-6796: LBrace          "{" at 571:37-571:38 (leading: Space)
-6797: KwReturn        "return" at 571:39-571:45 (leading: Space)
-6798: LParen          "(" at 571:46-571:47 (leading: Space)
-6799: Minus           "-" at 571:47-571:48
-6800: FloatLit        "65504.0" at 571:48-571:55
-6801: RParen          ")" at 571:55-571:56
-6802: Colon           ":" at 571:56-571:57
-6803: Ident           "float16" at 571:57-571:64
-6804: Semicolon       ";" at 571:64-571:65
-6805: RBrace          "}" at 571:66-571:67 (leading: Space)
-6806: KwPub           "pub" at 572:5-572:8 (leading: Newline, Space)
-6807: KwFn            "fn" at 572:9-572:11 (leading: Space)
-6808: Ident           "__max_value" at 572:12-572:23 (leading: Space)
-6809: LParen          "(" at 572:23-572:24
-6810: RParen          ")" at 572:24-572:25
-6811: Arrow           "->" at 572:26-572:28 (leading: Space)
-6812: Ident           "float16" at 572:29-572:36 (leading: Space)
-6813: LBrace          "{" at 572:37-572:38 (leading: Space)
-6814: KwReturn        "return" at 572:39-572:45 (leading: Space)
-6815: LParen          "(" at 572:46-572:47 (leading: Space)
-6816: FloatLit        "65504.0" at 572:47-572:54
-6817: RParen          ")" at 572:54-572:55
-6818: Colon           ":" at 572:55-572:56
-6819: Ident           "float16" at 572:56-572:63
-6820: Semicolon       ";" at 572:63-572:64
-6821: RBrace          "}" at 572:65-572:66 (leading: Space)
-6822: At              "@" at 573:5-573:6 (leading: Newline, Space)
-6823: Ident           "intrinsic" at 573:6-573:15
-6824: KwFn            "fn" at 573:16-573:18 (leading: Space)
-6825: Ident           "__add" at 573:19-573:24 (leading: Space)
-6826: LParen          "(" at 573:24-573:25
-6827: Ident           "self" at 573:25-573:29
-6828: Colon           ":" at 573:29-573:30
-6829: Ident           "float16" at 573:31-573:38 (leading: Space)
-6830: Comma           "," at 573:38-573:39
-6831: Ident           "other" at 573:40-573:45 (leading: Space)
-6832: Colon           ":" at 573:45-573:46
-6833: Ident           "float16" at 573:47-573:54 (leading: Space)
-6834: RParen          ")" at 573:54-573:55
-6835: Arrow           "->" at 573:56-573:58 (leading: Space)
-6836: Ident           "float16" at 573:59-573:66 (leading: Space)
-6837: Semicolon       ";" at 573:66-573:67
-6838: At              "@" at 574:5-574:6 (leading: Newline, Space)
-6839: Ident           "intrinsic" at 574:6-574:15
-6840: KwFn            "fn" at 574:16-574:18 (leading: Space)
-6841: Ident           "__sub" at 574:19-574:24 (leading: Space)
-6842: LParen          "(" at 574:24-574:25
-6843: Ident           "self" at 574:25-574:29
-6844: Colon           ":" at 574:29-574:30
-6845: Ident           "float16" at 574:31-574:38 (leading: Space)
-6846: Comma           "," at 574:38-574:39
-6847: Ident           "other" at 574:40-574:45 (leading: Space)
-6848: Colon           ":" at 574:45-574:46
-6849: Ident           "float16" at 574:47-574:54 (leading: Space)
-6850: RParen          ")" at 574:54-574:55
-6851: Arrow           "->" at 574:56-574:58 (leading: Space)
-6852: Ident           "float16" at 574:59-574:66 (leading: Space)
-6853: Semicolon       ";" at 574:66-574:67
-6854: At              "@" at 575:5-575:6 (leading: Newline, Space)
-6855: Ident           "intrinsic" at 575:6-575:15
-6856: KwFn            "fn" at 575:16-575:18 (leading: Space)
-6857: Ident           "__mul" at 575:19-575:24 (leading: Space)
-6858: LParen          "(" at 575:24-575:25
-6859: Ident           "self" at 575:25-575:29
-6860: Colon           ":" at 575:29-575:30
-6861: Ident           "float16" at 575:31-575:38 (leading: Space)
-6862: Comma           "," at 575:38-575:39
-6863: Ident           "other" at 575:40-575:45 (leading: Space)
-6864: Colon           ":" at 575:45-575:46
-6865: Ident           "float16" at 575:47-575:54 (leading: Space)
-6866: RParen          ")" at 575:54-575:55
-6867: Arrow           "->" at 575:56-575:58 (leading: Space)
-6868: Ident           "float16" at 575:59-575:66 (leading: Space)
-6869: Semicolon       ";" at 575:66-575:67
-6870: At              "@" at 576:5-576:6 (leading: Newline, Space)
-6871: Ident           "intrinsic" at 576:6-576:15
-6872: KwFn            "fn" at 576:16-576:18 (leading: Space)
-6873: Ident           "__div" at 576:19-576:24 (leading: Space)
-6874: LParen          "(" at 576:24-576:25
-6875: Ident           "self" at 576:25-576:29
-6876: Colon           ":" at 576:29-576:30
-6877: Ident           "float16" at 576:31-576:38 (leading: Space)
-6878: Comma           "," at 576:38-576:39
-6879: Ident           "other" at 576:40-576:45 (leading: Space)
-6880: Colon           ":" at 576:45-576:46
-6881: Ident           "float16" at 576:47-576:54 (leading: Space)
-6882: RParen          ")" at 576:54-576:55
-6883: Arrow           "->" at 576:56-576:58 (leading: Space)
-6884: Ident           "float16" at 576:59-576:66 (leading: Space)
-6885: Semicolon       ";" at 576:66-576:67
-6886: At              "@" at 577:5-577:6 (leading: Newline, Space)
-6887: Ident           "intrinsic" at 577:6-577:15
-6888: KwFn            "fn" at 577:16-577:18 (leading: Space)
-6889: Ident           "__mod" at 577:19-577:24 (leading: Space)
-6890: LParen          "(" at 577:24-577:25
-6891: Ident           "self" at 577:25-577:29
-6892: Colon           ":" at 577:29-577:30
-6893: Ident           "float16" at 577:31-577:38 (leading: Space)
-6894: Comma           "," at 577:38-577:39
-6895: Ident           "other" at 577:40-577:45 (leading: Space)
-6896: Colon           ":" at 577:45-577:46
-6897: Ident           "float16" at 577:47-577:54 (leading: Space)
-6898: RParen          ")" at 577:54-577:55
-6899: Arrow           "->" at 577:56-577:58 (leading: Space)
-6900: Ident           "float16" at 577:59-577:66 (leading: Space)
-6901: Semicolon       ";" at 577:66-577:67
-6902: At              "@" at 578:5-578:6 (leading: Newline, Space)
-6903: Ident           "intrinsic" at 578:6-578:15
-6904: KwFn            "fn" at 578:16-578:18 (leading: Space)
-6905: Ident           "__lt" at 578:19-578:23 (leading: Space)
-6906: LParen          "(" at 578:23-578:24
-6907: Ident           "self" at 578:24-578:28
-6908: Colon           ":" at 578:28-578:29
-6909: Ident           "float16" at 578:30-578:37 (leading: Space)
-6910: Comma           "," at 578:37-578:38
-6911: Ident           "other" at 578:39-578:44 (leading: Space)
-6912: Colon           ":" at 578:44-578:45
-6913: Ident           "float16" at 578:46-578:53 (leading: Space)
-6914: RParen          ")" at 578:53-578:54
-6915: Arrow           "->" at 578:55-578:57 (leading: Space)
-6916: Ident           "bool" at 578:58-578:62 (leading: Space)
-6917: Semicolon       ";" at 578:62-578:63
-6918: At              "@" at 579:5-579:6 (leading: Newline, Space)
-6919: Ident           "intrinsic" at 579:6-579:15
-6920: KwFn            "fn" at 579:16-579:18 (leading: Space)
-6921: Ident           "__le" at 579:19-579:23 (leading: Space)
-6922: LParen          "(" at 579:23-579:24
-6923: Ident           "self" at 579:24-579:28
-6924: Colon           ":" at 579:28-579:29
-6925: Ident           "float16" at 579:30-579:37 (leading: Space)
-6926: Comma           "," at 579:37-579:38
-6927: Ident           "other" at 579:39-579:44 (leading: Space)
-6928: Colon           ":" at 579:44-579:45
-6929: Ident           "float16" at 579:46-579:53 (leading: Space)
-6930: RParen          ")" at 579:53-579:54
-6931: Arrow           "->" at 579:55-579:57 (leading: Space)
-6932: Ident           "bool" at 579:58-579:62 (leading: Space)
-6933: Semicolon       ";" at 579:62-579:63
-6934: At              "@" at 580:5-580:6 (leading: Newline, Space)
-6935: Ident           "intrinsic" at 580:6-580:15
-6936: KwFn            "fn" at 580:16-580:18 (leading: Space)
-6937: Ident           "__eq" at 580:19-580:23 (leading: Space)
-6938: LParen          "(" at 580:23-580:24
-6939: Ident           "self" at 580:24-580:28
-6940: Colon           ":" at 580:28-580:29
-6941: Ident           "float16" at 580:30-580:37 (leading: Space)
-6942: Comma           "," at 580:37-580:38
-6943: Ident           "other" at 580:39-580:44 (leading: Space)
-6944: Colon           ":" at 580:44-580:45
-6945: Ident           "float16" at 580:46-580:53 (leading: Space)
-6946: RParen          ")" at 580:53-580:54
-6947: Arrow           "->" at 580:55-580:57 (leading: Space)
-6948: Ident           "bool" at 580:58-580:62 (leading: Space)
-6949: Semicolon       ";" at 580:62-580:63
-6950: At              "@" at 581:5-581:6 (leading: Newline, Space)
-6951: Ident           "intrinsic" at 581:6-581:15
-6952: KwFn            "fn" at 581:16-581:18 (leading: Space)
-6953: Ident           "__ne" at 581:19-581:23 (leading: Space)
-6954: LParen          "(" at 581:23-581:24
-6955: Ident           "self" at 581:24-581:28
-6956: Colon           ":" at 581:28-581:29
-6957: Ident           "float16" at 581:30-581:37 (leading: Space)
-6958: Comma           "," at 581:37-581:38
-6959: Ident           "other" at 581:39-581:44 (leading: Space)
-6960: Colon           ":" at 581:44-581:45
-6961: Ident           "float16" at 581:46-581:53 (leading: Space)
-6962: RParen          ")" at 581:53-581:54
-6963: Arrow           "->" at 581:55-581:57 (leading: Space)
-6964: Ident           "bool" at 581:58-581:62 (leading: Space)
-6965: Semicolon       ";" at 581:62-581:63
-6966: At              "@" at 582:5-582:6 (leading: Newline, Space)
-6967: Ident           "intrinsic" at 582:6-582:15
-6968: KwFn            "fn" at 582:16-582:18 (leading: Space)
-6969: Ident           "__ge" at 582:19-582:23 (leading: Space)
-6970: LParen          "(" at 582:23-582:24
-6971: Ident           "self" at 582:24-582:28
-6972: Colon           ":" at 582:28-582:29
-6973: Ident           "float16" at 582:30-582:37 (leading: Space)
-6974: Comma           "," at 582:37-582:38
-6975: Ident           "other" at 582:39-582:44 (leading: Space)
-6976: Colon           ":" at 582:44-582:45
-6977: Ident           "float16" at 582:46-582:53 (leading: Space)
-6978: RParen          ")" at 582:53-582:54
-6979: Arrow           "->" at 582:55-582:57 (leading: Space)
-6980: Ident           "bool" at 582:58-582:62 (leading: Space)
-6981: Semicolon       ";" at 582:62-582:63
-6982: At              "@" at 583:5-583:6 (leading: Newline, Space)
-6983: Ident           "intrinsic" at 583:6-583:15
-6984: KwFn            "fn" at 583:16-583:18 (leading: Space)
-6985: Ident           "__gt" at 583:19-583:23 (leading: Space)
-6986: LParen          "(" at 583:23-583:24
-6987: Ident           "self" at 583:24-583:28
-6988: Colon           ":" at 583:28-583:29
-6989: Ident           "float16" at 583:30-583:37 (leading: Space)
-6990: Comma           "," at 583:37-583:38
-6991: Ident           "other" at 583:39-583:44 (leading: Space)
-6992: Colon           ":" at 583:44-583:45
-6993: Ident           "float16" at 583:46-583:53 (leading: Space)
-6994: RParen          ")" at 583:53-583:54
-6995: Arrow           "->" at 583:55-583:57 (leading: Space)
-6996: Ident           "bool" at 583:58-583:62 (leading: Space)
-6997: Semicolon       ";" at 583:62-583:63
-6998: At              "@" at 584:5-584:6 (leading: Newline, Space)
-6999: Ident           "intrinsic" at 584:6-584:15
-7000: KwFn            "fn" at 584:16-584:18 (leading: Space)
-7001: Ident           "__pos" at 584:19-584:24 (leading: Space)
-7002: LParen          "(" at 584:24-584:25
-7003: Ident           "self" at 584:25-584:29
-7004: Colon           ":" at 584:29-584:30
-7005: Ident           "float16" at 584:31-584:38 (leading: Space)
-7006: RParen          ")" at 584:38-584:39
-7007: Arrow           "->" at 584:40-584:42 (leading: Space)
-7008: Ident           "float16" at 584:43-584:50 (leading: Space)
-7009: Semicolon       ";" at 584:50-584:51
-7010: At              "@" at 585:5-585:6 (leading: Newline, Space)
-7011: Ident           "intrinsic" at 585:6-585:15
-7012: KwFn            "fn" at 585:16-585:18 (leading: Space)
-7013: Ident           "__neg" at 585:19-585:24 (leading: Space)
-7014: LParen          "(" at 585:24-585:25
-7015: Ident           "self" at 585:25-585:29
-7016: Colon           ":" at 585:29-585:30
-7017: Ident           "float16" at 585:31-585:38 (leading: Space)
-7018: RParen          ")" at 585:38-585:39
-7019: Arrow           "->" at 585:40-585:42 (leading: Space)
-7020: Ident           "float16" at 585:43-585:50 (leading: Space)
-7021: Semicolon       ";" at 585:50-585:51
-7022: At              "@" at 586:5-586:6 (leading: Newline, Space)
-7023: Ident           "intrinsic" at 586:6-586:15
-7024: KwFn            "fn" at 586:16-586:18 (leading: Space)
-7025: Ident           "__abs" at 586:19-586:24 (leading: Space)
-7026: LParen          "(" at 586:24-586:25
-7027: Ident           "self" at 586:25-586:29
-7028: Colon           ":" at 586:29-586:30
-7029: Ident           "float16" at 586:31-586:38 (leading: Space)
-7030: RParen          ")" at 586:38-586:39
-7031: Arrow           "->" at 586:40-586:42 (leading: Space)
-7032: Ident           "float16" at 586:43-586:50 (leading: Space)
-7033: Semicolon       ";" at 586:50-586:51
-7034: At              "@" at 587:5-587:6 (leading: Newline, Space)
-7035: Ident           "intrinsic" at 587:6-587:15
-7036: KwFn            "fn" at 587:16-587:18 (leading: Space)
-7037: Ident           "__to" at 587:19-587:23 (leading: Space)
-7038: LParen          "(" at 587:23-587:24
-7039: Ident           "self" at 587:24-587:28
-7040: Colon           ":" at 587:28-587:29
-7041: Ident           "float16" at 587:30-587:37 (leading: Space)
-7042: Comma           "," at 587:37-587:38
-7043: Ident           "target" at 587:39-587:45 (leading: Space)
-7044: Colon           ":" at 587:45-587:46
-7045: Ident           "float" at 587:47-587:52 (leading: Space)
-7046: RParen          ")" at 587:52-587:53
-7047: Arrow           "->" at 587:54-587:56 (leading: Space)
-7048: Ident           "float" at 587:57-587:62 (leading: Space)
-7049: Semicolon       ";" at 587:62-587:63
-7050: At              "@" at 588:5-588:6 (leading: Newline, Space)
-7051: Ident           "intrinsic" at 588:6-588:15
-7052: At              "@" at 588:16-588:17 (leading: Space)
-7053: Ident           "overload" at 588:17-588:25
-7054: KwFn            "fn" at 588:26-588:28 (leading: Space)
-7055: Ident           "__to" at 588:29-588:33 (leading: Space)
-7056: LParen          "(" at 588:33-588:34
-7057: Ident           "self" at 588:34-588:38
-7058: Colon           ":" at 588:38-588:39
-7059: Ident           "float16" at 588:40-588:47 (leading: Space)
-7060: Comma           "," at 588:47-588:48
-7061: Ident           "target" at 588:49-588:55 (leading: Space)
-7062: Colon           ":" at 588:55-588:56
-7063: Ident           "float32" at 588:57-588:64 (leading: Space)
-7064: RParen          ")" at 588:64-588:65
-7065: Arrow           "->" at 588:66-588:68 (leading: Space)
-7066: Ident           "float32" at 588:69-588:76 (leading: Space)
-7067: Semicolon       ";" at 588:76-588:77
-7068: At              "@" at 589:5-589:6 (leading: Newline, Space)
-7069: Ident           "intrinsic" at 589:6-589:15
-7070: At              "@" at 589:16-589:17 (leading: Space)
-7071: Ident           "overload" at 589:17-589:25
-7072: KwFn            "fn" at 589:26-589:28 (leading: Space)
-7073: Ident           "__to" at 589:29-589:33 (leading: Space)
-7074: LParen          "(" at 589:33-589:34
-7075: Ident           "self" at 589:34-589:38
-7076: Colon           ":" at 589:38-589:39
-7077: Ident           "float16" at 589:40-589:47 (leading: Space)
-7078: Comma           "," at 589:47-589:48
-7079: Ident           "target" at 589:49-589:55 (leading: Space)
-7080: Colon           ":" at 589:55-589:56
-7081: Ident           "float64" at 589:57-589:64 (leading: Space)
-7082: RParen          ")" at 589:64-589:65
-7083: Arrow           "->" at 589:66-589:68 (leading: Space)
-7084: Ident           "float64" at 589:69-589:76 (leading: Space)
-7085: Semicolon       ";" at 589:76-589:77
-7086: At              "@" at 590:5-590:6 (leading: Newline, Space)
-7087: Ident           "intrinsic" at 590:6-590:15
-7088: KwPub           "pub" at 590:16-590:19 (leading: Space)
-7089: KwFn            "fn" at 590:20-590:22 (leading: Space)
-7090: Ident           "from_str" at 590:23-590:31 (leading: Space)
-7091: LParen          "(" at 590:31-590:32
-7092: Ident           "s" at 590:32-590:33
-7093: Colon           ":" at 590:33-590:34
-7094: Amp             "&" at 590:35-590:36 (leading: Space)
-7095: Ident           "string" at 590:36-590:42
-7096: RParen          ")" at 590:42-590:43
-7097: Arrow           "->" at 590:44-590:46 (leading: Space)
-7098: Ident           "Erring" at 590:47-590:53 (leading: Space)
-7099: Lt              "<" at 590:53-590:54
-7100: Ident           "float16" at 590:54-590:61
-7101: Comma           "," at 590:61-590:62
-7102: Ident           "Error" at 590:63-590:68 (leading: Space)
-7103: Gt              ">" at 590:68-590:69
-7104: Semicolon       ";" at 590:69-590:70
-7105: RBrace          "}" at 591:1-591:2 (leading: Newline)
-7106: KwExtern        "extern" at 593:1-593:7 (leading: Newline)
-7107: Lt              "<" at 593:7-593:8
-7108: Ident           "float32" at 593:8-593:15
-7109: Gt              ">" at 593:15-593:16
-7110: LBrace          "{" at 593:17-593:18 (leading: Space)
-7111: KwPub           "pub" at 594:5-594:8 (leading: Newline, Space)
-7112: KwFn            "fn" at 594:9-594:11 (leading: Space)
-7113: Ident           "__min_value" at 594:12-594:23 (leading: Space)
-7114: LParen          "(" at 594:23-594:24
-7115: RParen          ")" at 594:24-594:25
-7116: Arrow           "->" at 594:26-594:28 (leading: Space)
-7117: Ident           "float32" at 594:29-594:36 (leading: Space)
-7118: LBrace          "{" at 594:37-594:38 (leading: Space)
-7119: KwReturn        "return" at 594:39-594:45 (leading: Space)
-7120: LParen          "(" at 594:46-594:47 (leading: Space)
-7121: Minus           "-" at 594:47-594:48
-7122: FloatLit        "3.402_823_466_385_2886e+38" at 594:48-594:74
-7123: RParen          ")" at 594:74-594:75
-7124: Colon           ":" at 594:75-594:76
-7125: Ident           "float32" at 594:76-594:83
-7126: Semicolon       ";" at 594:83-594:84
-7127: RBrace          "}" at 594:85-594:86 (leading: Space)
-7128: KwPub           "pub" at 595:5-595:8 (leading: Newline, Space)
-7129: KwFn            "fn" at 595:9-595:11 (leading: Space)
-7130: Ident           "__max_value" at 595:12-595:23 (leading: Space)
-7131: LParen          "(" at 595:23-595:24
-7132: RParen          ")" at 595:24-595:25
-7133: Arrow           "->" at 595:26-595:28 (leading: Space)
-7134: Ident           "float32" at 595:29-595:36 (leading: Space)
-7135: LBrace          "{" at 595:37-595:38 (leading: Space)
-7136: KwReturn        "return" at 595:39-595:45 (leading: Space)
-7137: LParen          "(" at 595:46-595:47 (leading: Space)
-7138: FloatLit        "3.402_823_466_385_2886e+38" at 595:47-595:73
-7139: RParen          ")" at 595:73-595:74
-7140: Colon           ":" at 595:74-595:75
-7141: Ident           "float32" at 595:75-595:82
-7142: Semicolon       ";" at 595:82-595:83
-7143: RBrace          "}" at 595:84-595:85 (leading: Space)
-7144: At              "@" at 596:5-596:6 (leading: Newline, Space)
-7145: Ident           "intrinsic" at 596:6-596:15
-7146: KwFn            "fn" at 596:16-596:18 (leading: Space)
-7147: Ident           "__add" at 596:19-596:24 (leading: Space)
-7148: LParen          "(" at 596:24-596:25
-7149: Ident           "self" at 596:25-596:29
-7150: Colon           ":" at 596:29-596:30
-7151: Ident           "float32" at 596:31-596:38 (leading: Space)
-7152: Comma           "," at 596:38-596:39
-7153: Ident           "other" at 596:40-596:45 (leading: Space)
-7154: Colon           ":" at 596:45-596:46
-7155: Ident           "float32" at 596:47-596:54 (leading: Space)
-7156: RParen          ")" at 596:54-596:55
-7157: Arrow           "->" at 596:56-596:58 (leading: Space)
-7158: Ident           "float32" at 596:59-596:66 (leading: Space)
-7159: Semicolon       ";" at 596:66-596:67
-7160: At              "@" at 597:5-597:6 (leading: Newline, Space)
-7161: Ident           "intrinsic" at 597:6-597:15
-7162: KwFn            "fn" at 597:16-597:18 (leading: Space)
-7163: Ident           "__sub" at 597:19-597:24 (leading: Space)
-7164: LParen          "(" at 597:24-597:25
-7165: Ident           "self" at 597:25-597:29
-7166: Colon           ":" at 597:29-597:30
-7167: Ident           "float32" at 597:31-597:38 (leading: Space)
-7168: Comma           "," at 597:38-597:39
-7169: Ident           "other" at 597:40-597:45 (leading: Space)
-7170: Colon           ":" at 597:45-597:46
-7171: Ident           "float32" at 597:47-597:54 (leading: Space)
-7172: RParen          ")" at 597:54-597:55
-7173: Arrow           "->" at 597:56-597:58 (leading: Space)
-7174: Ident           "float32" at 597:59-597:66 (leading: Space)
-7175: Semicolon       ";" at 597:66-597:67
-7176: At              "@" at 598:5-598:6 (leading: Newline, Space)
-7177: Ident           "intrinsic" at 598:6-598:15
-7178: KwFn            "fn" at 598:16-598:18 (leading: Space)
-7179: Ident           "__mul" at 598:19-598:24 (leading: Space)
-7180: LParen          "(" at 598:24-598:25
-7181: Ident           "self" at 598:25-598:29
-7182: Colon           ":" at 598:29-598:30
-7183: Ident           "float32" at 598:31-598:38 (leading: Space)
-7184: Comma           "," at 598:38-598:39
-7185: Ident           "other" at 598:40-598:45 (leading: Space)
-7186: Colon           ":" at 598:45-598:46
-7187: Ident           "float32" at 598:47-598:54 (leading: Space)
-7188: RParen          ")" at 598:54-598:55
-7189: Arrow           "->" at 598:56-598:58 (leading: Space)
-7190: Ident           "float32" at 598:59-598:66 (leading: Space)
-7191: Semicolon       ";" at 598:66-598:67
-7192: At              "@" at 599:5-599:6 (leading: Newline, Space)
-7193: Ident           "intrinsic" at 599:6-599:15
-7194: KwFn            "fn" at 599:16-599:18 (leading: Space)
-7195: Ident           "__div" at 599:19-599:24 (leading: Space)
-7196: LParen          "(" at 599:24-599:25
-7197: Ident           "self" at 599:25-599:29
-7198: Colon           ":" at 599:29-599:30
-7199: Ident           "float32" at 599:31-599:38 (leading: Space)
-7200: Comma           "," at 599:38-599:39
-7201: Ident           "other" at 599:40-599:45 (leading: Space)
-7202: Colon           ":" at 599:45-599:46
-7203: Ident           "float32" at 599:47-599:54 (leading: Space)
-7204: RParen          ")" at 599:54-599:55
-7205: Arrow           "->" at 599:56-599:58 (leading: Space)
-7206: Ident           "float32" at 599:59-599:66 (leading: Space)
-7207: Semicolon       ";" at 599:66-599:67
-7208: At              "@" at 600:5-600:6 (leading: Newline, Space)
-7209: Ident           "intrinsic" at 600:6-600:15
-7210: KwFn            "fn" at 600:16-600:18 (leading: Space)
-7211: Ident           "__mod" at 600:19-600:24 (leading: Space)
-7212: LParen          "(" at 600:24-600:25
-7213: Ident           "self" at 600:25-600:29
-7214: Colon           ":" at 600:29-600:30
-7215: Ident           "float32" at 600:31-600:38 (leading: Space)
-7216: Comma           "," at 600:38-600:39
-7217: Ident           "other" at 600:40-600:45 (leading: Space)
-7218: Colon           ":" at 600:45-600:46
-7219: Ident           "float32" at 600:47-600:54 (leading: Space)
-7220: RParen          ")" at 600:54-600:55
-7221: Arrow           "->" at 600:56-600:58 (leading: Space)
-7222: Ident           "float32" at 600:59-600:66 (leading: Space)
-7223: Semicolon       ";" at 600:66-600:67
-7224: At              "@" at 601:5-601:6 (leading: Newline, Space)
-7225: Ident           "intrinsic" at 601:6-601:15
-7226: KwFn            "fn" at 601:16-601:18 (leading: Space)
-7227: Ident           "__lt" at 601:19-601:23 (leading: Space)
-7228: LParen          "(" at 601:23-601:24
-7229: Ident           "self" at 601:24-601:28
-7230: Colon           ":" at 601:28-601:29
-7231: Ident           "float32" at 601:30-601:37 (leading: Space)
-7232: Comma           "," at 601:37-601:38
-7233: Ident           "other" at 601:39-601:44 (leading: Space)
-7234: Colon           ":" at 601:44-601:45
-7235: Ident           "float32" at 601:46-601:53 (leading: Space)
-7236: RParen          ")" at 601:53-601:54
-7237: Arrow           "->" at 601:55-601:57 (leading: Space)
-7238: Ident           "bool" at 601:58-601:62 (leading: Space)
-7239: Semicolon       ";" at 601:62-601:63
-7240: At              "@" at 602:5-602:6 (leading: Newline, Space)
-7241: Ident           "intrinsic" at 602:6-602:15
-7242: KwFn            "fn" at 602:16-602:18 (leading: Space)
-7243: Ident           "__le" at 602:19-602:23 (leading: Space)
-7244: LParen          "(" at 602:23-602:24
-7245: Ident           "self" at 602:24-602:28
-7246: Colon           ":" at 602:28-602:29
-7247: Ident           "float32" at 602:30-602:37 (leading: Space)
-7248: Comma           "," at 602:37-602:38
-7249: Ident           "other" at 602:39-602:44 (leading: Space)
-7250: Colon           ":" at 602:44-602:45
-7251: Ident           "float32" at 602:46-602:53 (leading: Space)
-7252: RParen          ")" at 602:53-602:54
-7253: Arrow           "->" at 602:55-602:57 (leading: Space)
-7254: Ident           "bool" at 602:58-602:62 (leading: Space)
-7255: Semicolon       ";" at 602:62-602:63
-7256: At              "@" at 603:5-603:6 (leading: Newline, Space)
-7257: Ident           "intrinsic" at 603:6-603:15
-7258: KwFn            "fn" at 603:16-603:18 (leading: Space)
-7259: Ident           "__eq" at 603:19-603:23 (leading: Space)
-7260: LParen          "(" at 603:23-603:24
-7261: Ident           "self" at 603:24-603:28
-7262: Colon           ":" at 603:28-603:29
-7263: Ident           "float32" at 603:30-603:37 (leading: Space)
-7264: Comma           "," at 603:37-603:38
-7265: Ident           "other" at 603:39-603:44 (leading: Space)
-7266: Colon           ":" at 603:44-603:45
-7267: Ident           "float32" at 603:46-603:53 (leading: Space)
-7268: RParen          ")" at 603:53-603:54
-7269: Arrow           "->" at 603:55-603:57 (leading: Space)
-7270: Ident           "bool" at 603:58-603:62 (leading: Space)
-7271: Semicolon       ";" at 603:62-603:63
-7272: At              "@" at 604:5-604:6 (leading: Newline, Space)
-7273: Ident           "intrinsic" at 604:6-604:15
-7274: KwFn            "fn" at 604:16-604:18 (leading: Space)
-7275: Ident           "__ne" at 604:19-604:23 (leading: Space)
-7276: LParen          "(" at 604:23-604:24
-7277: Ident           "self" at 604:24-604:28
-7278: Colon           ":" at 604:28-604:29
-7279: Ident           "float32" at 604:30-604:37 (leading: Space)
-7280: Comma           "," at 604:37-604:38
-7281: Ident           "other" at 604:39-604:44 (leading: Space)
-7282: Colon           ":" at 604:44-604:45
-7283: Ident           "float32" at 604:46-604:53 (leading: Space)
-7284: RParen          ")" at 604:53-604:54
-7285: Arrow           "->" at 604:55-604:57 (leading: Space)
-7286: Ident           "bool" at 604:58-604:62 (leading: Space)
-7287: Semicolon       ";" at 604:62-604:63
-7288: At              "@" at 605:5-605:6 (leading: Newline, Space)
-7289: Ident           "intrinsic" at 605:6-605:15
-7290: KwFn            "fn" at 605:16-605:18 (leading: Space)
-7291: Ident           "__ge" at 605:19-605:23 (leading: Space)
-7292: LParen          "(" at 605:23-605:24
-7293: Ident           "self" at 605:24-605:28
-7294: Colon           ":" at 605:28-605:29
-7295: Ident           "float32" at 605:30-605:37 (leading: Space)
-7296: Comma           "," at 605:37-605:38
-7297: Ident           "other" at 605:39-605:44 (leading: Space)
-7298: Colon           ":" at 605:44-605:45
-7299: Ident           "float32" at 605:46-605:53 (leading: Space)
-7300: RParen          ")" at 605:53-605:54
-7301: Arrow           "->" at 605:55-605:57 (leading: Space)
-7302: Ident           "bool" at 605:58-605:62 (leading: Space)
-7303: Semicolon       ";" at 605:62-605:63
-7304: At              "@" at 606:5-606:6 (leading: Newline, Space)
-7305: Ident           "intrinsic" at 606:6-606:15
-7306: KwFn            "fn" at 606:16-606:18 (leading: Space)
-7307: Ident           "__gt" at 606:19-606:23 (leading: Space)
-7308: LParen          "(" at 606:23-606:24
-7309: Ident           "self" at 606:24-606:28
-7310: Colon           ":" at 606:28-606:29
-7311: Ident           "float32" at 606:30-606:37 (leading: Space)
-7312: Comma           "," at 606:37-606:38
-7313: Ident           "other" at 606:39-606:44 (leading: Space)
-7314: Colon           ":" at 606:44-606:45
-7315: Ident           "float32" at 606:46-606:53 (leading: Space)
-7316: RParen          ")" at 606:53-606:54
-7317: Arrow           "->" at 606:55-606:57 (leading: Space)
-7318: Ident           "bool" at 606:58-606:62 (leading: Space)
-7319: Semicolon       ";" at 606:62-606:63
-7320: At              "@" at 607:5-607:6 (leading: Newline, Space)
-7321: Ident           "intrinsic" at 607:6-607:15
-7322: KwFn            "fn" at 607:16-607:18 (leading: Space)
-7323: Ident           "__pos" at 607:19-607:24 (leading: Space)
-7324: LParen          "(" at 607:24-607:25
-7325: Ident           "self" at 607:25-607:29
-7326: Colon           ":" at 607:29-607:30
-7327: Ident           "float32" at 607:31-607:38 (leading: Space)
-7328: RParen          ")" at 607:38-607:39
-7329: Arrow           "->" at 607:40-607:42 (leading: Space)
-7330: Ident           "float32" at 607:43-607:50 (leading: Space)
-7331: Semicolon       ";" at 607:50-607:51
-7332: At              "@" at 608:5-608:6 (leading: Newline, Space)
-7333: Ident           "intrinsic" at 608:6-608:15
-7334: KwFn            "fn" at 608:16-608:18 (leading: Space)
-7335: Ident           "__neg" at 608:19-608:24 (leading: Space)
-7336: LParen          "(" at 608:24-608:25
-7337: Ident           "self" at 608:25-608:29
-7338: Colon           ":" at 608:29-608:30
-7339: Ident           "float32" at 608:31-608:38 (leading: Space)
-7340: RParen          ")" at 608:38-608:39
-7341: Arrow           "->" at 608:40-608:42 (leading: Space)
-7342: Ident           "float32" at 608:43-608:50 (leading: Space)
-7343: Semicolon       ";" at 608:50-608:51
-7344: At              "@" at 609:5-609:6 (leading: Newline, Space)
-7345: Ident           "intrinsic" at 609:6-609:15
-7346: KwFn            "fn" at 609:16-609:18 (leading: Space)
-7347: Ident           "__abs" at 609:19-609:24 (leading: Space)
-7348: LParen          "(" at 609:24-609:25
-7349: Ident           "self" at 609:25-609:29
-7350: Colon           ":" at 609:29-609:30
-7351: Ident           "float32" at 609:31-609:38 (leading: Space)
-7352: RParen          ")" at 609:38-609:39
-7353: Arrow           "->" at 609:40-609:42 (leading: Space)
-7354: Ident           "float32" at 609:43-609:50 (leading: Space)
-7355: Semicolon       ";" at 609:50-609:51
-7356: At              "@" at 610:5-610:6 (leading: Newline, Space)
-7357: Ident           "intrinsic" at 610:6-610:15
-7358: KwFn            "fn" at 610:16-610:18 (leading: Space)
-7359: Ident           "__to" at 610:19-610:23 (leading: Space)
-7360: LParen          "(" at 610:23-610:24
-7361: Ident           "self" at 610:24-610:28
-7362: Colon           ":" at 610:28-610:29
-7363: Ident           "float32" at 610:30-610:37 (leading: Space)
-7364: Comma           "," at 610:37-610:38
-7365: Ident           "target" at 610:39-610:45 (leading: Space)
-7366: Colon           ":" at 610:45-610:46
-7367: Ident           "float" at 610:47-610:52 (leading: Space)
-7368: RParen          ")" at 610:52-610:53
-7369: Arrow           "->" at 610:54-610:56 (leading: Space)
-7370: Ident           "float" at 610:57-610:62 (leading: Space)
-7371: Semicolon       ";" at 610:62-610:63
-7372: At              "@" at 611:5-611:6 (leading: Newline, Space)
-7373: Ident           "intrinsic" at 611:6-611:15
-7374: At              "@" at 611:16-611:17 (leading: Space)
-7375: Ident           "overload" at 611:17-611:25
-7376: KwFn            "fn" at 611:26-611:28 (leading: Space)
-7377: Ident           "__to" at 611:29-611:33 (leading: Space)
-7378: LParen          "(" at 611:33-611:34
-7379: Ident           "self" at 611:34-611:38
-7380: Colon           ":" at 611:38-611:39
-7381: Ident           "float32" at 611:40-611:47 (leading: Space)
-7382: Comma           "," at 611:47-611:48
-7383: Ident           "target" at 611:49-611:55 (leading: Space)
-7384: Colon           ":" at 611:55-611:56
-7385: Ident           "float16" at 611:57-611:64 (leading: Space)
-7386: RParen          ")" at 611:64-611:65
-7387: Arrow           "->" at 611:66-611:68 (leading: Space)
-7388: Ident           "float16" at 611:69-611:76 (leading: Space)
-7389: Semicolon       ";" at 611:76-611:77
-7390: At              "@" at 612:5-612:6 (leading: Newline, Space)
-7391: Ident           "intrinsic" at 612:6-612:15
-7392: At              "@" at 612:16-612:17 (leading: Space)
-7393: Ident           "overload" at 612:17-612:25
-7394: KwFn            "fn" at 612:26-612:28 (leading: Space)
-7395: Ident           "__to" at 612:29-612:33 (leading: Space)
-7396: LParen          "(" at 612:33-612:34
-7397: Ident           "self" at 612:34-612:38
-7398: Colon           ":" at 612:38-612:39
-7399: Ident           "float32" at 612:40-612:47 (leading: Space)
-7400: Comma           "," at 612:47-612:48
-7401: Ident           "target" at 612:49-612:55 (leading: Space)
-7402: Colon           ":" at 612:55-612:56
-7403: Ident           "float64" at 612:57-612:64 (leading: Space)
-7404: RParen          ")" at 612:64-612:65
-7405: Arrow           "->" at 612:66-612:68 (leading: Space)
-7406: Ident           "float64" at 612:69-612:76 (leading: Space)
-7407: Semicolon       ";" at 612:76-612:77
-7408: At              "@" at 613:5-613:6 (leading: Newline, Space)
-7409: Ident           "intrinsic" at 613:6-613:15
-7410: KwPub           "pub" at 613:16-613:19 (leading: Space)
-7411: KwFn            "fn" at 613:20-613:22 (leading: Space)
-7412: Ident           "from_str" at 613:23-613:31 (leading: Space)
-7413: LParen          "(" at 613:31-613:32
-7414: Ident           "s" at 613:32-613:33
-7415: Colon           ":" at 613:33-613:34
-7416: Amp             "&" at 613:35-613:36 (leading: Space)
-7417: Ident           "string" at 613:36-613:42
-7418: RParen          ")" at 613:42-613:43
-7419: Arrow           "->" at 613:44-613:46 (leading: Space)
-7420: Ident           "Erring" at 613:47-613:53 (leading: Space)
-7421: Lt              "<" at 613:53-613:54
-7422: Ident           "float32" at 613:54-613:61
-7423: Comma           "," at 613:61-613:62
-7424: Ident           "Error" at 613:63-613:68 (leading: Space)
-7425: Gt              ">" at 613:68-613:69
-7426: Semicolon       ";" at 613:69-613:70
-7427: RBrace          "}" at 614:1-614:2 (leading: Newline)
-7428: KwExtern        "extern" at 616:1-616:7 (leading: Newline)
-7429: Lt              "<" at 616:7-616:8
-7430: Ident           "float64" at 616:8-616:15
-7431: Gt              ">" at 616:15-616:16
-7432: LBrace          "{" at 616:17-616:18 (leading: Space)
-7433: KwPub           "pub" at 617:5-617:8 (leading: Newline, Space)
-7434: KwFn            "fn" at 617:9-617:11 (leading: Space)
-7435: Ident           "__min_value" at 617:12-617:23 (leading: Space)
-7436: LParen          "(" at 617:23-617:24
-7437: RParen          ")" at 617:24-617:25
-7438: Arrow           "->" at 617:26-617:28 (leading: Space)
-7439: Ident           "float64" at 617:29-617:36 (leading: Space)
-7440: LBrace          "{" at 617:37-617:38 (leading: Space)
-7441: KwReturn        "return" at 617:39-617:45 (leading: Space)
-7442: LParen          "(" at 617:46-617:47 (leading: Space)
-7443: Minus           "-" at 617:47-617:48
-7444: FloatLit        "1.797_693_134_862_3157e+308" at 617:48-617:75
-7445: RParen          ")" at 617:75-617:76
-7446: Colon           ":" at 617:76-617:77
-7447: Ident           "float64" at 617:77-617:84
-7448: Semicolon       ";" at 617:84-617:85
-7449: RBrace          "}" at 617:86-617:87 (leading: Space)
-7450: KwPub           "pub" at 618:5-618:8 (leading: Newline, Space)
-7451: KwFn            "fn" at 618:9-618:11 (leading: Space)
-7452: Ident           "__max_value" at 618:12-618:23 (leading: Space)
-7453: LParen          "(" at 618:23-618:24
-7454: RParen          ")" at 618:24-618:25
-7455: Arrow           "->" at 618:26-618:28 (leading: Space)
-7456: Ident           "float64" at 618:29-618:36 (leading: Space)
-7457: LBrace          "{" at 618:37-618:38 (leading: Space)
-7458: KwReturn        "return" at 618:39-618:45 (leading: Space)
-7459: LParen          "(" at 618:46-618:47 (leading: Space)
-7460: FloatLit        "1.797_693_134_862_3157e+308" at 618:47-618:74
-7461: RParen          ")" at 618:74-618:75
-7462: Colon           ":" at 618:75-618:76
-7463: Ident           "float64" at 618:76-618:83
-7464: Semicolon       ";" at 618:83-618:84
-7465: RBrace          "}" at 618:85-618:86 (leading: Space)
-7466: At              "@" at 619:5-619:6 (leading: Newline, Space)
-7467: Ident           "intrinsic" at 619:6-619:15
-7468: KwFn            "fn" at 619:16-619:18 (leading: Space)
-7469: Ident           "__add" at 619:19-619:24 (leading: Space)
-7470: LParen          "(" at 619:24-619:25
-7471: Ident           "self" at 619:25-619:29
-7472: Colon           ":" at 619:29-619:30
-7473: Ident           "float64" at 619:31-619:38 (leading: Space)
-7474: Comma           "," at 619:38-619:39
-7475: Ident           "other" at 619:40-619:45 (leading: Space)
-7476: Colon           ":" at 619:45-619:46
-7477: Ident           "float64" at 619:47-619:54 (leading: Space)
-7478: RParen          ")" at 619:54-619:55
-7479: Arrow           "->" at 619:56-619:58 (leading: Space)
-7480: Ident           "float64" at 619:59-619:66 (leading: Space)
-7481: Semicolon       ";" at 619:66-619:67
-7482: At              "@" at 620:5-620:6 (leading: Newline, Space)
-7483: Ident           "intrinsic" at 620:6-620:15
-7484: KwFn            "fn" at 620:16-620:18 (leading: Space)
-7485: Ident           "__sub" at 620:19-620:24 (leading: Space)
-7486: LParen          "(" at 620:24-620:25
-7487: Ident           "self" at 620:25-620:29
-7488: Colon           ":" at 620:29-620:30
-7489: Ident           "float64" at 620:31-620:38 (leading: Space)
-7490: Comma           "," at 620:38-620:39
-7491: Ident           "other" at 620:40-620:45 (leading: Space)
-7492: Colon           ":" at 620:45-620:46
-7493: Ident           "float64" at 620:47-620:54 (leading: Space)
-7494: RParen          ")" at 620:54-620:55
-7495: Arrow           "->" at 620:56-620:58 (leading: Space)
-7496: Ident           "float64" at 620:59-620:66 (leading: Space)
-7497: Semicolon       ";" at 620:66-620:67
-7498: At              "@" at 621:5-621:6 (leading: Newline, Space)
-7499: Ident           "intrinsic" at 621:6-621:15
-7500: KwFn            "fn" at 621:16-621:18 (leading: Space)
-7501: Ident           "__mul" at 621:19-621:24 (leading: Space)
-7502: LParen          "(" at 621:24-621:25
-7503: Ident           "self" at 621:25-621:29
-7504: Colon           ":" at 621:29-621:30
-7505: Ident           "float64" at 621:31-621:38 (leading: Space)
-7506: Comma           "," at 621:38-621:39
-7507: Ident           "other" at 621:40-621:45 (leading: Space)
-7508: Colon           ":" at 621:45-621:46
-7509: Ident           "float64" at 621:47-621:54 (leading: Space)
-7510: RParen          ")" at 621:54-621:55
-7511: Arrow           "->" at 621:56-621:58 (leading: Space)
-7512: Ident           "float64" at 621:59-621:66 (leading: Space)
-7513: Semicolon       ";" at 621:66-621:67
-7514: At              "@" at 622:5-622:6 (leading: Newline, Space)
-7515: Ident           "intrinsic" at 622:6-622:15
-7516: KwFn            "fn" at 622:16-622:18 (leading: Space)
-7517: Ident           "__div" at 622:19-622:24 (leading: Space)
-7518: LParen          "(" at 622:24-622:25
-7519: Ident           "self" at 622:25-622:29
-7520: Colon           ":" at 622:29-622:30
-7521: Ident           "float64" at 622:31-622:38 (leading: Space)
-7522: Comma           "," at 622:38-622:39
-7523: Ident           "other" at 622:40-622:45 (leading: Space)
-7524: Colon           ":" at 622:45-622:46
-7525: Ident           "float64" at 622:47-622:54 (leading: Space)
-7526: RParen          ")" at 622:54-622:55
-7527: Arrow           "->" at 622:56-622:58 (leading: Space)
-7528: Ident           "float64" at 622:59-622:66 (leading: Space)
-7529: Semicolon       ";" at 622:66-622:67
-7530: At              "@" at 623:5-623:6 (leading: Newline, Space)
-7531: Ident           "intrinsic" at 623:6-623:15
-7532: KwFn            "fn" at 623:16-623:18 (leading: Space)
-7533: Ident           "__mod" at 623:19-623:24 (leading: Space)
-7534: LParen          "(" at 623:24-623:25
-7535: Ident           "self" at 623:25-623:29
-7536: Colon           ":" at 623:29-623:30
-7537: Ident           "float64" at 623:31-623:38 (leading: Space)
-7538: Comma           "," at 623:38-623:39
-7539: Ident           "other" at 623:40-623:45 (leading: Space)
-7540: Colon           ":" at 623:45-623:46
-7541: Ident           "float64" at 623:47-623:54 (leading: Space)
-7542: RParen          ")" at 623:54-623:55
-7543: Arrow           "->" at 623:56-623:58 (leading: Space)
-7544: Ident           "float64" at 623:59-623:66 (leading: Space)
-7545: Semicolon       ";" at 623:66-623:67
-7546: At              "@" at 624:5-624:6 (leading: Newline, Space)
-7547: Ident           "intrinsic" at 624:6-624:15
-7548: KwFn            "fn" at 624:16-624:18 (leading: Space)
-7549: Ident           "__lt" at 624:19-624:23 (leading: Space)
-7550: LParen          "(" at 624:23-624:24
-7551: Ident           "self" at 624:24-624:28
-7552: Colon           ":" at 624:28-624:29
-7553: Ident           "float64" at 624:30-624:37 (leading: Space)
-7554: Comma           "," at 624:37-624:38
-7555: Ident           "other" at 624:39-624:44 (leading: Space)
-7556: Colon           ":" at 624:44-624:45
-7557: Ident           "float64" at 624:46-624:53 (leading: Space)
-7558: RParen          ")" at 624:53-624:54
-7559: Arrow           "->" at 624:55-624:57 (leading: Space)
-7560: Ident           "bool" at 624:58-624:62 (leading: Space)
-7561: Semicolon       ";" at 624:62-624:63
-7562: At              "@" at 625:5-625:6 (leading: Newline, Space)
-7563: Ident           "intrinsic" at 625:6-625:15
-7564: KwFn            "fn" at 625:16-625:18 (leading: Space)
-7565: Ident           "__le" at 625:19-625:23 (leading: Space)
-7566: LParen          "(" at 625:23-625:24
-7567: Ident           "self" at 625:24-625:28
-7568: Colon           ":" at 625:28-625:29
-7569: Ident           "float64" at 625:30-625:37 (leading: Space)
-7570: Comma           "," at 625:37-625:38
-7571: Ident           "other" at 625:39-625:44 (leading: Space)
-7572: Colon           ":" at 625:44-625:45
-7573: Ident           "float64" at 625:46-625:53 (leading: Space)
-7574: RParen          ")" at 625:53-625:54
-7575: Arrow           "->" at 625:55-625:57 (leading: Space)
-7576: Ident           "bool" at 625:58-625:62 (leading: Space)
-7577: Semicolon       ";" at 625:62-625:63
-7578: At              "@" at 626:5-626:6 (leading: Newline, Space)
-7579: Ident           "intrinsic" at 626:6-626:15
-7580: KwFn            "fn" at 626:16-626:18 (leading: Space)
-7581: Ident           "__eq" at 626:19-626:23 (leading: Space)
-7582: LParen          "(" at 626:23-626:24
-7583: Ident           "self" at 626:24-626:28
-7584: Colon           ":" at 626:28-626:29
-7585: Ident           "float64" at 626:30-626:37 (leading: Space)
-7586: Comma           "," at 626:37-626:38
-7587: Ident           "other" at 626:39-626:44 (leading: Space)
-7588: Colon           ":" at 626:44-626:45
-7589: Ident           "float64" at 626:46-626:53 (leading: Space)
-7590: RParen          ")" at 626:53-626:54
-7591: Arrow           "->" at 626:55-626:57 (leading: Space)
-7592: Ident           "bool" at 626:58-626:62 (leading: Space)
-7593: Semicolon       ";" at 626:62-626:63
-7594: At              "@" at 627:5-627:6 (leading: Newline, Space)
-7595: Ident           "intrinsic" at 627:6-627:15
-7596: KwFn            "fn" at 627:16-627:18 (leading: Space)
-7597: Ident           "__ne" at 627:19-627:23 (leading: Space)
-7598: LParen          "(" at 627:23-627:24
-7599: Ident           "self" at 627:24-627:28
-7600: Colon           ":" at 627:28-627:29
-7601: Ident           "float64" at 627:30-627:37 (leading: Space)
-7602: Comma           "," at 627:37-627:38
-7603: Ident           "other" at 627:39-627:44 (leading: Space)
-7604: Colon           ":" at 627:44-627:45
-7605: Ident           "float64" at 627:46-627:53 (leading: Space)
-7606: RParen          ")" at 627:53-627:54
-7607: Arrow           "->" at 627:55-627:57 (leading: Space)
-7608: Ident           "bool" at 627:58-627:62 (leading: Space)
-7609: Semicolon       ";" at 627:62-627:63
-7610: At              "@" at 628:5-628:6 (leading: Newline, Space)
-7611: Ident           "intrinsic" at 628:6-628:15
-7612: KwFn            "fn" at 628:16-628:18 (leading: Space)
-7613: Ident           "__ge" at 628:19-628:23 (leading: Space)
-7614: LParen          "(" at 628:23-628:24
-7615: Ident           "self" at 628:24-628:28
-7616: Colon           ":" at 628:28-628:29
-7617: Ident           "float64" at 628:30-628:37 (leading: Space)
-7618: Comma           "," at 628:37-628:38
-7619: Ident           "other" at 628:39-628:44 (leading: Space)
-7620: Colon           ":" at 628:44-628:45
-7621: Ident           "float64" at 628:46-628:53 (leading: Space)
-7622: RParen          ")" at 628:53-628:54
-7623: Arrow           "->" at 628:55-628:57 (leading: Space)
-7624: Ident           "bool" at 628:58-628:62 (leading: Space)
-7625: Semicolon       ";" at 628:62-628:63
-7626: At              "@" at 629:5-629:6 (leading: Newline, Space)
-7627: Ident           "intrinsic" at 629:6-629:15
-7628: KwFn            "fn" at 629:16-629:18 (leading: Space)
-7629: Ident           "__gt" at 629:19-629:23 (leading: Space)
-7630: LParen          "(" at 629:23-629:24
-7631: Ident           "self" at 629:24-629:28
-7632: Colon           ":" at 629:28-629:29
-7633: Ident           "float64" at 629:30-629:37 (leading: Space)
-7634: Comma           "," at 629:37-629:38
-7635: Ident           "other" at 629:39-629:44 (leading: Space)
-7636: Colon           ":" at 629:44-629:45
-7637: Ident           "float64" at 629:46-629:53 (leading: Space)
-7638: RParen          ")" at 629:53-629:54
-7639: Arrow           "->" at 629:55-629:57 (leading: Space)
-7640: Ident           "bool" at 629:58-629:62 (leading: Space)
-7641: Semicolon       ";" at 629:62-629:63
-7642: At              "@" at 630:5-630:6 (leading: Newline, Space)
-7643: Ident           "intrinsic" at 630:6-630:15
-7644: KwFn            "fn" at 630:16-630:18 (leading: Space)
-7645: Ident           "__pos" at 630:19-630:24 (leading: Space)
-7646: LParen          "(" at 630:24-630:25
-7647: Ident           "self" at 630:25-630:29
-7648: Colon           ":" at 630:29-630:30
-7649: Ident           "float64" at 630:31-630:38 (leading: Space)
-7650: RParen          ")" at 630:38-630:39
-7651: Arrow           "->" at 630:40-630:42 (leading: Space)
-7652: Ident           "float64" at 630:43-630:50 (leading: Space)
-7653: Semicolon       ";" at 630:50-630:51
-7654: At              "@" at 631:5-631:6 (leading: Newline, Space)
-7655: Ident           "intrinsic" at 631:6-631:15
-7656: KwFn            "fn" at 631:16-631:18 (leading: Space)
-7657: Ident           "__neg" at 631:19-631:24 (leading: Space)
-7658: LParen          "(" at 631:24-631:25
-7659: Ident           "self" at 631:25-631:29
-7660: Colon           ":" at 631:29-631:30
-7661: Ident           "float64" at 631:31-631:38 (leading: Space)
-7662: RParen          ")" at 631:38-631:39
-7663: Arrow           "->" at 631:40-631:42 (leading: Space)
-7664: Ident           "float64" at 631:43-631:50 (leading: Space)
-7665: Semicolon       ";" at 631:50-631:51
-7666: At              "@" at 632:5-632:6 (leading: Newline, Space)
-7667: Ident           "intrinsic" at 632:6-632:15
-7668: KwFn            "fn" at 632:16-632:18 (leading: Space)
-7669: Ident           "__abs" at 632:19-632:24 (leading: Space)
-7670: LParen          "(" at 632:24-632:25
-7671: Ident           "self" at 632:25-632:29
-7672: Colon           ":" at 632:29-632:30
-7673: Ident           "float64" at 632:31-632:38 (leading: Space)
-7674: RParen          ")" at 632:38-632:39
-7675: Arrow           "->" at 632:40-632:42 (leading: Space)
-7676: Ident           "float64" at 632:43-632:50 (leading: Space)
-7677: Semicolon       ";" at 632:50-632:51
-7678: At              "@" at 633:5-633:6 (leading: Newline, Space)
-7679: Ident           "intrinsic" at 633:6-633:15
-7680: KwFn            "fn" at 633:16-633:18 (leading: Space)
-7681: Ident           "__to" at 633:19-633:23 (leading: Space)
-7682: LParen          "(" at 633:23-633:24
-7683: Ident           "self" at 633:24-633:28
-7684: Colon           ":" at 633:28-633:29
-7685: Ident           "float64" at 633:30-633:37 (leading: Space)
-7686: Comma           "," at 633:37-633:38
-7687: Ident           "target" at 633:39-633:45 (leading: Space)
-7688: Colon           ":" at 633:45-633:46
-7689: Ident           "float" at 633:47-633:52 (leading: Space)
-7690: RParen          ")" at 633:52-633:53
-7691: Arrow           "->" at 633:54-633:56 (leading: Space)
-7692: Ident           "float" at 633:57-633:62 (leading: Space)
-7693: Semicolon       ";" at 633:62-633:63
-7694: At              "@" at 634:5-634:6 (leading: Newline, Space)
-7695: Ident           "intrinsic" at 634:6-634:15
-7696: At              "@" at 634:16-634:17 (leading: Space)
-7697: Ident           "overload" at 634:17-634:25
-7698: KwFn            "fn" at 634:26-634:28 (leading: Space)
-7699: Ident           "__to" at 634:29-634:33 (leading: Space)
-7700: LParen          "(" at 634:33-634:34
-7701: Ident           "self" at 634:34-634:38
-7702: Colon           ":" at 634:38-634:39
-7703: Ident           "float64" at 634:40-634:47 (leading: Space)
-7704: Comma           "," at 634:47-634:48
-7705: Ident           "target" at 634:49-634:55 (leading: Space)
-7706: Colon           ":" at 634:55-634:56
-7707: Ident           "float16" at 634:57-634:64 (leading: Space)
-7708: RParen          ")" at 634:64-634:65
-7709: Arrow           "->" at 634:66-634:68 (leading: Space)
-7710: Ident           "float16" at 634:69-634:76 (leading: Space)
-7711: Semicolon       ";" at 634:76-634:77
-7712: At              "@" at 635:5-635:6 (leading: Newline, Space)
-7713: Ident           "intrinsic" at 635:6-635:15
-7714: At              "@" at 635:16-635:17 (leading: Space)
-7715: Ident           "overload" at 635:17-635:25
-7716: KwFn            "fn" at 635:26-635:28 (leading: Space)
-7717: Ident           "__to" at 635:29-635:33 (leading: Space)
-7718: LParen          "(" at 635:33-635:34
-7719: Ident           "self" at 635:34-635:38
-7720: Colon           ":" at 635:38-635:39
-7721: Ident           "float64" at 635:40-635:47 (leading: Space)
-7722: Comma           "," at 635:47-635:48
-7723: Ident           "target" at 635:49-635:55 (leading: Space)
-7724: Colon           ":" at 635:55-635:56
-7725: Ident           "float32" at 635:57-635:64 (leading: Space)
-7726: RParen          ")" at 635:64-635:65
-7727: Arrow           "->" at 635:66-635:68 (leading: Space)
-7728: Ident           "float32" at 635:69-635:76 (leading: Space)
-7729: Semicolon       ";" at 635:76-635:77
-7730: At              "@" at 636:5-636:6 (leading: Newline, Space)
-7731: Ident           "intrinsic" at 636:6-636:15
-7732: KwPub           "pub" at 636:16-636:19 (leading: Space)
-7733: KwFn            "fn" at 636:20-636:22 (leading: Space)
-7734: Ident           "from_str" at 636:23-636:31 (leading: Space)
-7735: LParen          "(" at 636:31-636:32
-7736: Ident           "s" at 636:32-636:33
-7737: Colon           ":" at 636:33-636:34
-7738: Amp             "&" at 636:35-636:36 (leading: Space)
-7739: Ident           "string" at 636:36-636:42
-7740: RParen          ")" at 636:42-636:43
-7741: Arrow           "->" at 636:44-636:46 (leading: Space)
-7742: Ident           "Erring" at 636:47-636:53 (leading: Space)
-7743: Lt              "<" at 636:53-636:54
-7744: Ident           "float64" at 636:54-636:61
-7745: Comma           "," at 636:61-636:62
-7746: Ident           "Error" at 636:63-636:68 (leading: Space)
-7747: Gt              ">" at 636:68-636:69
-7748: Semicolon       ";" at 636:69-636:70
-7749: RBrace          "}" at 637:1-637:2 (leading: Newline)
-7750: KwExtern        "extern" at 639:1-639:7 (leading: Newline)
-7751: Lt              "<" at 639:7-639:8
-7752: Ident           "float" at 639:8-639:13
-7753: Gt              ">" at 639:13-639:14
-7754: LBrace          "{" at 639:15-639:16 (leading: Space)
-7755: At              "@" at 640:5-640:6 (leading: Newline, Space)
-7756: Ident           "intrinsic" at 640:6-640:15
-7757: KwFn            "fn" at 640:16-640:18 (leading: Space)
-7758: Ident           "__add" at 640:19-640:24 (leading: Space)
-7759: LParen          "(" at 640:24-640:25
-7760: Ident           "self" at 640:25-640:29
-7761: Colon           ":" at 640:29-640:30
-7762: Ident           "float" at 640:31-640:36 (leading: Space)
-7763: Comma           "," at 640:36-640:37
-7764: Ident           "other" at 640:38-640:43 (leading: Space)
-7765: Colon           ":" at 640:43-640:44
-7766: Ident           "float" at 640:45-640:50 (leading: Space)
-7767: RParen          ")" at 640:50-640:51
-7768: Arrow           "->" at 640:52-640:54 (leading: Space)
-7769: Ident           "float" at 640:55-640:60 (leading: Space)
-7770: Semicolon       ";" at 640:60-640:61
-7771: At              "@" at 641:5-641:6 (leading: Newline, Space)
-7772: Ident           "intrinsic" at 641:6-641:15
-7773: KwFn            "fn" at 641:16-641:18 (leading: Space)
-7774: Ident           "__sub" at 641:19-641:24 (leading: Space)
-7775: LParen          "(" at 641:24-641:25
-7776: Ident           "self" at 641:25-641:29
-7777: Colon           ":" at 641:29-641:30
-7778: Ident           "float" at 641:31-641:36 (leading: Space)
-7779: Comma           "," at 641:36-641:37
-7780: Ident           "other" at 641:38-641:43 (leading: Space)
-7781: Colon           ":" at 641:43-641:44
-7782: Ident           "float" at 641:45-641:50 (leading: Space)
-7783: RParen          ")" at 641:50-641:51
-7784: Arrow           "->" at 641:52-641:54 (leading: Space)
-7785: Ident           "float" at 641:55-641:60 (leading: Space)
-7786: Semicolon       ";" at 641:60-641:61
-7787: At              "@" at 642:5-642:6 (leading: Newline, Space)
-7788: Ident           "intrinsic" at 642:6-642:15
-7789: KwFn            "fn" at 642:16-642:18 (leading: Space)
-7790: Ident           "__mul" at 642:19-642:24 (leading: Space)
-7791: LParen          "(" at 642:24-642:25
-7792: Ident           "self" at 642:25-642:29
-7793: Colon           ":" at 642:29-642:30
-7794: Ident           "float" at 642:31-642:36 (leading: Space)
-7795: Comma           "," at 642:36-642:37
-7796: Ident           "other" at 642:38-642:43 (leading: Space)
-7797: Colon           ":" at 642:43-642:44
-7798: Ident           "float" at 642:45-642:50 (leading: Space)
-7799: RParen          ")" at 642:50-642:51
-7800: Arrow           "->" at 642:52-642:54 (leading: Space)
-7801: Ident           "float" at 642:55-642:60 (leading: Space)
-7802: Semicolon       ";" at 642:60-642:61
-7803: At              "@" at 643:5-643:6 (leading: Newline, Space)
-7804: Ident           "intrinsic" at 643:6-643:15
-7805: KwFn            "fn" at 643:16-643:18 (leading: Space)
-7806: Ident           "__div" at 643:19-643:24 (leading: Space)
-7807: LParen          "(" at 643:24-643:25
-7808: Ident           "self" at 643:25-643:29
-7809: Colon           ":" at 643:29-643:30
-7810: Ident           "float" at 643:31-643:36 (leading: Space)
-7811: Comma           "," at 643:36-643:37
-7812: Ident           "other" at 643:38-643:43 (leading: Space)
-7813: Colon           ":" at 643:43-643:44
-7814: Ident           "float" at 643:45-643:50 (leading: Space)
-7815: RParen          ")" at 643:50-643:51
-7816: Arrow           "->" at 643:52-643:54 (leading: Space)
-7817: Ident           "float" at 643:55-643:60 (leading: Space)
-7818: Semicolon       ";" at 643:60-643:61
-7819: At              "@" at 644:5-644:6 (leading: Newline, Space)
-7820: Ident           "intrinsic" at 644:6-644:15
-7821: KwFn            "fn" at 644:16-644:18 (leading: Space)
-7822: Ident           "__mod" at 644:19-644:24 (leading: Space)
-7823: LParen          "(" at 644:24-644:25
-7824: Ident           "self" at 644:25-644:29
-7825: Colon           ":" at 644:29-644:30
-7826: Ident           "float" at 644:31-644:36 (leading: Space)
-7827: Comma           "," at 644:36-644:37
-7828: Ident           "other" at 644:38-644:43 (leading: Space)
-7829: Colon           ":" at 644:43-644:44
-7830: Ident           "float" at 644:45-644:50 (leading: Space)
-7831: RParen          ")" at 644:50-644:51
-7832: Arrow           "->" at 644:52-644:54 (leading: Space)
-7833: Ident           "float" at 644:55-644:60 (leading: Space)
-7834: Semicolon       ";" at 644:60-644:61
-7835: At              "@" at 645:5-645:6 (leading: Newline, Space)
-7836: Ident           "intrinsic" at 645:6-645:15
-7837: KwFn            "fn" at 645:16-645:18 (leading: Space)
-7838: Ident           "__lt" at 645:19-645:23 (leading: Space)
-7839: LParen          "(" at 645:23-645:24
-7840: Ident           "self" at 645:24-645:28
-7841: Colon           ":" at 645:28-645:29
-7842: Ident           "float" at 645:30-645:35 (leading: Space)
-7843: Comma           "," at 645:35-645:36
-7844: Ident           "other" at 645:37-645:42 (leading: Space)
-7845: Colon           ":" at 645:42-645:43
-7846: Ident           "float" at 645:44-645:49 (leading: Space)
-7847: RParen          ")" at 645:49-645:50
-7848: Arrow           "->" at 645:51-645:53 (leading: Space)
-7849: Ident           "bool" at 645:54-645:58 (leading: Space)
-7850: Semicolon       ";" at 645:58-645:59
-7851: At              "@" at 646:5-646:6 (leading: Newline, Space)
-7852: Ident           "intrinsic" at 646:6-646:15
-7853: KwFn            "fn" at 646:16-646:18 (leading: Space)
-7854: Ident           "__le" at 646:19-646:23 (leading: Space)
-7855: LParen          "(" at 646:23-646:24
-7856: Ident           "self" at 646:24-646:28
-7857: Colon           ":" at 646:28-646:29
-7858: Ident           "float" at 646:30-646:35 (leading: Space)
-7859: Comma           "," at 646:35-646:36
-7860: Ident           "other" at 646:37-646:42 (leading: Space)
-7861: Colon           ":" at 646:42-646:43
-7862: Ident           "float" at 646:44-646:49 (leading: Space)
-7863: RParen          ")" at 646:49-646:50
-7864: Arrow           "->" at 646:51-646:53 (leading: Space)
-7865: Ident           "bool" at 646:54-646:58 (leading: Space)
-7866: Semicolon       ";" at 646:58-646:59
-7867: At              "@" at 647:5-647:6 (leading: Newline, Space)
-7868: Ident           "intrinsic" at 647:6-647:15
-7869: KwFn            "fn" at 647:16-647:18 (leading: Space)
-7870: Ident           "__eq" at 647:19-647:23 (leading: Space)
-7871: LParen          "(" at 647:23-647:24
-7872: Ident           "self" at 647:24-647:28
-7873: Colon           ":" at 647:28-647:29
-7874: Ident           "float" at 647:30-647:35 (leading: Space)
-7875: Comma           "," at 647:35-647:36
-7876: Ident           "other" at 647:37-647:42 (leading: Space)
-7877: Colon           ":" at 647:42-647:43
-7878: Ident           "float" at 647:44-647:49 (leading: Space)
-7879: RParen          ")" at 647:49-647:50
-7880: Arrow           "->" at 647:51-647:53 (leading: Space)
-7881: Ident           "bool" at 647:54-647:58 (leading: Space)
-7882: Semicolon       ";" at 647:58-647:59
-7883: At              "@" at 648:5-648:6 (leading: Newline, Space)
-7884: Ident           "intrinsic" at 648:6-648:15
-7885: KwFn            "fn" at 648:16-648:18 (leading: Space)
-7886: Ident           "__ne" at 648:19-648:23 (leading: Space)
-7887: LParen          "(" at 648:23-648:24
-7888: Ident           "self" at 648:24-648:28
-7889: Colon           ":" at 648:28-648:29
-7890: Ident           "float" at 648:30-648:35 (leading: Space)
-7891: Comma           "," at 648:35-648:36
-7892: Ident           "other" at 648:37-648:42 (leading: Space)
-7893: Colon           ":" at 648:42-648:43
-7894: Ident           "float" at 648:44-648:49 (leading: Space)
-7895: RParen          ")" at 648:49-648:50
-7896: Arrow           "->" at 648:51-648:53 (leading: Space)
-7897: Ident           "bool" at 648:54-648:58 (leading: Space)
-7898: Semicolon       ";" at 648:58-648:59
-7899: At              "@" at 649:5-649:6 (leading: Newline, Space)
-7900: Ident           "intrinsic" at 649:6-649:15
-7901: KwFn            "fn" at 649:16-649:18 (leading: Space)
-7902: Ident           "__ge" at 649:19-649:23 (leading: Space)
-7903: LParen          "(" at 649:23-649:24
-7904: Ident           "self" at 649:24-649:28
-7905: Colon           ":" at 649:28-649:29
-7906: Ident           "float" at 649:30-649:35 (leading: Space)
-7907: Comma           "," at 649:35-649:36
-7908: Ident           "other" at 649:37-649:42 (leading: Space)
-7909: Colon           ":" at 649:42-649:43
-7910: Ident           "float" at 649:44-649:49 (leading: Space)
-7911: RParen          ")" at 649:49-649:50
-7912: Arrow           "->" at 649:51-649:53 (leading: Space)
-7913: Ident           "bool" at 649:54-649:58 (leading: Space)
-7914: Semicolon       ";" at 649:58-649:59
-7915: At              "@" at 650:5-650:6 (leading: Newline, Space)
-7916: Ident           "intrinsic" at 650:6-650:15
-7917: KwFn            "fn" at 650:16-650:18 (leading: Space)
-7918: Ident           "__gt" at 650:19-650:23 (leading: Space)
-7919: LParen          "(" at 650:23-650:24
-7920: Ident           "self" at 650:24-650:28
-7921: Colon           ":" at 650:28-650:29
-7922: Ident           "float" at 650:30-650:35 (leading: Space)
-7923: Comma           "," at 650:35-650:36
-7924: Ident           "other" at 650:37-650:42 (leading: Space)
-7925: Colon           ":" at 650:42-650:43
-7926: Ident           "float" at 650:44-650:49 (leading: Space)
-7927: RParen          ")" at 650:49-650:50
-7928: Arrow           "->" at 650:51-650:53 (leading: Space)
-7929: Ident           "bool" at 650:54-650:58 (leading: Space)
-7930: Semicolon       ";" at 650:58-650:59
-7931: At              "@" at 651:5-651:6 (leading: Newline, Space)
-7932: Ident           "intrinsic" at 651:6-651:15
-7933: KwFn            "fn" at 651:16-651:18 (leading: Space)
-7934: Ident           "__pos" at 651:19-651:24 (leading: Space)
-7935: LParen          "(" at 651:24-651:25
-7936: Ident           "self" at 651:25-651:29
-7937: Colon           ":" at 651:29-651:30
-7938: Ident           "float" at 651:31-651:36 (leading: Space)
-7939: RParen          ")" at 651:36-651:37
-7940: Arrow           "->" at 651:38-651:40 (leading: Space)
-7941: Ident           "float" at 651:41-651:46 (leading: Space)
-7942: Semicolon       ";" at 651:46-651:47
-7943: At              "@" at 652:5-652:6 (leading: Newline, Space)
-7944: Ident           "intrinsic" at 652:6-652:15
-7945: KwFn            "fn" at 652:16-652:18 (leading: Space)
-7946: Ident           "__neg" at 652:19-652:24 (leading: Space)
-7947: LParen          "(" at 652:24-652:25
-7948: Ident           "self" at 652:25-652:29
-7949: Colon           ":" at 652:29-652:30
-7950: Ident           "float" at 652:31-652:36 (leading: Space)
-7951: RParen          ")" at 652:36-652:37
-7952: Arrow           "->" at 652:38-652:40 (leading: Space)
-7953: Ident           "float" at 652:41-652:46 (leading: Space)
-7954: Semicolon       ";" at 652:46-652:47
-7955: At              "@" at 653:5-653:6 (leading: Newline, Space)
-7956: Ident           "intrinsic" at 653:6-653:15
-7957: KwFn            "fn" at 653:16-653:18 (leading: Space)
-7958: Ident           "__abs" at 653:19-653:24 (leading: Space)
-7959: LParen          "(" at 653:24-653:25
-7960: Ident           "self" at 653:25-653:29
-7961: Colon           ":" at 653:29-653:30
-7962: Ident           "float" at 653:31-653:36 (leading: Space)
-7963: RParen          ")" at 653:36-653:37
-7964: Arrow           "->" at 653:38-653:40 (leading: Space)
-7965: Ident           "float" at 653:41-653:46 (leading: Space)
-7966: Semicolon       ";" at 653:46-653:47
-7967: At              "@" at 654:5-654:6 (leading: Newline, Space)
-7968: Ident           "intrinsic" at 654:6-654:15
-7969: KwFn            "fn" at 654:16-654:18 (leading: Space)
-7970: Ident           "__to" at 654:19-654:23 (leading: Space)
-7971: LParen          "(" at 654:23-654:24
-7972: Ident           "self" at 654:24-654:28
-7973: Colon           ":" at 654:28-654:29
-7974: Ident           "float" at 654:30-654:35 (leading: Space)
-7975: Comma           "," at 654:35-654:36
-7976: Ident           "target" at 654:37-654:43 (leading: Space)
-7977: Colon           ":" at 654:43-654:44
-7978: Ident           "string" at 654:45-654:51 (leading: Space)
-7979: RParen          ")" at 654:51-654:52
-7980: Arrow           "->" at 654:53-654:55 (leading: Space)
-7981: Ident           "string" at 654:56-654:62 (leading: Space)
-7982: Semicolon       ";" at 654:62-654:63
-7983: At              "@" at 655:5-655:6 (leading: Newline, Space)
-7984: Ident           "overload" at 655:6-655:14
-7985: KwPub           "pub" at 655:15-655:18 (leading: Space)
-7986: KwFn            "fn" at 655:19-655:21 (leading: Space)
-7987: Ident           "__to" at 655:22-655:26 (leading: Space)
-7988: LParen          "(" at 655:26-655:27
-7989: Ident           "self" at 655:27-655:31
-7990: Colon           ":" at 655:31-655:32
-7991: Amp             "&" at 655:33-655:34 (leading: Space)
-7992: Ident           "float" at 655:34-655:39
-7993: Comma           "," at 655:39-655:40
-7994: Underscore      "_" at 655:41-655:42 (leading: Space)
-7995: Colon           ":" at 655:42-655:43
-7996: Ident           "string" at 655:44-655:50 (leading: Space)
-7997: RParen          ")" at 655:50-655:51
-7998: Arrow           "->" at 655:52-655:54 (leading: Space)
-7999: Ident           "string" at 655:55-655:61 (leading: Space)
-8000: LBrace          "{" at 655:62-655:63 (leading: Space)
-8001: KwReturn        "return" at 656:9-656:15 (leading: Newline, Space)
-8002: LParen          "(" at 656:16-656:17 (leading: Space)
-8003: Star            "*" at 656:17-656:18
-8004: Ident           "self" at 656:18-656:22
-8005: RParen          ")" at 656:22-656:23
-8006: KwTo            "to" at 656:24-656:26 (leading: Space)
-8007: Ident           "string" at 656:27-656:33 (leading: Space)
-8008: Semicolon       ";" at 656:33-656:34
-8009: RBrace          "}" at 657:5-657:6 (leading: Newline, Space)
-8010: At              "@" at 658:5-658:6 (leading: Newline, Space)
-8011: Ident           "intrinsic" at 658:6-658:15
-8012: At              "@" at 658:16-658:17 (leading: Space)
-8013: Ident           "overload" at 658:17-658:25
-8014: KwFn            "fn" at 658:26-658:28 (leading: Space)
-8015: Ident           "__to" at 658:29-658:33 (leading: Space)
-8016: LParen          "(" at 658:33-658:34
-8017: Ident           "self" at 658:34-658:38
-8018: Colon           ":" at 658:38-658:39
-8019: Ident           "float" at 658:40-658:45 (leading: Space)
-8020: Comma           "," at 658:45-658:46
-8021: Ident           "target" at 658:47-658:53 (leading: Space)
-8022: Colon           ":" at 658:53-658:54
-8023: Ident           "int" at 658:55-658:58 (leading: Space)
-8024: RParen          ")" at 658:58-658:59
-8025: Arrow           "->" at 658:60-658:62 (leading: Space)
-8026: Ident           "int" at 658:63-658:66 (leading: Space)
-8027: Semicolon       ";" at 658:66-658:67
-8028: At              "@" at 659:5-659:6 (leading: Newline, Space)
-8029: Ident           "intrinsic" at 659:6-659:15
-8030: At              "@" at 659:16-659:17 (leading: Space)
-8031: Ident           "overload" at 659:17-659:25
-8032: KwFn            "fn" at 659:26-659:28 (leading: Space)
-8033: Ident           "__to" at 659:29-659:33 (leading: Space)
-8034: LParen          "(" at 659:33-659:34
-8035: Ident           "self" at 659:34-659:38
-8036: Colon           ":" at 659:38-659:39
-8037: Ident           "float" at 659:40-659:45 (leading: Space)
-8038: Comma           "," at 659:45-659:46
-8039: Ident           "target" at 659:47-659:53 (leading: Space)
-8040: Colon           ":" at 659:53-659:54
-8041: Ident           "uint" at 659:55-659:59 (leading: Space)
-8042: RParen          ")" at 659:59-659:60
-8043: Arrow           "->" at 659:61-659:63 (leading: Space)
-8044: Ident           "uint" at 659:64-659:68 (leading: Space)
-8045: Semicolon       ";" at 659:68-659:69
-8046: At              "@" at 660:5-660:6 (leading: Newline, Space)
-8047: Ident           "intrinsic" at 660:6-660:15
-8048: At              "@" at 660:16-660:17 (leading: Space)
-8049: Ident           "overload" at 660:17-660:25
-8050: KwFn            "fn" at 660:26-660:28 (leading: Space)
-8051: Ident           "__to" at 660:29-660:33 (leading: Space)
-8052: LParen          "(" at 660:33-660:34
-8053: Ident           "self" at 660:34-660:38
-8054: Colon           ":" at 660:38-660:39
-8055: Ident           "float" at 660:40-660:45 (leading: Space)
-8056: Comma           "," at 660:45-660:46
-8057: Ident           "target" at 660:47-660:53 (leading: Space)
-8058: Colon           ":" at 660:53-660:54
-8059: Ident           "int8" at 660:55-660:59 (leading: Space)
-8060: RParen          ")" at 660:59-660:60
-8061: Arrow           "->" at 660:61-660:63 (leading: Space)
-8062: Ident           "int8" at 660:64-660:68 (leading: Space)
-8063: Semicolon       ";" at 660:68-660:69
-8064: At              "@" at 661:5-661:6 (leading: Newline, Space)
-8065: Ident           "intrinsic" at 661:6-661:15
-8066: At              "@" at 661:16-661:17 (leading: Space)
-8067: Ident           "overload" at 661:17-661:25
-8068: KwFn            "fn" at 661:26-661:28 (leading: Space)
-8069: Ident           "__to" at 661:29-661:33 (leading: Space)
-8070: LParen          "(" at 661:33-661:34
-8071: Ident           "self" at 661:34-661:38
-8072: Colon           ":" at 661:38-661:39
-8073: Ident           "float" at 661:40-661:45 (leading: Space)
-8074: Comma           "," at 661:45-661:46
-8075: Ident           "target" at 661:47-661:53 (leading: Space)
-8076: Colon           ":" at 661:53-661:54
-8077: Ident           "int16" at 661:55-661:60 (leading: Space)
-8078: RParen          ")" at 661:60-661:61
-8079: Arrow           "->" at 661:62-661:64 (leading: Space)
-8080: Ident           "int16" at 661:65-661:70 (leading: Space)
-8081: Semicolon       ";" at 661:70-661:71
-8082: At              "@" at 662:5-662:6 (leading: Newline, Space)
-8083: Ident           "intrinsic" at 662:6-662:15
-8084: At              "@" at 662:16-662:17 (leading: Space)
-8085: Ident           "overload" at 662:17-662:25
-8086: KwFn            "fn" at 662:26-662:28 (leading: Space)
-8087: Ident           "__to" at 662:29-662:33 (leading: Space)
-8088: LParen          "(" at 662:33-662:34
-8089: Ident           "self" at 662:34-662:38
-8090: Colon           ":" at 662:38-662:39
-8091: Ident           "float" at 662:40-662:45 (leading: Space)
-8092: Comma           "," at 662:45-662:46
-8093: Ident           "target" at 662:47-662:53 (leading: Space)
-8094: Colon           ":" at 662:53-662:54
-8095: Ident           "int32" at 662:55-662:60 (leading: Space)
-8096: RParen          ")" at 662:60-662:61
-8097: Arrow           "->" at 662:62-662:64 (leading: Space)
-8098: Ident           "int32" at 662:65-662:70 (leading: Space)
-8099: Semicolon       ";" at 662:70-662:71
-8100: At              "@" at 663:5-663:6 (leading: Newline, Space)
-8101: Ident           "intrinsic" at 663:6-663:15
-8102: At              "@" at 663:16-663:17 (leading: Space)
-8103: Ident           "overload" at 663:17-663:25
-8104: KwFn            "fn" at 663:26-663:28 (leading: Space)
-8105: Ident           "__to" at 663:29-663:33 (leading: Space)
-8106: LParen          "(" at 663:33-663:34
-8107: Ident           "self" at 663:34-663:38
-8108: Colon           ":" at 663:38-663:39
-8109: Ident           "float" at 663:40-663:45 (leading: Space)
-8110: Comma           "," at 663:45-663:46
-8111: Ident           "target" at 663:47-663:53 (leading: Space)
-8112: Colon           ":" at 663:53-663:54
-8113: Ident           "int64" at 663:55-663:60 (leading: Space)
-8114: RParen          ")" at 663:60-663:61
-8115: Arrow           "->" at 663:62-663:64 (leading: Space)
-8116: Ident           "int64" at 663:65-663:70 (leading: Space)
-8117: Semicolon       ";" at 663:70-663:71
-8118: At              "@" at 664:5-664:6 (leading: Newline, Space)
-8119: Ident           "intrinsic" at 664:6-664:15
-8120: At              "@" at 664:16-664:17 (leading: Space)
-8121: Ident           "overload" at 664:17-664:25
-8122: KwFn            "fn" at 664:26-664:28 (leading: Space)
-8123: Ident           "__to" at 664:29-664:33 (leading: Space)
-8124: LParen          "(" at 664:33-664:34
-8125: Ident           "self" at 664:34-664:38
-8126: Colon           ":" at 664:38-664:39
-8127: Ident           "float" at 664:40-664:45 (leading: Space)
-8128: Comma           "," at 664:45-664:46
-8129: Ident           "target" at 664:47-664:53 (leading: Space)
-8130: Colon           ":" at 664:53-664:54
-8131: Ident           "uint8" at 664:55-664:60 (leading: Space)
-8132: RParen          ")" at 664:60-664:61
-8133: Arrow           "->" at 664:62-664:64 (leading: Space)
-8134: Ident           "uint8" at 664:65-664:70 (leading: Space)
-8135: Semicolon       ";" at 664:70-664:71
-8136: At              "@" at 665:5-665:6 (leading: Newline, Space)
-8137: Ident           "intrinsic" at 665:6-665:15
-8138: At              "@" at 665:16-665:17 (leading: Space)
-8139: Ident           "overload" at 665:17-665:25
-8140: KwFn            "fn" at 665:26-665:28 (leading: Space)
-8141: Ident           "__to" at 665:29-665:33 (leading: Space)
-8142: LParen          "(" at 665:33-665:34
-8143: Ident           "self" at 665:34-665:38
-8144: Colon           ":" at 665:38-665:39
-8145: Ident           "float" at 665:40-665:45 (leading: Space)
-8146: Comma           "," at 665:45-665:46
-8147: Ident           "target" at 665:47-665:53 (leading: Space)
-8148: Colon           ":" at 665:53-665:54
-8149: Ident           "uint16" at 665:55-665:61 (leading: Space)
-8150: RParen          ")" at 665:61-665:62
-8151: Arrow           "->" at 665:63-665:65 (leading: Space)
-8152: Ident           "uint16" at 665:66-665:72 (leading: Space)
-8153: Semicolon       ";" at 665:72-665:73
-8154: At              "@" at 666:5-666:6 (leading: Newline, Space)
-8155: Ident           "intrinsic" at 666:6-666:15
-8156: At              "@" at 666:16-666:17 (leading: Space)
-8157: Ident           "overload" at 666:17-666:25
-8158: KwFn            "fn" at 666:26-666:28 (leading: Space)
-8159: Ident           "__to" at 666:29-666:33 (leading: Space)
-8160: LParen          "(" at 666:33-666:34
-8161: Ident           "self" at 666:34-666:38
-8162: Colon           ":" at 666:38-666:39
-8163: Ident           "float" at 666:40-666:45 (leading: Space)
-8164: Comma           "," at 666:45-666:46
-8165: Ident           "target" at 666:47-666:53 (leading: Space)
-8166: Colon           ":" at 666:53-666:54
-8167: Ident           "uint32" at 666:55-666:61 (leading: Space)
-8168: RParen          ")" at 666:61-666:62
-8169: Arrow           "->" at 666:63-666:65 (leading: Space)
-8170: Ident           "uint32" at 666:66-666:72 (leading: Space)
-8171: Semicolon       ";" at 666:72-666:73
-8172: At              "@" at 667:5-667:6 (leading: Newline, Space)
-8173: Ident           "intrinsic" at 667:6-667:15
-8174: At              "@" at 667:16-667:17 (leading: Space)
-8175: Ident           "overload" at 667:17-667:25
-8176: KwFn            "fn" at 667:26-667:28 (leading: Space)
-8177: Ident           "__to" at 667:29-667:33 (leading: Space)
-8178: LParen          "(" at 667:33-667:34
-8179: Ident           "self" at 667:34-667:38
-8180: Colon           ":" at 667:38-667:39
-8181: Ident           "float" at 667:40-667:45 (leading: Space)
-8182: Comma           "," at 667:45-667:46
-8183: Ident           "target" at 667:47-667:53 (leading: Space)
-8184: Colon           ":" at 667:53-667:54
-8185: Ident           "uint64" at 667:55-667:61 (leading: Space)
-8186: RParen          ")" at 667:61-667:62
-8187: Arrow           "->" at 667:63-667:65 (leading: Space)
-8188: Ident           "uint64" at 667:66-667:72 (leading: Space)
-8189: Semicolon       ";" at 667:72-667:73
-8190: At              "@" at 668:5-668:6 (leading: Newline, Space)
-8191: Ident           "intrinsic" at 668:6-668:15
-8192: At              "@" at 668:16-668:17 (leading: Space)
-8193: Ident           "overload" at 668:17-668:25
-8194: KwFn            "fn" at 668:26-668:28 (leading: Space)
-8195: Ident           "__to" at 668:29-668:33 (leading: Space)
-8196: LParen          "(" at 668:33-668:34
-8197: Ident           "self" at 668:34-668:38
-8198: Colon           ":" at 668:38-668:39
-8199: Ident           "float" at 668:40-668:45 (leading: Space)
-8200: Comma           "," at 668:45-668:46
-8201: Ident           "target" at 668:47-668:53 (leading: Space)
-8202: Colon           ":" at 668:53-668:54
-8203: Ident           "float16" at 668:55-668:62 (leading: Space)
-8204: RParen          ")" at 668:62-668:63
-8205: Arrow           "->" at 668:64-668:66 (leading: Space)
-8206: Ident           "float16" at 668:67-668:74 (leading: Space)
-8207: Semicolon       ";" at 668:74-668:75
-8208: At              "@" at 669:5-669:6 (leading: Newline, Space)
-8209: Ident           "intrinsic" at 669:6-669:15
-8210: At              "@" at 669:16-669:17 (leading: Space)
-8211: Ident           "overload" at 669:17-669:25
-8212: KwFn            "fn" at 669:26-669:28 (leading: Space)
-8213: Ident           "__to" at 669:29-669:33 (leading: Space)
-8214: LParen          "(" at 669:33-669:34
-8215: Ident           "self" at 669:34-669:38
-8216: Colon           ":" at 669:38-669:39
-8217: Ident           "float" at 669:40-669:45 (leading: Space)
-8218: Comma           "," at 669:45-669:46
-8219: Ident           "target" at 669:47-669:53 (leading: Space)
-8220: Colon           ":" at 669:53-669:54
-8221: Ident           "float32" at 669:55-669:62 (leading: Space)
-8222: RParen          ")" at 669:62-669:63
-8223: Arrow           "->" at 669:64-669:66 (leading: Space)
-8224: Ident           "float32" at 669:67-669:74 (leading: Space)
-8225: Semicolon       ";" at 669:74-669:75
-8226: At              "@" at 670:5-670:6 (leading: Newline, Space)
-8227: Ident           "intrinsic" at 670:6-670:15
-8228: At              "@" at 670:16-670:17 (leading: Space)
-8229: Ident           "overload" at 670:17-670:25
-8230: KwFn            "fn" at 670:26-670:28 (leading: Space)
-8231: Ident           "__to" at 670:29-670:33 (leading: Space)
-8232: LParen          "(" at 670:33-670:34
-8233: Ident           "self" at 670:34-670:38
-8234: Colon           ":" at 670:38-670:39
-8235: Ident           "float" at 670:40-670:45 (leading: Space)
-8236: Comma           "," at 670:45-670:46
-8237: Ident           "target" at 670:47-670:53 (leading: Space)
-8238: Colon           ":" at 670:53-670:54
-8239: Ident           "float64" at 670:55-670:62 (leading: Space)
-8240: RParen          ")" at 670:62-670:63
-8241: Arrow           "->" at 670:64-670:66 (leading: Space)
-8242: Ident           "float64" at 670:67-670:74 (leading: Space)
-8243: Semicolon       ";" at 670:74-670:75
-8244: At              "@" at 672:5-672:6 (leading: Newline, Space, LineComment, Newline, Space)
-8245: Ident           "intrinsic" at 672:6-672:15
-8246: KwPub           "pub" at 672:16-672:19 (leading: Space)
-8247: KwFn            "fn" at 672:20-672:22 (leading: Space)
-8248: Ident           "from_str" at 672:23-672:31 (leading: Space)
-8249: LParen          "(" at 672:31-672:32
-8250: Ident           "s" at 672:32-672:33
-8251: Colon           ":" at 672:33-672:34
-8252: Amp             "&" at 672:35-672:36 (leading: Space)
-8253: Ident           "string" at 672:36-672:42
-8254: RParen          ")" at 672:42-672:43
-8255: Arrow           "->" at 672:44-672:46 (leading: Space)
-8256: Ident           "Erring" at 672:47-672:53 (leading: Space)
-8257: Lt              "<" at 672:53-672:54
-8258: Ident           "float" at 672:54-672:59
-8259: Comma           "," at 672:59-672:60
-8260: Ident           "Error" at 672:61-672:66 (leading: Space)
-8261: Gt              ">" at 672:66-672:67
-8262: Semicolon       ";" at 672:67-672:68
-8263: RBrace          "}" at 673:1-673:2 (leading: Newline)
-8264: KwExtern        "extern" at 675:1-675:7 (leading: Newline)
-8265: Lt              "<" at 675:7-675:8
-8266: Ident           "string" at 675:8-675:14
-8267: Gt              ">" at 675:14-675:15
-8268: LBrace          "{" at 675:16-675:17 (leading: Space)
-8269: At              "@" at 676:5-676:6 (leading: Newline, Space)
-8270: Ident           "intrinsic" at 676:6-676:15
-8271: KwFn            "fn" at 676:16-676:18 (leading: Space)
-8272: Ident           "__add" at 676:19-676:24 (leading: Space)
-8273: LParen          "(" at 676:24-676:25
-8274: Ident           "self" at 676:25-676:29
-8275: Colon           ":" at 676:29-676:30
-8276: Amp             "&" at 676:31-676:32 (leading: Space)
-8277: Ident           "string" at 676:32-676:38
-8278: Comma           "," at 676:38-676:39
-8279: Ident           "other" at 676:40-676:45 (leading: Space)
-8280: Colon           ":" at 676:45-676:46
-8281: Amp             "&" at 676:47-676:48 (leading: Space)
-8282: Ident           "string" at 676:48-676:54
-8283: RParen          ")" at 676:54-676:55
-8284: Arrow           "->" at 676:56-676:58 (leading: Space)
-8285: Ident           "string" at 676:59-676:65 (leading: Space)
-8286: Semicolon       ";" at 676:65-676:66
-8287: At              "@" at 677:5-677:6 (leading: Newline, Space)
-8288: Ident           "intrinsic" at 677:6-677:15
-8289: KwFn            "fn" at 677:16-677:18 (leading: Space)
-8290: Ident           "__mul" at 677:19-677:24 (leading: Space)
-8291: LParen          "(" at 677:24-677:25
-8292: Ident           "self" at 677:25-677:29
-8293: Colon           ":" at 677:29-677:30
-8294: Amp             "&" at 677:31-677:32 (leading: Space)
-8295: Ident           "string" at 677:32-677:38
-8296: Comma           "," at 677:38-677:39
-8297: Ident           "other" at 677:40-677:45 (leading: Space)
-8298: Colon           ":" at 677:45-677:46
-8299: Ident           "int" at 677:47-677:50 (leading: Space)
-8300: RParen          ")" at 677:50-677:51
-8301: Arrow           "->" at 677:52-677:54 (leading: Space)
-8302: Ident           "string" at 677:55-677:61 (leading: Space)
-8303: Semicolon       ";" at 677:61-677:62
-8304: At              "@" at 678:5-678:6 (leading: Newline, Space)
-8305: Ident           "overload" at 678:6-678:14
-8306: KwPub           "pub" at 678:15-678:18 (leading: Space)
-8307: KwFn            "fn" at 678:19-678:21 (leading: Space)
-8308: Ident           "__mul" at 678:22-678:27 (leading: Space)
-8309: LParen          "(" at 678:27-678:28
-8310: Ident           "self" at 678:28-678:32
-8311: Colon           ":" at 678:32-678:33
-8312: Amp             "&" at 678:34-678:35 (leading: Space)
-8313: Ident           "string" at 678:35-678:41
-8314: Comma           "," at 678:41-678:42
-8315: Ident           "other" at 678:43-678:48 (leading: Space)
-8316: Colon           ":" at 678:48-678:49
-8317: Ident           "uint" at 678:50-678:54 (leading: Space)
-8318: RParen          ")" at 678:54-678:55
-8319: Arrow           "->" at 678:56-678:58 (leading: Space)
-8320: Ident           "string" at 678:59-678:65 (leading: Space)
-8321: LBrace          "{" at 678:66-678:67 (leading: Space)
-8322: KwReturn        "return" at 679:9-679:15 (leading: Newline, Space)
-8323: Ident           "self" at 679:16-679:20 (leading: Space)
-8324: Star            "*" at 679:21-679:22 (leading: Space)
-8325: LParen          "(" at 679:23-679:24 (leading: Space)
-8326: Ident           "other" at 679:24-679:29
-8327: KwTo            "to" at 679:30-679:32 (leading: Space)
-8328: Ident           "int" at 679:33-679:36 (leading: Space)
-8329: RParen          ")" at 679:36-679:37
-8330: Semicolon       ";" at 679:37-679:38
-8331: RBrace          "}" at 680:5-680:6 (leading: Newline, Space)
-8332: At              "@" at 681:5-681:6 (leading: Newline, Space)
-8333: Ident           "intrinsic" at 681:6-681:15
-8334: KwFn            "fn" at 681:16-681:18 (leading: Space)
-8335: Ident           "__eq" at 681:19-681:23 (leading: Space)
-8336: LParen          "(" at 681:23-681:24
-8337: Ident           "self" at 681:24-681:28
-8338: Colon           ":" at 681:28-681:29
-8339: Amp             "&" at 681:30-681:31 (leading: Space)
-8340: Ident           "string" at 681:31-681:37
-8341: Comma           "," at 681:37-681:38
-8342: Ident           "other" at 681:39-681:44 (leading: Space)
-8343: Colon           ":" at 681:44-681:45
-8344: Amp             "&" at 681:46-681:47 (leading: Space)
-8345: Ident           "string" at 681:47-681:53
-8346: RParen          ")" at 681:53-681:54
-8347: Arrow           "->" at 681:55-681:57 (leading: Space)
-8348: Ident           "bool" at 681:58-681:62 (leading: Space)
-8349: Semicolon       ";" at 681:62-681:63
-8350: At              "@" at 682:5-682:6 (leading: Newline, Space)
-8351: Ident           "intrinsic" at 682:6-682:15
-8352: KwFn            "fn" at 682:16-682:18 (leading: Space)
-8353: Ident           "__ne" at 682:19-682:23 (leading: Space)
-8354: LParen          "(" at 682:23-682:24
-8355: Ident           "self" at 682:24-682:28
-8356: Colon           ":" at 682:28-682:29
-8357: Amp             "&" at 682:30-682:31 (leading: Space)
-8358: Ident           "string" at 682:31-682:37
-8359: Comma           "," at 682:37-682:38
-8360: Ident           "other" at 682:39-682:44 (leading: Space)
-8361: Colon           ":" at 682:44-682:45
-8362: Amp             "&" at 682:46-682:47 (leading: Space)
-8363: Ident           "string" at 682:47-682:53
-8364: RParen          ")" at 682:53-682:54
-8365: Arrow           "->" at 682:55-682:57 (leading: Space)
-8366: Ident           "bool" at 682:58-682:62 (leading: Space)
-8367: Semicolon       ";" at 682:62-682:63
-8368: At              "@" at 683:5-683:6 (leading: Newline, Space)
-8369: Ident           "intrinsic" at 683:6-683:15
-8370: KwFn            "fn" at 683:16-683:18 (leading: Space)
-8371: Ident           "__to" at 683:19-683:23 (leading: Space)
-8372: LParen          "(" at 683:23-683:24
-8373: Ident           "self" at 683:24-683:28
-8374: Colon           ":" at 683:28-683:29
-8375: Amp             "&" at 683:30-683:31 (leading: Space)
-8376: Ident           "string" at 683:31-683:37
-8377: Comma           "," at 683:37-683:38
-8378: Ident           "target" at 683:39-683:45 (leading: Space)
-8379: Colon           ":" at 683:45-683:46
-8380: Ident           "int" at 683:47-683:50 (leading: Space)
-8381: RParen          ")" at 683:50-683:51
-8382: Arrow           "->" at 683:52-683:54 (leading: Space)
-8383: Ident           "int" at 683:55-683:58 (leading: Space)
-8384: Semicolon       ";" at 683:58-683:59
-8385: At              "@" at 684:5-684:6 (leading: Newline, Space)
-8386: Ident           "intrinsic" at 684:6-684:15
-8387: At              "@" at 684:16-684:17 (leading: Space)
-8388: Ident           "overload" at 684:17-684:25
-8389: KwFn            "fn" at 684:26-684:28 (leading: Space)
-8390: Ident           "__to" at 684:29-684:33 (leading: Space)
-8391: LParen          "(" at 684:33-684:34
-8392: Ident           "self" at 684:34-684:38
-8393: Colon           ":" at 684:38-684:39
-8394: Amp             "&" at 684:40-684:41 (leading: Space)
-8395: Ident           "string" at 684:41-684:47
-8396: Comma           "," at 684:47-684:48
-8397: Ident           "target" at 684:49-684:55 (leading: Space)
-8398: Colon           ":" at 684:55-684:56
-8399: Ident           "uint" at 684:57-684:61 (leading: Space)
-8400: RParen          ")" at 684:61-684:62
-8401: Arrow           "->" at 684:63-684:65 (leading: Space)
-8402: Ident           "uint" at 684:66-684:70 (leading: Space)
-8403: Semicolon       ";" at 684:70-684:71
-8404: At              "@" at 685:5-685:6 (leading: Newline, Space)
-8405: Ident           "intrinsic" at 685:6-685:15
-8406: At              "@" at 685:16-685:17 (leading: Space)
-8407: Ident           "overload" at 685:17-685:25
-8408: KwFn            "fn" at 685:26-685:28 (leading: Space)
-8409: Ident           "__to" at 685:29-685:33 (leading: Space)
-8410: LParen          "(" at 685:33-685:34
-8411: Ident           "self" at 685:34-685:38
-8412: Colon           ":" at 685:38-685:39
-8413: Amp             "&" at 685:40-685:41 (leading: Space)
-8414: Ident           "string" at 685:41-685:47
-8415: Comma           "," at 685:47-685:48
-8416: Ident           "target" at 685:49-685:55 (leading: Space)
-8417: Colon           ":" at 685:55-685:56
-8418: Ident           "float" at 685:57-685:62 (leading: Space)
-8419: RParen          ")" at 685:62-685:63
-8420: Arrow           "->" at 685:64-685:66 (leading: Space)
-8421: Ident           "float" at 685:67-685:72 (leading: Space)
-8422: Semicolon       ";" at 685:72-685:73
-8423: At              "@" at 686:5-686:6 (leading: Newline, Space)
-8424: Ident           "overload" at 686:6-686:14
-8425: KwPub           "pub" at 686:15-686:18 (leading: Space)
-8426: KwFn            "fn" at 686:19-686:21 (leading: Space)
-8427: Ident           "__to" at 686:22-686:26 (leading: Space)
-8428: LParen          "(" at 686:26-686:27
-8429: Ident           "self" at 686:27-686:31
-8430: Colon           ":" at 686:31-686:32
-8431: Amp             "&" at 686:33-686:34 (leading: Space)
-8432: Ident           "string" at 686:34-686:40
-8433: Comma           "," at 686:40-686:41
-8434: Underscore      "_" at 686:42-686:43 (leading: Space)
-8435: Colon           ":" at 686:43-686:44
-8436: Ident           "string" at 686:45-686:51 (leading: Space)
-8437: RParen          ")" at 686:51-686:52
-8438: Arrow           "->" at 686:53-686:55 (leading: Space)
-8439: Ident           "string" at 686:56-686:62 (leading: Space)
-8440: LBrace          "{" at 686:63-686:64 (leading: Space)
-8441: KwReturn        "return" at 687:9-687:15 (leading: Newline, Space)
-8442: Ident           "self" at 687:16-687:20 (leading: Space)
-8443: Dot             "." at 687:20-687:21
-8444: Ident           "__clone" at 687:21-687:28
-8445: LParen          "(" at 687:28-687:29
-8446: RParen          ")" at 687:29-687:30
-8447: Semicolon       ";" at 687:30-687:31
-8448: RBrace          "}" at 688:5-688:6 (leading: Newline, Space)
-8449: At              "@" at 689:5-689:6 (leading: Newline, Space)
-8450: Ident           "overload" at 689:6-689:14
-8451: KwPub           "pub" at 690:5-690:8 (leading: Newline, Space)
-8452: KwFn            "fn" at 690:9-690:11 (leading: Space)
-8453: Ident           "__to" at 690:12-690:16 (leading: Space)
-8454: LParen          "(" at 690:16-690:17
-8455: Ident           "self" at 690:17-690:21
-8456: Colon           ":" at 690:21-690:22
-8457: Amp             "&" at 690:23-690:24 (leading: Space)
-8458: Ident           "string" at 690:24-690:30
-8459: Comma           "," at 690:30-690:31
-8460: Underscore      "_" at 690:32-690:33 (leading: Space)
-8461: Colon           ":" at 690:33-690:34
-8462: Ident           "byte" at 690:35-690:39 (leading: Space)
-8463: LBracket        "[" at 690:39-690:40
-8464: RBracket        "]" at 690:40-690:41
-8465: RParen          ")" at 690:41-690:42
-8466: Arrow           "->" at 690:43-690:45 (leading: Space)
-8467: Ident           "byte" at 690:46-690:50 (leading: Space)
-8468: LBracket        "[" at 690:50-690:51
-8469: RBracket        "]" at 690:51-690:52
-8470: LBrace          "{" at 690:53-690:54 (leading: Space)
-8471: KwLet           "let" at 691:9-691:12 (leading: Newline, Space)
-8472: KwMut           "mut" at 691:13-691:16 (leading: Space)
-8473: Ident           "out" at 691:17-691:20 (leading: Space)
-8474: Colon           ":" at 691:20-691:21
-8475: Ident           "byte" at 691:22-691:26 (leading: Space)
-8476: LBracket        "[" at 691:26-691:27
-8477: RBracket        "]" at 691:27-691:28
-8478: Assign          "=" at 691:29-691:30 (leading: Space)
-8479: LBracket        "[" at 691:31-691:32 (leading: Space)
-8480: RBracket        "]" at 691:32-691:33
-8481: Semicolon       ";" at 691:33-691:34
-8482: Ident           "rt_array_append_raw_bytes" at 692:9-692:34 (leading: Newline, Space)
-8483: LParen          "(" at 692:34-692:35
-8484: Amp             "&" at 692:35-692:36
-8485: KwMut           "mut" at 692:36-692:39
-8486: Ident           "out" at 692:40-692:43 (leading: Space)
-8487: Comma           "," at 692:43-692:44
-8488: Ident           "rt_string_ptr" at 692:45-692:58 (leading: Space)
-8489: LParen          "(" at 692:58-692:59
-8490: Ident           "self" at 692:59-692:63
-8491: RParen          ")" at 692:63-692:64
-8492: Comma           "," at 692:64-692:65
-8493: Ident           "rt_string_len_bytes" at 692:66-692:85 (leading: Space)
-8494: LParen          "(" at 692:85-692:86
-8495: Ident           "self" at 692:86-692:90
-8496: RParen          ")" at 692:90-692:91
-8497: KwTo            "to" at 692:92-692:94 (leading: Space)
-8498: Ident           "uint64" at 692:95-692:101 (leading: Space)
-8499: RParen          ")" at 692:101-692:102
-8500: Semicolon       ";" at 692:102-692:103
-8501: KwReturn        "return" at 693:9-693:15 (leading: Newline, Space)
-8502: Ident           "out" at 693:16-693:19 (leading: Space)
-8503: Semicolon       ";" at 693:19-693:20
-8504: RBrace          "}" at 694:5-694:6 (leading: Newline, Space)
-8505: At              "@" at 695:5-695:6 (leading: Newline, Space)
-8506: Ident           "intrinsic" at 695:6-695:15
-8507: KwFn            "fn" at 695:16-695:18 (leading: Space)
-8508: Ident           "__len" at 695:19-695:24 (leading: Space)
-8509: LParen          "(" at 695:24-695:25
-8510: Ident           "self" at 695:25-695:29
-8511: Colon           ":" at 695:29-695:30
-8512: Amp             "&" at 695:31-695:32 (leading: Space)
-8513: Ident           "string" at 695:32-695:38
-8514: RParen          ")" at 695:38-695:39
-8515: Arrow           "->" at 695:40-695:42 (leading: Space)
-8516: Ident           "uint" at 695:43-695:47 (leading: Space)
-8517: Semicolon       ";" at 695:47-695:48
-8518: At              "@" at 696:5-696:6 (leading: Newline, Space)
-8519: Ident           "intrinsic" at 696:6-696:15
-8520: KwFn            "fn" at 696:16-696:18 (leading: Space)
-8521: Ident           "__clone" at 696:19-696:26 (leading: Space)
-8522: LParen          "(" at 696:26-696:27
-8523: Ident           "self" at 696:27-696:31
-8524: Colon           ":" at 696:31-696:32
-8525: Amp             "&" at 696:33-696:34 (leading: Space)
-8526: Ident           "string" at 696:34-696:40
-8527: RParen          ")" at 696:40-696:41
-8528: Arrow           "->" at 696:42-696:44 (leading: Space)
-8529: Ident           "string" at 696:45-696:51 (leading: Space)
-8530: Semicolon       ";" at 696:51-696:52
-8531: At              "@" at 697:5-697:6 (leading: Newline, Space)
-8532: Ident           "intrinsic" at 697:6-697:15
-8533: At              "@" at 697:16-697:17 (leading: Space)
-8534: Ident           "overload" at 697:17-697:25
-8535: KwFn            "fn" at 697:26-697:28 (leading: Space)
-8536: Ident           "__index" at 697:29-697:36 (leading: Space)
-8537: LParen          "(" at 697:36-697:37
-8538: Ident           "self" at 697:37-697:41
-8539: Colon           ":" at 697:41-697:42
-8540: Amp             "&" at 697:43-697:44 (leading: Space)
-8541: Ident           "string" at 697:44-697:50
-8542: Comma           "," at 697:50-697:51
-8543: Ident           "index" at 697:52-697:57 (leading: Space)
-8544: Colon           ":" at 697:57-697:58
-8545: Ident           "int" at 697:59-697:62 (leading: Space)
-8546: RParen          ")" at 697:62-697:63
-8547: Arrow           "->" at 697:64-697:66 (leading: Space)
-8548: Ident           "uint32" at 697:67-697:73 (leading: Space)
-8549: Semicolon       ";" at 697:73-697:74
-8550: At              "@" at 698:5-698:6 (leading: Newline, Space)
-8551: Ident           "intrinsic" at 698:6-698:15
-8552: At              "@" at 698:16-698:17 (leading: Space)
-8553: Ident           "overload" at 698:17-698:25
-8554: KwFn            "fn" at 698:26-698:28 (leading: Space)
-8555: Ident           "__index" at 698:29-698:36 (leading: Space)
-8556: LParen          "(" at 698:36-698:37
-8557: Ident           "self" at 698:37-698:41
-8558: Colon           ":" at 698:41-698:42
-8559: Amp             "&" at 698:43-698:44 (leading: Space)
-8560: Ident           "string" at 698:44-698:50
-8561: Comma           "," at 698:50-698:51
-8562: Ident           "index" at 698:52-698:57 (leading: Space)
-8563: Colon           ":" at 698:57-698:58
-8564: Ident           "Range" at 698:59-698:64 (leading: Space)
-8565: Lt              "<" at 698:64-698:65
-8566: Ident           "int" at 698:65-698:68
-8567: Gt              ">" at 698:68-698:69
-8568: RParen          ")" at 698:69-698:70
-8569: Arrow           "->" at 698:71-698:73 (leading: Space)
-8570: Ident           "string" at 698:74-698:80 (leading: Space)
-8571: Semicolon       ";" at 698:80-698:81
-8572: RBrace          "}" at 699:1-699:2 (leading: Newline)
-8573: At              "@" at 701:1-701:2 (leading: Newline)
-8574: Ident           "intrinsic" at 701:2-701:11
-8575: KwPub           "pub" at 702:1-702:4 (leading: Newline)
-8576: KwType          "type" at 702:5-702:9 (leading: Space)
-8577: Ident           "BytesView" at 702:10-702:19 (leading: Space)
-8578: Assign          "=" at 702:20-702:21 (leading: Space)
-8579: LBrace          "{" at 702:22-702:23 (leading: Space)
-8580: Ident           "owner" at 703:5-703:10 (leading: Newline, Space)
-8581: Colon           ":" at 703:10-703:11
-8582: Ident           "string" at 703:12-703:18 (leading: Space)
-8583: Comma           "," at 703:18-703:19
-8584: Ident           "ptr" at 704:5-704:8 (leading: Newline, Space)
-8585: Colon           ":" at 704:8-704:9
-8586: Star            "*" at 704:10-704:11 (leading: Space)
-8587: Ident           "byte" at 704:11-704:15
-8588: Comma           "," at 704:15-704:16
-8589: Ident           "len" at 705:5-705:8 (leading: Newline, Space)
-8590: Colon           ":" at 705:8-705:9
-8591: Ident           "uint" at 705:10-705:14 (leading: Space)
-8592: Comma           "," at 705:14-705:15
-8593: RBrace          "}" at 706:1-706:2 (leading: Newline)
-8594: Semicolon       ";" at 706:2-706:3
-8595: KwExtern        "extern" at 708:1-708:7 (leading: Newline)
-8596: Lt              "<" at 708:7-708:8
-8597: Ident           "BytesView" at 708:8-708:17
-8598: Gt              ">" at 708:17-708:18
-8599: LBrace          "{" at 708:19-708:20 (leading: Space)
-8600: At              "@" at 709:5-709:6 (leading: Newline, Space)
-8601: Ident           "intrinsic" at 709:6-709:15
-8602: KwFn            "fn" at 709:16-709:18 (leading: Space)
-8603: Ident           "__len" at 709:19-709:24 (leading: Space)
-8604: LParen          "(" at 709:24-709:25
-8605: Ident           "self" at 709:25-709:29
-8606: Colon           ":" at 709:29-709:30
-8607: Amp             "&" at 709:31-709:32 (leading: Space)
-8608: Ident           "BytesView" at 709:32-709:41
-8609: RParen          ")" at 709:41-709:42
-8610: Arrow           "->" at 709:43-709:45 (leading: Space)
-8611: Ident           "uint" at 709:46-709:50 (leading: Space)
-8612: Semicolon       ";" at 709:50-709:51
-8613: At              "@" at 710:5-710:6 (leading: Newline, Space)
-8614: Ident           "intrinsic" at 710:6-710:15
-8615: KwFn            "fn" at 710:16-710:18 (leading: Space)
-8616: Ident           "__index" at 710:19-710:26 (leading: Space)
-8617: LParen          "(" at 710:26-710:27
-8618: Ident           "self" at 710:27-710:31
-8619: Colon           ":" at 710:31-710:32
-8620: Amp             "&" at 710:33-710:34 (leading: Space)
-8621: Ident           "BytesView" at 710:34-710:43
-8622: Comma           "," at 710:43-710:44
-8623: Ident           "index" at 710:45-710:50 (leading: Space)
-8624: Colon           ":" at 710:50-710:51
-8625: Ident           "int" at 710:52-710:55 (leading: Space)
-8626: RParen          ")" at 710:55-710:56
-8627: Arrow           "->" at 710:57-710:59 (leading: Space)
-8628: Ident           "uint8" at 710:60-710:65 (leading: Space)
-8629: Semicolon       ";" at 710:65-710:66
-8630: At              "@" at 711:5-711:6 (leading: Newline, Space)
-8631: Ident           "intrinsic" at 711:6-711:15
-8632: At              "@" at 711:16-711:17 (leading: Space)
-8633: Ident           "overload" at 711:17-711:25
-8634: KwFn            "fn" at 711:26-711:28 (leading: Space)
-8635: Ident           "__index" at 711:29-711:36 (leading: Space)
-8636: LParen          "(" at 711:36-711:37
-8637: Ident           "self" at 711:37-711:41
-8638: Colon           ":" at 711:41-711:42
-8639: Amp             "&" at 711:43-711:44 (leading: Space)
-8640: Ident           "BytesView" at 711:44-711:53
-8641: Comma           "," at 711:53-711:54
-8642: Ident           "index" at 711:55-711:60 (leading: Space)
-8643: Colon           ":" at 711:60-711:61
-8644: Ident           "int64" at 711:62-711:67 (leading: Space)
-8645: RParen          ")" at 711:67-711:68
-8646: Arrow           "->" at 711:69-711:71 (leading: Space)
-8647: Ident           "uint8" at 711:72-711:77 (leading: Space)
-8648: Semicolon       ";" at 711:77-711:78
-8649: RBrace          "}" at 712:1-712:2 (leading: Newline)
-8650: KwExtern        "extern" at 714:1-714:7 (leading: Newline)
-8651: Lt              "<" at 714:7-714:8
-8652: Ident           "bool" at 714:8-714:12
-8653: Gt              ">" at 714:12-714:13
-8654: LBrace          "{" at 714:14-714:15 (leading: Space)
-8655: At              "@" at 715:5-715:6 (leading: Newline, Space)
-8656: Ident           "intrinsic" at 715:6-715:15
-8657: KwFn            "fn" at 715:16-715:18 (leading: Space)
-8658: Ident           "__eq" at 715:19-715:23 (leading: Space)
-8659: LParen          "(" at 715:23-715:24
-8660: Ident           "self" at 715:24-715:28
-8661: Colon           ":" at 715:28-715:29
-8662: Ident           "bool" at 715:30-715:34 (leading: Space)
-8663: Comma           "," at 715:34-715:35
-8664: Ident           "other" at 715:36-715:41 (leading: Space)
-8665: Colon           ":" at 715:41-715:42
-8666: Ident           "bool" at 715:43-715:47 (leading: Space)
-8667: RParen          ")" at 715:47-715:48
-8668: Arrow           "->" at 715:49-715:51 (leading: Space)
-8669: Ident           "bool" at 715:52-715:56 (leading: Space)
-8670: Semicolon       ";" at 715:56-715:57
-8671: At              "@" at 716:5-716:6 (leading: Newline, Space)
-8672: Ident           "intrinsic" at 716:6-716:15
-8673: KwFn            "fn" at 716:16-716:18 (leading: Space)
-8674: Ident           "__ne" at 716:19-716:23 (leading: Space)
-8675: LParen          "(" at 716:23-716:24
-8676: Ident           "self" at 716:24-716:28
-8677: Colon           ":" at 716:28-716:29
-8678: Ident           "bool" at 716:30-716:34 (leading: Space)
-8679: Comma           "," at 716:34-716:35
-8680: Ident           "other" at 716:36-716:41 (leading: Space)
-8681: Colon           ":" at 716:41-716:42
-8682: Ident           "bool" at 716:43-716:47 (leading: Space)
-8683: RParen          ")" at 716:47-716:48
-8684: Arrow           "->" at 716:49-716:51 (leading: Space)
-8685: Ident           "bool" at 716:52-716:56 (leading: Space)
-8686: Semicolon       ";" at 716:56-716:57
-8687: At              "@" at 717:5-717:6 (leading: Newline, Space)
-8688: Ident           "intrinsic" at 717:6-717:15
-8689: KwFn            "fn" at 717:16-717:18 (leading: Space)
-8690: Ident           "__not" at 717:19-717:24 (leading: Space)
-8691: LParen          "(" at 717:24-717:25
-8692: Ident           "self" at 717:25-717:29
-8693: Colon           ":" at 717:29-717:30
-8694: Ident           "bool" at 717:31-717:35 (leading: Space)
-8695: RParen          ")" at 717:35-717:36
-8696: Arrow           "->" at 717:37-717:39 (leading: Space)
-8697: Ident           "bool" at 717:40-717:44 (leading: Space)
-8698: Semicolon       ";" at 717:44-717:45
-8699: At              "@" at 718:5-718:6 (leading: Newline, Space)
-8700: Ident           "intrinsic" at 718:6-718:15
-8701: KwFn            "fn" at 718:16-718:18 (leading: Space)
-8702: Ident           "__to" at 718:19-718:23 (leading: Space)
-8703: LParen          "(" at 718:23-718:24
-8704: Ident           "self" at 718:24-718:28
-8705: Colon           ":" at 718:28-718:29
-8706: Ident           "bool" at 718:30-718:34 (leading: Space)
-8707: Comma           "," at 718:34-718:35
-8708: Ident           "target" at 718:36-718:42 (leading: Space)
-8709: Colon           ":" at 718:42-718:43
-8710: Ident           "string" at 718:44-718:50 (leading: Space)
-8711: RParen          ")" at 718:50-718:51
-8712: Arrow           "->" at 718:52-718:54 (leading: Space)
-8713: Ident           "string" at 718:55-718:61 (leading: Space)
-8714: Semicolon       ";" at 718:61-718:62
-8715: At              "@" at 719:5-719:6 (leading: Newline, Space)
-8716: Ident           "overload" at 719:6-719:14
-8717: KwPub           "pub" at 719:15-719:18 (leading: Space)
-8718: KwFn            "fn" at 719:19-719:21 (leading: Space)
-8719: Ident           "__to" at 719:22-719:26 (leading: Space)
-8720: LParen          "(" at 719:26-719:27
-8721: Ident           "self" at 719:27-719:31
-8722: Colon           ":" at 719:31-719:32
-8723: Amp             "&" at 719:33-719:34 (leading: Space)
-8724: Ident           "bool" at 719:34-719:38
-8725: Comma           "," at 719:38-719:39
-8726: Underscore      "_" at 719:40-719:41 (leading: Space)
-8727: Colon           ":" at 719:41-719:42
-8728: Ident           "string" at 719:43-719:49 (leading: Space)
-8729: RParen          ")" at 719:49-719:50
-8730: Arrow           "->" at 719:51-719:53 (leading: Space)
-8731: Ident           "string" at 719:54-719:60 (leading: Space)
-8732: LBrace          "{" at 719:61-719:62 (leading: Space)
-8733: KwReturn        "return" at 720:9-720:15 (leading: Newline, Space)
-8734: LParen          "(" at 720:16-720:17 (leading: Space)
-8735: Star            "*" at 720:17-720:18
-8736: Ident           "self" at 720:18-720:22
-8737: RParen          ")" at 720:22-720:23
-8738: KwTo            "to" at 720:24-720:26 (leading: Space)
-8739: Ident           "string" at 720:27-720:33 (leading: Space)
-8740: Semicolon       ";" at 720:33-720:34
-8741: RBrace          "}" at 721:5-721:6 (leading: Newline, Space)
-8742: At              "@" at 722:5-722:6 (leading: Newline, Space)
-8743: Ident           "intrinsic" at 722:6-722:15
-8744: At              "@" at 722:16-722:17 (leading: Space)
-8745: Ident           "overload" at 722:17-722:25
-8746: KwFn            "fn" at 722:26-722:28 (leading: Space)
-8747: Ident           "__to" at 722:29-722:33 (leading: Space)
-8748: LParen          "(" at 722:33-722:34
-8749: Ident           "self" at 722:34-722:38
-8750: Colon           ":" at 722:38-722:39
-8751: Ident           "bool" at 722:40-722:44 (leading: Space)
-8752: Comma           "," at 722:44-722:45
-8753: Ident           "target" at 722:46-722:52 (leading: Space)
-8754: Colon           ":" at 722:52-722:53
-8755: Ident           "int" at 722:54-722:57 (leading: Space)
-8756: RParen          ")" at 722:57-722:58
-8757: Arrow           "->" at 722:59-722:61 (leading: Space)
-8758: Ident           "int" at 722:62-722:65 (leading: Space)
-8759: Semicolon       ";" at 722:65-722:66
-8760: At              "@" at 724:5-724:6 (leading: Newline, Space, LineComment, Newline, Space)
-8761: Ident           "intrinsic" at 724:6-724:15
-8762: KwPub           "pub" at 724:16-724:19 (leading: Space)
-8763: KwFn            "fn" at 724:20-724:22 (leading: Space)
-8764: Ident           "from_str" at 724:23-724:31 (leading: Space)
-8765: LParen          "(" at 724:31-724:32
-8766: Ident           "s" at 724:32-724:33
-8767: Colon           ":" at 724:33-724:34
-8768: Amp             "&" at 724:35-724:36 (leading: Space)
-8769: Ident           "string" at 724:36-724:42
-8770: RParen          ")" at 724:42-724:43
-8771: Arrow           "->" at 724:44-724:46 (leading: Space)
-8772: Ident           "Erring" at 724:47-724:53 (leading: Space)
-8773: Lt              "<" at 724:53-724:54
-8774: Ident           "bool" at 724:54-724:58
-8775: Comma           "," at 724:58-724:59
-8776: Ident           "Error" at 724:60-724:65 (leading: Space)
-8777: Gt              ">" at 724:65-724:66
-8778: Semicolon       ";" at 724:66-724:67
-8779: RBrace          "}" at 725:1-725:2 (leading: Newline)
-8780: KwExtern        "extern" at 727:1-727:7 (leading: Newline)
-8781: Lt              "<" at 727:7-727:8
-8782: Ident           "Array" at 727:8-727:13
-8783: Lt              "<" at 727:13-727:14
-8784: Ident           "T" at 727:14-727:15
-8785: Shr             ">>" at 727:15-727:17
-8786: LBrace          "{" at 727:18-727:19 (leading: Space)
-8787: At              "@" at 728:5-728:6 (leading: Newline, Space)
-8788: Ident           "intrinsic" at 728:6-728:15
-8789: KwFn            "fn" at 728:16-728:18 (leading: Space)
-8790: Ident           "__add" at 728:19-728:24 (leading: Space)
-8791: LParen          "(" at 728:24-728:25
-8792: Ident           "self" at 728:25-728:29
-8793: Colon           ":" at 728:29-728:30
-8794: Amp             "&" at 728:31-728:32 (leading: Space)
-8795: Ident           "Array" at 728:32-728:37
-8796: Lt              "<" at 728:37-728:38
-8797: Ident           "T" at 728:38-728:39
-8798: Gt              ">" at 728:39-728:40
-8799: Comma           "," at 728:40-728:41
-8800: Ident           "other" at 728:42-728:47 (leading: Space)
-8801: Colon           ":" at 728:47-728:48
-8802: Amp             "&" at 728:49-728:50 (leading: Space)
-8803: Ident           "Array" at 728:50-728:55
-8804: Lt              "<" at 728:55-728:56
-8805: Ident           "T" at 728:56-728:57
-8806: Gt              ">" at 728:57-728:58
-8807: RParen          ")" at 728:58-728:59
-8808: Arrow           "->" at 728:60-728:62 (leading: Space)
-8809: Ident           "Array" at 728:63-728:68 (leading: Space)
-8810: Lt              "<" at 728:68-728:69
-8811: Ident           "T" at 728:69-728:70
-8812: Gt              ">" at 728:70-728:71
-8813: Semicolon       ";" at 728:71-728:72
-8814: At              "@" at 729:5-729:6 (leading: Newline, Space)
-8815: Ident           "intrinsic" at 729:6-729:15
-8816: KwFn            "fn" at 729:16-729:18 (leading: Space)
-8817: Ident           "__index" at 729:19-729:26 (leading: Space)
-8818: LParen          "(" at 729:26-729:27
-8819: Ident           "self" at 729:27-729:31
-8820: Colon           ":" at 729:31-729:32
-8821: Amp             "&" at 729:33-729:34 (leading: Space)
-8822: Ident           "Array" at 729:34-729:39
-8823: Lt              "<" at 729:39-729:40
-8824: Ident           "T" at 729:40-729:41
-8825: Gt              ">" at 729:41-729:42
-8826: Comma           "," at 729:42-729:43
-8827: Ident           "index" at 729:44-729:49 (leading: Space)
-8828: Colon           ":" at 729:49-729:50
-8829: Ident           "int" at 729:51-729:54 (leading: Space)
-8830: RParen          ")" at 729:54-729:55
-8831: Arrow           "->" at 729:56-729:58 (leading: Space)
-8832: Amp             "&" at 729:59-729:60 (leading: Space)
-8833: Ident           "T" at 729:60-729:61
-8834: Semicolon       ";" at 729:61-729:62
-8835: At              "@" at 730:5-730:6 (leading: Newline, Space)
-8836: Ident           "intrinsic" at 730:6-730:15
-8837: At              "@" at 730:16-730:17 (leading: Space)
-8838: Ident           "overload" at 730:17-730:25
-8839: KwFn            "fn" at 730:26-730:28 (leading: Space)
-8840: Ident           "__index" at 730:29-730:36 (leading: Space)
-8841: LParen          "(" at 730:36-730:37
-8842: Ident           "self" at 730:37-730:41
-8843: Colon           ":" at 730:41-730:42
-8844: Amp             "&" at 730:43-730:44 (leading: Space)
-8845: Ident           "Array" at 730:44-730:49
-8846: Lt              "<" at 730:49-730:50
-8847: Ident           "T" at 730:50-730:51
-8848: Gt              ">" at 730:51-730:52
-8849: Comma           "," at 730:52-730:53
-8850: Ident           "index" at 730:54-730:59 (leading: Space)
-8851: Colon           ":" at 730:59-730:60
-8852: Ident           "Range" at 730:61-730:66 (leading: Space)
-8853: Lt              "<" at 730:66-730:67
-8854: Ident           "int" at 730:67-730:70
-8855: Gt              ">" at 730:70-730:71
-8856: RParen          ")" at 730:71-730:72
-8857: Arrow           "->" at 730:73-730:75 (leading: Space)
-8858: Ident           "Array" at 730:76-730:81 (leading: Space)
-8859: Lt              "<" at 730:81-730:82
-8860: Ident           "T" at 730:82-730:83
-8861: Gt              ">" at 730:83-730:84
-8862: Semicolon       ";" at 730:84-730:85
-8863: At              "@" at 731:5-731:6 (leading: Newline, Space)
-8864: Ident           "intrinsic" at 731:6-731:15
-8865: KwFn            "fn" at 731:16-731:18 (leading: Space)
-8866: Ident           "__index_set" at 731:19-731:30 (leading: Space)
-8867: LParen          "(" at 731:30-731:31
-8868: Ident           "self" at 731:31-731:35
-8869: Colon           ":" at 731:35-731:36
-8870: Amp             "&" at 731:37-731:38 (leading: Space)
-8871: KwMut           "mut" at 731:38-731:41
-8872: Ident           "Array" at 731:42-731:47 (leading: Space)
-8873: Lt              "<" at 731:47-731:48
-8874: Ident           "T" at 731:48-731:49
-8875: Gt              ">" at 731:49-731:50
-8876: Comma           "," at 731:50-731:51
-8877: Ident           "index" at 731:52-731:57 (leading: Space)
-8878: Colon           ":" at 731:57-731:58
-8879: Ident           "int" at 731:59-731:62 (leading: Space)
-8880: Comma           "," at 731:62-731:63
-8881: Ident           "value" at 731:64-731:69 (leading: Space)
-8882: Colon           ":" at 731:69-731:70
-8883: Ident           "T" at 731:71-731:72 (leading: Space)
-8884: RParen          ")" at 731:72-731:73
-8885: Arrow           "->" at 731:74-731:76 (leading: Space)
-8886: NothingLit      "nothing" at 731:77-731:84 (leading: Space)
-8887: Semicolon       ";" at 731:84-731:85
-8888: At              "@" at 732:5-732:6 (leading: Newline, Space)
-8889: Ident           "intrinsic" at 732:6-732:15
-8890: KwFn            "fn" at 732:16-732:18 (leading: Space)
-8891: Ident           "__range" at 732:19-732:26 (leading: Space)
-8892: LParen          "(" at 732:26-732:27
-8893: Ident           "self" at 732:27-732:31
-8894: Colon           ":" at 732:31-732:32
-8895: Amp             "&" at 732:33-732:34 (leading: Space)
-8896: Ident           "Array" at 732:34-732:39
-8897: Lt              "<" at 732:39-732:40
-8898: Ident           "T" at 732:40-732:41
-8899: Gt              ">" at 732:41-732:42
-8900: RParen          ")" at 732:42-732:43
-8901: Arrow           "->" at 732:44-732:46 (leading: Space)
-8902: Ident           "Range" at 732:47-732:52 (leading: Space)
-8903: Lt              "<" at 732:52-732:53
-8904: Ident           "T" at 732:53-732:54
-8905: Gt              ">" at 732:54-732:55
-8906: Semicolon       ";" at 732:55-732:56
-8907: At              "@" at 733:5-733:6 (leading: Newline, Space)
-8908: Ident           "intrinsic" at 733:6-733:15
-8909: KwFn            "fn" at 733:16-733:18 (leading: Space)
-8910: Ident           "__len" at 733:19-733:24 (leading: Space)
-8911: LParen          "(" at 733:24-733:25
-8912: Ident           "self" at 733:25-733:29
-8913: Colon           ":" at 733:29-733:30
-8914: Amp             "&" at 733:31-733:32 (leading: Space)
-8915: Ident           "Array" at 733:32-733:37
-8916: Lt              "<" at 733:37-733:38
-8917: Ident           "T" at 733:38-733:39
-8918: Gt              ">" at 733:39-733:40
-8919: RParen          ")" at 733:40-733:41
-8920: Arrow           "->" at 733:42-733:44 (leading: Space)
-8921: Ident           "uint" at 733:45-733:49 (leading: Space)
-8922: Semicolon       ";" at 733:49-733:50
-8923: RBrace          "}" at 734:1-734:2 (leading: Newline)
-8924: KwExtern        "extern" at 736:1-736:7 (leading: Newline)
-8925: Lt              "<" at 736:7-736:8
-8926: Ident           "ArrayFixed" at 736:8-736:18
-8927: Lt              "<" at 736:18-736:19
-8928: Ident           "T" at 736:19-736:20
-8929: Comma           "," at 736:20-736:21
-8930: Ident           "N" at 736:22-736:23 (leading: Space)
-8931: Shr             ">>" at 736:23-736:25
-8932: LBrace          "{" at 736:26-736:27 (leading: Space)
-8933: At              "@" at 737:5-737:6 (leading: Newline, Space)
-8934: Ident           "intrinsic" at 737:6-737:15
-8935: KwFn            "fn" at 737:16-737:18 (leading: Space)
-8936: Ident           "__add" at 737:19-737:24 (leading: Space)
-8937: LParen          "(" at 737:24-737:25
-8938: Ident           "self" at 737:25-737:29
-8939: Colon           ":" at 737:29-737:30
-8940: Amp             "&" at 737:31-737:32 (leading: Space)
-8941: Ident           "ArrayFixed" at 737:32-737:42
-8942: Lt              "<" at 737:42-737:43
-8943: Ident           "T" at 737:43-737:44
-8944: Comma           "," at 737:44-737:45
-8945: Ident           "N" at 737:46-737:47 (leading: Space)
-8946: Gt              ">" at 737:47-737:48
-8947: Comma           "," at 737:48-737:49
-8948: Ident           "other" at 737:50-737:55 (leading: Space)
-8949: Colon           ":" at 737:55-737:56
-8950: Amp             "&" at 737:57-737:58 (leading: Space)
-8951: Ident           "ArrayFixed" at 737:58-737:68
-8952: Lt              "<" at 737:68-737:69
-8953: Ident           "T" at 737:69-737:70
-8954: Comma           "," at 737:70-737:71
-8955: Ident           "N" at 737:72-737:73 (leading: Space)
-8956: Gt              ">" at 737:73-737:74
-8957: RParen          ")" at 737:74-737:75
-8958: Arrow           "->" at 737:76-737:78 (leading: Space)
-8959: Ident           "ArrayFixed" at 737:79-737:89 (leading: Space)
-8960: Lt              "<" at 737:89-737:90
-8961: Ident           "T" at 737:90-737:91
-8962: Comma           "," at 737:91-737:92
-8963: Ident           "N" at 737:93-737:94 (leading: Space)
-8964: Gt              ">" at 737:94-737:95
-8965: Semicolon       ";" at 737:95-737:96
-8966: At              "@" at 738:5-738:6 (leading: Newline, Space)
-8967: Ident           "intrinsic" at 738:6-738:15
-8968: KwFn            "fn" at 738:16-738:18 (leading: Space)
-8969: Ident           "__index" at 738:19-738:26 (leading: Space)
-8970: LParen          "(" at 738:26-738:27
-8971: Ident           "self" at 738:27-738:31
-8972: Colon           ":" at 738:31-738:32
-8973: Amp             "&" at 738:33-738:34 (leading: Space)
-8974: Ident           "ArrayFixed" at 738:34-738:44
-8975: Lt              "<" at 738:44-738:45
-8976: Ident           "T" at 738:45-738:46
-8977: Comma           "," at 738:46-738:47
-8978: Ident           "N" at 738:48-738:49 (leading: Space)
-8979: Gt              ">" at 738:49-738:50
-8980: Comma           "," at 738:50-738:51
-8981: Ident           "index" at 738:52-738:57 (leading: Space)
-8982: Colon           ":" at 738:57-738:58
-8983: Ident           "int" at 738:59-738:62 (leading: Space)
-8984: RParen          ")" at 738:62-738:63
-8985: Arrow           "->" at 738:64-738:66 (leading: Space)
-8986: Amp             "&" at 738:67-738:68 (leading: Space)
-8987: Ident           "T" at 738:68-738:69
-8988: Semicolon       ";" at 738:69-738:70
-8989: At              "@" at 739:5-739:6 (leading: Newline, Space)
-8990: Ident           "intrinsic" at 739:6-739:15
-8991: At              "@" at 739:16-739:17 (leading: Space)
-8992: Ident           "overload" at 739:17-739:25
-8993: KwFn            "fn" at 739:26-739:28 (leading: Space)
-8994: Ident           "__index" at 739:29-739:36 (leading: Space)
-8995: LParen          "(" at 739:36-739:37
-8996: Ident           "self" at 739:37-739:41
-8997: Colon           ":" at 739:41-739:42
-8998: Amp             "&" at 739:43-739:44 (leading: Space)
-8999: Ident           "ArrayFixed" at 739:44-739:54
-9000: Lt              "<" at 739:54-739:55
-9001: Ident           "T" at 739:55-739:56
-9002: Comma           "," at 739:56-739:57
-9003: Ident           "N" at 739:58-739:59 (leading: Space)
-9004: Gt              ">" at 739:59-739:60
-9005: Comma           "," at 739:60-739:61
-9006: Ident           "index" at 739:62-739:67 (leading: Space)
-9007: Colon           ":" at 739:67-739:68
-9008: Ident           "Range" at 739:69-739:74 (leading: Space)
-9009: Lt              "<" at 739:74-739:75
-9010: Ident           "int" at 739:75-739:78
-9011: Gt              ">" at 739:78-739:79
-9012: RParen          ")" at 739:79-739:80
-9013: Arrow           "->" at 739:81-739:83 (leading: Space)
-9014: Ident           "Array" at 739:84-739:89 (leading: Space)
-9015: Lt              "<" at 739:89-739:90
-9016: Ident           "T" at 739:90-739:91
-9017: Gt              ">" at 739:91-739:92
-9018: Semicolon       ";" at 739:92-739:93
-9019: At              "@" at 740:5-740:6 (leading: Newline, Space)
-9020: Ident           "intrinsic" at 740:6-740:15
-9021: KwFn            "fn" at 740:16-740:18 (leading: Space)
-9022: Ident           "__index_set" at 740:19-740:30 (leading: Space)
-9023: LParen          "(" at 740:30-740:31
-9024: Ident           "self" at 740:31-740:35
-9025: Colon           ":" at 740:35-740:36
-9026: Amp             "&" at 740:37-740:38 (leading: Space)
-9027: KwMut           "mut" at 740:38-740:41
-9028: Ident           "ArrayFixed" at 740:42-740:52 (leading: Space)
-9029: Lt              "<" at 740:52-740:53
-9030: Ident           "T" at 740:53-740:54
-9031: Comma           "," at 740:54-740:55
-9032: Ident           "N" at 740:56-740:57 (leading: Space)
-9033: Gt              ">" at 740:57-740:58
-9034: Comma           "," at 740:58-740:59
-9035: Ident           "index" at 740:60-740:65 (leading: Space)
-9036: Colon           ":" at 740:65-740:66
-9037: Ident           "int" at 740:67-740:70 (leading: Space)
-9038: Comma           "," at 740:70-740:71
-9039: Ident           "value" at 740:72-740:77 (leading: Space)
-9040: Colon           ":" at 740:77-740:78
-9041: Ident           "T" at 740:79-740:80 (leading: Space)
-9042: RParen          ")" at 740:80-740:81
-9043: Arrow           "->" at 740:82-740:84 (leading: Space)
-9044: NothingLit      "nothing" at 740:85-740:92 (leading: Space)
-9045: Semicolon       ";" at 740:92-740:93
-9046: At              "@" at 741:5-741:6 (leading: Newline, Space)
-9047: Ident           "intrinsic" at 741:6-741:15
-9048: KwFn            "fn" at 741:16-741:18 (leading: Space)
-9049: Ident           "__range" at 741:19-741:26 (leading: Space)
-9050: LParen          "(" at 741:26-741:27
-9051: Ident           "self" at 741:27-741:31
-9052: Colon           ":" at 741:31-741:32
-9053: Amp             "&" at 741:33-741:34 (leading: Space)
-9054: Ident           "ArrayFixed" at 741:34-741:44
-9055: Lt              "<" at 741:44-741:45
-9056: Ident           "T" at 741:45-741:46
-9057: Comma           "," at 741:46-741:47
-9058: Ident           "N" at 741:48-741:49 (leading: Space)
-9059: Gt              ">" at 741:49-741:50
-9060: RParen          ")" at 741:50-741:51
-9061: Arrow           "->" at 741:52-741:54 (leading: Space)
-9062: Ident           "Range" at 741:55-741:60 (leading: Space)
-9063: Lt              "<" at 741:60-741:61
-9064: Ident           "T" at 741:61-741:62
-9065: Gt              ">" at 741:62-741:63
-9066: Semicolon       ";" at 741:63-741:64
-9067: At              "@" at 742:5-742:6 (leading: Newline, Space)
-9068: Ident           "intrinsic" at 742:6-742:15
-9069: KwFn            "fn" at 742:16-742:18 (leading: Space)
-9070: Ident           "__len" at 742:19-742:24 (leading: Space)
-9071: LParen          "(" at 742:24-742:25
-9072: Ident           "self" at 742:25-742:29
-9073: Colon           ":" at 742:29-742:30
-9074: Amp             "&" at 742:31-742:32 (leading: Space)
-9075: Ident           "ArrayFixed" at 742:32-742:42
-9076: Lt              "<" at 742:42-742:43
-9077: Ident           "T" at 742:43-742:44
-9078: Comma           "," at 742:44-742:45
-9079: Ident           "N" at 742:46-742:47 (leading: Space)
-9080: Gt              ">" at 742:47-742:48
-9081: RParen          ")" at 742:48-742:49
-9082: Arrow           "->" at 742:50-742:52 (leading: Space)
-9083: Ident           "uint" at 742:53-742:57 (leading: Space)
-9084: Semicolon       ";" at 742:57-742:58
-9085: RBrace          "}" at 743:1-743:2 (leading: Newline)
-9086: At              "@" at 745:1-745:2 (leading: Newline)
-9087: Ident           "intrinsic" at 745:2-745:11
-9088: KwPub           "pub" at 746:1-746:4 (leading: Newline)
-9089: KwFn            "fn" at 746:5-746:7 (leading: Space)
-9090: Ident           "default" at 746:8-746:15 (leading: Space)
-9091: Lt              "<" at 746:15-746:16
-9092: Ident           "T" at 746:16-746:17
-9093: Gt              ">" at 746:17-746:18
-9094: LParen          "(" at 746:18-746:19
-9095: RParen          ")" at 746:19-746:20
-9096: Arrow           "->" at 746:21-746:23 (leading: Space)
-9097: Ident           "T" at 746:24-746:25 (leading: Space)
-9098: Semicolon       ";" at 746:25-746:26
-9099: At              "@" at 748:1-748:2 (leading: Newline)
-9100: Ident           "intrinsic" at 748:2-748:11
-9101: KwPub           "pub" at 749:1-749:4 (leading: Newline)
-9102: KwFn            "fn" at 749:5-749:7 (leading: Space)
-9103: Ident           "size_of" at 749:8-749:15 (leading: Space)
-9104: Lt              "<" at 749:15-749:16
-9105: Ident           "T" at 749:16-749:17
-9106: Gt              ">" at 749:17-749:18
-9107: LParen          "(" at 749:18-749:19
-9108: RParen          ")" at 749:19-749:20
-9109: Arrow           "->" at 749:21-749:23 (leading: Space)
-9110: Ident           "uint" at 749:24-749:28 (leading: Space)
-9111: Semicolon       ";" at 749:28-749:29
-9112: At              "@" at 751:1-751:2 (leading: Newline)
-9113: Ident           "intrinsic" at 751:2-751:11
-9114: KwPub           "pub" at 752:1-752:4 (leading: Newline)
-9115: KwFn            "fn" at 752:5-752:7 (leading: Space)
-9116: Ident           "align_of" at 752:8-752:16 (leading: Space)
-9117: Lt              "<" at 752:16-752:17
-9118: Ident           "T" at 752:17-752:18
-9119: Gt              ">" at 752:18-752:19
-9120: LParen          "(" at 752:19-752:20
-9121: RParen          ")" at 752:20-752:21
-9122: Arrow           "->" at 752:22-752:24 (leading: Space)
-9123: Ident           "uint" at 752:25-752:29 (leading: Space)
-9124: Semicolon       ";" at 752:29-752:30
-9125: KwPub           "pub" at 754:1-754:4 (leading: Newline)
-9126: KwContract      "contract" at 754:5-754:13 (leading: Space)
-9127: Ident           "ErrorLike" at 754:14-754:23 (leading: Space)
-9128: LBrace          "{" at 754:23-754:24
-9129: KwField         "field" at 755:5-755:10 (leading: Newline, Space)
-9130: Ident           "message" at 755:11-755:18 (leading: Space)
-9131: Colon           ":" at 755:18-755:19
-9132: Ident           "string" at 755:20-755:26 (leading: Space)
-9133: Semicolon       ";" at 755:26-755:27
-9134: KwField         "field" at 756:5-756:10 (leading: Newline, Space)
-9135: Ident           "code" at 756:11-756:15 (leading: Space)
-9136: Colon           ":" at 756:15-756:16
-9137: Ident           "uint" at 756:17-756:21 (leading: Space)
-9138: Semicolon       ";" at 756:21-756:22
-9139: RBrace          "}" at 757:1-757:2 (leading: Newline)
-9140: At              "@" at 759:1-759:2 (leading: Newline)
-9141: Ident           "intrinsic" at 759:2-759:11
-9142: KwPub           "pub" at 760:1-760:4 (leading: Newline)
-9143: KwFn            "fn" at 760:5-760:7 (leading: Space)
-9144: Ident           "exit" at 760:8-760:12 (leading: Space)
-9145: Lt              "<" at 760:12-760:13
-9146: Ident           "E" at 760:13-760:14
-9147: Colon           ":" at 760:14-760:15
-9148: Ident           "ErrorLike" at 760:16-760:25 (leading: Space)
-9149: Gt              ">" at 760:25-760:26
-9150: LParen          "(" at 760:26-760:27
-9151: Ident           "e" at 760:27-760:28
-9152: Colon           ":" at 760:28-760:29
-9153: Ident           "E" at 760:30-760:31 (leading: Space)
-9154: RParen          ")" at 760:31-760:32
-9155: Arrow           "->" at 760:33-760:35 (leading: Space)
-9156: NothingLit      "nothing" at 760:36-760:43 (leading: Space)
-9157: Semicolon       ";" at 760:43-760:44
-9158: At              "@" at 762:1-762:2 (leading: Newline)
-9159: Ident           "intrinsic" at 762:2-762:11
-9160: KwPub           "pub" at 763:1-763:4 (leading: Newline)
-9161: KwFn            "fn" at 763:5-763:7 (leading: Space)
-9162: Ident           "rt_panic" at 763:8-763:16 (leading: Space)
-9163: LParen          "(" at 763:16-763:17
-9164: Ident           "ptr" at 763:17-763:20
-9165: Colon           ":" at 763:20-763:21
-9166: Star            "*" at 763:22-763:23 (leading: Space)
-9167: Ident           "byte" at 763:23-763:27
-9168: Comma           "," at 763:27-763:28
-9169: Ident           "length" at 763:29-763:35 (leading: Space)
-9170: Colon           ":" at 763:35-763:36
-9171: Ident           "uint" at 763:37-763:41 (leading: Space)
-9172: RParen          ")" at 763:41-763:42
-9173: Arrow           "->" at 763:43-763:45 (leading: Space)
-9174: NothingLit      "nothing" at 763:46-763:53 (leading: Space)
-9175: Semicolon       ";" at 763:53-763:54
-9176: KwPub           "pub" at 765:1-765:4 (leading: Newline)
-9177: KwFn            "fn" at 765:5-765:7 (leading: Space)
-9178: Ident           "panic" at 765:8-765:13 (leading: Space)
-9179: LParen          "(" at 765:13-765:14
-9180: Ident           "msg" at 765:14-765:17
-9181: Colon           ":" at 765:17-765:18
-9182: Ident           "string" at 765:19-765:25 (leading: Space)
-9183: RParen          ")" at 765:25-765:26
-9184: Arrow           "->" at 765:27-765:29 (leading: Space)
-9185: NothingLit      "nothing" at 765:30-765:37 (leading: Space)
-9186: LBrace          "{" at 765:38-765:39 (leading: Space)
-9187: KwLet           "let" at 766:5-766:8 (leading: Newline, Space)
-9188: Ident           "ptr" at 766:9-766:12 (leading: Space)
-9189: Assign          "=" at 766:13-766:14 (leading: Space)
-9190: Ident           "rt_string_ptr" at 766:15-766:28 (leading: Space)
-9191: LParen          "(" at 766:28-766:29
-9192: Amp             "&" at 766:29-766:30
-9193: Ident           "msg" at 766:30-766:33
-9194: RParen          ")" at 766:33-766:34
-9195: Semicolon       ";" at 766:34-766:35
-9196: KwLet           "let" at 767:5-767:8 (leading: Newline, Space)
-9197: Ident           "length" at 767:9-767:15 (leading: Space)
-9198: Assign          "=" at 767:16-767:17 (leading: Space)
-9199: Ident           "rt_string_len_bytes" at 767:18-767:37 (leading: Space)
-9200: LParen          "(" at 767:37-767:38
-9201: Amp             "&" at 767:38-767:39
-9202: Ident           "msg" at 767:39-767:42
-9203: RParen          ")" at 767:42-767:43
-9204: Semicolon       ";" at 767:43-767:44
-9205: Ident           "rt_panic" at 768:5-768:13 (leading: Newline, Space)
-9206: LParen          "(" at 768:13-768:14
-9207: Ident           "ptr" at 768:14-768:17
-9208: Comma           "," at 768:17-768:18
-9209: Ident           "length" at 768:19-768:25 (leading: Space)
-9210: RParen          ")" at 768:25-768:26
-9211: Semicolon       ";" at 768:26-768:27
-9212: RBrace          "}" at 769:1-769:2 (leading: Newline)
-9213: At              "@" at 771:1-771:2 (leading: Newline)
-9214: Ident           "intrinsic" at 771:2-771:11
-9215: KwPub           "pub" at 772:1-772:4 (leading: Newline)
-9216: KwType          "type" at 772:5-772:9 (leading: Space)
-9217: Ident           "RwLock" at 772:10-772:16 (leading: Space)
-9218: Assign          "=" at 772:17-772:18 (leading: Space)
-9219: LBrace          "{" at 772:19-772:20 (leading: Space)
-9220: Ident           "__opaque" at 773:5-773:13 (leading: Newline, Space)
-9221: Colon           ":" at 773:13-773:14
-9222: Star            "*" at 773:15-773:16 (leading: Space)
-9223: Ident           "byte" at 773:16-773:20
-9224: Comma           "," at 773:20-773:21
-9225: RBrace          "}" at 774:1-774:2 (leading: Newline)
-9226: Semicolon       ";" at 774:2-774:3
-9227: KwExtern        "extern" at 776:1-776:7 (leading: Newline)
-9228: Lt              "<" at 776:7-776:8
-9229: Ident           "RwLock" at 776:8-776:14
-9230: Gt              ">" at 776:14-776:15
-9231: LBrace          "{" at 776:16-776:17 (leading: Space)
-9232: At              "@" at 777:5-777:6 (leading: Newline, Space)
-9233: Ident           "intrinsic" at 777:6-777:15
-9234: KwPub           "pub" at 777:16-777:19 (leading: Space)
-9235: KwFn            "fn" at 777:20-777:22 (leading: Space)
-9236: Ident           "new" at 777:23-777:26 (leading: Space)
-9237: LParen          "(" at 777:26-777:27
-9238: RParen          ")" at 777:27-777:28
-9239: Arrow           "->" at 777:29-777:31 (leading: Space)
-9240: Ident           "RwLock" at 777:32-777:38 (leading: Space)
-9241: Semicolon       ";" at 777:38-777:39
-9242: At              "@" at 778:5-778:6 (leading: Newline, Space)
-9243: Ident           "intrinsic" at 778:6-778:15
-9244: KwPub           "pub" at 778:16-778:19 (leading: Space)
-9245: KwFn            "fn" at 778:20-778:22 (leading: Space)
-9246: Ident           "read_lock" at 778:23-778:32 (leading: Space)
-9247: LParen          "(" at 778:32-778:33
-9248: Ident           "self" at 778:33-778:37
-9249: Colon           ":" at 778:37-778:38
-9250: Amp             "&" at 778:39-778:40 (leading: Space)
-9251: KwMut           "mut" at 778:40-778:43
-9252: Ident           "RwLock" at 778:44-778:50 (leading: Space)
-9253: RParen          ")" at 778:50-778:51
-9254: Arrow           "->" at 778:52-778:54 (leading: Space)
-9255: NothingLit      "nothing" at 778:55-778:62 (leading: Space)
-9256: Semicolon       ";" at 778:62-778:63
-9257: At              "@" at 779:5-779:6 (leading: Newline, Space)
-9258: Ident           "intrinsic" at 779:6-779:15
-9259: KwPub           "pub" at 779:16-779:19 (leading: Space)
-9260: KwFn            "fn" at 779:20-779:22 (leading: Space)
-9261: Ident           "read_unlock" at 779:23-779:34 (leading: Space)
-9262: LParen          "(" at 779:34-779:35
-9263: Ident           "self" at 779:35-779:39
-9264: Colon           ":" at 779:39-779:40
-9265: Amp             "&" at 779:41-779:42 (leading: Space)
-9266: KwMut           "mut" at 779:42-779:45
-9267: Ident           "RwLock" at 779:46-779:52 (leading: Space)
-9268: RParen          ")" at 779:52-779:53
-9269: Arrow           "->" at 779:54-779:56 (leading: Space)
-9270: NothingLit      "nothing" at 779:57-779:64 (leading: Space)
-9271: Semicolon       ";" at 779:64-779:65
-9272: At              "@" at 780:5-780:6 (leading: Newline, Space)
-9273: Ident           "intrinsic" at 780:6-780:15
-9274: KwPub           "pub" at 780:16-780:19 (leading: Space)
-9275: KwFn            "fn" at 780:20-780:22 (leading: Space)
-9276: Ident           "write_lock" at 780:23-780:33 (leading: Space)
-9277: LParen          "(" at 780:33-780:34
-9278: Ident           "self" at 780:34-780:38
-9279: Colon           ":" at 780:38-780:39
-9280: Amp             "&" at 780:40-780:41 (leading: Space)
-9281: KwMut           "mut" at 780:41-780:44
-9282: Ident           "RwLock" at 780:45-780:51 (leading: Space)
-9283: RParen          ")" at 780:51-780:52
-9284: Arrow           "->" at 780:53-780:55 (leading: Space)
-9285: NothingLit      "nothing" at 780:56-780:63 (leading: Space)
-9286: Semicolon       ";" at 780:63-780:64
-9287: At              "@" at 781:5-781:6 (leading: Newline, Space)
-9288: Ident           "intrinsic" at 781:6-781:15
-9289: KwPub           "pub" at 781:16-781:19 (leading: Space)
-9290: KwFn            "fn" at 781:20-781:22 (leading: Space)
-9291: Ident           "write_unlock" at 781:23-781:35 (leading: Space)
-9292: LParen          "(" at 781:35-781:36
-9293: Ident           "self" at 781:36-781:40
-9294: Colon           ":" at 781:40-781:41
-9295: Amp             "&" at 781:42-781:43 (leading: Space)
-9296: KwMut           "mut" at 781:43-781:46
-9297: Ident           "RwLock" at 781:47-781:53 (leading: Space)
-9298: RParen          ")" at 781:53-781:54
-9299: Arrow           "->" at 781:55-781:57 (leading: Space)
-9300: NothingLit      "nothing" at 781:58-781:65 (leading: Space)
-9301: Semicolon       ";" at 781:65-781:66
-9302: At              "@" at 782:5-782:6 (leading: Newline, Space)
-9303: Ident           "intrinsic" at 782:6-782:15
-9304: KwPub           "pub" at 782:16-782:19 (leading: Space)
-9305: KwFn            "fn" at 782:20-782:22 (leading: Space)
-9306: Ident           "try_read_lock" at 782:23-782:36 (leading: Space)
-9307: LParen          "(" at 782:36-782:37
-9308: Ident           "self" at 782:37-782:41
-9309: Colon           ":" at 782:41-782:42
-9310: Amp             "&" at 782:43-782:44 (leading: Space)
-9311: KwMut           "mut" at 782:44-782:47
-9312: Ident           "RwLock" at 782:48-782:54 (leading: Space)
-9313: RParen          ")" at 782:54-782:55
-9314: Arrow           "->" at 782:56-782:58 (leading: Space)
-9315: Ident           "bool" at 782:59-782:63 (leading: Space)
-9316: Semicolon       ";" at 782:63-782:64
-9317: At              "@" at 783:5-783:6 (leading: Newline, Space)
-9318: Ident           "intrinsic" at 783:6-783:15
-9319: KwPub           "pub" at 783:16-783:19 (leading: Space)
-9320: KwFn            "fn" at 783:20-783:22 (leading: Space)
-9321: Ident           "try_write_lock" at 783:23-783:37 (leading: Space)
-9322: LParen          "(" at 783:37-783:38
-9323: Ident           "self" at 783:38-783:42
-9324: Colon           ":" at 783:42-783:43
-9325: Amp             "&" at 783:44-783:45 (leading: Space)
-9326: KwMut           "mut" at 783:45-783:48
-9327: Ident           "RwLock" at 783:49-783:55 (leading: Space)
-9328: RParen          ")" at 783:55-783:56
-9329: Arrow           "->" at 783:57-783:59 (leading: Space)
-9330: Ident           "bool" at 783:60-783:64 (leading: Space)
-9331: Semicolon       ";" at 783:64-783:65
-9332: RBrace          "}" at 784:1-784:2 (leading: Newline)
-9333: At              "@" at 792:1-792:2 (leading: Newline, LineComment, Newline, LineComment, Newline, LineComment, Newline, LineComment, Newline, LineComment, Newline)
-9334: Ident           "intrinsic" at 792:2-792:11
-9335: KwPub           "pub" at 793:1-793:4 (leading: Newline)
-9336: KwFn            "fn" at 793:5-793:7 (leading: Space)
-9337: Ident           "atomic_load" at 793:8-793:19 (leading: Space)
-9338: LParen          "(" at 793:19-793:20
-9339: Ident           "ptr" at 793:20-793:23
-9340: Colon           ":" at 793:23-793:24
-9341: Amp             "&" at 793:25-793:26 (leading: Space)
-9342: Ident           "int" at 793:26-793:29
-9343: RParen          ")" at 793:29-793:30
-9344: Arrow           "->" at 793:31-793:33 (leading: Space)
-9345: Ident           "int" at 793:34-793:37 (leading: Space)
-9346: Semicolon       ";" at 793:37-793:38
-9347: At              "@" at 795:1-795:2 (leading: Newline)
-9348: Ident           "intrinsic" at 795:2-795:11
-9349: At              "@" at 796:1-796:2 (leading: Newline)
-9350: Ident           "overload" at 796:2-796:10
-9351: KwPub           "pub" at 797:1-797:4 (leading: Newline)
-9352: KwFn            "fn" at 797:5-797:7 (leading: Space)
-9353: Ident           "atomic_load" at 797:8-797:19 (leading: Space)
-9354: LParen          "(" at 797:19-797:20
-9355: Ident           "ptr" at 797:20-797:23
-9356: Colon           ":" at 797:23-797:24
-9357: Amp             "&" at 797:25-797:26 (leading: Space)
-9358: Ident           "uint" at 797:26-797:30
-9359: RParen          ")" at 797:30-797:31
-9360: Arrow           "->" at 797:32-797:34 (leading: Space)
-9361: Ident           "uint" at 797:35-797:39 (leading: Space)
-9362: Semicolon       ";" at 797:39-797:40
-9363: At              "@" at 799:1-799:2 (leading: Newline)
-9364: Ident           "intrinsic" at 799:2-799:11
-9365: At              "@" at 800:1-800:2 (leading: Newline)
-9366: Ident           "overload" at 800:2-800:10
-9367: KwPub           "pub" at 801:1-801:4 (leading: Newline)
-9368: KwFn            "fn" at 801:5-801:7 (leading: Space)
-9369: Ident           "atomic_load" at 801:8-801:19 (leading: Space)
-9370: LParen          "(" at 801:19-801:20
-9371: Ident           "ptr" at 801:20-801:23
-9372: Colon           ":" at 801:23-801:24
-9373: Amp             "&" at 801:25-801:26 (leading: Space)
-9374: Ident           "bool" at 801:26-801:30
-9375: RParen          ")" at 801:30-801:31
-9376: Arrow           "->" at 801:32-801:34 (leading: Space)
-9377: Ident           "bool" at 801:35-801:39 (leading: Space)
-9378: Semicolon       ";" at 801:39-801:40
-9379: At              "@" at 804:1-804:2 (leading: Newline, LineComment, Newline)
-9380: Ident           "intrinsic" at 804:2-804:11
-9381: KwPub           "pub" at 805:1-805:4 (leading: Newline)
-9382: KwFn            "fn" at 805:5-805:7 (leading: Space)
-9383: Ident           "atomic_store" at 805:8-805:20 (leading: Space)
-9384: LParen          "(" at 805:20-805:21
-9385: Ident           "ptr" at 805:21-805:24
-9386: Colon           ":" at 805:24-805:25
-9387: Amp             "&" at 805:26-805:27 (leading: Space)
-9388: KwMut           "mut" at 805:27-805:30
-9389: Ident           "int" at 805:31-805:34 (leading: Space)
-9390: Comma           "," at 805:34-805:35
-9391: Ident           "value" at 805:36-805:41 (leading: Space)
-9392: Colon           ":" at 805:41-805:42
-9393: Ident           "int" at 805:43-805:46 (leading: Space)
-9394: RParen          ")" at 805:46-805:47
-9395: Arrow           "->" at 805:48-805:50 (leading: Space)
-9396: NothingLit      "nothing" at 805:51-805:58 (leading: Space)
-9397: Semicolon       ";" at 805:58-805:59
-9398: At              "@" at 807:1-807:2 (leading: Newline)
-9399: Ident           "intrinsic" at 807:2-807:11
-9400: At              "@" at 808:1-808:2 (leading: Newline)
-9401: Ident           "overload" at 808:2-808:10
-9402: KwPub           "pub" at 809:1-809:4 (leading: Newline)
-9403: KwFn            "fn" at 809:5-809:7 (leading: Space)
-9404: Ident           "atomic_store" at 809:8-809:20 (leading: Space)
-9405: LParen          "(" at 809:20-809:21
-9406: Ident           "ptr" at 809:21-809:24
-9407: Colon           ":" at 809:24-809:25
-9408: Amp             "&" at 809:26-809:27 (leading: Space)
-9409: KwMut           "mut" at 809:27-809:30
-9410: Ident           "uint" at 809:31-809:35 (leading: Space)
-9411: Comma           "," at 809:35-809:36
-9412: Ident           "value" at 809:37-809:42 (leading: Space)
-9413: Colon           ":" at 809:42-809:43
-9414: Ident           "uint" at 809:44-809:48 (leading: Space)
-9415: RParen          ")" at 809:48-809:49
-9416: Arrow           "->" at 809:50-809:52 (leading: Space)
-9417: NothingLit      "nothing" at 809:53-809:60 (leading: Space)
-9418: Semicolon       ";" at 809:60-809:61
-9419: At              "@" at 811:1-811:2 (leading: Newline)
-9420: Ident           "intrinsic" at 811:2-811:11
-9421: At              "@" at 812:1-812:2 (leading: Newline)
-9422: Ident           "overload" at 812:2-812:10
-9423: KwPub           "pub" at 813:1-813:4 (leading: Newline)
-9424: KwFn            "fn" at 813:5-813:7 (leading: Space)
-9425: Ident           "atomic_store" at 813:8-813:20 (leading: Space)
-9426: LParen          "(" at 813:20-813:21
-9427: Ident           "ptr" at 813:21-813:24
-9428: Colon           ":" at 813:24-813:25
-9429: Amp             "&" at 813:26-813:27 (leading: Space)
-9430: KwMut           "mut" at 813:27-813:30
-9431: Ident           "bool" at 813:31-813:35 (leading: Space)
-9432: Comma           "," at 813:35-813:36
-9433: Ident           "value" at 813:37-813:42 (leading: Space)
-9434: Colon           ":" at 813:42-813:43
-9435: Ident           "bool" at 813:44-813:48 (leading: Space)
-9436: RParen          ")" at 813:48-813:49
-9437: Arrow           "->" at 813:50-813:52 (leading: Space)
-9438: NothingLit      "nothing" at 813:53-813:60 (leading: Space)
-9439: Semicolon       ";" at 813:60-813:61
-9440: At              "@" at 816:1-816:2 (leading: Newline, LineComment, Newline)
-9441: Ident           "intrinsic" at 816:2-816:11
-9442: KwPub           "pub" at 817:1-817:4 (leading: Newline)
-9443: KwFn            "fn" at 817:5-817:7 (leading: Space)
-9444: Ident           "atomic_exchange" at 817:8-817:23 (leading: Space)
-9445: LParen          "(" at 817:23-817:24
-9446: Ident           "ptr" at 817:24-817:27
-9447: Colon           ":" at 817:27-817:28
-9448: Amp             "&" at 817:29-817:30 (leading: Space)
-9449: KwMut           "mut" at 817:30-817:33
-9450: Ident           "int" at 817:34-817:37 (leading: Space)
-9451: Comma           "," at 817:37-817:38
-9452: Ident           "new_val" at 817:39-817:46 (leading: Space)
-9453: Colon           ":" at 817:46-817:47
-9454: Ident           "int" at 817:48-817:51 (leading: Space)
-9455: RParen          ")" at 817:51-817:52
-9456: Arrow           "->" at 817:53-817:55 (leading: Space)
-9457: Ident           "int" at 817:56-817:59 (leading: Space)
-9458: Semicolon       ";" at 817:59-817:60
-9459: At              "@" at 819:1-819:2 (leading: Newline)
-9460: Ident           "intrinsic" at 819:2-819:11
-9461: At              "@" at 820:1-820:2 (leading: Newline)
-9462: Ident           "overload" at 820:2-820:10
-9463: KwPub           "pub" at 821:1-821:4 (leading: Newline)
-9464: KwFn            "fn" at 821:5-821:7 (leading: Space)
-9465: Ident           "atomic_exchange" at 821:8-821:23 (leading: Space)
-9466: LParen          "(" at 821:23-821:24
-9467: Ident           "ptr" at 821:24-821:27
-9468: Colon           ":" at 821:27-821:28
-9469: Amp             "&" at 821:29-821:30 (leading: Space)
-9470: KwMut           "mut" at 821:30-821:33
-9471: Ident           "uint" at 821:34-821:38 (leading: Space)
-9472: Comma           "," at 821:38-821:39
-9473: Ident           "new_val" at 821:40-821:47 (leading: Space)
-9474: Colon           ":" at 821:47-821:48
-9475: Ident           "uint" at 821:49-821:53 (leading: Space)
-9476: RParen          ")" at 821:53-821:54
-9477: Arrow           "->" at 821:55-821:57 (leading: Space)
-9478: Ident           "uint" at 821:58-821:62 (leading: Space)
-9479: Semicolon       ";" at 821:62-821:63
-9480: At              "@" at 823:1-823:2 (leading: Newline)
-9481: Ident           "intrinsic" at 823:2-823:11
-9482: At              "@" at 824:1-824:2 (leading: Newline)
-9483: Ident           "overload" at 824:2-824:10
-9484: KwPub           "pub" at 825:1-825:4 (leading: Newline)
-9485: KwFn            "fn" at 825:5-825:7 (leading: Space)
-9486: Ident           "atomic_exchange" at 825:8-825:23 (leading: Space)
-9487: LParen          "(" at 825:23-825:24
-9488: Ident           "ptr" at 825:24-825:27
-9489: Colon           ":" at 825:27-825:28
-9490: Amp             "&" at 825:29-825:30 (leading: Space)
-9491: KwMut           "mut" at 825:30-825:33
-9492: Ident           "bool" at 825:34-825:38 (leading: Space)
-9493: Comma           "," at 825:38-825:39
-9494: Ident           "new_val" at 825:40-825:47 (leading: Space)
-9495: Colon           ":" at 825:47-825:48
-9496: Ident           "bool" at 825:49-825:53 (leading: Space)
-9497: RParen          ")" at 825:53-825:54
-9498: Arrow           "->" at 825:55-825:57 (leading: Space)
-9499: Ident           "bool" at 825:58-825:62 (leading: Space)
-9500: Semicolon       ";" at 825:62-825:63
-9501: At              "@" at 829:1-829:2 (leading: Newline, LineComment, Newline, LineComment, Newline)
-9502: Ident           "intrinsic" at 829:2-829:11
-9503: KwPub           "pub" at 830:1-830:4 (leading: Newline)
-9504: KwFn            "fn" at 830:5-830:7 (leading: Space)
-9505: Ident           "atomic_compare_exchange" at 830:8-830:31 (leading: Space)
-9506: LParen          "(" at 830:31-830:32
-9507: Ident           "ptr" at 830:32-830:35
-9508: Colon           ":" at 830:35-830:36
-9509: Amp             "&" at 830:37-830:38 (leading: Space)
-9510: KwMut           "mut" at 830:38-830:41
-9511: Ident           "int" at 830:42-830:45 (leading: Space)
-9512: Comma           "," at 830:45-830:46
-9513: Ident           "expected" at 830:47-830:55 (leading: Space)
-9514: Colon           ":" at 830:55-830:56
-9515: Ident           "int" at 830:57-830:60 (leading: Space)
-9516: Comma           "," at 830:60-830:61
-9517: Ident           "desired" at 830:62-830:69 (leading: Space)
-9518: Colon           ":" at 830:69-830:70
-9519: Ident           "int" at 830:71-830:74 (leading: Space)
-9520: RParen          ")" at 830:74-830:75
-9521: Arrow           "->" at 830:76-830:78 (leading: Space)
-9522: Ident           "bool" at 830:79-830:83 (leading: Space)
-9523: Semicolon       ";" at 830:83-830:84
-9524: At              "@" at 832:1-832:2 (leading: Newline)
-9525: Ident           "intrinsic" at 832:2-832:11
-9526: At              "@" at 833:1-833:2 (leading: Newline)
-9527: Ident           "overload" at 833:2-833:10
-9528: KwPub           "pub" at 834:1-834:4 (leading: Newline)
-9529: KwFn            "fn" at 834:5-834:7 (leading: Space)
-9530: Ident           "atomic_compare_exchange" at 834:8-834:31 (leading: Space)
-9531: LParen          "(" at 834:31-834:32
-9532: Ident           "ptr" at 834:32-834:35
-9533: Colon           ":" at 834:35-834:36
-9534: Amp             "&" at 834:37-834:38 (leading: Space)
-9535: KwMut           "mut" at 834:38-834:41
-9536: Ident           "uint" at 834:42-834:46 (leading: Space)
-9537: Comma           "," at 834:46-834:47
-9538: Ident           "expected" at 834:48-834:56 (leading: Space)
-9539: Colon           ":" at 834:56-834:57
-9540: Ident           "uint" at 834:58-834:62 (leading: Space)
-9541: Comma           "," at 834:62-834:63
-9542: Ident           "desired" at 834:64-834:71 (leading: Space)
-9543: Colon           ":" at 834:71-834:72
-9544: Ident           "uint" at 834:73-834:77 (leading: Space)
-9545: RParen          ")" at 834:77-834:78
-9546: Arrow           "->" at 834:79-834:81 (leading: Space)
-9547: Ident           "bool" at 834:82-834:86 (leading: Space)
-9548: Semicolon       ";" at 834:86-834:87
-9549: At              "@" at 836:1-836:2 (leading: Newline)
-9550: Ident           "intrinsic" at 836:2-836:11
-9551: At              "@" at 837:1-837:2 (leading: Newline)
-9552: Ident           "overload" at 837:2-837:10
-9553: KwPub           "pub" at 838:1-838:4 (leading: Newline)
-9554: KwFn            "fn" at 838:5-838:7 (leading: Space)
-9555: Ident           "atomic_compare_exchange" at 838:8-838:31 (leading: Space)
-9556: LParen          "(" at 838:31-838:32
-9557: Ident           "ptr" at 838:32-838:35
-9558: Colon           ":" at 838:35-838:36
-9559: Amp             "&" at 838:37-838:38 (leading: Space)
-9560: KwMut           "mut" at 838:38-838:41
-9561: Ident           "bool" at 838:42-838:46 (leading: Space)
-9562: Comma           "," at 838:46-838:47
-9563: Ident           "expected" at 838:48-838:56 (leading: Space)
-9564: Colon           ":" at 838:56-838:57
-9565: Ident           "bool" at 838:58-838:62 (leading: Space)
-9566: Comma           "," at 838:62-838:63
-9567: Ident           "desired" at 838:64-838:71 (leading: Space)
-9568: Colon           ":" at 838:71-838:72
-9569: Ident           "bool" at 838:73-838:77 (leading: Space)
-9570: RParen          ")" at 838:77-838:78
-9571: Arrow           "->" at 838:79-838:81 (leading: Space)
-9572: Ident           "bool" at 838:82-838:86 (leading: Space)
-9573: Semicolon       ";" at 838:86-838:87
-9574: At              "@" at 841:1-841:2 (leading: Newline, LineComment, Newline)
-9575: Ident           "intrinsic" at 841:2-841:11
-9576: KwPub           "pub" at 842:1-842:4 (leading: Newline)
-9577: KwFn            "fn" at 842:5-842:7 (leading: Space)
-9578: Ident           "atomic_fetch_add" at 842:8-842:24 (leading: Space)
-9579: LParen          "(" at 842:24-842:25
-9580: Ident           "ptr" at 842:25-842:28
-9581: Colon           ":" at 842:28-842:29
-9582: Amp             "&" at 842:30-842:31 (leading: Space)
-9583: KwMut           "mut" at 842:31-842:34
-9584: Ident           "int" at 842:35-842:38 (leading: Space)
-9585: Comma           "," at 842:38-842:39
-9586: Ident           "delta" at 842:40-842:45 (leading: Space)
-9587: Colon           ":" at 842:45-842:46
-9588: Ident           "int" at 842:47-842:50 (leading: Space)
-9589: RParen          ")" at 842:50-842:51
-9590: Arrow           "->" at 842:52-842:54 (leading: Space)
-9591: Ident           "int" at 842:55-842:58 (leading: Space)
-9592: Semicolon       ";" at 842:58-842:59
-9593: At              "@" at 844:1-844:2 (leading: Newline)
-9594: Ident           "intrinsic" at 844:2-844:11
-9595: At              "@" at 845:1-845:2 (leading: Newline)
-9596: Ident           "overload" at 845:2-845:10
-9597: KwPub           "pub" at 846:1-846:4 (leading: Newline)
-9598: KwFn            "fn" at 846:5-846:7 (leading: Space)
-9599: Ident           "atomic_fetch_add" at 846:8-846:24 (leading: Space)
-9600: LParen          "(" at 846:24-846:25
-9601: Ident           "ptr" at 846:25-846:28
-9602: Colon           ":" at 846:28-846:29
-9603: Amp             "&" at 846:30-846:31 (leading: Space)
-9604: KwMut           "mut" at 846:31-846:34
-9605: Ident           "uint" at 846:35-846:39 (leading: Space)
-9606: Comma           "," at 846:39-846:40
-9607: Ident           "delta" at 846:41-846:46 (leading: Space)
-9608: Colon           ":" at 846:46-846:47
-9609: Ident           "uint" at 846:48-846:52 (leading: Space)
-9610: RParen          ")" at 846:52-846:53
-9611: Arrow           "->" at 846:54-846:56 (leading: Space)
-9612: Ident           "uint" at 846:57-846:61 (leading: Space)
-9613: Semicolon       ";" at 846:61-846:62
-9614: At              "@" at 849:1-849:2 (leading: Newline, LineComment, Newline)
-9615: Ident           "intrinsic" at 849:2-849:11
-9616: KwPub           "pub" at 850:1-850:4 (leading: Newline)
-9617: KwFn            "fn" at 850:5-850:7 (leading: Space)
-9618: Ident           "atomic_fetch_sub" at 850:8-850:24 (leading: Space)
-9619: LParen          "(" at 850:24-850:25
-9620: Ident           "ptr" at 850:25-850:28
-9621: Colon           ":" at 850:28-850:29
-9622: Amp             "&" at 850:30-850:31 (leading: Space)
-9623: KwMut           "mut" at 850:31-850:34
-9624: Ident           "int" at 850:35-850:38 (leading: Space)
-9625: Comma           "," at 850:38-850:39
-9626: Ident           "delta" at 850:40-850:45 (leading: Space)
-9627: Colon           ":" at 850:45-850:46
-9628: Ident           "int" at 850:47-850:50 (leading: Space)
-9629: RParen          ")" at 850:50-850:51
-9630: Arrow           "->" at 850:52-850:54 (leading: Space)
-9631: Ident           "int" at 850:55-850:58 (leading: Space)
-9632: Semicolon       ";" at 850:58-850:59
-9633: At              "@" at 852:1-852:2 (leading: Newline)
-9634: Ident           "intrinsic" at 852:2-852:11
-9635: At              "@" at 853:1-853:2 (leading: Newline)
-9636: Ident           "overload" at 853:2-853:10
-9637: KwPub           "pub" at 854:1-854:4 (leading: Newline)
-9638: KwFn            "fn" at 854:5-854:7 (leading: Space)
-9639: Ident           "atomic_fetch_sub" at 854:8-854:24 (leading: Space)
-9640: LParen          "(" at 854:24-854:25
-9641: Ident           "ptr" at 854:25-854:28
-9642: Colon           ":" at 854:28-854:29
-9643: Amp             "&" at 854:30-854:31 (leading: Space)
-9644: KwMut           "mut" at 854:31-854:34
-9645: Ident           "uint" at 854:35-854:39 (leading: Space)
-9646: Comma           "," at 854:39-854:40
-9647: Ident           "delta" at 854:41-854:46 (leading: Space)
-9648: Colon           ":" at 854:46-854:47
-9649: Ident           "uint" at 854:48-854:52 (leading: Space)
-9650: RParen          ")" at 854:52-854:53
-9651: Arrow           "->" at 854:54-854:56 (leading: Space)
-9652: Ident           "uint" at 854:57-854:61 (leading: Space)
-9653: Semicolon       ";" at 854:61-854:62
-9654: At              "@" at 859:1-859:2 (leading: Newline, LineComment, Newline, LineComment, Newline)
-9655: Ident           "intrinsic" at 859:2-859:11
-9656: KwPub           "pub" at 860:1-860:4 (leading: Newline)
-9657: KwFn            "fn" at 860:5-860:7 (leading: Space)
-9658: Ident           "rt_argv" at 860:8-860:15 (leading: Space)
-9659: LParen          "(" at 860:15-860:16
-9660: RParen          ")" at 860:16-860:17
-9661: Arrow           "->" at 860:18-860:20 (leading: Space)
-9662: Ident           "string" at 860:21-860:27 (leading: Space)
-9663: LBracket        "[" at 860:27-860:28
-9664: RBracket        "]" at 860:28-860:29
-9665: Semicolon       ";" at 860:29-860:30
-9666: At              "@" at 863:1-863:2 (leading: Newline, LineComment, Newline)
-9667: Ident           "intrinsic" at 863:2-863:11
-9668: KwPub           "pub" at 864:1-864:4 (leading: Newline)
-9669: KwFn            "fn" at 864:5-864:7 (leading: Space)
-9670: Ident           "rt_stdin_read_all" at 864:8-864:25 (leading: Space)
-9671: LParen          "(" at 864:25-864:26
-9672: RParen          ")" at 864:26-864:27
-9673: Arrow           "->" at 864:28-864:30 (leading: Space)
-9674: Ident           "string" at 864:31-864:37 (leading: Space)
-9675: Semicolon       ";" at 864:37-864:38
-9676: At              "@" at 867:1-867:2 (leading: Newline, LineComment, Newline)
-9677: Ident           "intrinsic" at 867:2-867:11
-9678: KwPub           "pub" at 868:1-868:4 (leading: Newline)
-9679: KwFn            "fn" at 868:5-868:7 (leading: Space)
-9680: Ident           "rt_exit" at 868:8-868:15 (leading: Space)
-9681: LParen          "(" at 868:15-868:16
-9682: Ident           "code" at 868:16-868:20
-9683: Colon           ":" at 868:20-868:21
-9684: Ident           "int" at 868:22-868:25 (leading: Space)
-9685: RParen          ")" at 868:25-868:26
-9686: Arrow           "->" at 868:27-868:29 (leading: Space)
-9687: NothingLit      "nothing" at 868:30-868:37 (leading: Space)
-9688: Semicolon       ";" at 868:37-868:38
-9689: EOF             at 869:1-869:1
+1571: Ident           "K" at 143:59-143:60 (leading: Space)
+1572: Comma           "," at 143:60-143:61
+1573: Ident           "value" at 143:62-143:67 (leading: Space)
+1574: Colon           ":" at 143:67-143:68
+1575: Ident           "V" at 143:69-143:70 (leading: Space)
+1576: RParen          ")" at 143:70-143:71
+1577: Arrow           "->" at 143:72-143:74 (leading: Space)
+1578: Ident           "Option" at 143:75-143:81 (leading: Space)
+1579: Lt              "<" at 143:81-143:82
+1580: Ident           "V" at 143:82-143:83
+1581: Gt              ">" at 143:83-143:84
+1582: Semicolon       ";" at 143:84-143:85
+1583: At              "@" at 144:1-144:2 (leading: Newline)
+1584: Ident           "intrinsic" at 144:2-144:11
+1585: KwFn            "fn" at 144:12-144:14 (leading: Space)
+1586: Ident           "rt_map_remove" at 144:15-144:28 (leading: Space)
+1587: Lt              "<" at 144:28-144:29
+1588: Ident           "K" at 144:29-144:30
+1589: Comma           "," at 144:30-144:31
+1590: Ident           "V" at 144:32-144:33 (leading: Space)
+1591: Gt              ">" at 144:33-144:34
+1592: LParen          "(" at 144:34-144:35
+1593: Ident           "m" at 144:35-144:36
+1594: Colon           ":" at 144:36-144:37
+1595: Amp             "&" at 144:38-144:39 (leading: Space)
+1596: KwMut           "mut" at 144:39-144:42
+1597: Ident           "Map" at 144:43-144:46 (leading: Space)
+1598: Lt              "<" at 144:46-144:47
+1599: Ident           "K" at 144:47-144:48
+1600: Comma           "," at 144:48-144:49
+1601: Ident           "V" at 144:50-144:51 (leading: Space)
+1602: Gt              ">" at 144:51-144:52
+1603: Comma           "," at 144:52-144:53
+1604: Ident           "key" at 144:54-144:57 (leading: Space)
+1605: Colon           ":" at 144:57-144:58
+1606: Amp             "&" at 144:59-144:60 (leading: Space)
+1607: Ident           "K" at 144:60-144:61
+1608: RParen          ")" at 144:61-144:62
+1609: Arrow           "->" at 144:63-144:65 (leading: Space)
+1610: Ident           "Option" at 144:66-144:72 (leading: Space)
+1611: Lt              "<" at 144:72-144:73
+1612: Ident           "V" at 144:73-144:74
+1613: Gt              ">" at 144:74-144:75
+1614: Semicolon       ";" at 144:75-144:76
+1615: At              "@" at 145:1-145:2 (leading: Newline)
+1616: Ident           "intrinsic" at 145:2-145:11
+1617: KwFn            "fn" at 145:12-145:14 (leading: Space)
+1618: Ident           "rt_map_keys" at 145:15-145:26 (leading: Space)
+1619: Lt              "<" at 145:26-145:27
+1620: Ident           "K" at 145:27-145:28
+1621: Comma           "," at 145:28-145:29
+1622: Ident           "V" at 145:30-145:31 (leading: Space)
+1623: Gt              ">" at 145:31-145:32
+1624: LParen          "(" at 145:32-145:33
+1625: Ident           "m" at 145:33-145:34
+1626: Colon           ":" at 145:34-145:35
+1627: Amp             "&" at 145:36-145:37 (leading: Space)
+1628: Ident           "Map" at 145:37-145:40
+1629: Lt              "<" at 145:40-145:41
+1630: Ident           "K" at 145:41-145:42
+1631: Comma           "," at 145:42-145:43
+1632: Ident           "V" at 145:44-145:45 (leading: Space)
+1633: Gt              ">" at 145:45-145:46
+1634: RParen          ")" at 145:46-145:47
+1635: Arrow           "->" at 145:48-145:50 (leading: Space)
+1636: Ident           "K" at 145:51-145:52 (leading: Space)
+1637: LBracket        "[" at 145:52-145:53
+1638: RBracket        "]" at 145:53-145:54
+1639: Semicolon       ";" at 145:54-145:55
+1640: At              "@" at 148:1-148:2 (leading: Newline, LineComment, Newline)
+1641: Ident           "intrinsic" at 148:2-148:11
+1642: KwPub           "pub" at 149:1-149:4 (leading: Newline)
+1643: KwFn            "fn" at 149:5-149:7 (leading: Space)
+1644: Ident           "readline" at 149:8-149:16 (leading: Space)
+1645: LParen          "(" at 149:16-149:17
+1646: RParen          ")" at 149:17-149:18
+1647: Arrow           "->" at 149:19-149:21 (leading: Space)
+1648: Ident           "string" at 149:22-149:28 (leading: Space)
+1649: Semicolon       ";" at 149:28-149:29
+1650: At              "@" at 151:1-151:2 (leading: Newline)
+1651: Ident           "intrinsic" at 151:2-151:11
+1652: KwPub           "pub" at 152:1-152:4 (leading: Newline)
+1653: KwType          "type" at 152:5-152:9 (leading: Space)
+1654: Ident           "Range" at 152:10-152:15 (leading: Space)
+1655: Lt              "<" at 152:15-152:16
+1656: Ident           "T" at 152:16-152:17
+1657: Gt              ">" at 152:17-152:18
+1658: Assign          "=" at 152:19-152:20 (leading: Space)
+1659: LBrace          "{" at 152:21-152:22 (leading: Space)
+1660: Ident           "__state" at 153:5-153:12 (leading: Newline, Space)
+1661: Colon           ":" at 153:12-153:13
+1662: Star            "*" at 153:14-153:15 (leading: Space)
+1663: Ident           "byte" at 153:15-153:19
+1664: Comma           "," at 153:19-153:20
+1665: RBrace          "}" at 154:1-154:2 (leading: Newline)
+1666: Semicolon       ";" at 154:2-154:3
+1667: At              "@" at 157:1-157:2 (leading: Newline, LineComment, Newline)
+1668: Ident           "intrinsic" at 157:2-157:11
+1669: KwPub           "pub" at 157:12-157:15 (leading: Space)
+1670: KwFn            "fn" at 157:16-157:18 (leading: Space)
+1671: Ident           "rt_range_int_new" at 157:19-157:35 (leading: Space)
+1672: LParen          "(" at 157:35-157:36
+1673: Ident           "start" at 157:36-157:41
+1674: Colon           ":" at 157:41-157:42
+1675: Ident           "int" at 157:43-157:46 (leading: Space)
+1676: Comma           "," at 157:46-157:47
+1677: Ident           "end" at 157:48-157:51 (leading: Space)
+1678: Colon           ":" at 157:51-157:52
+1679: Ident           "int" at 157:53-157:56 (leading: Space)
+1680: Comma           "," at 157:56-157:57
+1681: Ident           "inclusive" at 157:58-157:67 (leading: Space)
+1682: Colon           ":" at 157:67-157:68
+1683: Ident           "bool" at 157:69-157:73 (leading: Space)
+1684: RParen          ")" at 157:73-157:74
+1685: Arrow           "->" at 157:75-157:77 (leading: Space)
+1686: Ident           "Range" at 157:78-157:83 (leading: Space)
+1687: Lt              "<" at 157:83-157:84
+1688: Ident           "int" at 157:84-157:87
+1689: Gt              ">" at 157:87-157:88
+1690: Semicolon       ";" at 157:88-157:89
+1691: At              "@" at 158:1-158:2 (leading: Newline)
+1692: Ident           "intrinsic" at 158:2-158:11
+1693: KwPub           "pub" at 158:12-158:15 (leading: Space)
+1694: KwFn            "fn" at 158:16-158:18 (leading: Space)
+1695: Ident           "rt_range_int_from_start" at 158:19-158:42 (leading: Space)
+1696: LParen          "(" at 158:42-158:43
+1697: Ident           "start" at 158:43-158:48
+1698: Colon           ":" at 158:48-158:49
+1699: Ident           "int" at 158:50-158:53 (leading: Space)
+1700: Comma           "," at 158:53-158:54
+1701: Ident           "inclusive" at 158:55-158:64 (leading: Space)
+1702: Colon           ":" at 158:64-158:65
+1703: Ident           "bool" at 158:66-158:70 (leading: Space)
+1704: RParen          ")" at 158:70-158:71
+1705: Arrow           "->" at 158:72-158:74 (leading: Space)
+1706: Ident           "Range" at 158:75-158:80 (leading: Space)
+1707: Lt              "<" at 158:80-158:81
+1708: Ident           "int" at 158:81-158:84
+1709: Gt              ">" at 158:84-158:85
+1710: Semicolon       ";" at 158:85-158:86
+1711: At              "@" at 159:1-159:2 (leading: Newline)
+1712: Ident           "intrinsic" at 159:2-159:11
+1713: KwPub           "pub" at 159:12-159:15 (leading: Space)
+1714: KwFn            "fn" at 159:16-159:18 (leading: Space)
+1715: Ident           "rt_range_int_to_end" at 159:19-159:38 (leading: Space)
+1716: LParen          "(" at 159:38-159:39
+1717: Ident           "end" at 159:39-159:42
+1718: Colon           ":" at 159:42-159:43
+1719: Ident           "int" at 159:44-159:47 (leading: Space)
+1720: Comma           "," at 159:47-159:48
+1721: Ident           "inclusive" at 159:49-159:58 (leading: Space)
+1722: Colon           ":" at 159:58-159:59
+1723: Ident           "bool" at 159:60-159:64 (leading: Space)
+1724: RParen          ")" at 159:64-159:65
+1725: Arrow           "->" at 159:66-159:68 (leading: Space)
+1726: Ident           "Range" at 159:69-159:74 (leading: Space)
+1727: Lt              "<" at 159:74-159:75
+1728: Ident           "int" at 159:75-159:78
+1729: Gt              ">" at 159:78-159:79
+1730: Semicolon       ";" at 159:79-159:80
+1731: At              "@" at 160:1-160:2 (leading: Newline)
+1732: Ident           "intrinsic" at 160:2-160:11
+1733: KwPub           "pub" at 160:12-160:15 (leading: Space)
+1734: KwFn            "fn" at 160:16-160:18 (leading: Space)
+1735: Ident           "rt_range_int_full" at 160:19-160:36 (leading: Space)
+1736: LParen          "(" at 160:36-160:37
+1737: Ident           "inclusive" at 160:37-160:46
+1738: Colon           ":" at 160:46-160:47
+1739: Ident           "bool" at 160:48-160:52 (leading: Space)
+1740: RParen          ")" at 160:52-160:53
+1741: Arrow           "->" at 160:54-160:56 (leading: Space)
+1742: Ident           "Range" at 160:57-160:62 (leading: Space)
+1743: Lt              "<" at 160:62-160:63
+1744: Ident           "int" at 160:63-160:66
+1745: Gt              ">" at 160:66-160:67
+1746: Semicolon       ";" at 160:67-160:68
+1747: KwExtern        "extern" at 162:1-162:7 (leading: Newline)
+1748: Lt              "<" at 162:7-162:8
+1749: Ident           "Range" at 162:8-162:13
+1750: Lt              "<" at 162:13-162:14
+1751: Ident           "T" at 162:14-162:15
+1752: Shr             ">>" at 162:15-162:17
+1753: LBrace          "{" at 162:18-162:19 (leading: Space)
+1754: At              "@" at 163:5-163:6 (leading: Newline, Space)
+1755: Ident           "intrinsic" at 163:6-163:15
+1756: KwPub           "pub" at 163:16-163:19 (leading: Space)
+1757: KwFn            "fn" at 163:20-163:22 (leading: Space)
+1758: Ident           "next" at 163:23-163:27 (leading: Space)
+1759: LParen          "(" at 163:27-163:28
+1760: Ident           "self" at 163:28-163:32
+1761: Colon           ":" at 163:32-163:33
+1762: Amp             "&" at 163:34-163:35 (leading: Space)
+1763: KwMut           "mut" at 163:35-163:38
+1764: Ident           "Range" at 163:39-163:44 (leading: Space)
+1765: Lt              "<" at 163:44-163:45
+1766: Ident           "T" at 163:45-163:46
+1767: Gt              ">" at 163:46-163:47
+1768: RParen          ")" at 163:47-163:48
+1769: Arrow           "->" at 163:49-163:51 (leading: Space)
+1770: Ident           "Option" at 163:52-163:58 (leading: Space)
+1771: Lt              "<" at 163:58-163:59
+1772: Ident           "T" at 163:59-163:60
+1773: Gt              ">" at 163:60-163:61
+1774: Semicolon       ";" at 163:61-163:62
+1775: RBrace          "}" at 164:1-164:2 (leading: Newline)
+1776: KwPub           "pub" at 166:1-166:4 (leading: Newline)
+1777: KwType          "type" at 166:5-166:9 (leading: Space)
+1778: Ident           "HeapStats" at 166:10-166:19 (leading: Space)
+1779: Assign          "=" at 166:20-166:21 (leading: Space)
+1780: LBrace          "{" at 166:22-166:23 (leading: Space)
+1781: Ident           "alloc_count" at 167:5-167:16 (leading: Newline, Space)
+1782: Colon           ":" at 167:16-167:17
+1783: Ident           "uint" at 167:18-167:22 (leading: Space)
+1784: Comma           "," at 167:22-167:23
+1785: Ident           "free_count" at 168:5-168:15 (leading: Newline, Space)
+1786: Colon           ":" at 168:15-168:16
+1787: Ident           "uint" at 168:17-168:21 (leading: Space)
+1788: Comma           "," at 168:21-168:22
+1789: Ident           "live_blocks" at 169:5-169:16 (leading: Newline, Space)
+1790: Colon           ":" at 169:16-169:17
+1791: Ident           "uint" at 169:18-169:22 (leading: Space)
+1792: Comma           "," at 169:22-169:23
+1793: Ident           "live_bytes" at 170:5-170:15 (leading: Newline, Space)
+1794: Colon           ":" at 170:15-170:16
+1795: Ident           "uint" at 170:17-170:21 (leading: Space)
+1796: Comma           "," at 170:21-170:22
+1797: Ident           "rc_increments" at 171:5-171:18 (leading: Newline, Space)
+1798: Colon           ":" at 171:18-171:19
+1799: Ident           "uint" at 171:20-171:24 (leading: Space)
+1800: Comma           "," at 171:24-171:25
+1801: Ident           "rc_decrements" at 172:5-172:18 (leading: Newline, Space)
+1802: Colon           ":" at 172:18-172:19
+1803: Ident           "uint" at 172:20-172:24 (leading: Space)
+1804: Comma           "," at 172:24-172:25
+1805: RBrace          "}" at 173:1-173:2 (leading: Newline)
+1806: Semicolon       ";" at 173:2-173:3
+1807: At              "@" at 179:1-179:2 (leading: Newline, LineComment, Newline, LineComment, Newline, LineComment, Newline, LineComment, Newline)
+1808: Ident           "intrinsic" at 179:2-179:11
+1809: KwPub           "pub" at 179:12-179:15 (leading: Space)
+1810: KwFn            "fn" at 179:16-179:18 (leading: Space)
+1811: Ident           "rt_heap_stats" at 179:19-179:32 (leading: Space)
+1812: LParen          "(" at 179:32-179:33
+1813: RParen          ")" at 179:33-179:34
+1814: Arrow           "->" at 179:35-179:37 (leading: Space)
+1815: Ident           "HeapStats" at 179:38-179:47 (leading: Space)
+1816: Semicolon       ";" at 179:47-179:48
+1817: At              "@" at 181:1-181:2 (leading: Newline, LineComment, Newline)
+1818: Ident           "intrinsic" at 181:2-181:11
+1819: KwPub           "pub" at 181:12-181:15 (leading: Space)
+1820: KwFn            "fn" at 181:16-181:18 (leading: Space)
+1821: Ident           "rt_heap_dump" at 181:19-181:31 (leading: Space)
+1822: LParen          "(" at 181:31-181:32
+1823: RParen          ")" at 181:32-181:33
+1824: Arrow           "->" at 181:34-181:36 (leading: Space)
+1825: Ident           "string" at 181:37-181:43 (leading: Space)
+1826: Semicolon       ";" at 181:43-181:44
+1827: At              "@" at 183:1-183:2 (leading: Newline, LineComment, Newline)
+1828: Ident           "intrinsic" at 183:2-183:11
+1829: KwPub           "pub" at 183:12-183:15 (leading: Space)
+1830: KwFn            "fn" at 183:16-183:18 (leading: Space)
+1831: Ident           "rt_worker_count" at 183:19-183:34 (leading: Space)
+1832: LParen          "(" at 183:34-183:35
+1833: RParen          ")" at 183:35-183:36
+1834: Arrow           "->" at 183:37-183:39 (leading: Space)
+1835: Ident           "uint" at 183:40-183:44 (leading: Space)
+1836: Semicolon       ";" at 183:44-183:45
+1837: KwPub           "pub" at 185:1-185:4 (leading: Newline)
+1838: KwType          "type" at 185:5-185:9 (leading: Space)
+1839: Ident           "Task" at 185:10-185:14 (leading: Space)
+1840: Lt              "<" at 185:14-185:15
+1841: Ident           "T" at 185:15-185:16
+1842: Gt              ">" at 185:16-185:17
+1843: Assign          "=" at 185:18-185:19 (leading: Space)
+1844: LBrace          "{" at 185:20-185:21 (leading: Space)
+1845: Ident           "__opaque" at 186:5-186:13 (leading: Newline, Space)
+1846: Colon           ":" at 186:13-186:14
+1847: Ident           "int" at 186:15-186:18 (leading: Space)
+1848: Comma           "," at 186:18-186:19
+1849: RBrace          "}" at 187:1-187:2 (leading: Newline)
+1850: Semicolon       ";" at 187:2-187:3
+1851: KwPub           "pub" at 189:1-189:4 (leading: Newline)
+1852: KwTag           "tag" at 189:5-189:8 (leading: Space)
+1853: Ident           "Cancelled" at 189:9-189:18 (leading: Space)
+1854: LParen          "(" at 189:18-189:19
+1855: RParen          ")" at 189:19-189:20
+1856: Semicolon       ";" at 189:20-189:21
+1857: KwPub           "pub" at 190:1-190:4 (leading: Newline)
+1858: KwType          "type" at 190:5-190:9 (leading: Space)
+1859: Ident           "TaskResult" at 190:10-190:20 (leading: Space)
+1860: Lt              "<" at 190:20-190:21
+1861: Ident           "T" at 190:21-190:22
+1862: Gt              ">" at 190:22-190:23
+1863: Assign          "=" at 190:24-190:25 (leading: Space)
+1864: Ident           "Success" at 190:26-190:33 (leading: Space)
+1865: LParen          "(" at 190:33-190:34
+1866: Ident           "T" at 190:34-190:35
+1867: RParen          ")" at 190:35-190:36
+1868: Pipe            "|" at 190:37-190:38 (leading: Space)
+1869: Ident           "Cancelled" at 190:39-190:48 (leading: Space)
+1870: Semicolon       ";" at 190:48-190:49
+1871: At              "@" at 192:1-192:2 (leading: Newline)
+1872: Ident           "intrinsic" at 192:2-192:11
+1873: KwFn            "fn" at 192:12-192:14 (leading: Space)
+1874: Ident           "rt_scope_enter" at 192:15-192:29 (leading: Space)
+1875: LParen          "(" at 192:29-192:30
+1876: Ident           "failfast" at 192:30-192:38
+1877: Colon           ":" at 192:38-192:39
+1878: Ident           "bool" at 192:40-192:44 (leading: Space)
+1879: RParen          ")" at 192:44-192:45
+1880: Arrow           "->" at 192:46-192:48 (leading: Space)
+1881: Ident           "uint" at 192:49-192:53 (leading: Space)
+1882: Semicolon       ";" at 192:53-192:54
+1883: At              "@" at 193:1-193:2 (leading: Newline)
+1884: Ident           "intrinsic" at 193:2-193:11
+1885: KwFn            "fn" at 193:12-193:14 (leading: Space)
+1886: Ident           "rt_scope_register_child" at 193:15-193:38 (leading: Space)
+1887: Lt              "<" at 193:38-193:39
+1888: Ident           "T" at 193:39-193:40
+1889: Gt              ">" at 193:40-193:41
+1890: LParen          "(" at 193:41-193:42
+1891: Ident           "scope" at 193:42-193:47
+1892: Colon           ":" at 193:47-193:48
+1893: Ident           "uint" at 193:49-193:53 (leading: Space)
+1894: Comma           "," at 193:53-193:54
+1895: Ident           "child" at 193:55-193:60 (leading: Space)
+1896: Colon           ":" at 193:60-193:61
+1897: Ident           "Task" at 193:62-193:66 (leading: Space)
+1898: Lt              "<" at 193:66-193:67
+1899: Ident           "T" at 193:67-193:68
+1900: Gt              ">" at 193:68-193:69
+1901: RParen          ")" at 193:69-193:70
+1902: Arrow           "->" at 193:71-193:73 (leading: Space)
+1903: NothingLit      "nothing" at 193:74-193:81 (leading: Space)
+1904: Semicolon       ";" at 193:81-193:82
+1905: At              "@" at 194:1-194:2 (leading: Newline)
+1906: Ident           "intrinsic" at 194:2-194:11
+1907: KwFn            "fn" at 194:12-194:14 (leading: Space)
+1908: Ident           "rt_scope_cancel_all" at 194:15-194:34 (leading: Space)
+1909: LParen          "(" at 194:34-194:35
+1910: Ident           "scope" at 194:35-194:40
+1911: Colon           ":" at 194:40-194:41
+1912: Ident           "uint" at 194:42-194:46 (leading: Space)
+1913: RParen          ")" at 194:46-194:47
+1914: Arrow           "->" at 194:48-194:50 (leading: Space)
+1915: NothingLit      "nothing" at 194:51-194:58 (leading: Space)
+1916: Semicolon       ";" at 194:58-194:59
+1917: At              "@" at 195:1-195:2 (leading: Newline)
+1918: Ident           "intrinsic" at 195:2-195:11
+1919: KwFn            "fn" at 195:12-195:14 (leading: Space)
+1920: Ident           "rt_scope_join_all" at 195:15-195:32 (leading: Space)
+1921: LParen          "(" at 195:32-195:33
+1922: Ident           "scope" at 195:33-195:38
+1923: Colon           ":" at 195:38-195:39
+1924: Ident           "uint" at 195:40-195:44 (leading: Space)
+1925: RParen          ")" at 195:44-195:45
+1926: Arrow           "->" at 195:46-195:48 (leading: Space)
+1927: Ident           "bool" at 195:49-195:53 (leading: Space)
+1928: Semicolon       ";" at 195:53-195:54
+1929: At              "@" at 196:1-196:2 (leading: Newline)
+1930: Ident           "intrinsic" at 196:2-196:11
+1931: KwFn            "fn" at 196:12-196:14 (leading: Space)
+1932: Ident           "rt_scope_exit" at 196:15-196:28 (leading: Space)
+1933: LParen          "(" at 196:28-196:29
+1934: Ident           "scope" at 196:29-196:34
+1935: Colon           ":" at 196:34-196:35
+1936: Ident           "uint" at 196:36-196:40 (leading: Space)
+1937: RParen          ")" at 196:40-196:41
+1938: Arrow           "->" at 196:42-196:44 (leading: Space)
+1939: NothingLit      "nothing" at 196:45-196:52 (leading: Space)
+1940: Semicolon       ";" at 196:52-196:53
+1941: KwExtern        "extern" at 198:1-198:7 (leading: Newline)
+1942: Lt              "<" at 198:7-198:8
+1943: Ident           "Task" at 198:8-198:12
+1944: Lt              "<" at 198:12-198:13
+1945: Ident           "T" at 198:13-198:14
+1946: Shr             ">>" at 198:14-198:16
+1947: LBrace          "{" at 198:17-198:18 (leading: Space)
+1948: At              "@" at 199:5-199:6 (leading: Newline, Space)
+1949: Ident           "intrinsic" at 199:6-199:15
+1950: KwPub           "pub" at 199:16-199:19 (leading: Space)
+1951: KwFn            "fn" at 199:20-199:22 (leading: Space)
+1952: Ident           "clone" at 199:23-199:28 (leading: Space)
+1953: LParen          "(" at 199:28-199:29
+1954: Ident           "self" at 199:29-199:33
+1955: Colon           ":" at 199:33-199:34
+1956: Amp             "&" at 199:35-199:36 (leading: Space)
+1957: Ident           "Task" at 199:36-199:40
+1958: Lt              "<" at 199:40-199:41
+1959: Ident           "T" at 199:41-199:42
+1960: Gt              ">" at 199:42-199:43
+1961: RParen          ")" at 199:43-199:44
+1962: Arrow           "->" at 199:45-199:47 (leading: Space)
+1963: Ident           "Task" at 199:48-199:52 (leading: Space)
+1964: Lt              "<" at 199:52-199:53
+1965: Ident           "T" at 199:53-199:54
+1966: Gt              ">" at 199:54-199:55
+1967: Semicolon       ";" at 199:55-199:56
+1968: At              "@" at 200:5-200:6 (leading: Newline, Space)
+1969: Ident           "intrinsic" at 200:6-200:15
+1970: KwPub           "pub" at 200:16-200:19 (leading: Space)
+1971: KwFn            "fn" at 200:20-200:22 (leading: Space)
+1972: Ident           "cancel" at 200:23-200:29 (leading: Space)
+1973: LParen          "(" at 200:29-200:30
+1974: Ident           "self" at 200:30-200:34
+1975: Colon           ":" at 200:34-200:35
+1976: Amp             "&" at 200:36-200:37 (leading: Space)
+1977: Ident           "Task" at 200:37-200:41
+1978: Lt              "<" at 200:41-200:42
+1979: Ident           "T" at 200:42-200:43
+1980: Gt              ">" at 200:43-200:44
+1981: RParen          ")" at 200:44-200:45
+1982: Arrow           "->" at 200:46-200:48 (leading: Space)
+1983: NothingLit      "nothing" at 200:49-200:56 (leading: Space)
+1984: Semicolon       ";" at 200:56-200:57
+1985: At              "@" at 201:5-201:6 (leading: Newline, Space)
+1986: Ident           "intrinsic" at 201:6-201:15
+1987: KwPub           "pub" at 201:16-201:19 (leading: Space)
+1988: KwFn            "fn" at 201:20-201:22 (leading: Space)
+1989: Ident           "await" at 201:23-201:28 (leading: Space)
+1990: LParen          "(" at 201:28-201:29
+1991: Ident           "self" at 201:29-201:33
+1992: Colon           ":" at 201:33-201:34
+1993: KwOwn           "own" at 201:35-201:38 (leading: Space)
+1994: Ident           "Task" at 201:39-201:43 (leading: Space)
+1995: Lt              "<" at 201:43-201:44
+1996: Ident           "T" at 201:44-201:45
+1997: Gt              ">" at 201:45-201:46
+1998: RParen          ")" at 201:46-201:47
+1999: Arrow           "->" at 201:48-201:50 (leading: Space)
+2000: Ident           "TaskResult" at 201:51-201:61 (leading: Space)
+2001: Lt              "<" at 201:61-201:62
+2002: Ident           "T" at 201:62-201:63
+2003: Gt              ">" at 201:63-201:64
+2004: Semicolon       ";" at 201:64-201:65
+2005: RBrace          "}" at 202:1-202:2 (leading: Newline)
+2006: At              "@" at 206:1-206:2 (leading: Newline, LineComment, Newline, LineComment, Newline)
+2007: Ident           "intrinsic" at 206:2-206:11
+2008: KwPub           "pub" at 207:1-207:4 (leading: Newline)
+2009: KwFn            "fn" at 207:5-207:7 (leading: Space)
+2010: Ident           "checkpoint" at 207:8-207:18 (leading: Space)
+2011: LParen          "(" at 207:18-207:19
+2012: RParen          ")" at 207:19-207:20
+2013: Arrow           "->" at 207:21-207:23 (leading: Space)
+2014: Ident           "Task" at 207:24-207:28 (leading: Space)
+2015: Lt              "<" at 207:28-207:29
+2016: NothingLit      "nothing" at 207:29-207:36
+2017: Gt              ">" at 207:36-207:37
+2018: Semicolon       ";" at 207:37-207:38
+2019: At              "@" at 210:1-210:2 (leading: Newline, LineComment, Newline)
+2020: Ident           "intrinsic" at 210:2-210:11
+2021: KwPub           "pub" at 210:12-210:15 (leading: Space)
+2022: KwFn            "fn" at 210:16-210:18 (leading: Space)
+2023: Ident           "sleep" at 210:19-210:24 (leading: Space)
+2024: LParen          "(" at 210:24-210:25
+2025: Ident           "ms" at 210:25-210:27
+2026: Colon           ":" at 210:27-210:28
+2027: Ident           "uint" at 210:29-210:33 (leading: Space)
+2028: RParen          ")" at 210:33-210:34
+2029: Arrow           "->" at 210:35-210:37 (leading: Space)
+2030: Ident           "Task" at 210:38-210:42 (leading: Space)
+2031: Lt              "<" at 210:42-210:43
+2032: NothingLit      "nothing" at 210:43-210:50
+2033: Gt              ">" at 210:50-210:51
+2034: Semicolon       ";" at 210:51-210:52
+2035: At              "@" at 214:1-214:2 (leading: Newline, LineComment, Newline, LineComment, Newline)
+2036: Ident           "intrinsic" at 214:2-214:11
+2037: KwPub           "pub" at 214:12-214:15 (leading: Space)
+2038: KwFn            "fn" at 214:16-214:18 (leading: Space)
+2039: Ident           "timeout" at 214:19-214:26 (leading: Space)
+2040: Lt              "<" at 214:26-214:27
+2041: Ident           "T" at 214:27-214:28
+2042: Gt              ">" at 214:28-214:29
+2043: LParen          "(" at 214:29-214:30
+2044: Ident           "t" at 214:30-214:31
+2045: Colon           ":" at 214:31-214:32
+2046: Ident           "Task" at 214:33-214:37 (leading: Space)
+2047: Lt              "<" at 214:37-214:38
+2048: Ident           "T" at 214:38-214:39
+2049: Gt              ">" at 214:39-214:40
+2050: Comma           "," at 214:40-214:41
+2051: Ident           "ms" at 214:42-214:44 (leading: Space)
+2052: Colon           ":" at 214:44-214:45
+2053: Ident           "uint" at 214:46-214:50 (leading: Space)
+2054: RParen          ")" at 214:50-214:51
+2055: Arrow           "->" at 214:52-214:54 (leading: Space)
+2056: Ident           "TaskResult" at 214:55-214:65 (leading: Space)
+2057: Lt              "<" at 214:65-214:66
+2058: Ident           "T" at 214:66-214:67
+2059: Gt              ">" at 214:67-214:68
+2060: Semicolon       ";" at 214:68-214:69
+2061: At              "@" at 217:1-217:2 (leading: Newline, LineComment, Newline)
+2062: Ident           "copy" at 217:2-217:6
+2063: At              "@" at 218:1-218:2 (leading: Newline)
+2064: Ident           "intrinsic" at 218:2-218:11
+2065: KwPub           "pub" at 219:1-219:4 (leading: Newline)
+2066: KwType          "type" at 219:5-219:9 (leading: Space)
+2067: Ident           "Channel" at 219:10-219:17 (leading: Space)
+2068: Lt              "<" at 219:17-219:18
+2069: Ident           "T" at 219:18-219:19
+2070: Gt              ">" at 219:19-219:20
+2071: Assign          "=" at 219:21-219:22 (leading: Space)
+2072: LBrace          "{" at 219:23-219:24 (leading: Space)
+2073: Ident           "__opaque" at 220:5-220:13 (leading: Newline, Space)
+2074: Colon           ":" at 220:13-220:14
+2075: Star            "*" at 220:15-220:16 (leading: Space)
+2076: Ident           "byte" at 220:16-220:20
+2077: Comma           "," at 220:20-220:21
+2078: RBrace          "}" at 221:1-221:2 (leading: Newline)
+2079: Semicolon       ";" at 221:2-221:3
+2080: KwExtern        "extern" at 223:1-223:7 (leading: Newline)
+2081: Lt              "<" at 223:7-223:8
+2082: Ident           "Channel" at 223:8-223:15
+2083: Lt              "<" at 223:15-223:16
+2084: Ident           "T" at 223:16-223:17
+2085: Shr             ">>" at 223:17-223:19
+2086: LBrace          "{" at 223:20-223:21 (leading: Space)
+2087: At              "@" at 225:5-225:6 (leading: Newline, Space, LineComment, Newline, Space)
+2088: Ident           "intrinsic" at 225:6-225:15
+2089: KwPub           "pub" at 225:16-225:19 (leading: Space)
+2090: KwFn            "fn" at 225:20-225:22 (leading: Space)
+2091: Ident           "new" at 225:23-225:26 (leading: Space)
+2092: LParen          "(" at 225:26-225:27
+2093: Ident           "capacity" at 225:27-225:35
+2094: Colon           ":" at 225:35-225:36
+2095: Ident           "uint" at 225:37-225:41 (leading: Space)
+2096: RParen          ")" at 225:41-225:42
+2097: Arrow           "->" at 225:43-225:45 (leading: Space)
+2098: KwOwn           "own" at 225:46-225:49 (leading: Space)
+2099: Ident           "Channel" at 225:50-225:57 (leading: Space)
+2100: Lt              "<" at 225:57-225:58
+2101: Ident           "T" at 225:58-225:59
+2102: Gt              ">" at 225:59-225:60
+2103: Semicolon       ";" at 225:60-225:61
+2104: At              "@" at 227:5-227:6 (leading: Newline, Space, LineComment, Newline, Space)
+2105: Ident           "intrinsic" at 227:6-227:15
+2106: KwPub           "pub" at 227:16-227:19 (leading: Space)
+2107: KwFn            "fn" at 227:20-227:22 (leading: Space)
+2108: Ident           "send" at 227:23-227:27 (leading: Space)
+2109: LParen          "(" at 227:27-227:28
+2110: Ident           "self" at 227:28-227:32
+2111: Colon           ":" at 227:32-227:33
+2112: Amp             "&" at 227:34-227:35 (leading: Space)
+2113: Ident           "Channel" at 227:35-227:42
+2114: Lt              "<" at 227:42-227:43
+2115: Ident           "T" at 227:43-227:44
+2116: Gt              ">" at 227:44-227:45
+2117: Comma           "," at 227:45-227:46
+2118: Ident           "value" at 227:47-227:52 (leading: Space)
+2119: Colon           ":" at 227:52-227:53
+2120: KwOwn           "own" at 227:54-227:57 (leading: Space)
+2121: Ident           "T" at 227:58-227:59 (leading: Space)
+2122: RParen          ")" at 227:59-227:60
+2123: Arrow           "->" at 227:61-227:63 (leading: Space)
+2124: NothingLit      "nothing" at 227:64-227:71 (leading: Space)
+2125: Semicolon       ";" at 227:71-227:72
+2126: At              "@" at 229:5-229:6 (leading: Newline, Space, LineComment, Newline, Space)
+2127: Ident           "intrinsic" at 229:6-229:15
+2128: KwPub           "pub" at 229:16-229:19 (leading: Space)
+2129: KwFn            "fn" at 229:20-229:22 (leading: Space)
+2130: Ident           "recv" at 229:23-229:27 (leading: Space)
+2131: LParen          "(" at 229:27-229:28
+2132: Ident           "self" at 229:28-229:32
+2133: Colon           ":" at 229:32-229:33
+2134: Amp             "&" at 229:34-229:35 (leading: Space)
+2135: Ident           "Channel" at 229:35-229:42
+2136: Lt              "<" at 229:42-229:43
+2137: Ident           "T" at 229:43-229:44
+2138: Gt              ">" at 229:44-229:45
+2139: RParen          ")" at 229:45-229:46
+2140: Arrow           "->" at 229:47-229:49 (leading: Space)
+2141: Ident           "Option" at 229:50-229:56 (leading: Space)
+2142: Lt              "<" at 229:56-229:57
+2143: Ident           "T" at 229:57-229:58
+2144: Gt              ">" at 229:58-229:59
+2145: Semicolon       ";" at 229:59-229:60
+2146: At              "@" at 231:5-231:6 (leading: Newline, Space, LineComment, Newline, Space)
+2147: Ident           "intrinsic" at 231:6-231:15
+2148: KwPub           "pub" at 231:16-231:19 (leading: Space)
+2149: KwFn            "fn" at 231:20-231:22 (leading: Space)
+2150: Ident           "try_send" at 231:23-231:31 (leading: Space)
+2151: LParen          "(" at 231:31-231:32
+2152: Ident           "self" at 231:32-231:36
+2153: Colon           ":" at 231:36-231:37
+2154: Amp             "&" at 231:38-231:39 (leading: Space)
+2155: Ident           "Channel" at 231:39-231:46
+2156: Lt              "<" at 231:46-231:47
+2157: Ident           "T" at 231:47-231:48
+2158: Gt              ">" at 231:48-231:49
+2159: Comma           "," at 231:49-231:50
+2160: Ident           "value" at 231:51-231:56 (leading: Space)
+2161: Colon           ":" at 231:56-231:57
+2162: KwOwn           "own" at 231:58-231:61 (leading: Space)
+2163: Ident           "T" at 231:62-231:63 (leading: Space)
+2164: RParen          ")" at 231:63-231:64
+2165: Arrow           "->" at 231:65-231:67 (leading: Space)
+2166: Ident           "bool" at 231:68-231:72 (leading: Space)
+2167: Semicolon       ";" at 231:72-231:73
+2168: At              "@" at 233:5-233:6 (leading: Newline, Space, LineComment, Newline, Space)
+2169: Ident           "intrinsic" at 233:6-233:15
+2170: KwPub           "pub" at 233:16-233:19 (leading: Space)
+2171: KwFn            "fn" at 233:20-233:22 (leading: Space)
+2172: Ident           "try_recv" at 233:23-233:31 (leading: Space)
+2173: LParen          "(" at 233:31-233:32
+2174: Ident           "self" at 233:32-233:36
+2175: Colon           ":" at 233:36-233:37
+2176: Amp             "&" at 233:38-233:39 (leading: Space)
+2177: Ident           "Channel" at 233:39-233:46
+2178: Lt              "<" at 233:46-233:47
+2179: Ident           "T" at 233:47-233:48
+2180: Gt              ">" at 233:48-233:49
+2181: RParen          ")" at 233:49-233:50
+2182: Arrow           "->" at 233:51-233:53 (leading: Space)
+2183: Ident           "Option" at 233:54-233:60 (leading: Space)
+2184: Lt              "<" at 233:60-233:61
+2185: Ident           "T" at 233:61-233:62
+2186: Gt              ">" at 233:62-233:63
+2187: Semicolon       ";" at 233:63-233:64
+2188: At              "@" at 235:5-235:6 (leading: Newline, Space, LineComment, Newline, Space)
+2189: Ident           "intrinsic" at 235:6-235:15
+2190: KwPub           "pub" at 235:16-235:19 (leading: Space)
+2191: KwFn            "fn" at 235:20-235:22 (leading: Space)
+2192: Ident           "close" at 235:23-235:28 (leading: Space)
+2193: LParen          "(" at 235:28-235:29
+2194: Ident           "self" at 235:29-235:33
+2195: Colon           ":" at 235:33-235:34
+2196: Amp             "&" at 235:35-235:36 (leading: Space)
+2197: Ident           "Channel" at 235:36-235:43
+2198: Lt              "<" at 235:43-235:44
+2199: Ident           "T" at 235:44-235:45
+2200: Gt              ">" at 235:45-235:46
+2201: RParen          ")" at 235:46-235:47
+2202: Arrow           "->" at 235:48-235:50 (leading: Space)
+2203: NothingLit      "nothing" at 235:51-235:58 (leading: Space)
+2204: Semicolon       ";" at 235:58-235:59
+2205: RBrace          "}" at 236:1-236:2 (leading: Newline)
+2206: At              "@" at 238:1-238:2 (leading: Newline)
+2207: Ident           "intrinsic" at 238:2-238:11
+2208: KwFn            "fn" at 239:1-239:3 (leading: Newline)
+2209: Ident           "make_channel" at 239:4-239:16 (leading: Space)
+2210: Lt              "<" at 239:16-239:17
+2211: Ident           "T" at 239:17-239:18
+2212: Gt              ">" at 239:18-239:19
+2213: LParen          "(" at 239:19-239:20
+2214: Ident           "capacity" at 239:20-239:28
+2215: Colon           ":" at 239:28-239:29
+2216: Ident           "uint" at 239:30-239:34 (leading: Space)
+2217: RParen          ")" at 239:34-239:35
+2218: Arrow           "->" at 239:36-239:38 (leading: Space)
+2219: KwOwn           "own" at 239:39-239:42 (leading: Space)
+2220: Ident           "Channel" at 239:43-239:50 (leading: Space)
+2221: Lt              "<" at 239:50-239:51
+2222: Ident           "T" at 239:51-239:52
+2223: Gt              ">" at 239:52-239:53
+2224: Semicolon       ";" at 239:53-239:54
+2225: KwPub           "pub" at 241:1-241:4 (leading: Newline)
+2226: KwContract      "contract" at 241:5-241:13 (leading: Space)
+2227: Ident           "Bounded" at 241:14-241:21 (leading: Space)
+2228: Lt              "<" at 241:21-241:22
+2229: Ident           "T" at 241:22-241:23
+2230: Gt              ">" at 241:23-241:24
+2231: LBrace          "{" at 241:25-241:26 (leading: Space)
+2232: KwFn            "fn" at 242:5-242:7 (leading: Newline, Space)
+2233: Ident           "__min_value" at 242:8-242:19 (leading: Space)
+2234: LParen          "(" at 242:19-242:20
+2235: RParen          ")" at 242:20-242:21
+2236: Arrow           "->" at 242:22-242:24 (leading: Space)
+2237: Ident           "T" at 242:25-242:26 (leading: Space)
+2238: Semicolon       ";" at 242:26-242:27
+2239: KwFn            "fn" at 243:5-243:7 (leading: Newline, Space)
+2240: Ident           "__max_value" at 243:8-243:19 (leading: Space)
+2241: LParen          "(" at 243:19-243:20
+2242: RParen          ")" at 243:20-243:21
+2243: Arrow           "->" at 243:22-243:24 (leading: Space)
+2244: Ident           "T" at 243:25-243:26 (leading: Space)
+2245: Semicolon       ";" at 243:26-243:27
+2246: RBrace          "}" at 244:1-244:2 (leading: Newline)
+2247: KwPub           "pub" at 246:1-246:4 (leading: Newline)
+2248: KwContract      "contract" at 246:5-246:13 (leading: Space)
+2249: Ident           "HasLength" at 246:14-246:23 (leading: Space)
+2250: Lt              "<" at 246:23-246:24
+2251: Ident           "T" at 246:24-246:25
+2252: Gt              ">" at 246:25-246:26
+2253: LBrace          "{" at 246:27-246:28 (leading: Space)
+2254: KwFn            "fn" at 247:5-247:7 (leading: Newline, Space)
+2255: Ident           "__len" at 247:8-247:13 (leading: Space)
+2256: LParen          "(" at 247:13-247:14
+2257: Ident           "self" at 247:14-247:18
+2258: Colon           ":" at 247:18-247:19
+2259: Amp             "&" at 247:20-247:21 (leading: Space)
+2260: Ident           "T" at 247:21-247:22
+2261: RParen          ")" at 247:22-247:23
+2262: Arrow           "->" at 247:24-247:26 (leading: Space)
+2263: Ident           "uint" at 247:27-247:31 (leading: Space)
+2264: Semicolon       ";" at 247:31-247:32
+2265: RBrace          "}" at 248:1-248:2 (leading: Newline)
+2266: KwPub           "pub" at 250:1-250:4 (leading: Newline)
+2267: KwContract      "contract" at 250:5-250:13 (leading: Space)
+2268: Ident           "Printable" at 250:14-250:23 (leading: Space)
+2269: Lt              "<" at 250:23-250:24
+2270: Ident           "T" at 250:24-250:25
+2271: Gt              ">" at 250:25-250:26
+2272: LBrace          "{" at 250:27-250:28 (leading: Space)
+2273: KwFn            "fn" at 251:5-251:7 (leading: Newline, Space)
+2274: Ident           "__to" at 251:8-251:12 (leading: Space)
+2275: LParen          "(" at 251:12-251:13
+2276: Ident           "self" at 251:13-251:17
+2277: Colon           ":" at 251:17-251:18
+2278: Amp             "&" at 251:19-251:20 (leading: Space)
+2279: Ident           "T" at 251:20-251:21
+2280: Comma           "," at 251:21-251:22
+2281: Ident           "target" at 251:23-251:29 (leading: Space)
+2282: Colon           ":" at 251:29-251:30
+2283: Ident           "string" at 251:31-251:37 (leading: Space)
+2284: RParen          ")" at 251:37-251:38
+2285: Arrow           "->" at 251:39-251:41 (leading: Space)
+2286: Ident           "string" at 251:42-251:48 (leading: Space)
+2287: Semicolon       ";" at 251:48-251:49
+2288: RBrace          "}" at 252:1-252:2 (leading: Newline)
+2289: KwPub           "pub" at 254:1-254:4 (leading: Newline)
+2290: KwFn            "fn" at 254:5-254:7 (leading: Space)
+2291: Ident           "max_value" at 254:8-254:17 (leading: Space)
+2292: Lt              "<" at 254:17-254:18
+2293: Ident           "T" at 254:18-254:19
+2294: Colon           ":" at 254:19-254:20
+2295: Ident           "Bounded" at 254:21-254:28 (leading: Space)
+2296: Lt              "<" at 254:28-254:29
+2297: Ident           "T" at 254:29-254:30
+2298: Shr             ">>" at 254:30-254:32
+2299: LParen          "(" at 254:32-254:33
+2300: RParen          ")" at 254:33-254:34
+2301: Arrow           "->" at 254:35-254:37 (leading: Space)
+2302: Ident           "T" at 254:38-254:39 (leading: Space)
+2303: LBrace          "{" at 254:40-254:41 (leading: Space)
+2304: KwReturn        "return" at 255:5-255:11 (leading: Newline, Space)
+2305: Ident           "T" at 255:12-255:13 (leading: Space)
+2306: Dot             "." at 255:13-255:14
+2307: Ident           "__max_value" at 255:14-255:25
+2308: LParen          "(" at 255:25-255:26
+2309: RParen          ")" at 255:26-255:27
+2310: Semicolon       ";" at 255:27-255:28
+2311: RBrace          "}" at 256:1-256:2 (leading: Newline)
+2312: KwPub           "pub" at 258:1-258:4 (leading: Newline)
+2313: KwFn            "fn" at 258:5-258:7 (leading: Space)
+2314: Ident           "min_value" at 258:8-258:17 (leading: Space)
+2315: Lt              "<" at 258:17-258:18
+2316: Ident           "T" at 258:18-258:19
+2317: Colon           ":" at 258:19-258:20
+2318: Ident           "Bounded" at 258:21-258:28 (leading: Space)
+2319: Lt              "<" at 258:28-258:29
+2320: Ident           "T" at 258:29-258:30
+2321: Shr             ">>" at 258:30-258:32
+2322: LParen          "(" at 258:32-258:33
+2323: RParen          ")" at 258:33-258:34
+2324: Arrow           "->" at 258:35-258:37 (leading: Space)
+2325: Ident           "T" at 258:38-258:39 (leading: Space)
+2326: LBrace          "{" at 258:40-258:41 (leading: Space)
+2327: KwReturn        "return" at 259:5-259:11 (leading: Newline, Space)
+2328: Ident           "T" at 259:12-259:13 (leading: Space)
+2329: Dot             "." at 259:13-259:14
+2330: Ident           "__min_value" at 259:14-259:25
+2331: LParen          "(" at 259:25-259:26
+2332: RParen          ")" at 259:26-259:27
+2333: Semicolon       ";" at 259:27-259:28
+2334: RBrace          "}" at 260:1-260:2 (leading: Newline)
+2335: KwExtern        "extern" at 262:1-262:7 (leading: Newline)
+2336: Lt              "<" at 262:7-262:8
+2337: Ident           "int" at 262:8-262:11
+2338: Gt              ">" at 262:11-262:12
+2339: LBrace          "{" at 262:13-262:14 (leading: Space)
+2340: At              "@" at 263:5-263:6 (leading: Newline, Space)
+2341: Ident           "intrinsic" at 263:6-263:15
+2342: KwFn            "fn" at 263:16-263:18 (leading: Space)
+2343: Ident           "__add" at 263:19-263:24 (leading: Space)
+2344: LParen          "(" at 263:24-263:25
+2345: Ident           "self" at 263:25-263:29
+2346: Colon           ":" at 263:29-263:30
+2347: Ident           "int" at 263:31-263:34 (leading: Space)
+2348: Comma           "," at 263:34-263:35
+2349: Ident           "other" at 263:36-263:41 (leading: Space)
+2350: Colon           ":" at 263:41-263:42
+2351: Ident           "int" at 263:43-263:46 (leading: Space)
+2352: RParen          ")" at 263:46-263:47
+2353: Arrow           "->" at 263:48-263:50 (leading: Space)
+2354: Ident           "int" at 263:51-263:54 (leading: Space)
+2355: Semicolon       ";" at 263:54-263:55
+2356: At              "@" at 264:5-264:6 (leading: Newline, Space)
+2357: Ident           "intrinsic" at 264:6-264:15
+2358: KwFn            "fn" at 264:16-264:18 (leading: Space)
+2359: Ident           "__sub" at 264:19-264:24 (leading: Space)
+2360: LParen          "(" at 264:24-264:25
+2361: Ident           "self" at 264:25-264:29
+2362: Colon           ":" at 264:29-264:30
+2363: Ident           "int" at 264:31-264:34 (leading: Space)
+2364: Comma           "," at 264:34-264:35
+2365: Ident           "other" at 264:36-264:41 (leading: Space)
+2366: Colon           ":" at 264:41-264:42
+2367: Ident           "int" at 264:43-264:46 (leading: Space)
+2368: RParen          ")" at 264:46-264:47
+2369: Arrow           "->" at 264:48-264:50 (leading: Space)
+2370: Ident           "int" at 264:51-264:54 (leading: Space)
+2371: Semicolon       ";" at 264:54-264:55
+2372: At              "@" at 265:5-265:6 (leading: Newline, Space)
+2373: Ident           "intrinsic" at 265:6-265:15
+2374: KwFn            "fn" at 265:16-265:18 (leading: Space)
+2375: Ident           "__mul" at 265:19-265:24 (leading: Space)
+2376: LParen          "(" at 265:24-265:25
+2377: Ident           "self" at 265:25-265:29
+2378: Colon           ":" at 265:29-265:30
+2379: Ident           "int" at 265:31-265:34 (leading: Space)
+2380: Comma           "," at 265:34-265:35
+2381: Ident           "other" at 265:36-265:41 (leading: Space)
+2382: Colon           ":" at 265:41-265:42
+2383: Ident           "int" at 265:43-265:46 (leading: Space)
+2384: RParen          ")" at 265:46-265:47
+2385: Arrow           "->" at 265:48-265:50 (leading: Space)
+2386: Ident           "int" at 265:51-265:54 (leading: Space)
+2387: Semicolon       ";" at 265:54-265:55
+2388: At              "@" at 266:5-266:6 (leading: Newline, Space)
+2389: Ident           "intrinsic" at 266:6-266:15
+2390: KwFn            "fn" at 266:16-266:18 (leading: Space)
+2391: Ident           "__div" at 266:19-266:24 (leading: Space)
+2392: LParen          "(" at 266:24-266:25
+2393: Ident           "self" at 266:25-266:29
+2394: Colon           ":" at 266:29-266:30
+2395: Ident           "int" at 266:31-266:34 (leading: Space)
+2396: Comma           "," at 266:34-266:35
+2397: Ident           "other" at 266:36-266:41 (leading: Space)
+2398: Colon           ":" at 266:41-266:42
+2399: Ident           "int" at 266:43-266:46 (leading: Space)
+2400: RParen          ")" at 266:46-266:47
+2401: Arrow           "->" at 266:48-266:50 (leading: Space)
+2402: Ident           "int" at 266:51-266:54 (leading: Space)
+2403: Semicolon       ";" at 266:54-266:55
+2404: At              "@" at 267:5-267:6 (leading: Newline, Space)
+2405: Ident           "intrinsic" at 267:6-267:15
+2406: KwFn            "fn" at 267:16-267:18 (leading: Space)
+2407: Ident           "__mod" at 267:19-267:24 (leading: Space)
+2408: LParen          "(" at 267:24-267:25
+2409: Ident           "self" at 267:25-267:29
+2410: Colon           ":" at 267:29-267:30
+2411: Ident           "int" at 267:31-267:34 (leading: Space)
+2412: Comma           "," at 267:34-267:35
+2413: Ident           "other" at 267:36-267:41 (leading: Space)
+2414: Colon           ":" at 267:41-267:42
+2415: Ident           "int" at 267:43-267:46 (leading: Space)
+2416: RParen          ")" at 267:46-267:47
+2417: Arrow           "->" at 267:48-267:50 (leading: Space)
+2418: Ident           "int" at 267:51-267:54 (leading: Space)
+2419: Semicolon       ";" at 267:54-267:55
+2420: At              "@" at 268:5-268:6 (leading: Newline, Space)
+2421: Ident           "intrinsic" at 268:6-268:15
+2422: KwFn            "fn" at 268:16-268:18 (leading: Space)
+2423: Ident           "__bit_and" at 268:19-268:28 (leading: Space)
+2424: LParen          "(" at 268:28-268:29
+2425: Ident           "self" at 268:29-268:33
+2426: Colon           ":" at 268:33-268:34
+2427: Ident           "int" at 268:35-268:38 (leading: Space)
+2428: Comma           "," at 268:38-268:39
+2429: Ident           "other" at 268:40-268:45 (leading: Space)
+2430: Colon           ":" at 268:45-268:46
+2431: Ident           "int" at 268:47-268:50 (leading: Space)
+2432: RParen          ")" at 268:50-268:51
+2433: Arrow           "->" at 268:52-268:54 (leading: Space)
+2434: Ident           "int" at 268:55-268:58 (leading: Space)
+2435: Semicolon       ";" at 268:58-268:59
+2436: At              "@" at 269:5-269:6 (leading: Newline, Space)
+2437: Ident           "intrinsic" at 269:6-269:15
+2438: KwFn            "fn" at 269:16-269:18 (leading: Space)
+2439: Ident           "__bit_or" at 269:19-269:27 (leading: Space)
+2440: LParen          "(" at 269:27-269:28
+2441: Ident           "self" at 269:28-269:32
+2442: Colon           ":" at 269:32-269:33
+2443: Ident           "int" at 269:34-269:37 (leading: Space)
+2444: Comma           "," at 269:37-269:38
+2445: Ident           "other" at 269:39-269:44 (leading: Space)
+2446: Colon           ":" at 269:44-269:45
+2447: Ident           "int" at 269:46-269:49 (leading: Space)
+2448: RParen          ")" at 269:49-269:50
+2449: Arrow           "->" at 269:51-269:53 (leading: Space)
+2450: Ident           "int" at 269:54-269:57 (leading: Space)
+2451: Semicolon       ";" at 269:57-269:58
+2452: At              "@" at 270:5-270:6 (leading: Newline, Space)
+2453: Ident           "intrinsic" at 270:6-270:15
+2454: KwFn            "fn" at 270:16-270:18 (leading: Space)
+2455: Ident           "__bit_xor" at 270:19-270:28 (leading: Space)
+2456: LParen          "(" at 270:28-270:29
+2457: Ident           "self" at 270:29-270:33
+2458: Colon           ":" at 270:33-270:34
+2459: Ident           "int" at 270:35-270:38 (leading: Space)
+2460: Comma           "," at 270:38-270:39
+2461: Ident           "other" at 270:40-270:45 (leading: Space)
+2462: Colon           ":" at 270:45-270:46
+2463: Ident           "int" at 270:47-270:50 (leading: Space)
+2464: RParen          ")" at 270:50-270:51
+2465: Arrow           "->" at 270:52-270:54 (leading: Space)
+2466: Ident           "int" at 270:55-270:58 (leading: Space)
+2467: Semicolon       ";" at 270:58-270:59
+2468: At              "@" at 271:5-271:6 (leading: Newline, Space)
+2469: Ident           "intrinsic" at 271:6-271:15
+2470: KwFn            "fn" at 271:16-271:18 (leading: Space)
+2471: Ident           "__shl" at 271:19-271:24 (leading: Space)
+2472: LParen          "(" at 271:24-271:25
+2473: Ident           "self" at 271:25-271:29
+2474: Colon           ":" at 271:29-271:30
+2475: Ident           "int" at 271:31-271:34 (leading: Space)
+2476: Comma           "," at 271:34-271:35
+2477: Ident           "other" at 271:36-271:41 (leading: Space)
+2478: Colon           ":" at 271:41-271:42
+2479: Ident           "int" at 271:43-271:46 (leading: Space)
+2480: RParen          ")" at 271:46-271:47
+2481: Arrow           "->" at 271:48-271:50 (leading: Space)
+2482: Ident           "int" at 271:51-271:54 (leading: Space)
+2483: Semicolon       ";" at 271:54-271:55
+2484: At              "@" at 272:5-272:6 (leading: Newline, Space)
+2485: Ident           "intrinsic" at 272:6-272:15
+2486: KwFn            "fn" at 272:16-272:18 (leading: Space)
+2487: Ident           "__shr" at 272:19-272:24 (leading: Space)
+2488: LParen          "(" at 272:24-272:25
+2489: Ident           "self" at 272:25-272:29
+2490: Colon           ":" at 272:29-272:30
+2491: Ident           "int" at 272:31-272:34 (leading: Space)
+2492: Comma           "," at 272:34-272:35
+2493: Ident           "other" at 272:36-272:41 (leading: Space)
+2494: Colon           ":" at 272:41-272:42
+2495: Ident           "int" at 272:43-272:46 (leading: Space)
+2496: RParen          ")" at 272:46-272:47
+2497: Arrow           "->" at 272:48-272:50 (leading: Space)
+2498: Ident           "int" at 272:51-272:54 (leading: Space)
+2499: Semicolon       ";" at 272:54-272:55
+2500: At              "@" at 273:5-273:6 (leading: Newline, Space)
+2501: Ident           "intrinsic" at 273:6-273:15
+2502: KwFn            "fn" at 273:16-273:18 (leading: Space)
+2503: Ident           "__lt" at 273:19-273:23 (leading: Space)
+2504: LParen          "(" at 273:23-273:24
+2505: Ident           "self" at 273:24-273:28
+2506: Colon           ":" at 273:28-273:29
+2507: Ident           "int" at 273:30-273:33 (leading: Space)
+2508: Comma           "," at 273:33-273:34
+2509: Ident           "other" at 273:35-273:40 (leading: Space)
+2510: Colon           ":" at 273:40-273:41
+2511: Ident           "int" at 273:42-273:45 (leading: Space)
+2512: RParen          ")" at 273:45-273:46
+2513: Arrow           "->" at 273:47-273:49 (leading: Space)
+2514: Ident           "bool" at 273:50-273:54 (leading: Space)
+2515: Semicolon       ";" at 273:54-273:55
+2516: At              "@" at 274:5-274:6 (leading: Newline, Space)
+2517: Ident           "intrinsic" at 274:6-274:15
+2518: KwFn            "fn" at 274:16-274:18 (leading: Space)
+2519: Ident           "__le" at 274:19-274:23 (leading: Space)
+2520: LParen          "(" at 274:23-274:24
+2521: Ident           "self" at 274:24-274:28
+2522: Colon           ":" at 274:28-274:29
+2523: Ident           "int" at 274:30-274:33 (leading: Space)
+2524: Comma           "," at 274:33-274:34
+2525: Ident           "other" at 274:35-274:40 (leading: Space)
+2526: Colon           ":" at 274:40-274:41
+2527: Ident           "int" at 274:42-274:45 (leading: Space)
+2528: RParen          ")" at 274:45-274:46
+2529: Arrow           "->" at 274:47-274:49 (leading: Space)
+2530: Ident           "bool" at 274:50-274:54 (leading: Space)
+2531: Semicolon       ";" at 274:54-274:55
+2532: At              "@" at 275:5-275:6 (leading: Newline, Space)
+2533: Ident           "intrinsic" at 275:6-275:15
+2534: KwFn            "fn" at 275:16-275:18 (leading: Space)
+2535: Ident           "__eq" at 275:19-275:23 (leading: Space)
+2536: LParen          "(" at 275:23-275:24
+2537: Ident           "self" at 275:24-275:28
+2538: Colon           ":" at 275:28-275:29
+2539: Ident           "int" at 275:30-275:33 (leading: Space)
+2540: Comma           "," at 275:33-275:34
+2541: Ident           "other" at 275:35-275:40 (leading: Space)
+2542: Colon           ":" at 275:40-275:41
+2543: Ident           "int" at 275:42-275:45 (leading: Space)
+2544: RParen          ")" at 275:45-275:46
+2545: Arrow           "->" at 275:47-275:49 (leading: Space)
+2546: Ident           "bool" at 275:50-275:54 (leading: Space)
+2547: Semicolon       ";" at 275:54-275:55
+2548: At              "@" at 276:5-276:6 (leading: Newline, Space)
+2549: Ident           "intrinsic" at 276:6-276:15
+2550: KwFn            "fn" at 276:16-276:18 (leading: Space)
+2551: Ident           "__ne" at 276:19-276:23 (leading: Space)
+2552: LParen          "(" at 276:23-276:24
+2553: Ident           "self" at 276:24-276:28
+2554: Colon           ":" at 276:28-276:29
+2555: Ident           "int" at 276:30-276:33 (leading: Space)
+2556: Comma           "," at 276:33-276:34
+2557: Ident           "other" at 276:35-276:40 (leading: Space)
+2558: Colon           ":" at 276:40-276:41
+2559: Ident           "int" at 276:42-276:45 (leading: Space)
+2560: RParen          ")" at 276:45-276:46
+2561: Arrow           "->" at 276:47-276:49 (leading: Space)
+2562: Ident           "bool" at 276:50-276:54 (leading: Space)
+2563: Semicolon       ";" at 276:54-276:55
+2564: At              "@" at 277:5-277:6 (leading: Newline, Space)
+2565: Ident           "intrinsic" at 277:6-277:15
+2566: KwFn            "fn" at 277:16-277:18 (leading: Space)
+2567: Ident           "__ge" at 277:19-277:23 (leading: Space)
+2568: LParen          "(" at 277:23-277:24
+2569: Ident           "self" at 277:24-277:28
+2570: Colon           ":" at 277:28-277:29
+2571: Ident           "int" at 277:30-277:33 (leading: Space)
+2572: Comma           "," at 277:33-277:34
+2573: Ident           "other" at 277:35-277:40 (leading: Space)
+2574: Colon           ":" at 277:40-277:41
+2575: Ident           "int" at 277:42-277:45 (leading: Space)
+2576: RParen          ")" at 277:45-277:46
+2577: Arrow           "->" at 277:47-277:49 (leading: Space)
+2578: Ident           "bool" at 277:50-277:54 (leading: Space)
+2579: Semicolon       ";" at 277:54-277:55
+2580: At              "@" at 278:5-278:6 (leading: Newline, Space)
+2581: Ident           "intrinsic" at 278:6-278:15
+2582: KwFn            "fn" at 278:16-278:18 (leading: Space)
+2583: Ident           "__gt" at 278:19-278:23 (leading: Space)
+2584: LParen          "(" at 278:23-278:24
+2585: Ident           "self" at 278:24-278:28
+2586: Colon           ":" at 278:28-278:29
+2587: Ident           "int" at 278:30-278:33 (leading: Space)
+2588: Comma           "," at 278:33-278:34
+2589: Ident           "other" at 278:35-278:40 (leading: Space)
+2590: Colon           ":" at 278:40-278:41
+2591: Ident           "int" at 278:42-278:45 (leading: Space)
+2592: RParen          ")" at 278:45-278:46
+2593: Arrow           "->" at 278:47-278:49 (leading: Space)
+2594: Ident           "bool" at 278:50-278:54 (leading: Space)
+2595: Semicolon       ";" at 278:54-278:55
+2596: At              "@" at 279:5-279:6 (leading: Newline, Space)
+2597: Ident           "intrinsic" at 279:6-279:15
+2598: KwFn            "fn" at 279:16-279:18 (leading: Space)
+2599: Ident           "__pos" at 279:19-279:24 (leading: Space)
+2600: LParen          "(" at 279:24-279:25
+2601: Ident           "self" at 279:25-279:29
+2602: Colon           ":" at 279:29-279:30
+2603: Ident           "int" at 279:31-279:34 (leading: Space)
+2604: RParen          ")" at 279:34-279:35
+2605: Arrow           "->" at 279:36-279:38 (leading: Space)
+2606: Ident           "int" at 279:39-279:42 (leading: Space)
+2607: Semicolon       ";" at 279:42-279:43
+2608: At              "@" at 280:5-280:6 (leading: Newline, Space)
+2609: Ident           "intrinsic" at 280:6-280:15
+2610: KwFn            "fn" at 280:16-280:18 (leading: Space)
+2611: Ident           "__neg" at 280:19-280:24 (leading: Space)
+2612: LParen          "(" at 280:24-280:25
+2613: Ident           "self" at 280:25-280:29
+2614: Colon           ":" at 280:29-280:30
+2615: Ident           "int" at 280:31-280:34 (leading: Space)
+2616: RParen          ")" at 280:34-280:35
+2617: Arrow           "->" at 280:36-280:38 (leading: Space)
+2618: Ident           "int" at 280:39-280:42 (leading: Space)
+2619: Semicolon       ";" at 280:42-280:43
+2620: At              "@" at 281:5-281:6 (leading: Newline, Space)
+2621: Ident           "intrinsic" at 281:6-281:15
+2622: KwFn            "fn" at 281:16-281:18 (leading: Space)
+2623: Ident           "__abs" at 281:19-281:24 (leading: Space)
+2624: LParen          "(" at 281:24-281:25
+2625: Ident           "self" at 281:25-281:29
+2626: Colon           ":" at 281:29-281:30
+2627: Ident           "int" at 281:31-281:34 (leading: Space)
+2628: RParen          ")" at 281:34-281:35
+2629: Arrow           "->" at 281:36-281:38 (leading: Space)
+2630: Ident           "int" at 281:39-281:42 (leading: Space)
+2631: Semicolon       ";" at 281:42-281:43
+2632: At              "@" at 282:5-282:6 (leading: Newline, Space)
+2633: Ident           "intrinsic" at 282:6-282:15
+2634: KwFn            "fn" at 282:16-282:18 (leading: Space)
+2635: Ident           "__to" at 282:19-282:23 (leading: Space)
+2636: LParen          "(" at 282:23-282:24
+2637: Ident           "self" at 282:24-282:28
+2638: Colon           ":" at 282:28-282:29
+2639: Ident           "int" at 282:30-282:33 (leading: Space)
+2640: Comma           "," at 282:33-282:34
+2641: Ident           "target" at 282:35-282:41 (leading: Space)
+2642: Colon           ":" at 282:41-282:42
+2643: Ident           "string" at 282:43-282:49 (leading: Space)
+2644: RParen          ")" at 282:49-282:50
+2645: Arrow           "->" at 282:51-282:53 (leading: Space)
+2646: Ident           "string" at 282:54-282:60 (leading: Space)
+2647: Semicolon       ";" at 282:60-282:61
+2648: At              "@" at 283:5-283:6 (leading: Newline, Space)
+2649: Ident           "overload" at 283:6-283:14
+2650: KwPub           "pub" at 283:15-283:18 (leading: Space)
+2651: KwFn            "fn" at 283:19-283:21 (leading: Space)
+2652: Ident           "__to" at 283:22-283:26 (leading: Space)
+2653: LParen          "(" at 283:26-283:27
+2654: Ident           "self" at 283:27-283:31
+2655: Colon           ":" at 283:31-283:32
+2656: Amp             "&" at 283:33-283:34 (leading: Space)
+2657: Ident           "int" at 283:34-283:37
+2658: Comma           "," at 283:37-283:38
+2659: Underscore      "_" at 283:39-283:40 (leading: Space)
+2660: Colon           ":" at 283:40-283:41
+2661: Ident           "string" at 283:42-283:48 (leading: Space)
+2662: RParen          ")" at 283:48-283:49
+2663: Arrow           "->" at 283:50-283:52 (leading: Space)
+2664: Ident           "string" at 283:53-283:59 (leading: Space)
+2665: LBrace          "{" at 283:60-283:61 (leading: Space)
+2666: KwReturn        "return" at 284:9-284:15 (leading: Newline, Space)
+2667: LParen          "(" at 284:16-284:17 (leading: Space)
+2668: Star            "*" at 284:17-284:18
+2669: Ident           "self" at 284:18-284:22
+2670: RParen          ")" at 284:22-284:23
+2671: KwTo            "to" at 284:24-284:26 (leading: Space)
+2672: Ident           "string" at 284:27-284:33 (leading: Space)
+2673: Semicolon       ";" at 284:33-284:34
+2674: RBrace          "}" at 285:5-285:6 (leading: Newline, Space)
+2675: At              "@" at 286:5-286:6 (leading: Newline, Space)
+2676: Ident           "intrinsic" at 286:6-286:15
+2677: At              "@" at 286:16-286:17 (leading: Space)
+2678: Ident           "overload" at 286:17-286:25
+2679: KwFn            "fn" at 286:26-286:28 (leading: Space)
+2680: Ident           "__to" at 286:29-286:33 (leading: Space)
+2681: LParen          "(" at 286:33-286:34
+2682: Ident           "self" at 286:34-286:38
+2683: Colon           ":" at 286:38-286:39
+2684: Ident           "int" at 286:40-286:43 (leading: Space)
+2685: Comma           "," at 286:43-286:44
+2686: Ident           "target" at 286:45-286:51 (leading: Space)
+2687: Colon           ":" at 286:51-286:52
+2688: Ident           "float" at 286:53-286:58 (leading: Space)
+2689: RParen          ")" at 286:58-286:59
+2690: Arrow           "->" at 286:60-286:62 (leading: Space)
+2691: Ident           "float" at 286:63-286:68 (leading: Space)
+2692: Semicolon       ";" at 286:68-286:69
+2693: At              "@" at 287:5-287:6 (leading: Newline, Space)
+2694: Ident           "intrinsic" at 287:6-287:15
+2695: At              "@" at 287:16-287:17 (leading: Space)
+2696: Ident           "overload" at 287:17-287:25
+2697: KwFn            "fn" at 287:26-287:28 (leading: Space)
+2698: Ident           "__to" at 287:29-287:33 (leading: Space)
+2699: LParen          "(" at 287:33-287:34
+2700: Ident           "self" at 287:34-287:38
+2701: Colon           ":" at 287:38-287:39
+2702: Ident           "int" at 287:40-287:43 (leading: Space)
+2703: Comma           "," at 287:43-287:44
+2704: Ident           "target" at 287:45-287:51 (leading: Space)
+2705: Colon           ":" at 287:51-287:52
+2706: Ident           "uint" at 287:53-287:57 (leading: Space)
+2707: RParen          ")" at 287:57-287:58
+2708: Arrow           "->" at 287:59-287:61 (leading: Space)
+2709: Ident           "uint" at 287:62-287:66 (leading: Space)
+2710: Semicolon       ";" at 287:66-287:67
+2711: At              "@" at 288:5-288:6 (leading: Newline, Space)
+2712: Ident           "intrinsic" at 288:6-288:15
+2713: At              "@" at 288:16-288:17 (leading: Space)
+2714: Ident           "overload" at 288:17-288:25
+2715: KwFn            "fn" at 288:26-288:28 (leading: Space)
+2716: Ident           "__to" at 288:29-288:33 (leading: Space)
+2717: LParen          "(" at 288:33-288:34
+2718: Ident           "self" at 288:34-288:38
+2719: Colon           ":" at 288:38-288:39
+2720: Ident           "int" at 288:40-288:43 (leading: Space)
+2721: Comma           "," at 288:43-288:44
+2722: Ident           "target" at 288:45-288:51 (leading: Space)
+2723: Colon           ":" at 288:51-288:52
+2724: Ident           "int8" at 288:53-288:57 (leading: Space)
+2725: RParen          ")" at 288:57-288:58
+2726: Arrow           "->" at 288:59-288:61 (leading: Space)
+2727: Ident           "int8" at 288:62-288:66 (leading: Space)
+2728: Semicolon       ";" at 288:66-288:67
+2729: At              "@" at 289:5-289:6 (leading: Newline, Space)
+2730: Ident           "intrinsic" at 289:6-289:15
+2731: At              "@" at 289:16-289:17 (leading: Space)
+2732: Ident           "overload" at 289:17-289:25
+2733: KwFn            "fn" at 289:26-289:28 (leading: Space)
+2734: Ident           "__to" at 289:29-289:33 (leading: Space)
+2735: LParen          "(" at 289:33-289:34
+2736: Ident           "self" at 289:34-289:38
+2737: Colon           ":" at 289:38-289:39
+2738: Ident           "int" at 289:40-289:43 (leading: Space)
+2739: Comma           "," at 289:43-289:44
+2740: Ident           "target" at 289:45-289:51 (leading: Space)
+2741: Colon           ":" at 289:51-289:52
+2742: Ident           "int16" at 289:53-289:58 (leading: Space)
+2743: RParen          ")" at 289:58-289:59
+2744: Arrow           "->" at 289:60-289:62 (leading: Space)
+2745: Ident           "int16" at 289:63-289:68 (leading: Space)
+2746: Semicolon       ";" at 289:68-289:69
+2747: At              "@" at 290:5-290:6 (leading: Newline, Space)
+2748: Ident           "intrinsic" at 290:6-290:15
+2749: At              "@" at 290:16-290:17 (leading: Space)
+2750: Ident           "overload" at 290:17-290:25
+2751: KwFn            "fn" at 290:26-290:28 (leading: Space)
+2752: Ident           "__to" at 290:29-290:33 (leading: Space)
+2753: LParen          "(" at 290:33-290:34
+2754: Ident           "self" at 290:34-290:38
+2755: Colon           ":" at 290:38-290:39
+2756: Ident           "int" at 290:40-290:43 (leading: Space)
+2757: Comma           "," at 290:43-290:44
+2758: Ident           "target" at 290:45-290:51 (leading: Space)
+2759: Colon           ":" at 290:51-290:52
+2760: Ident           "int32" at 290:53-290:58 (leading: Space)
+2761: RParen          ")" at 290:58-290:59
+2762: Arrow           "->" at 290:60-290:62 (leading: Space)
+2763: Ident           "int32" at 290:63-290:68 (leading: Space)
+2764: Semicolon       ";" at 290:68-290:69
+2765: At              "@" at 291:5-291:6 (leading: Newline, Space)
+2766: Ident           "intrinsic" at 291:6-291:15
+2767: At              "@" at 291:16-291:17 (leading: Space)
+2768: Ident           "overload" at 291:17-291:25
+2769: KwFn            "fn" at 291:26-291:28 (leading: Space)
+2770: Ident           "__to" at 291:29-291:33 (leading: Space)
+2771: LParen          "(" at 291:33-291:34
+2772: Ident           "self" at 291:34-291:38
+2773: Colon           ":" at 291:38-291:39
+2774: Ident           "int" at 291:40-291:43 (leading: Space)
+2775: Comma           "," at 291:43-291:44
+2776: Ident           "target" at 291:45-291:51 (leading: Space)
+2777: Colon           ":" at 291:51-291:52
+2778: Ident           "int64" at 291:53-291:58 (leading: Space)
+2779: RParen          ")" at 291:58-291:59
+2780: Arrow           "->" at 291:60-291:62 (leading: Space)
+2781: Ident           "int64" at 291:63-291:68 (leading: Space)
+2782: Semicolon       ";" at 291:68-291:69
+2783: At              "@" at 292:5-292:6 (leading: Newline, Space)
+2784: Ident           "intrinsic" at 292:6-292:15
+2785: At              "@" at 292:16-292:17 (leading: Space)
+2786: Ident           "overload" at 292:17-292:25
+2787: KwFn            "fn" at 292:26-292:28 (leading: Space)
+2788: Ident           "__to" at 292:29-292:33 (leading: Space)
+2789: LParen          "(" at 292:33-292:34
+2790: Ident           "self" at 292:34-292:38
+2791: Colon           ":" at 292:38-292:39
+2792: Ident           "int" at 292:40-292:43 (leading: Space)
+2793: Comma           "," at 292:43-292:44
+2794: Ident           "target" at 292:45-292:51 (leading: Space)
+2795: Colon           ":" at 292:51-292:52
+2796: Ident           "uint8" at 292:53-292:58 (leading: Space)
+2797: RParen          ")" at 292:58-292:59
+2798: Arrow           "->" at 292:60-292:62 (leading: Space)
+2799: Ident           "uint8" at 292:63-292:68 (leading: Space)
+2800: Semicolon       ";" at 292:68-292:69
+2801: At              "@" at 293:5-293:6 (leading: Newline, Space)
+2802: Ident           "intrinsic" at 293:6-293:15
+2803: At              "@" at 293:16-293:17 (leading: Space)
+2804: Ident           "overload" at 293:17-293:25
+2805: KwFn            "fn" at 293:26-293:28 (leading: Space)
+2806: Ident           "__to" at 293:29-293:33 (leading: Space)
+2807: LParen          "(" at 293:33-293:34
+2808: Ident           "self" at 293:34-293:38
+2809: Colon           ":" at 293:38-293:39
+2810: Ident           "int" at 293:40-293:43 (leading: Space)
+2811: Comma           "," at 293:43-293:44
+2812: Ident           "target" at 293:45-293:51 (leading: Space)
+2813: Colon           ":" at 293:51-293:52
+2814: Ident           "uint16" at 293:53-293:59 (leading: Space)
+2815: RParen          ")" at 293:59-293:60
+2816: Arrow           "->" at 293:61-293:63 (leading: Space)
+2817: Ident           "uint16" at 293:64-293:70 (leading: Space)
+2818: Semicolon       ";" at 293:70-293:71
+2819: At              "@" at 294:5-294:6 (leading: Newline, Space)
+2820: Ident           "intrinsic" at 294:6-294:15
+2821: At              "@" at 294:16-294:17 (leading: Space)
+2822: Ident           "overload" at 294:17-294:25
+2823: KwFn            "fn" at 294:26-294:28 (leading: Space)
+2824: Ident           "__to" at 294:29-294:33 (leading: Space)
+2825: LParen          "(" at 294:33-294:34
+2826: Ident           "self" at 294:34-294:38
+2827: Colon           ":" at 294:38-294:39
+2828: Ident           "int" at 294:40-294:43 (leading: Space)
+2829: Comma           "," at 294:43-294:44
+2830: Ident           "target" at 294:45-294:51 (leading: Space)
+2831: Colon           ":" at 294:51-294:52
+2832: Ident           "uint32" at 294:53-294:59 (leading: Space)
+2833: RParen          ")" at 294:59-294:60
+2834: Arrow           "->" at 294:61-294:63 (leading: Space)
+2835: Ident           "uint32" at 294:64-294:70 (leading: Space)
+2836: Semicolon       ";" at 294:70-294:71
+2837: At              "@" at 295:5-295:6 (leading: Newline, Space)
+2838: Ident           "intrinsic" at 295:6-295:15
+2839: At              "@" at 295:16-295:17 (leading: Space)
+2840: Ident           "overload" at 295:17-295:25
+2841: KwFn            "fn" at 295:26-295:28 (leading: Space)
+2842: Ident           "__to" at 295:29-295:33 (leading: Space)
+2843: LParen          "(" at 295:33-295:34
+2844: Ident           "self" at 295:34-295:38
+2845: Colon           ":" at 295:38-295:39
+2846: Ident           "int" at 295:40-295:43 (leading: Space)
+2847: Comma           "," at 295:43-295:44
+2848: Ident           "target" at 295:45-295:51 (leading: Space)
+2849: Colon           ":" at 295:51-295:52
+2850: Ident           "uint64" at 295:53-295:59 (leading: Space)
+2851: RParen          ")" at 295:59-295:60
+2852: Arrow           "->" at 295:61-295:63 (leading: Space)
+2853: Ident           "uint64" at 295:64-295:70 (leading: Space)
+2854: Semicolon       ";" at 295:70-295:71
+2855: At              "@" at 296:5-296:6 (leading: Newline, Space)
+2856: Ident           "intrinsic" at 296:6-296:15
+2857: At              "@" at 296:16-296:17 (leading: Space)
+2858: Ident           "overload" at 296:17-296:25
+2859: KwFn            "fn" at 296:26-296:28 (leading: Space)
+2860: Ident           "__to" at 296:29-296:33 (leading: Space)
+2861: LParen          "(" at 296:33-296:34
+2862: Ident           "self" at 296:34-296:38
+2863: Colon           ":" at 296:38-296:39
+2864: Ident           "int" at 296:40-296:43 (leading: Space)
+2865: Comma           "," at 296:43-296:44
+2866: Ident           "target" at 296:45-296:51 (leading: Space)
+2867: Colon           ":" at 296:51-296:52
+2868: Ident           "float16" at 296:53-296:60 (leading: Space)
+2869: RParen          ")" at 296:60-296:61
+2870: Arrow           "->" at 296:62-296:64 (leading: Space)
+2871: Ident           "float16" at 296:65-296:72 (leading: Space)
+2872: Semicolon       ";" at 296:72-296:73
+2873: At              "@" at 297:5-297:6 (leading: Newline, Space)
+2874: Ident           "intrinsic" at 297:6-297:15
+2875: At              "@" at 297:16-297:17 (leading: Space)
+2876: Ident           "overload" at 297:17-297:25
+2877: KwFn            "fn" at 297:26-297:28 (leading: Space)
+2878: Ident           "__to" at 297:29-297:33 (leading: Space)
+2879: LParen          "(" at 297:33-297:34
+2880: Ident           "self" at 297:34-297:38
+2881: Colon           ":" at 297:38-297:39
+2882: Ident           "int" at 297:40-297:43 (leading: Space)
+2883: Comma           "," at 297:43-297:44
+2884: Ident           "target" at 297:45-297:51 (leading: Space)
+2885: Colon           ":" at 297:51-297:52
+2886: Ident           "float32" at 297:53-297:60 (leading: Space)
+2887: RParen          ")" at 297:60-297:61
+2888: Arrow           "->" at 297:62-297:64 (leading: Space)
+2889: Ident           "float32" at 297:65-297:72 (leading: Space)
+2890: Semicolon       ";" at 297:72-297:73
+2891: At              "@" at 298:5-298:6 (leading: Newline, Space)
+2892: Ident           "intrinsic" at 298:6-298:15
+2893: At              "@" at 298:16-298:17 (leading: Space)
+2894: Ident           "overload" at 298:17-298:25
+2895: KwFn            "fn" at 298:26-298:28 (leading: Space)
+2896: Ident           "__to" at 298:29-298:33 (leading: Space)
+2897: LParen          "(" at 298:33-298:34
+2898: Ident           "self" at 298:34-298:38
+2899: Colon           ":" at 298:38-298:39
+2900: Ident           "int" at 298:40-298:43 (leading: Space)
+2901: Comma           "," at 298:43-298:44
+2902: Ident           "target" at 298:45-298:51 (leading: Space)
+2903: Colon           ":" at 298:51-298:52
+2904: Ident           "float64" at 298:53-298:60 (leading: Space)
+2905: RParen          ")" at 298:60-298:61
+2906: Arrow           "->" at 298:62-298:64 (leading: Space)
+2907: Ident           "float64" at 298:65-298:72 (leading: Space)
+2908: Semicolon       ";" at 298:72-298:73
+2909: At              "@" at 300:5-300:6 (leading: Newline, Space, LineComment, Newline, Space)
+2910: Ident           "intrinsic" at 300:6-300:15
+2911: KwPub           "pub" at 300:16-300:19 (leading: Space)
+2912: KwFn            "fn" at 300:20-300:22 (leading: Space)
+2913: Ident           "from_str" at 300:23-300:31 (leading: Space)
+2914: LParen          "(" at 300:31-300:32
+2915: Ident           "s" at 300:32-300:33
+2916: Colon           ":" at 300:33-300:34
+2917: Amp             "&" at 300:35-300:36 (leading: Space)
+2918: Ident           "string" at 300:36-300:42
+2919: RParen          ")" at 300:42-300:43
+2920: Arrow           "->" at 300:44-300:46 (leading: Space)
+2921: Ident           "Erring" at 300:47-300:53 (leading: Space)
+2922: Lt              "<" at 300:53-300:54
+2923: Ident           "int" at 300:54-300:57
+2924: Comma           "," at 300:57-300:58
+2925: Ident           "Error" at 300:59-300:64 (leading: Space)
+2926: Gt              ">" at 300:64-300:65
+2927: Semicolon       ";" at 300:65-300:66
+2928: RBrace          "}" at 301:1-301:2 (leading: Newline)
+2929: KwExtern        "extern" at 303:1-303:7 (leading: Newline)
+2930: Lt              "<" at 303:7-303:8
+2931: Ident           "uint" at 303:8-303:12
+2932: Gt              ">" at 303:12-303:13
+2933: LBrace          "{" at 303:14-303:15 (leading: Space)
+2934: At              "@" at 304:5-304:6 (leading: Newline, Space)
+2935: Ident           "intrinsic" at 304:6-304:15
+2936: KwFn            "fn" at 304:16-304:18 (leading: Space)
+2937: Ident           "__add" at 304:19-304:24 (leading: Space)
+2938: LParen          "(" at 304:24-304:25
+2939: Ident           "self" at 304:25-304:29
+2940: Colon           ":" at 304:29-304:30
+2941: Ident           "uint" at 304:31-304:35 (leading: Space)
+2942: Comma           "," at 304:35-304:36
+2943: Ident           "other" at 304:37-304:42 (leading: Space)
+2944: Colon           ":" at 304:42-304:43
+2945: Ident           "uint" at 304:44-304:48 (leading: Space)
+2946: RParen          ")" at 304:48-304:49
+2947: Arrow           "->" at 304:50-304:52 (leading: Space)
+2948: Ident           "uint" at 304:53-304:57 (leading: Space)
+2949: Semicolon       ";" at 304:57-304:58
+2950: At              "@" at 305:5-305:6 (leading: Newline, Space)
+2951: Ident           "intrinsic" at 305:6-305:15
+2952: KwFn            "fn" at 305:16-305:18 (leading: Space)
+2953: Ident           "__sub" at 305:19-305:24 (leading: Space)
+2954: LParen          "(" at 305:24-305:25
+2955: Ident           "self" at 305:25-305:29
+2956: Colon           ":" at 305:29-305:30
+2957: Ident           "uint" at 305:31-305:35 (leading: Space)
+2958: Comma           "," at 305:35-305:36
+2959: Ident           "other" at 305:37-305:42 (leading: Space)
+2960: Colon           ":" at 305:42-305:43
+2961: Ident           "uint" at 305:44-305:48 (leading: Space)
+2962: RParen          ")" at 305:48-305:49
+2963: Arrow           "->" at 305:50-305:52 (leading: Space)
+2964: Ident           "uint" at 305:53-305:57 (leading: Space)
+2965: Semicolon       ";" at 305:57-305:58
+2966: At              "@" at 306:5-306:6 (leading: Newline, Space)
+2967: Ident           "intrinsic" at 306:6-306:15
+2968: KwFn            "fn" at 306:16-306:18 (leading: Space)
+2969: Ident           "__mul" at 306:19-306:24 (leading: Space)
+2970: LParen          "(" at 306:24-306:25
+2971: Ident           "self" at 306:25-306:29
+2972: Colon           ":" at 306:29-306:30
+2973: Ident           "uint" at 306:31-306:35 (leading: Space)
+2974: Comma           "," at 306:35-306:36
+2975: Ident           "other" at 306:37-306:42 (leading: Space)
+2976: Colon           ":" at 306:42-306:43
+2977: Ident           "uint" at 306:44-306:48 (leading: Space)
+2978: RParen          ")" at 306:48-306:49
+2979: Arrow           "->" at 306:50-306:52 (leading: Space)
+2980: Ident           "uint" at 306:53-306:57 (leading: Space)
+2981: Semicolon       ";" at 306:57-306:58
+2982: At              "@" at 307:5-307:6 (leading: Newline, Space)
+2983: Ident           "intrinsic" at 307:6-307:15
+2984: KwFn            "fn" at 307:16-307:18 (leading: Space)
+2985: Ident           "__div" at 307:19-307:24 (leading: Space)
+2986: LParen          "(" at 307:24-307:25
+2987: Ident           "self" at 307:25-307:29
+2988: Colon           ":" at 307:29-307:30
+2989: Ident           "uint" at 307:31-307:35 (leading: Space)
+2990: Comma           "," at 307:35-307:36
+2991: Ident           "other" at 307:37-307:42 (leading: Space)
+2992: Colon           ":" at 307:42-307:43
+2993: Ident           "uint" at 307:44-307:48 (leading: Space)
+2994: RParen          ")" at 307:48-307:49
+2995: Arrow           "->" at 307:50-307:52 (leading: Space)
+2996: Ident           "uint" at 307:53-307:57 (leading: Space)
+2997: Semicolon       ";" at 307:57-307:58
+2998: At              "@" at 308:5-308:6 (leading: Newline, Space)
+2999: Ident           "intrinsic" at 308:6-308:15
+3000: KwFn            "fn" at 308:16-308:18 (leading: Space)
+3001: Ident           "__mod" at 308:19-308:24 (leading: Space)
+3002: LParen          "(" at 308:24-308:25
+3003: Ident           "self" at 308:25-308:29
+3004: Colon           ":" at 308:29-308:30
+3005: Ident           "uint" at 308:31-308:35 (leading: Space)
+3006: Comma           "," at 308:35-308:36
+3007: Ident           "other" at 308:37-308:42 (leading: Space)
+3008: Colon           ":" at 308:42-308:43
+3009: Ident           "uint" at 308:44-308:48 (leading: Space)
+3010: RParen          ")" at 308:48-308:49
+3011: Arrow           "->" at 308:50-308:52 (leading: Space)
+3012: Ident           "uint" at 308:53-308:57 (leading: Space)
+3013: Semicolon       ";" at 308:57-308:58
+3014: At              "@" at 309:5-309:6 (leading: Newline, Space)
+3015: Ident           "intrinsic" at 309:6-309:15
+3016: KwFn            "fn" at 309:16-309:18 (leading: Space)
+3017: Ident           "__bit_and" at 309:19-309:28 (leading: Space)
+3018: LParen          "(" at 309:28-309:29
+3019: Ident           "self" at 309:29-309:33
+3020: Colon           ":" at 309:33-309:34
+3021: Ident           "uint" at 309:35-309:39 (leading: Space)
+3022: Comma           "," at 309:39-309:40
+3023: Ident           "other" at 309:41-309:46 (leading: Space)
+3024: Colon           ":" at 309:46-309:47
+3025: Ident           "uint" at 309:48-309:52 (leading: Space)
+3026: RParen          ")" at 309:52-309:53
+3027: Arrow           "->" at 309:54-309:56 (leading: Space)
+3028: Ident           "uint" at 309:57-309:61 (leading: Space)
+3029: Semicolon       ";" at 309:61-309:62
+3030: At              "@" at 310:5-310:6 (leading: Newline, Space)
+3031: Ident           "intrinsic" at 310:6-310:15
+3032: KwFn            "fn" at 310:16-310:18 (leading: Space)
+3033: Ident           "__bit_or" at 310:19-310:27 (leading: Space)
+3034: LParen          "(" at 310:27-310:28
+3035: Ident           "self" at 310:28-310:32
+3036: Colon           ":" at 310:32-310:33
+3037: Ident           "uint" at 310:34-310:38 (leading: Space)
+3038: Comma           "," at 310:38-310:39
+3039: Ident           "other" at 310:40-310:45 (leading: Space)
+3040: Colon           ":" at 310:45-310:46
+3041: Ident           "uint" at 310:47-310:51 (leading: Space)
+3042: RParen          ")" at 310:51-310:52
+3043: Arrow           "->" at 310:53-310:55 (leading: Space)
+3044: Ident           "uint" at 310:56-310:60 (leading: Space)
+3045: Semicolon       ";" at 310:60-310:61
+3046: At              "@" at 311:5-311:6 (leading: Newline, Space)
+3047: Ident           "intrinsic" at 311:6-311:15
+3048: KwFn            "fn" at 311:16-311:18 (leading: Space)
+3049: Ident           "__bit_xor" at 311:19-311:28 (leading: Space)
+3050: LParen          "(" at 311:28-311:29
+3051: Ident           "self" at 311:29-311:33
+3052: Colon           ":" at 311:33-311:34
+3053: Ident           "uint" at 311:35-311:39 (leading: Space)
+3054: Comma           "," at 311:39-311:40
+3055: Ident           "other" at 311:41-311:46 (leading: Space)
+3056: Colon           ":" at 311:46-311:47
+3057: Ident           "uint" at 311:48-311:52 (leading: Space)
+3058: RParen          ")" at 311:52-311:53
+3059: Arrow           "->" at 311:54-311:56 (leading: Space)
+3060: Ident           "uint" at 311:57-311:61 (leading: Space)
+3061: Semicolon       ";" at 311:61-311:62
+3062: At              "@" at 312:5-312:6 (leading: Newline, Space)
+3063: Ident           "intrinsic" at 312:6-312:15
+3064: KwFn            "fn" at 312:16-312:18 (leading: Space)
+3065: Ident           "__shl" at 312:19-312:24 (leading: Space)
+3066: LParen          "(" at 312:24-312:25
+3067: Ident           "self" at 312:25-312:29
+3068: Colon           ":" at 312:29-312:30
+3069: Ident           "uint" at 312:31-312:35 (leading: Space)
+3070: Comma           "," at 312:35-312:36
+3071: Ident           "other" at 312:37-312:42 (leading: Space)
+3072: Colon           ":" at 312:42-312:43
+3073: Ident           "uint" at 312:44-312:48 (leading: Space)
+3074: RParen          ")" at 312:48-312:49
+3075: Arrow           "->" at 312:50-312:52 (leading: Space)
+3076: Ident           "uint" at 312:53-312:57 (leading: Space)
+3077: Semicolon       ";" at 312:57-312:58
+3078: At              "@" at 313:5-313:6 (leading: Newline, Space)
+3079: Ident           "intrinsic" at 313:6-313:15
+3080: KwFn            "fn" at 313:16-313:18 (leading: Space)
+3081: Ident           "__shr" at 313:19-313:24 (leading: Space)
+3082: LParen          "(" at 313:24-313:25
+3083: Ident           "self" at 313:25-313:29
+3084: Colon           ":" at 313:29-313:30
+3085: Ident           "uint" at 313:31-313:35 (leading: Space)
+3086: Comma           "," at 313:35-313:36
+3087: Ident           "other" at 313:37-313:42 (leading: Space)
+3088: Colon           ":" at 313:42-313:43
+3089: Ident           "uint" at 313:44-313:48 (leading: Space)
+3090: RParen          ")" at 313:48-313:49
+3091: Arrow           "->" at 313:50-313:52 (leading: Space)
+3092: Ident           "uint" at 313:53-313:57 (leading: Space)
+3093: Semicolon       ";" at 313:57-313:58
+3094: At              "@" at 314:5-314:6 (leading: Newline, Space)
+3095: Ident           "intrinsic" at 314:6-314:15
+3096: KwFn            "fn" at 314:16-314:18 (leading: Space)
+3097: Ident           "__lt" at 314:19-314:23 (leading: Space)
+3098: LParen          "(" at 314:23-314:24
+3099: Ident           "self" at 314:24-314:28
+3100: Colon           ":" at 314:28-314:29
+3101: Ident           "uint" at 314:30-314:34 (leading: Space)
+3102: Comma           "," at 314:34-314:35
+3103: Ident           "other" at 314:36-314:41 (leading: Space)
+3104: Colon           ":" at 314:41-314:42
+3105: Ident           "uint" at 314:43-314:47 (leading: Space)
+3106: RParen          ")" at 314:47-314:48
+3107: Arrow           "->" at 314:49-314:51 (leading: Space)
+3108: Ident           "bool" at 314:52-314:56 (leading: Space)
+3109: Semicolon       ";" at 314:56-314:57
+3110: At              "@" at 315:5-315:6 (leading: Newline, Space)
+3111: Ident           "intrinsic" at 315:6-315:15
+3112: KwFn            "fn" at 315:16-315:18 (leading: Space)
+3113: Ident           "__le" at 315:19-315:23 (leading: Space)
+3114: LParen          "(" at 315:23-315:24
+3115: Ident           "self" at 315:24-315:28
+3116: Colon           ":" at 315:28-315:29
+3117: Ident           "uint" at 315:30-315:34 (leading: Space)
+3118: Comma           "," at 315:34-315:35
+3119: Ident           "other" at 315:36-315:41 (leading: Space)
+3120: Colon           ":" at 315:41-315:42
+3121: Ident           "uint" at 315:43-315:47 (leading: Space)
+3122: RParen          ")" at 315:47-315:48
+3123: Arrow           "->" at 315:49-315:51 (leading: Space)
+3124: Ident           "bool" at 315:52-315:56 (leading: Space)
+3125: Semicolon       ";" at 315:56-315:57
+3126: At              "@" at 316:5-316:6 (leading: Newline, Space)
+3127: Ident           "intrinsic" at 316:6-316:15
+3128: KwFn            "fn" at 316:16-316:18 (leading: Space)
+3129: Ident           "__eq" at 316:19-316:23 (leading: Space)
+3130: LParen          "(" at 316:23-316:24
+3131: Ident           "self" at 316:24-316:28
+3132: Colon           ":" at 316:28-316:29
+3133: Ident           "uint" at 316:30-316:34 (leading: Space)
+3134: Comma           "," at 316:34-316:35
+3135: Ident           "other" at 316:36-316:41 (leading: Space)
+3136: Colon           ":" at 316:41-316:42
+3137: Ident           "uint" at 316:43-316:47 (leading: Space)
+3138: RParen          ")" at 316:47-316:48
+3139: Arrow           "->" at 316:49-316:51 (leading: Space)
+3140: Ident           "bool" at 316:52-316:56 (leading: Space)
+3141: Semicolon       ";" at 316:56-316:57
+3142: At              "@" at 317:5-317:6 (leading: Newline, Space)
+3143: Ident           "intrinsic" at 317:6-317:15
+3144: KwFn            "fn" at 317:16-317:18 (leading: Space)
+3145: Ident           "__ne" at 317:19-317:23 (leading: Space)
+3146: LParen          "(" at 317:23-317:24
+3147: Ident           "self" at 317:24-317:28
+3148: Colon           ":" at 317:28-317:29
+3149: Ident           "uint" at 317:30-317:34 (leading: Space)
+3150: Comma           "," at 317:34-317:35
+3151: Ident           "other" at 317:36-317:41 (leading: Space)
+3152: Colon           ":" at 317:41-317:42
+3153: Ident           "uint" at 317:43-317:47 (leading: Space)
+3154: RParen          ")" at 317:47-317:48
+3155: Arrow           "->" at 317:49-317:51 (leading: Space)
+3156: Ident           "bool" at 317:52-317:56 (leading: Space)
+3157: Semicolon       ";" at 317:56-317:57
+3158: At              "@" at 318:5-318:6 (leading: Newline, Space)
+3159: Ident           "intrinsic" at 318:6-318:15
+3160: KwFn            "fn" at 318:16-318:18 (leading: Space)
+3161: Ident           "__ge" at 318:19-318:23 (leading: Space)
+3162: LParen          "(" at 318:23-318:24
+3163: Ident           "self" at 318:24-318:28
+3164: Colon           ":" at 318:28-318:29
+3165: Ident           "uint" at 318:30-318:34 (leading: Space)
+3166: Comma           "," at 318:34-318:35
+3167: Ident           "other" at 318:36-318:41 (leading: Space)
+3168: Colon           ":" at 318:41-318:42
+3169: Ident           "uint" at 318:43-318:47 (leading: Space)
+3170: RParen          ")" at 318:47-318:48
+3171: Arrow           "->" at 318:49-318:51 (leading: Space)
+3172: Ident           "bool" at 318:52-318:56 (leading: Space)
+3173: Semicolon       ";" at 318:56-318:57
+3174: At              "@" at 319:5-319:6 (leading: Newline, Space)
+3175: Ident           "intrinsic" at 319:6-319:15
+3176: KwFn            "fn" at 319:16-319:18 (leading: Space)
+3177: Ident           "__gt" at 319:19-319:23 (leading: Space)
+3178: LParen          "(" at 319:23-319:24
+3179: Ident           "self" at 319:24-319:28
+3180: Colon           ":" at 319:28-319:29
+3181: Ident           "uint" at 319:30-319:34 (leading: Space)
+3182: Comma           "," at 319:34-319:35
+3183: Ident           "other" at 319:36-319:41 (leading: Space)
+3184: Colon           ":" at 319:41-319:42
+3185: Ident           "uint" at 319:43-319:47 (leading: Space)
+3186: RParen          ")" at 319:47-319:48
+3187: Arrow           "->" at 319:49-319:51 (leading: Space)
+3188: Ident           "bool" at 319:52-319:56 (leading: Space)
+3189: Semicolon       ";" at 319:56-319:57
+3190: At              "@" at 320:5-320:6 (leading: Newline, Space)
+3191: Ident           "intrinsic" at 320:6-320:15
+3192: KwFn            "fn" at 320:16-320:18 (leading: Space)
+3193: Ident           "__pos" at 320:19-320:24 (leading: Space)
+3194: LParen          "(" at 320:24-320:25
+3195: Ident           "self" at 320:25-320:29
+3196: Colon           ":" at 320:29-320:30
+3197: Ident           "uint" at 320:31-320:35 (leading: Space)
+3198: RParen          ")" at 320:35-320:36
+3199: Arrow           "->" at 320:37-320:39 (leading: Space)
+3200: Ident           "uint" at 320:40-320:44 (leading: Space)
+3201: Semicolon       ";" at 320:44-320:45
+3202: At              "@" at 321:5-321:6 (leading: Newline, Space)
+3203: Ident           "intrinsic" at 321:6-321:15
+3204: KwFn            "fn" at 321:16-321:18 (leading: Space)
+3205: Ident           "__abs" at 321:19-321:24 (leading: Space)
+3206: LParen          "(" at 321:24-321:25
+3207: Ident           "self" at 321:25-321:29
+3208: Colon           ":" at 321:29-321:30
+3209: Ident           "uint" at 321:31-321:35 (leading: Space)
+3210: RParen          ")" at 321:35-321:36
+3211: Arrow           "->" at 321:37-321:39 (leading: Space)
+3212: Ident           "uint" at 321:40-321:44 (leading: Space)
+3213: Semicolon       ";" at 321:44-321:45
+3214: At              "@" at 322:5-322:6 (leading: Newline, Space)
+3215: Ident           "intrinsic" at 322:6-322:15
+3216: KwFn            "fn" at 322:16-322:18 (leading: Space)
+3217: Ident           "__to" at 322:19-322:23 (leading: Space)
+3218: LParen          "(" at 322:23-322:24
+3219: Ident           "self" at 322:24-322:28
+3220: Colon           ":" at 322:28-322:29
+3221: Ident           "uint" at 322:30-322:34 (leading: Space)
+3222: Comma           "," at 322:34-322:35
+3223: Ident           "target" at 322:36-322:42 (leading: Space)
+3224: Colon           ":" at 322:42-322:43
+3225: Ident           "string" at 322:44-322:50 (leading: Space)
+3226: RParen          ")" at 322:50-322:51
+3227: Arrow           "->" at 322:52-322:54 (leading: Space)
+3228: Ident           "string" at 322:55-322:61 (leading: Space)
+3229: Semicolon       ";" at 322:61-322:62
+3230: At              "@" at 323:5-323:6 (leading: Newline, Space)
+3231: Ident           "overload" at 323:6-323:14
+3232: KwPub           "pub" at 323:15-323:18 (leading: Space)
+3233: KwFn            "fn" at 323:19-323:21 (leading: Space)
+3234: Ident           "__to" at 323:22-323:26 (leading: Space)
+3235: LParen          "(" at 323:26-323:27
+3236: Ident           "self" at 323:27-323:31
+3237: Colon           ":" at 323:31-323:32
+3238: Amp             "&" at 323:33-323:34 (leading: Space)
+3239: Ident           "uint" at 323:34-323:38
+3240: Comma           "," at 323:38-323:39
+3241: Underscore      "_" at 323:40-323:41 (leading: Space)
+3242: Colon           ":" at 323:41-323:42
+3243: Ident           "string" at 323:43-323:49 (leading: Space)
+3244: RParen          ")" at 323:49-323:50
+3245: Arrow           "->" at 323:51-323:53 (leading: Space)
+3246: Ident           "string" at 323:54-323:60 (leading: Space)
+3247: LBrace          "{" at 323:61-323:62 (leading: Space)
+3248: KwReturn        "return" at 324:9-324:15 (leading: Newline, Space)
+3249: LParen          "(" at 324:16-324:17 (leading: Space)
+3250: Star            "*" at 324:17-324:18
+3251: Ident           "self" at 324:18-324:22
+3252: RParen          ")" at 324:22-324:23
+3253: KwTo            "to" at 324:24-324:26 (leading: Space)
+3254: Ident           "string" at 324:27-324:33 (leading: Space)
+3255: Semicolon       ";" at 324:33-324:34
+3256: RBrace          "}" at 325:5-325:6 (leading: Newline, Space)
+3257: At              "@" at 326:5-326:6 (leading: Newline, Space)
+3258: Ident           "intrinsic" at 326:6-326:15
+3259: At              "@" at 326:16-326:17 (leading: Space)
+3260: Ident           "overload" at 326:17-326:25
+3261: KwFn            "fn" at 326:26-326:28 (leading: Space)
+3262: Ident           "__to" at 326:29-326:33 (leading: Space)
+3263: LParen          "(" at 326:33-326:34
+3264: Ident           "self" at 326:34-326:38
+3265: Colon           ":" at 326:38-326:39
+3266: Ident           "uint" at 326:40-326:44 (leading: Space)
+3267: Comma           "," at 326:44-326:45
+3268: Ident           "target" at 326:46-326:52 (leading: Space)
+3269: Colon           ":" at 326:52-326:53
+3270: Ident           "int" at 326:54-326:57 (leading: Space)
+3271: RParen          ")" at 326:57-326:58
+3272: Arrow           "->" at 326:59-326:61 (leading: Space)
+3273: Ident           "int" at 326:62-326:65 (leading: Space)
+3274: Semicolon       ";" at 326:65-326:66
+3275: At              "@" at 327:5-327:6 (leading: Newline, Space)
+3276: Ident           "intrinsic" at 327:6-327:15
+3277: At              "@" at 327:16-327:17 (leading: Space)
+3278: Ident           "overload" at 327:17-327:25
+3279: KwFn            "fn" at 327:26-327:28 (leading: Space)
+3280: Ident           "__to" at 327:29-327:33 (leading: Space)
+3281: LParen          "(" at 327:33-327:34
+3282: Ident           "self" at 327:34-327:38
+3283: Colon           ":" at 327:38-327:39
+3284: Ident           "uint" at 327:40-327:44 (leading: Space)
+3285: Comma           "," at 327:44-327:45
+3286: Ident           "target" at 327:46-327:52 (leading: Space)
+3287: Colon           ":" at 327:52-327:53
+3288: Ident           "float" at 327:54-327:59 (leading: Space)
+3289: RParen          ")" at 327:59-327:60
+3290: Arrow           "->" at 327:61-327:63 (leading: Space)
+3291: Ident           "float" at 327:64-327:69 (leading: Space)
+3292: Semicolon       ";" at 327:69-327:70
+3293: At              "@" at 328:5-328:6 (leading: Newline, Space)
+3294: Ident           "intrinsic" at 328:6-328:15
+3295: At              "@" at 328:16-328:17 (leading: Space)
+3296: Ident           "overload" at 328:17-328:25
+3297: KwFn            "fn" at 328:26-328:28 (leading: Space)
+3298: Ident           "__to" at 328:29-328:33 (leading: Space)
+3299: LParen          "(" at 328:33-328:34
+3300: Ident           "self" at 328:34-328:38
+3301: Colon           ":" at 328:38-328:39
+3302: Ident           "uint" at 328:40-328:44 (leading: Space)
+3303: Comma           "," at 328:44-328:45
+3304: Ident           "target" at 328:46-328:52 (leading: Space)
+3305: Colon           ":" at 328:52-328:53
+3306: Ident           "int8" at 328:54-328:58 (leading: Space)
+3307: RParen          ")" at 328:58-328:59
+3308: Arrow           "->" at 328:60-328:62 (leading: Space)
+3309: Ident           "int8" at 328:63-328:67 (leading: Space)
+3310: Semicolon       ";" at 328:67-328:68
+3311: At              "@" at 329:5-329:6 (leading: Newline, Space)
+3312: Ident           "intrinsic" at 329:6-329:15
+3313: At              "@" at 329:16-329:17 (leading: Space)
+3314: Ident           "overload" at 329:17-329:25
+3315: KwFn            "fn" at 329:26-329:28 (leading: Space)
+3316: Ident           "__to" at 329:29-329:33 (leading: Space)
+3317: LParen          "(" at 329:33-329:34
+3318: Ident           "self" at 329:34-329:38
+3319: Colon           ":" at 329:38-329:39
+3320: Ident           "uint" at 329:40-329:44 (leading: Space)
+3321: Comma           "," at 329:44-329:45
+3322: Ident           "target" at 329:46-329:52 (leading: Space)
+3323: Colon           ":" at 329:52-329:53
+3324: Ident           "int16" at 329:54-329:59 (leading: Space)
+3325: RParen          ")" at 329:59-329:60
+3326: Arrow           "->" at 329:61-329:63 (leading: Space)
+3327: Ident           "int16" at 329:64-329:69 (leading: Space)
+3328: Semicolon       ";" at 329:69-329:70
+3329: At              "@" at 330:5-330:6 (leading: Newline, Space)
+3330: Ident           "intrinsic" at 330:6-330:15
+3331: At              "@" at 330:16-330:17 (leading: Space)
+3332: Ident           "overload" at 330:17-330:25
+3333: KwFn            "fn" at 330:26-330:28 (leading: Space)
+3334: Ident           "__to" at 330:29-330:33 (leading: Space)
+3335: LParen          "(" at 330:33-330:34
+3336: Ident           "self" at 330:34-330:38
+3337: Colon           ":" at 330:38-330:39
+3338: Ident           "uint" at 330:40-330:44 (leading: Space)
+3339: Comma           "," at 330:44-330:45
+3340: Ident           "target" at 330:46-330:52 (leading: Space)
+3341: Colon           ":" at 330:52-330:53
+3342: Ident           "int32" at 330:54-330:59 (leading: Space)
+3343: RParen          ")" at 330:59-330:60
+3344: Arrow           "->" at 330:61-330:63 (leading: Space)
+3345: Ident           "int32" at 330:64-330:69 (leading: Space)
+3346: Semicolon       ";" at 330:69-330:70
+3347: At              "@" at 331:5-331:6 (leading: Newline, Space)
+3348: Ident           "intrinsic" at 331:6-331:15
+3349: At              "@" at 331:16-331:17 (leading: Space)
+3350: Ident           "overload" at 331:17-331:25
+3351: KwFn            "fn" at 331:26-331:28 (leading: Space)
+3352: Ident           "__to" at 331:29-331:33 (leading: Space)
+3353: LParen          "(" at 331:33-331:34
+3354: Ident           "self" at 331:34-331:38
+3355: Colon           ":" at 331:38-331:39
+3356: Ident           "uint" at 331:40-331:44 (leading: Space)
+3357: Comma           "," at 331:44-331:45
+3358: Ident           "target" at 331:46-331:52 (leading: Space)
+3359: Colon           ":" at 331:52-331:53
+3360: Ident           "int64" at 331:54-331:59 (leading: Space)
+3361: RParen          ")" at 331:59-331:60
+3362: Arrow           "->" at 331:61-331:63 (leading: Space)
+3363: Ident           "int64" at 331:64-331:69 (leading: Space)
+3364: Semicolon       ";" at 331:69-331:70
+3365: At              "@" at 332:5-332:6 (leading: Newline, Space)
+3366: Ident           "intrinsic" at 332:6-332:15
+3367: At              "@" at 332:16-332:17 (leading: Space)
+3368: Ident           "overload" at 332:17-332:25
+3369: KwFn            "fn" at 332:26-332:28 (leading: Space)
+3370: Ident           "__to" at 332:29-332:33 (leading: Space)
+3371: LParen          "(" at 332:33-332:34
+3372: Ident           "self" at 332:34-332:38
+3373: Colon           ":" at 332:38-332:39
+3374: Ident           "uint" at 332:40-332:44 (leading: Space)
+3375: Comma           "," at 332:44-332:45
+3376: Ident           "target" at 332:46-332:52 (leading: Space)
+3377: Colon           ":" at 332:52-332:53
+3378: Ident           "uint8" at 332:54-332:59 (leading: Space)
+3379: RParen          ")" at 332:59-332:60
+3380: Arrow           "->" at 332:61-332:63 (leading: Space)
+3381: Ident           "uint8" at 332:64-332:69 (leading: Space)
+3382: Semicolon       ";" at 332:69-332:70
+3383: At              "@" at 333:5-333:6 (leading: Newline, Space)
+3384: Ident           "intrinsic" at 333:6-333:15
+3385: At              "@" at 333:16-333:17 (leading: Space)
+3386: Ident           "overload" at 333:17-333:25
+3387: KwFn            "fn" at 333:26-333:28 (leading: Space)
+3388: Ident           "__to" at 333:29-333:33 (leading: Space)
+3389: LParen          "(" at 333:33-333:34
+3390: Ident           "self" at 333:34-333:38
+3391: Colon           ":" at 333:38-333:39
+3392: Ident           "uint" at 333:40-333:44 (leading: Space)
+3393: Comma           "," at 333:44-333:45
+3394: Ident           "target" at 333:46-333:52 (leading: Space)
+3395: Colon           ":" at 333:52-333:53
+3396: Ident           "uint16" at 333:54-333:60 (leading: Space)
+3397: RParen          ")" at 333:60-333:61
+3398: Arrow           "->" at 333:62-333:64 (leading: Space)
+3399: Ident           "uint16" at 333:65-333:71 (leading: Space)
+3400: Semicolon       ";" at 333:71-333:72
+3401: At              "@" at 334:5-334:6 (leading: Newline, Space)
+3402: Ident           "intrinsic" at 334:6-334:15
+3403: At              "@" at 334:16-334:17 (leading: Space)
+3404: Ident           "overload" at 334:17-334:25
+3405: KwFn            "fn" at 334:26-334:28 (leading: Space)
+3406: Ident           "__to" at 334:29-334:33 (leading: Space)
+3407: LParen          "(" at 334:33-334:34
+3408: Ident           "self" at 334:34-334:38
+3409: Colon           ":" at 334:38-334:39
+3410: Ident           "uint" at 334:40-334:44 (leading: Space)
+3411: Comma           "," at 334:44-334:45
+3412: Ident           "target" at 334:46-334:52 (leading: Space)
+3413: Colon           ":" at 334:52-334:53
+3414: Ident           "uint32" at 334:54-334:60 (leading: Space)
+3415: RParen          ")" at 334:60-334:61
+3416: Arrow           "->" at 334:62-334:64 (leading: Space)
+3417: Ident           "uint32" at 334:65-334:71 (leading: Space)
+3418: Semicolon       ";" at 334:71-334:72
+3419: At              "@" at 335:5-335:6 (leading: Newline, Space)
+3420: Ident           "intrinsic" at 335:6-335:15
+3421: At              "@" at 335:16-335:17 (leading: Space)
+3422: Ident           "overload" at 335:17-335:25
+3423: KwFn            "fn" at 335:26-335:28 (leading: Space)
+3424: Ident           "__to" at 335:29-335:33 (leading: Space)
+3425: LParen          "(" at 335:33-335:34
+3426: Ident           "self" at 335:34-335:38
+3427: Colon           ":" at 335:38-335:39
+3428: Ident           "uint" at 335:40-335:44 (leading: Space)
+3429: Comma           "," at 335:44-335:45
+3430: Ident           "target" at 335:46-335:52 (leading: Space)
+3431: Colon           ":" at 335:52-335:53
+3432: Ident           "uint64" at 335:54-335:60 (leading: Space)
+3433: RParen          ")" at 335:60-335:61
+3434: Arrow           "->" at 335:62-335:64 (leading: Space)
+3435: Ident           "uint64" at 335:65-335:71 (leading: Space)
+3436: Semicolon       ";" at 335:71-335:72
+3437: At              "@" at 336:5-336:6 (leading: Newline, Space)
+3438: Ident           "intrinsic" at 336:6-336:15
+3439: At              "@" at 336:16-336:17 (leading: Space)
+3440: Ident           "overload" at 336:17-336:25
+3441: KwFn            "fn" at 336:26-336:28 (leading: Space)
+3442: Ident           "__to" at 336:29-336:33 (leading: Space)
+3443: LParen          "(" at 336:33-336:34
+3444: Ident           "self" at 336:34-336:38
+3445: Colon           ":" at 336:38-336:39
+3446: Ident           "uint" at 336:40-336:44 (leading: Space)
+3447: Comma           "," at 336:44-336:45
+3448: Ident           "target" at 336:46-336:52 (leading: Space)
+3449: Colon           ":" at 336:52-336:53
+3450: Ident           "float16" at 336:54-336:61 (leading: Space)
+3451: RParen          ")" at 336:61-336:62
+3452: Arrow           "->" at 336:63-336:65 (leading: Space)
+3453: Ident           "float16" at 336:66-336:73 (leading: Space)
+3454: Semicolon       ";" at 336:73-336:74
+3455: At              "@" at 337:5-337:6 (leading: Newline, Space)
+3456: Ident           "intrinsic" at 337:6-337:15
+3457: At              "@" at 337:16-337:17 (leading: Space)
+3458: Ident           "overload" at 337:17-337:25
+3459: KwFn            "fn" at 337:26-337:28 (leading: Space)
+3460: Ident           "__to" at 337:29-337:33 (leading: Space)
+3461: LParen          "(" at 337:33-337:34
+3462: Ident           "self" at 337:34-337:38
+3463: Colon           ":" at 337:38-337:39
+3464: Ident           "uint" at 337:40-337:44 (leading: Space)
+3465: Comma           "," at 337:44-337:45
+3466: Ident           "target" at 337:46-337:52 (leading: Space)
+3467: Colon           ":" at 337:52-337:53
+3468: Ident           "float32" at 337:54-337:61 (leading: Space)
+3469: RParen          ")" at 337:61-337:62
+3470: Arrow           "->" at 337:63-337:65 (leading: Space)
+3471: Ident           "float32" at 337:66-337:73 (leading: Space)
+3472: Semicolon       ";" at 337:73-337:74
+3473: At              "@" at 338:5-338:6 (leading: Newline, Space)
+3474: Ident           "intrinsic" at 338:6-338:15
+3475: At              "@" at 338:16-338:17 (leading: Space)
+3476: Ident           "overload" at 338:17-338:25
+3477: KwFn            "fn" at 338:26-338:28 (leading: Space)
+3478: Ident           "__to" at 338:29-338:33 (leading: Space)
+3479: LParen          "(" at 338:33-338:34
+3480: Ident           "self" at 338:34-338:38
+3481: Colon           ":" at 338:38-338:39
+3482: Ident           "uint" at 338:40-338:44 (leading: Space)
+3483: Comma           "," at 338:44-338:45
+3484: Ident           "target" at 338:46-338:52 (leading: Space)
+3485: Colon           ":" at 338:52-338:53
+3486: Ident           "float64" at 338:54-338:61 (leading: Space)
+3487: RParen          ")" at 338:61-338:62
+3488: Arrow           "->" at 338:63-338:65 (leading: Space)
+3489: Ident           "float64" at 338:66-338:73 (leading: Space)
+3490: Semicolon       ";" at 338:73-338:74
+3491: At              "@" at 340:5-340:6 (leading: Newline, Space, LineComment, Newline, Space)
+3492: Ident           "intrinsic" at 340:6-340:15
+3493: KwPub           "pub" at 340:16-340:19 (leading: Space)
+3494: KwFn            "fn" at 340:20-340:22 (leading: Space)
+3495: Ident           "from_str" at 340:23-340:31 (leading: Space)
+3496: LParen          "(" at 340:31-340:32
+3497: Ident           "s" at 340:32-340:33
+3498: Colon           ":" at 340:33-340:34
+3499: Amp             "&" at 340:35-340:36 (leading: Space)
+3500: Ident           "string" at 340:36-340:42
+3501: RParen          ")" at 340:42-340:43
+3502: Arrow           "->" at 340:44-340:46 (leading: Space)
+3503: Ident           "Erring" at 340:47-340:53 (leading: Space)
+3504: Lt              "<" at 340:53-340:54
+3505: Ident           "uint" at 340:54-340:58
+3506: Comma           "," at 340:58-340:59
+3507: Ident           "Error" at 340:60-340:65 (leading: Space)
+3508: Gt              ">" at 340:65-340:66
+3509: Semicolon       ";" at 340:66-340:67
+3510: RBrace          "}" at 341:1-341:2 (leading: Newline)
+3511: KwExtern        "extern" at 343:1-343:7 (leading: Newline)
+3512: Lt              "<" at 343:7-343:8
+3513: Ident           "int8" at 343:8-343:12
+3514: Gt              ">" at 343:12-343:13
+3515: LBrace          "{" at 343:14-343:15 (leading: Space)
+3516: KwPub           "pub" at 344:5-344:8 (leading: Newline, Space)
+3517: KwFn            "fn" at 344:9-344:11 (leading: Space)
+3518: Ident           "__min_value" at 344:12-344:23 (leading: Space)
+3519: LParen          "(" at 344:23-344:24
+3520: RParen          ")" at 344:24-344:25
+3521: Arrow           "->" at 344:26-344:28 (leading: Space)
+3522: Ident           "int8" at 344:29-344:33 (leading: Space)
+3523: LBrace          "{" at 344:34-344:35 (leading: Space)
+3524: KwReturn        "return" at 344:36-344:42 (leading: Space)
+3525: LParen          "(" at 344:43-344:44 (leading: Space)
+3526: Minus           "-" at 344:44-344:45
+3527: IntLit          "128" at 344:45-344:48
+3528: RParen          ")" at 344:48-344:49
+3529: Colon           ":" at 344:49-344:50
+3530: Ident           "int8" at 344:50-344:54
+3531: Semicolon       ";" at 344:54-344:55
+3532: RBrace          "}" at 344:56-344:57 (leading: Space)
+3533: KwPub           "pub" at 345:5-345:8 (leading: Newline, Space)
+3534: KwFn            "fn" at 345:9-345:11 (leading: Space)
+3535: Ident           "__max_value" at 345:12-345:23 (leading: Space)
+3536: LParen          "(" at 345:23-345:24
+3537: RParen          ")" at 345:24-345:25
+3538: Arrow           "->" at 345:26-345:28 (leading: Space)
+3539: Ident           "int8" at 345:29-345:33 (leading: Space)
+3540: LBrace          "{" at 345:34-345:35 (leading: Space)
+3541: KwReturn        "return" at 345:36-345:42 (leading: Space)
+3542: LParen          "(" at 345:43-345:44 (leading: Space)
+3543: IntLit          "127" at 345:44-345:47
+3544: RParen          ")" at 345:47-345:48
+3545: Colon           ":" at 345:48-345:49
+3546: Ident           "int8" at 345:49-345:53
+3547: Semicolon       ";" at 345:53-345:54
+3548: RBrace          "}" at 345:55-345:56 (leading: Space)
+3549: At              "@" at 346:5-346:6 (leading: Newline, Space)
+3550: Ident           "intrinsic" at 346:6-346:15
+3551: KwFn            "fn" at 346:16-346:18 (leading: Space)
+3552: Ident           "__add" at 346:19-346:24 (leading: Space)
+3553: LParen          "(" at 346:24-346:25
+3554: Ident           "self" at 346:25-346:29
+3555: Colon           ":" at 346:29-346:30
+3556: Ident           "int8" at 346:31-346:35 (leading: Space)
+3557: Comma           "," at 346:35-346:36
+3558: Ident           "other" at 346:37-346:42 (leading: Space)
+3559: Colon           ":" at 346:42-346:43
+3560: Ident           "int8" at 346:44-346:48 (leading: Space)
+3561: RParen          ")" at 346:48-346:49
+3562: Arrow           "->" at 346:50-346:52 (leading: Space)
+3563: Ident           "int8" at 346:53-346:57 (leading: Space)
+3564: Semicolon       ";" at 346:57-346:58
+3565: At              "@" at 347:5-347:6 (leading: Newline, Space)
+3566: Ident           "intrinsic" at 347:6-347:15
+3567: KwFn            "fn" at 347:16-347:18 (leading: Space)
+3568: Ident           "__sub" at 347:19-347:24 (leading: Space)
+3569: LParen          "(" at 347:24-347:25
+3570: Ident           "self" at 347:25-347:29
+3571: Colon           ":" at 347:29-347:30
+3572: Ident           "int8" at 347:31-347:35 (leading: Space)
+3573: Comma           "," at 347:35-347:36
+3574: Ident           "other" at 347:37-347:42 (leading: Space)
+3575: Colon           ":" at 347:42-347:43
+3576: Ident           "int8" at 347:44-347:48 (leading: Space)
+3577: RParen          ")" at 347:48-347:49
+3578: Arrow           "->" at 347:50-347:52 (leading: Space)
+3579: Ident           "int8" at 347:53-347:57 (leading: Space)
+3580: Semicolon       ";" at 347:57-347:58
+3581: At              "@" at 348:5-348:6 (leading: Newline, Space)
+3582: Ident           "intrinsic" at 348:6-348:15
+3583: KwFn            "fn" at 348:16-348:18 (leading: Space)
+3584: Ident           "__mul" at 348:19-348:24 (leading: Space)
+3585: LParen          "(" at 348:24-348:25
+3586: Ident           "self" at 348:25-348:29
+3587: Colon           ":" at 348:29-348:30
+3588: Ident           "int8" at 348:31-348:35 (leading: Space)
+3589: Comma           "," at 348:35-348:36
+3590: Ident           "other" at 348:37-348:42 (leading: Space)
+3591: Colon           ":" at 348:42-348:43
+3592: Ident           "int8" at 348:44-348:48 (leading: Space)
+3593: RParen          ")" at 348:48-348:49
+3594: Arrow           "->" at 348:50-348:52 (leading: Space)
+3595: Ident           "int8" at 348:53-348:57 (leading: Space)
+3596: Semicolon       ";" at 348:57-348:58
+3597: At              "@" at 349:5-349:6 (leading: Newline, Space)
+3598: Ident           "intrinsic" at 349:6-349:15
+3599: KwFn            "fn" at 349:16-349:18 (leading: Space)
+3600: Ident           "__div" at 349:19-349:24 (leading: Space)
+3601: LParen          "(" at 349:24-349:25
+3602: Ident           "self" at 349:25-349:29
+3603: Colon           ":" at 349:29-349:30
+3604: Ident           "int8" at 349:31-349:35 (leading: Space)
+3605: Comma           "," at 349:35-349:36
+3606: Ident           "other" at 349:37-349:42 (leading: Space)
+3607: Colon           ":" at 349:42-349:43
+3608: Ident           "int8" at 349:44-349:48 (leading: Space)
+3609: RParen          ")" at 349:48-349:49
+3610: Arrow           "->" at 349:50-349:52 (leading: Space)
+3611: Ident           "int8" at 349:53-349:57 (leading: Space)
+3612: Semicolon       ";" at 349:57-349:58
+3613: At              "@" at 350:5-350:6 (leading: Newline, Space)
+3614: Ident           "intrinsic" at 350:6-350:15
+3615: KwFn            "fn" at 350:16-350:18 (leading: Space)
+3616: Ident           "__mod" at 350:19-350:24 (leading: Space)
+3617: LParen          "(" at 350:24-350:25
+3618: Ident           "self" at 350:25-350:29
+3619: Colon           ":" at 350:29-350:30
+3620: Ident           "int8" at 350:31-350:35 (leading: Space)
+3621: Comma           "," at 350:35-350:36
+3622: Ident           "other" at 350:37-350:42 (leading: Space)
+3623: Colon           ":" at 350:42-350:43
+3624: Ident           "int8" at 350:44-350:48 (leading: Space)
+3625: RParen          ")" at 350:48-350:49
+3626: Arrow           "->" at 350:50-350:52 (leading: Space)
+3627: Ident           "int8" at 350:53-350:57 (leading: Space)
+3628: Semicolon       ";" at 350:57-350:58
+3629: At              "@" at 351:5-351:6 (leading: Newline, Space)
+3630: Ident           "intrinsic" at 351:6-351:15
+3631: KwFn            "fn" at 351:16-351:18 (leading: Space)
+3632: Ident           "__bit_and" at 351:19-351:28 (leading: Space)
+3633: LParen          "(" at 351:28-351:29
+3634: Ident           "self" at 351:29-351:33
+3635: Colon           ":" at 351:33-351:34
+3636: Ident           "int8" at 351:35-351:39 (leading: Space)
+3637: Comma           "," at 351:39-351:40
+3638: Ident           "other" at 351:41-351:46 (leading: Space)
+3639: Colon           ":" at 351:46-351:47
+3640: Ident           "int8" at 351:48-351:52 (leading: Space)
+3641: RParen          ")" at 351:52-351:53
+3642: Arrow           "->" at 351:54-351:56 (leading: Space)
+3643: Ident           "int8" at 351:57-351:61 (leading: Space)
+3644: Semicolon       ";" at 351:61-351:62
+3645: At              "@" at 352:5-352:6 (leading: Newline, Space)
+3646: Ident           "intrinsic" at 352:6-352:15
+3647: KwFn            "fn" at 352:16-352:18 (leading: Space)
+3648: Ident           "__bit_or" at 352:19-352:27 (leading: Space)
+3649: LParen          "(" at 352:27-352:28
+3650: Ident           "self" at 352:28-352:32
+3651: Colon           ":" at 352:32-352:33
+3652: Ident           "int8" at 352:34-352:38 (leading: Space)
+3653: Comma           "," at 352:38-352:39
+3654: Ident           "other" at 352:40-352:45 (leading: Space)
+3655: Colon           ":" at 352:45-352:46
+3656: Ident           "int8" at 352:47-352:51 (leading: Space)
+3657: RParen          ")" at 352:51-352:52
+3658: Arrow           "->" at 352:53-352:55 (leading: Space)
+3659: Ident           "int8" at 352:56-352:60 (leading: Space)
+3660: Semicolon       ";" at 352:60-352:61
+3661: At              "@" at 353:5-353:6 (leading: Newline, Space)
+3662: Ident           "intrinsic" at 353:6-353:15
+3663: KwFn            "fn" at 353:16-353:18 (leading: Space)
+3664: Ident           "__bit_xor" at 353:19-353:28 (leading: Space)
+3665: LParen          "(" at 353:28-353:29
+3666: Ident           "self" at 353:29-353:33
+3667: Colon           ":" at 353:33-353:34
+3668: Ident           "int8" at 353:35-353:39 (leading: Space)
+3669: Comma           "," at 353:39-353:40
+3670: Ident           "other" at 353:41-353:46 (leading: Space)
+3671: Colon           ":" at 353:46-353:47
+3672: Ident           "int8" at 353:48-353:52 (leading: Space)
+3673: RParen          ")" at 353:52-353:53
+3674: Arrow           "->" at 353:54-353:56 (leading: Space)
+3675: Ident           "int8" at 353:57-353:61 (leading: Space)
+3676: Semicolon       ";" at 353:61-353:62
+3677: At              "@" at 354:5-354:6 (leading: Newline, Space)
+3678: Ident           "intrinsic" at 354:6-354:15
+3679: KwFn            "fn" at 354:16-354:18 (leading: Space)
+3680: Ident           "__shl" at 354:19-354:24 (leading: Space)
+3681: LParen          "(" at 354:24-354:25
+3682: Ident           "self" at 354:25-354:29
+3683: Colon           ":" at 354:29-354:30
+3684: Ident           "int8" at 354:31-354:35 (leading: Space)
+3685: Comma           "," at 354:35-354:36
+3686: Ident           "other" at 354:37-354:42 (leading: Space)
+3687: Colon           ":" at 354:42-354:43
+3688: Ident           "int8" at 354:44-354:48 (leading: Space)
+3689: RParen          ")" at 354:48-354:49
+3690: Arrow           "->" at 354:50-354:52 (leading: Space)
+3691: Ident           "int8" at 354:53-354:57 (leading: Space)
+3692: Semicolon       ";" at 354:57-354:58
+3693: At              "@" at 355:5-355:6 (leading: Newline, Space)
+3694: Ident           "intrinsic" at 355:6-355:15
+3695: KwFn            "fn" at 355:16-355:18 (leading: Space)
+3696: Ident           "__shr" at 355:19-355:24 (leading: Space)
+3697: LParen          "(" at 355:24-355:25
+3698: Ident           "self" at 355:25-355:29
+3699: Colon           ":" at 355:29-355:30
+3700: Ident           "int8" at 355:31-355:35 (leading: Space)
+3701: Comma           "," at 355:35-355:36
+3702: Ident           "other" at 355:37-355:42 (leading: Space)
+3703: Colon           ":" at 355:42-355:43
+3704: Ident           "int8" at 355:44-355:48 (leading: Space)
+3705: RParen          ")" at 355:48-355:49
+3706: Arrow           "->" at 355:50-355:52 (leading: Space)
+3707: Ident           "int8" at 355:53-355:57 (leading: Space)
+3708: Semicolon       ";" at 355:57-355:58
+3709: At              "@" at 356:5-356:6 (leading: Newline, Space)
+3710: Ident           "intrinsic" at 356:6-356:15
+3711: KwFn            "fn" at 356:16-356:18 (leading: Space)
+3712: Ident           "__lt" at 356:19-356:23 (leading: Space)
+3713: LParen          "(" at 356:23-356:24
+3714: Ident           "self" at 356:24-356:28
+3715: Colon           ":" at 356:28-356:29
+3716: Ident           "int8" at 356:30-356:34 (leading: Space)
+3717: Comma           "," at 356:34-356:35
+3718: Ident           "other" at 356:36-356:41 (leading: Space)
+3719: Colon           ":" at 356:41-356:42
+3720: Ident           "int8" at 356:43-356:47 (leading: Space)
+3721: RParen          ")" at 356:47-356:48
+3722: Arrow           "->" at 356:49-356:51 (leading: Space)
+3723: Ident           "bool" at 356:52-356:56 (leading: Space)
+3724: Semicolon       ";" at 356:56-356:57
+3725: At              "@" at 357:5-357:6 (leading: Newline, Space)
+3726: Ident           "intrinsic" at 357:6-357:15
+3727: KwFn            "fn" at 357:16-357:18 (leading: Space)
+3728: Ident           "__le" at 357:19-357:23 (leading: Space)
+3729: LParen          "(" at 357:23-357:24
+3730: Ident           "self" at 357:24-357:28
+3731: Colon           ":" at 357:28-357:29
+3732: Ident           "int8" at 357:30-357:34 (leading: Space)
+3733: Comma           "," at 357:34-357:35
+3734: Ident           "other" at 357:36-357:41 (leading: Space)
+3735: Colon           ":" at 357:41-357:42
+3736: Ident           "int8" at 357:43-357:47 (leading: Space)
+3737: RParen          ")" at 357:47-357:48
+3738: Arrow           "->" at 357:49-357:51 (leading: Space)
+3739: Ident           "bool" at 357:52-357:56 (leading: Space)
+3740: Semicolon       ";" at 357:56-357:57
+3741: At              "@" at 358:5-358:6 (leading: Newline, Space)
+3742: Ident           "intrinsic" at 358:6-358:15
+3743: KwFn            "fn" at 358:16-358:18 (leading: Space)
+3744: Ident           "__eq" at 358:19-358:23 (leading: Space)
+3745: LParen          "(" at 358:23-358:24
+3746: Ident           "self" at 358:24-358:28
+3747: Colon           ":" at 358:28-358:29
+3748: Ident           "int8" at 358:30-358:34 (leading: Space)
+3749: Comma           "," at 358:34-358:35
+3750: Ident           "other" at 358:36-358:41 (leading: Space)
+3751: Colon           ":" at 358:41-358:42
+3752: Ident           "int8" at 358:43-358:47 (leading: Space)
+3753: RParen          ")" at 358:47-358:48
+3754: Arrow           "->" at 358:49-358:51 (leading: Space)
+3755: Ident           "bool" at 358:52-358:56 (leading: Space)
+3756: Semicolon       ";" at 358:56-358:57
+3757: At              "@" at 359:5-359:6 (leading: Newline, Space)
+3758: Ident           "intrinsic" at 359:6-359:15
+3759: KwFn            "fn" at 359:16-359:18 (leading: Space)
+3760: Ident           "__ne" at 359:19-359:23 (leading: Space)
+3761: LParen          "(" at 359:23-359:24
+3762: Ident           "self" at 359:24-359:28
+3763: Colon           ":" at 359:28-359:29
+3764: Ident           "int8" at 359:30-359:34 (leading: Space)
+3765: Comma           "," at 359:34-359:35
+3766: Ident           "other" at 359:36-359:41 (leading: Space)
+3767: Colon           ":" at 359:41-359:42
+3768: Ident           "int8" at 359:43-359:47 (leading: Space)
+3769: RParen          ")" at 359:47-359:48
+3770: Arrow           "->" at 359:49-359:51 (leading: Space)
+3771: Ident           "bool" at 359:52-359:56 (leading: Space)
+3772: Semicolon       ";" at 359:56-359:57
+3773: At              "@" at 360:5-360:6 (leading: Newline, Space)
+3774: Ident           "intrinsic" at 360:6-360:15
+3775: KwFn            "fn" at 360:16-360:18 (leading: Space)
+3776: Ident           "__ge" at 360:19-360:23 (leading: Space)
+3777: LParen          "(" at 360:23-360:24
+3778: Ident           "self" at 360:24-360:28
+3779: Colon           ":" at 360:28-360:29
+3780: Ident           "int8" at 360:30-360:34 (leading: Space)
+3781: Comma           "," at 360:34-360:35
+3782: Ident           "other" at 360:36-360:41 (leading: Space)
+3783: Colon           ":" at 360:41-360:42
+3784: Ident           "int8" at 360:43-360:47 (leading: Space)
+3785: RParen          ")" at 360:47-360:48
+3786: Arrow           "->" at 360:49-360:51 (leading: Space)
+3787: Ident           "bool" at 360:52-360:56 (leading: Space)
+3788: Semicolon       ";" at 360:56-360:57
+3789: At              "@" at 361:5-361:6 (leading: Newline, Space)
+3790: Ident           "intrinsic" at 361:6-361:15
+3791: KwFn            "fn" at 361:16-361:18 (leading: Space)
+3792: Ident           "__gt" at 361:19-361:23 (leading: Space)
+3793: LParen          "(" at 361:23-361:24
+3794: Ident           "self" at 361:24-361:28
+3795: Colon           ":" at 361:28-361:29
+3796: Ident           "int8" at 361:30-361:34 (leading: Space)
+3797: Comma           "," at 361:34-361:35
+3798: Ident           "other" at 361:36-361:41 (leading: Space)
+3799: Colon           ":" at 361:41-361:42
+3800: Ident           "int8" at 361:43-361:47 (leading: Space)
+3801: RParen          ")" at 361:47-361:48
+3802: Arrow           "->" at 361:49-361:51 (leading: Space)
+3803: Ident           "bool" at 361:52-361:56 (leading: Space)
+3804: Semicolon       ";" at 361:56-361:57
+3805: At              "@" at 362:5-362:6 (leading: Newline, Space)
+3806: Ident           "intrinsic" at 362:6-362:15
+3807: KwFn            "fn" at 362:16-362:18 (leading: Space)
+3808: Ident           "__pos" at 362:19-362:24 (leading: Space)
+3809: LParen          "(" at 362:24-362:25
+3810: Ident           "self" at 362:25-362:29
+3811: Colon           ":" at 362:29-362:30
+3812: Ident           "int8" at 362:31-362:35 (leading: Space)
+3813: RParen          ")" at 362:35-362:36
+3814: Arrow           "->" at 362:37-362:39 (leading: Space)
+3815: Ident           "int8" at 362:40-362:44 (leading: Space)
+3816: Semicolon       ";" at 362:44-362:45
+3817: At              "@" at 363:5-363:6 (leading: Newline, Space)
+3818: Ident           "intrinsic" at 363:6-363:15
+3819: KwFn            "fn" at 363:16-363:18 (leading: Space)
+3820: Ident           "__neg" at 363:19-363:24 (leading: Space)
+3821: LParen          "(" at 363:24-363:25
+3822: Ident           "self" at 363:25-363:29
+3823: Colon           ":" at 363:29-363:30
+3824: Ident           "int8" at 363:31-363:35 (leading: Space)
+3825: RParen          ")" at 363:35-363:36
+3826: Arrow           "->" at 363:37-363:39 (leading: Space)
+3827: Ident           "int8" at 363:40-363:44 (leading: Space)
+3828: Semicolon       ";" at 363:44-363:45
+3829: At              "@" at 364:5-364:6 (leading: Newline, Space)
+3830: Ident           "intrinsic" at 364:6-364:15
+3831: KwFn            "fn" at 364:16-364:18 (leading: Space)
+3832: Ident           "__abs" at 364:19-364:24 (leading: Space)
+3833: LParen          "(" at 364:24-364:25
+3834: Ident           "self" at 364:25-364:29
+3835: Colon           ":" at 364:29-364:30
+3836: Ident           "int8" at 364:31-364:35 (leading: Space)
+3837: RParen          ")" at 364:35-364:36
+3838: Arrow           "->" at 364:37-364:39 (leading: Space)
+3839: Ident           "int8" at 364:40-364:44 (leading: Space)
+3840: Semicolon       ";" at 364:44-364:45
+3841: At              "@" at 365:5-365:6 (leading: Newline, Space)
+3842: Ident           "intrinsic" at 365:6-365:15
+3843: KwFn            "fn" at 365:16-365:18 (leading: Space)
+3844: Ident           "__to" at 365:19-365:23 (leading: Space)
+3845: LParen          "(" at 365:23-365:24
+3846: Ident           "self" at 365:24-365:28
+3847: Colon           ":" at 365:28-365:29
+3848: Ident           "int8" at 365:30-365:34 (leading: Space)
+3849: Comma           "," at 365:34-365:35
+3850: Ident           "target" at 365:36-365:42 (leading: Space)
+3851: Colon           ":" at 365:42-365:43
+3852: Ident           "int" at 365:44-365:47 (leading: Space)
+3853: RParen          ")" at 365:47-365:48
+3854: Arrow           "->" at 365:49-365:51 (leading: Space)
+3855: Ident           "int" at 365:52-365:55 (leading: Space)
+3856: Semicolon       ";" at 365:55-365:56
+3857: At              "@" at 366:5-366:6 (leading: Newline, Space)
+3858: Ident           "intrinsic" at 366:6-366:15
+3859: At              "@" at 366:16-366:17 (leading: Space)
+3860: Ident           "overload" at 366:17-366:25
+3861: KwFn            "fn" at 366:26-366:28 (leading: Space)
+3862: Ident           "__to" at 366:29-366:33 (leading: Space)
+3863: LParen          "(" at 366:33-366:34
+3864: Ident           "self" at 366:34-366:38
+3865: Colon           ":" at 366:38-366:39
+3866: Ident           "int8" at 366:40-366:44 (leading: Space)
+3867: Comma           "," at 366:44-366:45
+3868: Ident           "target" at 366:46-366:52 (leading: Space)
+3869: Colon           ":" at 366:52-366:53
+3870: Ident           "int16" at 366:54-366:59 (leading: Space)
+3871: RParen          ")" at 366:59-366:60
+3872: Arrow           "->" at 366:61-366:63 (leading: Space)
+3873: Ident           "int16" at 366:64-366:69 (leading: Space)
+3874: Semicolon       ";" at 366:69-366:70
+3875: At              "@" at 367:5-367:6 (leading: Newline, Space)
+3876: Ident           "intrinsic" at 367:6-367:15
+3877: At              "@" at 367:16-367:17 (leading: Space)
+3878: Ident           "overload" at 367:17-367:25
+3879: KwFn            "fn" at 367:26-367:28 (leading: Space)
+3880: Ident           "__to" at 367:29-367:33 (leading: Space)
+3881: LParen          "(" at 367:33-367:34
+3882: Ident           "self" at 367:34-367:38
+3883: Colon           ":" at 367:38-367:39
+3884: Ident           "int8" at 367:40-367:44 (leading: Space)
+3885: Comma           "," at 367:44-367:45
+3886: Ident           "target" at 367:46-367:52 (leading: Space)
+3887: Colon           ":" at 367:52-367:53
+3888: Ident           "int32" at 367:54-367:59 (leading: Space)
+3889: RParen          ")" at 367:59-367:60
+3890: Arrow           "->" at 367:61-367:63 (leading: Space)
+3891: Ident           "int32" at 367:64-367:69 (leading: Space)
+3892: Semicolon       ";" at 367:69-367:70
+3893: At              "@" at 368:5-368:6 (leading: Newline, Space)
+3894: Ident           "intrinsic" at 368:6-368:15
+3895: At              "@" at 368:16-368:17 (leading: Space)
+3896: Ident           "overload" at 368:17-368:25
+3897: KwFn            "fn" at 368:26-368:28 (leading: Space)
+3898: Ident           "__to" at 368:29-368:33 (leading: Space)
+3899: LParen          "(" at 368:33-368:34
+3900: Ident           "self" at 368:34-368:38
+3901: Colon           ":" at 368:38-368:39
+3902: Ident           "int8" at 368:40-368:44 (leading: Space)
+3903: Comma           "," at 368:44-368:45
+3904: Ident           "target" at 368:46-368:52 (leading: Space)
+3905: Colon           ":" at 368:52-368:53
+3906: Ident           "int64" at 368:54-368:59 (leading: Space)
+3907: RParen          ")" at 368:59-368:60
+3908: Arrow           "->" at 368:61-368:63 (leading: Space)
+3909: Ident           "int64" at 368:64-368:69 (leading: Space)
+3910: Semicolon       ";" at 368:69-368:70
+3911: At              "@" at 369:5-369:6 (leading: Newline, Space)
+3912: Ident           "intrinsic" at 369:6-369:15
+3913: KwPub           "pub" at 369:16-369:19 (leading: Space)
+3914: KwFn            "fn" at 369:20-369:22 (leading: Space)
+3915: Ident           "from_str" at 369:23-369:31 (leading: Space)
+3916: LParen          "(" at 369:31-369:32
+3917: Ident           "s" at 369:32-369:33
+3918: Colon           ":" at 369:33-369:34
+3919: Amp             "&" at 369:35-369:36 (leading: Space)
+3920: Ident           "string" at 369:36-369:42
+3921: RParen          ")" at 369:42-369:43
+3922: Arrow           "->" at 369:44-369:46 (leading: Space)
+3923: Ident           "Erring" at 369:47-369:53 (leading: Space)
+3924: Lt              "<" at 369:53-369:54
+3925: Ident           "int8" at 369:54-369:58
+3926: Comma           "," at 369:58-369:59
+3927: Ident           "Error" at 369:60-369:65 (leading: Space)
+3928: Gt              ">" at 369:65-369:66
+3929: Semicolon       ";" at 369:66-369:67
+3930: RBrace          "}" at 370:1-370:2 (leading: Newline)
+3931: KwExtern        "extern" at 372:1-372:7 (leading: Newline)
+3932: Lt              "<" at 372:7-372:8
+3933: Ident           "int16" at 372:8-372:13
+3934: Gt              ">" at 372:13-372:14
+3935: LBrace          "{" at 372:15-372:16 (leading: Space)
+3936: KwPub           "pub" at 373:5-373:8 (leading: Newline, Space)
+3937: KwFn            "fn" at 373:9-373:11 (leading: Space)
+3938: Ident           "__min_value" at 373:12-373:23 (leading: Space)
+3939: LParen          "(" at 373:23-373:24
+3940: RParen          ")" at 373:24-373:25
+3941: Arrow           "->" at 373:26-373:28 (leading: Space)
+3942: Ident           "int16" at 373:29-373:34 (leading: Space)
+3943: LBrace          "{" at 373:35-373:36 (leading: Space)
+3944: KwReturn        "return" at 373:37-373:43 (leading: Space)
+3945: LParen          "(" at 373:44-373:45 (leading: Space)
+3946: Minus           "-" at 373:45-373:46
+3947: IntLit          "32_768" at 373:46-373:52
+3948: RParen          ")" at 373:52-373:53
+3949: Colon           ":" at 373:53-373:54
+3950: Ident           "int16" at 373:54-373:59
+3951: Semicolon       ";" at 373:59-373:60
+3952: RBrace          "}" at 373:61-373:62 (leading: Space)
+3953: KwPub           "pub" at 374:5-374:8 (leading: Newline, Space)
+3954: KwFn            "fn" at 374:9-374:11 (leading: Space)
+3955: Ident           "__max_value" at 374:12-374:23 (leading: Space)
+3956: LParen          "(" at 374:23-374:24
+3957: RParen          ")" at 374:24-374:25
+3958: Arrow           "->" at 374:26-374:28 (leading: Space)
+3959: Ident           "int16" at 374:29-374:34 (leading: Space)
+3960: LBrace          "{" at 374:35-374:36 (leading: Space)
+3961: KwReturn        "return" at 374:37-374:43 (leading: Space)
+3962: LParen          "(" at 374:44-374:45 (leading: Space)
+3963: IntLit          "32_767" at 374:45-374:51
+3964: RParen          ")" at 374:51-374:52
+3965: Colon           ":" at 374:52-374:53
+3966: Ident           "int16" at 374:53-374:58
+3967: Semicolon       ";" at 374:58-374:59
+3968: RBrace          "}" at 374:60-374:61 (leading: Space)
+3969: At              "@" at 375:5-375:6 (leading: Newline, Space)
+3970: Ident           "intrinsic" at 375:6-375:15
+3971: KwFn            "fn" at 375:16-375:18 (leading: Space)
+3972: Ident           "__add" at 375:19-375:24 (leading: Space)
+3973: LParen          "(" at 375:24-375:25
+3974: Ident           "self" at 375:25-375:29
+3975: Colon           ":" at 375:29-375:30
+3976: Ident           "int16" at 375:31-375:36 (leading: Space)
+3977: Comma           "," at 375:36-375:37
+3978: Ident           "other" at 375:38-375:43 (leading: Space)
+3979: Colon           ":" at 375:43-375:44
+3980: Ident           "int16" at 375:45-375:50 (leading: Space)
+3981: RParen          ")" at 375:50-375:51
+3982: Arrow           "->" at 375:52-375:54 (leading: Space)
+3983: Ident           "int16" at 375:55-375:60 (leading: Space)
+3984: Semicolon       ";" at 375:60-375:61
+3985: At              "@" at 376:5-376:6 (leading: Newline, Space)
+3986: Ident           "intrinsic" at 376:6-376:15
+3987: KwFn            "fn" at 376:16-376:18 (leading: Space)
+3988: Ident           "__sub" at 376:19-376:24 (leading: Space)
+3989: LParen          "(" at 376:24-376:25
+3990: Ident           "self" at 376:25-376:29
+3991: Colon           ":" at 376:29-376:30
+3992: Ident           "int16" at 376:31-376:36 (leading: Space)
+3993: Comma           "," at 376:36-376:37
+3994: Ident           "other" at 376:38-376:43 (leading: Space)
+3995: Colon           ":" at 376:43-376:44
+3996: Ident           "int16" at 376:45-376:50 (leading: Space)
+3997: RParen          ")" at 376:50-376:51
+3998: Arrow           "->" at 376:52-376:54 (leading: Space)
+3999: Ident           "int16" at 376:55-376:60 (leading: Space)
+4000: Semicolon       ";" at 376:60-376:61
+4001: At              "@" at 377:5-377:6 (leading: Newline, Space)
+4002: Ident           "intrinsic" at 377:6-377:15
+4003: KwFn            "fn" at 377:16-377:18 (leading: Space)
+4004: Ident           "__mul" at 377:19-377:24 (leading: Space)
+4005: LParen          "(" at 377:24-377:25
+4006: Ident           "self" at 377:25-377:29
+4007: Colon           ":" at 377:29-377:30
+4008: Ident           "int16" at 377:31-377:36 (leading: Space)
+4009: Comma           "," at 377:36-377:37
+4010: Ident           "other" at 377:38-377:43 (leading: Space)
+4011: Colon           ":" at 377:43-377:44
+4012: Ident           "int16" at 377:45-377:50 (leading: Space)
+4013: RParen          ")" at 377:50-377:51
+4014: Arrow           "->" at 377:52-377:54 (leading: Space)
+4015: Ident           "int16" at 377:55-377:60 (leading: Space)
+4016: Semicolon       ";" at 377:60-377:61
+4017: At              "@" at 378:5-378:6 (leading: Newline, Space)
+4018: Ident           "intrinsic" at 378:6-378:15
+4019: KwFn            "fn" at 378:16-378:18 (leading: Space)
+4020: Ident           "__div" at 378:19-378:24 (leading: Space)
+4021: LParen          "(" at 378:24-378:25
+4022: Ident           "self" at 378:25-378:29
+4023: Colon           ":" at 378:29-378:30
+4024: Ident           "int16" at 378:31-378:36 (leading: Space)
+4025: Comma           "," at 378:36-378:37
+4026: Ident           "other" at 378:38-378:43 (leading: Space)
+4027: Colon           ":" at 378:43-378:44
+4028: Ident           "int16" at 378:45-378:50 (leading: Space)
+4029: RParen          ")" at 378:50-378:51
+4030: Arrow           "->" at 378:52-378:54 (leading: Space)
+4031: Ident           "int16" at 378:55-378:60 (leading: Space)
+4032: Semicolon       ";" at 378:60-378:61
+4033: At              "@" at 379:5-379:6 (leading: Newline, Space)
+4034: Ident           "intrinsic" at 379:6-379:15
+4035: KwFn            "fn" at 379:16-379:18 (leading: Space)
+4036: Ident           "__mod" at 379:19-379:24 (leading: Space)
+4037: LParen          "(" at 379:24-379:25
+4038: Ident           "self" at 379:25-379:29
+4039: Colon           ":" at 379:29-379:30
+4040: Ident           "int16" at 379:31-379:36 (leading: Space)
+4041: Comma           "," at 379:36-379:37
+4042: Ident           "other" at 379:38-379:43 (leading: Space)
+4043: Colon           ":" at 379:43-379:44
+4044: Ident           "int16" at 379:45-379:50 (leading: Space)
+4045: RParen          ")" at 379:50-379:51
+4046: Arrow           "->" at 379:52-379:54 (leading: Space)
+4047: Ident           "int16" at 379:55-379:60 (leading: Space)
+4048: Semicolon       ";" at 379:60-379:61
+4049: At              "@" at 380:5-380:6 (leading: Newline, Space)
+4050: Ident           "intrinsic" at 380:6-380:15
+4051: KwFn            "fn" at 380:16-380:18 (leading: Space)
+4052: Ident           "__bit_and" at 380:19-380:28 (leading: Space)
+4053: LParen          "(" at 380:28-380:29
+4054: Ident           "self" at 380:29-380:33
+4055: Colon           ":" at 380:33-380:34
+4056: Ident           "int16" at 380:35-380:40 (leading: Space)
+4057: Comma           "," at 380:40-380:41
+4058: Ident           "other" at 380:42-380:47 (leading: Space)
+4059: Colon           ":" at 380:47-380:48
+4060: Ident           "int16" at 380:49-380:54 (leading: Space)
+4061: RParen          ")" at 380:54-380:55
+4062: Arrow           "->" at 380:56-380:58 (leading: Space)
+4063: Ident           "int16" at 380:59-380:64 (leading: Space)
+4064: Semicolon       ";" at 380:64-380:65
+4065: At              "@" at 381:5-381:6 (leading: Newline, Space)
+4066: Ident           "intrinsic" at 381:6-381:15
+4067: KwFn            "fn" at 381:16-381:18 (leading: Space)
+4068: Ident           "__bit_or" at 381:19-381:27 (leading: Space)
+4069: LParen          "(" at 381:27-381:28
+4070: Ident           "self" at 381:28-381:32
+4071: Colon           ":" at 381:32-381:33
+4072: Ident           "int16" at 381:34-381:39 (leading: Space)
+4073: Comma           "," at 381:39-381:40
+4074: Ident           "other" at 381:41-381:46 (leading: Space)
+4075: Colon           ":" at 381:46-381:47
+4076: Ident           "int16" at 381:48-381:53 (leading: Space)
+4077: RParen          ")" at 381:53-381:54
+4078: Arrow           "->" at 381:55-381:57 (leading: Space)
+4079: Ident           "int16" at 381:58-381:63 (leading: Space)
+4080: Semicolon       ";" at 381:63-381:64
+4081: At              "@" at 382:5-382:6 (leading: Newline, Space)
+4082: Ident           "intrinsic" at 382:6-382:15
+4083: KwFn            "fn" at 382:16-382:18 (leading: Space)
+4084: Ident           "__bit_xor" at 382:19-382:28 (leading: Space)
+4085: LParen          "(" at 382:28-382:29
+4086: Ident           "self" at 382:29-382:33
+4087: Colon           ":" at 382:33-382:34
+4088: Ident           "int16" at 382:35-382:40 (leading: Space)
+4089: Comma           "," at 382:40-382:41
+4090: Ident           "other" at 382:42-382:47 (leading: Space)
+4091: Colon           ":" at 382:47-382:48
+4092: Ident           "int16" at 382:49-382:54 (leading: Space)
+4093: RParen          ")" at 382:54-382:55
+4094: Arrow           "->" at 382:56-382:58 (leading: Space)
+4095: Ident           "int16" at 382:59-382:64 (leading: Space)
+4096: Semicolon       ";" at 382:64-382:65
+4097: At              "@" at 383:5-383:6 (leading: Newline, Space)
+4098: Ident           "intrinsic" at 383:6-383:15
+4099: KwFn            "fn" at 383:16-383:18 (leading: Space)
+4100: Ident           "__shl" at 383:19-383:24 (leading: Space)
+4101: LParen          "(" at 383:24-383:25
+4102: Ident           "self" at 383:25-383:29
+4103: Colon           ":" at 383:29-383:30
+4104: Ident           "int16" at 383:31-383:36 (leading: Space)
+4105: Comma           "," at 383:36-383:37
+4106: Ident           "other" at 383:38-383:43 (leading: Space)
+4107: Colon           ":" at 383:43-383:44
+4108: Ident           "int16" at 383:45-383:50 (leading: Space)
+4109: RParen          ")" at 383:50-383:51
+4110: Arrow           "->" at 383:52-383:54 (leading: Space)
+4111: Ident           "int16" at 383:55-383:60 (leading: Space)
+4112: Semicolon       ";" at 383:60-383:61
+4113: At              "@" at 384:5-384:6 (leading: Newline, Space)
+4114: Ident           "intrinsic" at 384:6-384:15
+4115: KwFn            "fn" at 384:16-384:18 (leading: Space)
+4116: Ident           "__shr" at 384:19-384:24 (leading: Space)
+4117: LParen          "(" at 384:24-384:25
+4118: Ident           "self" at 384:25-384:29
+4119: Colon           ":" at 384:29-384:30
+4120: Ident           "int16" at 384:31-384:36 (leading: Space)
+4121: Comma           "," at 384:36-384:37
+4122: Ident           "other" at 384:38-384:43 (leading: Space)
+4123: Colon           ":" at 384:43-384:44
+4124: Ident           "int16" at 384:45-384:50 (leading: Space)
+4125: RParen          ")" at 384:50-384:51
+4126: Arrow           "->" at 384:52-384:54 (leading: Space)
+4127: Ident           "int16" at 384:55-384:60 (leading: Space)
+4128: Semicolon       ";" at 384:60-384:61
+4129: At              "@" at 385:5-385:6 (leading: Newline, Space)
+4130: Ident           "intrinsic" at 385:6-385:15
+4131: KwFn            "fn" at 385:16-385:18 (leading: Space)
+4132: Ident           "__lt" at 385:19-385:23 (leading: Space)
+4133: LParen          "(" at 385:23-385:24
+4134: Ident           "self" at 385:24-385:28
+4135: Colon           ":" at 385:28-385:29
+4136: Ident           "int16" at 385:30-385:35 (leading: Space)
+4137: Comma           "," at 385:35-385:36
+4138: Ident           "other" at 385:37-385:42 (leading: Space)
+4139: Colon           ":" at 385:42-385:43
+4140: Ident           "int16" at 385:44-385:49 (leading: Space)
+4141: RParen          ")" at 385:49-385:50
+4142: Arrow           "->" at 385:51-385:53 (leading: Space)
+4143: Ident           "bool" at 385:54-385:58 (leading: Space)
+4144: Semicolon       ";" at 385:58-385:59
+4145: At              "@" at 386:5-386:6 (leading: Newline, Space)
+4146: Ident           "intrinsic" at 386:6-386:15
+4147: KwFn            "fn" at 386:16-386:18 (leading: Space)
+4148: Ident           "__le" at 386:19-386:23 (leading: Space)
+4149: LParen          "(" at 386:23-386:24
+4150: Ident           "self" at 386:24-386:28
+4151: Colon           ":" at 386:28-386:29
+4152: Ident           "int16" at 386:30-386:35 (leading: Space)
+4153: Comma           "," at 386:35-386:36
+4154: Ident           "other" at 386:37-386:42 (leading: Space)
+4155: Colon           ":" at 386:42-386:43
+4156: Ident           "int16" at 386:44-386:49 (leading: Space)
+4157: RParen          ")" at 386:49-386:50
+4158: Arrow           "->" at 386:51-386:53 (leading: Space)
+4159: Ident           "bool" at 386:54-386:58 (leading: Space)
+4160: Semicolon       ";" at 386:58-386:59
+4161: At              "@" at 387:5-387:6 (leading: Newline, Space)
+4162: Ident           "intrinsic" at 387:6-387:15
+4163: KwFn            "fn" at 387:16-387:18 (leading: Space)
+4164: Ident           "__eq" at 387:19-387:23 (leading: Space)
+4165: LParen          "(" at 387:23-387:24
+4166: Ident           "self" at 387:24-387:28
+4167: Colon           ":" at 387:28-387:29
+4168: Ident           "int16" at 387:30-387:35 (leading: Space)
+4169: Comma           "," at 387:35-387:36
+4170: Ident           "other" at 387:37-387:42 (leading: Space)
+4171: Colon           ":" at 387:42-387:43
+4172: Ident           "int16" at 387:44-387:49 (leading: Space)
+4173: RParen          ")" at 387:49-387:50
+4174: Arrow           "->" at 387:51-387:53 (leading: Space)
+4175: Ident           "bool" at 387:54-387:58 (leading: Space)
+4176: Semicolon       ";" at 387:58-387:59
+4177: At              "@" at 388:5-388:6 (leading: Newline, Space)
+4178: Ident           "intrinsic" at 388:6-388:15
+4179: KwFn            "fn" at 388:16-388:18 (leading: Space)
+4180: Ident           "__ne" at 388:19-388:23 (leading: Space)
+4181: LParen          "(" at 388:23-388:24
+4182: Ident           "self" at 388:24-388:28
+4183: Colon           ":" at 388:28-388:29
+4184: Ident           "int16" at 388:30-388:35 (leading: Space)
+4185: Comma           "," at 388:35-388:36
+4186: Ident           "other" at 388:37-388:42 (leading: Space)
+4187: Colon           ":" at 388:42-388:43
+4188: Ident           "int16" at 388:44-388:49 (leading: Space)
+4189: RParen          ")" at 388:49-388:50
+4190: Arrow           "->" at 388:51-388:53 (leading: Space)
+4191: Ident           "bool" at 388:54-388:58 (leading: Space)
+4192: Semicolon       ";" at 388:58-388:59
+4193: At              "@" at 389:5-389:6 (leading: Newline, Space)
+4194: Ident           "intrinsic" at 389:6-389:15
+4195: KwFn            "fn" at 389:16-389:18 (leading: Space)
+4196: Ident           "__ge" at 389:19-389:23 (leading: Space)
+4197: LParen          "(" at 389:23-389:24
+4198: Ident           "self" at 389:24-389:28
+4199: Colon           ":" at 389:28-389:29
+4200: Ident           "int16" at 389:30-389:35 (leading: Space)
+4201: Comma           "," at 389:35-389:36
+4202: Ident           "other" at 389:37-389:42 (leading: Space)
+4203: Colon           ":" at 389:42-389:43
+4204: Ident           "int16" at 389:44-389:49 (leading: Space)
+4205: RParen          ")" at 389:49-389:50
+4206: Arrow           "->" at 389:51-389:53 (leading: Space)
+4207: Ident           "bool" at 389:54-389:58 (leading: Space)
+4208: Semicolon       ";" at 389:58-389:59
+4209: At              "@" at 390:5-390:6 (leading: Newline, Space)
+4210: Ident           "intrinsic" at 390:6-390:15
+4211: KwFn            "fn" at 390:16-390:18 (leading: Space)
+4212: Ident           "__gt" at 390:19-390:23 (leading: Space)
+4213: LParen          "(" at 390:23-390:24
+4214: Ident           "self" at 390:24-390:28
+4215: Colon           ":" at 390:28-390:29
+4216: Ident           "int16" at 390:30-390:35 (leading: Space)
+4217: Comma           "," at 390:35-390:36
+4218: Ident           "other" at 390:37-390:42 (leading: Space)
+4219: Colon           ":" at 390:42-390:43
+4220: Ident           "int16" at 390:44-390:49 (leading: Space)
+4221: RParen          ")" at 390:49-390:50
+4222: Arrow           "->" at 390:51-390:53 (leading: Space)
+4223: Ident           "bool" at 390:54-390:58 (leading: Space)
+4224: Semicolon       ";" at 390:58-390:59
+4225: At              "@" at 391:5-391:6 (leading: Newline, Space)
+4226: Ident           "intrinsic" at 391:6-391:15
+4227: KwFn            "fn" at 391:16-391:18 (leading: Space)
+4228: Ident           "__pos" at 391:19-391:24 (leading: Space)
+4229: LParen          "(" at 391:24-391:25
+4230: Ident           "self" at 391:25-391:29
+4231: Colon           ":" at 391:29-391:30
+4232: Ident           "int16" at 391:31-391:36 (leading: Space)
+4233: RParen          ")" at 391:36-391:37
+4234: Arrow           "->" at 391:38-391:40 (leading: Space)
+4235: Ident           "int16" at 391:41-391:46 (leading: Space)
+4236: Semicolon       ";" at 391:46-391:47
+4237: At              "@" at 392:5-392:6 (leading: Newline, Space)
+4238: Ident           "intrinsic" at 392:6-392:15
+4239: KwFn            "fn" at 392:16-392:18 (leading: Space)
+4240: Ident           "__neg" at 392:19-392:24 (leading: Space)
+4241: LParen          "(" at 392:24-392:25
+4242: Ident           "self" at 392:25-392:29
+4243: Colon           ":" at 392:29-392:30
+4244: Ident           "int16" at 392:31-392:36 (leading: Space)
+4245: RParen          ")" at 392:36-392:37
+4246: Arrow           "->" at 392:38-392:40 (leading: Space)
+4247: Ident           "int16" at 392:41-392:46 (leading: Space)
+4248: Semicolon       ";" at 392:46-392:47
+4249: At              "@" at 393:5-393:6 (leading: Newline, Space)
+4250: Ident           "intrinsic" at 393:6-393:15
+4251: KwFn            "fn" at 393:16-393:18 (leading: Space)
+4252: Ident           "__abs" at 393:19-393:24 (leading: Space)
+4253: LParen          "(" at 393:24-393:25
+4254: Ident           "self" at 393:25-393:29
+4255: Colon           ":" at 393:29-393:30
+4256: Ident           "int16" at 393:31-393:36 (leading: Space)
+4257: RParen          ")" at 393:36-393:37
+4258: Arrow           "->" at 393:38-393:40 (leading: Space)
+4259: Ident           "int16" at 393:41-393:46 (leading: Space)
+4260: Semicolon       ";" at 393:46-393:47
+4261: At              "@" at 394:5-394:6 (leading: Newline, Space)
+4262: Ident           "intrinsic" at 394:6-394:15
+4263: KwFn            "fn" at 394:16-394:18 (leading: Space)
+4264: Ident           "__to" at 394:19-394:23 (leading: Space)
+4265: LParen          "(" at 394:23-394:24
+4266: Ident           "self" at 394:24-394:28
+4267: Colon           ":" at 394:28-394:29
+4268: Ident           "int16" at 394:30-394:35 (leading: Space)
+4269: Comma           "," at 394:35-394:36
+4270: Ident           "target" at 394:37-394:43 (leading: Space)
+4271: Colon           ":" at 394:43-394:44
+4272: Ident           "int" at 394:45-394:48 (leading: Space)
+4273: RParen          ")" at 394:48-394:49
+4274: Arrow           "->" at 394:50-394:52 (leading: Space)
+4275: Ident           "int" at 394:53-394:56 (leading: Space)
+4276: Semicolon       ";" at 394:56-394:57
+4277: At              "@" at 395:5-395:6 (leading: Newline, Space)
+4278: Ident           "intrinsic" at 395:6-395:15
+4279: At              "@" at 395:16-395:17 (leading: Space)
+4280: Ident           "overload" at 395:17-395:25
+4281: KwFn            "fn" at 395:26-395:28 (leading: Space)
+4282: Ident           "__to" at 395:29-395:33 (leading: Space)
+4283: LParen          "(" at 395:33-395:34
+4284: Ident           "self" at 395:34-395:38
+4285: Colon           ":" at 395:38-395:39
+4286: Ident           "int16" at 395:40-395:45 (leading: Space)
+4287: Comma           "," at 395:45-395:46
+4288: Ident           "target" at 395:47-395:53 (leading: Space)
+4289: Colon           ":" at 395:53-395:54
+4290: Ident           "int8" at 395:55-395:59 (leading: Space)
+4291: RParen          ")" at 395:59-395:60
+4292: Arrow           "->" at 395:61-395:63 (leading: Space)
+4293: Ident           "int8" at 395:64-395:68 (leading: Space)
+4294: Semicolon       ";" at 395:68-395:69
+4295: At              "@" at 396:5-396:6 (leading: Newline, Space)
+4296: Ident           "intrinsic" at 396:6-396:15
+4297: At              "@" at 396:16-396:17 (leading: Space)
+4298: Ident           "overload" at 396:17-396:25
+4299: KwFn            "fn" at 396:26-396:28 (leading: Space)
+4300: Ident           "__to" at 396:29-396:33 (leading: Space)
+4301: LParen          "(" at 396:33-396:34
+4302: Ident           "self" at 396:34-396:38
+4303: Colon           ":" at 396:38-396:39
+4304: Ident           "int16" at 396:40-396:45 (leading: Space)
+4305: Comma           "," at 396:45-396:46
+4306: Ident           "target" at 396:47-396:53 (leading: Space)
+4307: Colon           ":" at 396:53-396:54
+4308: Ident           "int32" at 396:55-396:60 (leading: Space)
+4309: RParen          ")" at 396:60-396:61
+4310: Arrow           "->" at 396:62-396:64 (leading: Space)
+4311: Ident           "int32" at 396:65-396:70 (leading: Space)
+4312: Semicolon       ";" at 396:70-396:71
+4313: At              "@" at 397:5-397:6 (leading: Newline, Space)
+4314: Ident           "intrinsic" at 397:6-397:15
+4315: At              "@" at 397:16-397:17 (leading: Space)
+4316: Ident           "overload" at 397:17-397:25
+4317: KwFn            "fn" at 397:26-397:28 (leading: Space)
+4318: Ident           "__to" at 397:29-397:33 (leading: Space)
+4319: LParen          "(" at 397:33-397:34
+4320: Ident           "self" at 397:34-397:38
+4321: Colon           ":" at 397:38-397:39
+4322: Ident           "int16" at 397:40-397:45 (leading: Space)
+4323: Comma           "," at 397:45-397:46
+4324: Ident           "target" at 397:47-397:53 (leading: Space)
+4325: Colon           ":" at 397:53-397:54
+4326: Ident           "int64" at 397:55-397:60 (leading: Space)
+4327: RParen          ")" at 397:60-397:61
+4328: Arrow           "->" at 397:62-397:64 (leading: Space)
+4329: Ident           "int64" at 397:65-397:70 (leading: Space)
+4330: Semicolon       ";" at 397:70-397:71
+4331: At              "@" at 398:5-398:6 (leading: Newline, Space)
+4332: Ident           "intrinsic" at 398:6-398:15
+4333: KwPub           "pub" at 398:16-398:19 (leading: Space)
+4334: KwFn            "fn" at 398:20-398:22 (leading: Space)
+4335: Ident           "from_str" at 398:23-398:31 (leading: Space)
+4336: LParen          "(" at 398:31-398:32
+4337: Ident           "s" at 398:32-398:33
+4338: Colon           ":" at 398:33-398:34
+4339: Amp             "&" at 398:35-398:36 (leading: Space)
+4340: Ident           "string" at 398:36-398:42
+4341: RParen          ")" at 398:42-398:43
+4342: Arrow           "->" at 398:44-398:46 (leading: Space)
+4343: Ident           "Erring" at 398:47-398:53 (leading: Space)
+4344: Lt              "<" at 398:53-398:54
+4345: Ident           "int16" at 398:54-398:59
+4346: Comma           "," at 398:59-398:60
+4347: Ident           "Error" at 398:61-398:66 (leading: Space)
+4348: Gt              ">" at 398:66-398:67
+4349: Semicolon       ";" at 398:67-398:68
+4350: RBrace          "}" at 399:1-399:2 (leading: Newline)
+4351: KwExtern        "extern" at 401:1-401:7 (leading: Newline)
+4352: Lt              "<" at 401:7-401:8
+4353: Ident           "int32" at 401:8-401:13
+4354: Gt              ">" at 401:13-401:14
+4355: LBrace          "{" at 401:15-401:16 (leading: Space)
+4356: KwPub           "pub" at 402:5-402:8 (leading: Newline, Space)
+4357: KwFn            "fn" at 402:9-402:11 (leading: Space)
+4358: Ident           "__min_value" at 402:12-402:23 (leading: Space)
+4359: LParen          "(" at 402:23-402:24
+4360: RParen          ")" at 402:24-402:25
+4361: Arrow           "->" at 402:26-402:28 (leading: Space)
+4362: Ident           "int32" at 402:29-402:34 (leading: Space)
+4363: LBrace          "{" at 402:35-402:36 (leading: Space)
+4364: KwReturn        "return" at 402:37-402:43 (leading: Space)
+4365: LParen          "(" at 402:44-402:45 (leading: Space)
+4366: Minus           "-" at 402:45-402:46
+4367: IntLit          "2_147_483_648" at 402:46-402:59
+4368: RParen          ")" at 402:59-402:60
+4369: Colon           ":" at 402:60-402:61
+4370: Ident           "int32" at 402:61-402:66
+4371: Semicolon       ";" at 402:66-402:67
+4372: RBrace          "}" at 402:68-402:69 (leading: Space)
+4373: KwPub           "pub" at 403:5-403:8 (leading: Newline, Space)
+4374: KwFn            "fn" at 403:9-403:11 (leading: Space)
+4375: Ident           "__max_value" at 403:12-403:23 (leading: Space)
+4376: LParen          "(" at 403:23-403:24
+4377: RParen          ")" at 403:24-403:25
+4378: Arrow           "->" at 403:26-403:28 (leading: Space)
+4379: Ident           "int32" at 403:29-403:34 (leading: Space)
+4380: LBrace          "{" at 403:35-403:36 (leading: Space)
+4381: KwReturn        "return" at 403:37-403:43 (leading: Space)
+4382: LParen          "(" at 403:44-403:45 (leading: Space)
+4383: IntLit          "2_147_483_647" at 403:45-403:58
+4384: RParen          ")" at 403:58-403:59
+4385: Colon           ":" at 403:59-403:60
+4386: Ident           "int32" at 403:60-403:65
+4387: Semicolon       ";" at 403:65-403:66
+4388: RBrace          "}" at 403:67-403:68 (leading: Space)
+4389: At              "@" at 404:5-404:6 (leading: Newline, Space)
+4390: Ident           "intrinsic" at 404:6-404:15
+4391: KwFn            "fn" at 404:16-404:18 (leading: Space)
+4392: Ident           "__add" at 404:19-404:24 (leading: Space)
+4393: LParen          "(" at 404:24-404:25
+4394: Ident           "self" at 404:25-404:29
+4395: Colon           ":" at 404:29-404:30
+4396: Ident           "int32" at 404:31-404:36 (leading: Space)
+4397: Comma           "," at 404:36-404:37
+4398: Ident           "other" at 404:38-404:43 (leading: Space)
+4399: Colon           ":" at 404:43-404:44
+4400: Ident           "int32" at 404:45-404:50 (leading: Space)
+4401: RParen          ")" at 404:50-404:51
+4402: Arrow           "->" at 404:52-404:54 (leading: Space)
+4403: Ident           "int32" at 404:55-404:60 (leading: Space)
+4404: Semicolon       ";" at 404:60-404:61
+4405: At              "@" at 405:5-405:6 (leading: Newline, Space)
+4406: Ident           "intrinsic" at 405:6-405:15
+4407: KwFn            "fn" at 405:16-405:18 (leading: Space)
+4408: Ident           "__sub" at 405:19-405:24 (leading: Space)
+4409: LParen          "(" at 405:24-405:25
+4410: Ident           "self" at 405:25-405:29
+4411: Colon           ":" at 405:29-405:30
+4412: Ident           "int32" at 405:31-405:36 (leading: Space)
+4413: Comma           "," at 405:36-405:37
+4414: Ident           "other" at 405:38-405:43 (leading: Space)
+4415: Colon           ":" at 405:43-405:44
+4416: Ident           "int32" at 405:45-405:50 (leading: Space)
+4417: RParen          ")" at 405:50-405:51
+4418: Arrow           "->" at 405:52-405:54 (leading: Space)
+4419: Ident           "int32" at 405:55-405:60 (leading: Space)
+4420: Semicolon       ";" at 405:60-405:61
+4421: At              "@" at 406:5-406:6 (leading: Newline, Space)
+4422: Ident           "intrinsic" at 406:6-406:15
+4423: KwFn            "fn" at 406:16-406:18 (leading: Space)
+4424: Ident           "__mul" at 406:19-406:24 (leading: Space)
+4425: LParen          "(" at 406:24-406:25
+4426: Ident           "self" at 406:25-406:29
+4427: Colon           ":" at 406:29-406:30
+4428: Ident           "int32" at 406:31-406:36 (leading: Space)
+4429: Comma           "," at 406:36-406:37
+4430: Ident           "other" at 406:38-406:43 (leading: Space)
+4431: Colon           ":" at 406:43-406:44
+4432: Ident           "int32" at 406:45-406:50 (leading: Space)
+4433: RParen          ")" at 406:50-406:51
+4434: Arrow           "->" at 406:52-406:54 (leading: Space)
+4435: Ident           "int32" at 406:55-406:60 (leading: Space)
+4436: Semicolon       ";" at 406:60-406:61
+4437: At              "@" at 407:5-407:6 (leading: Newline, Space)
+4438: Ident           "intrinsic" at 407:6-407:15
+4439: KwFn            "fn" at 407:16-407:18 (leading: Space)
+4440: Ident           "__div" at 407:19-407:24 (leading: Space)
+4441: LParen          "(" at 407:24-407:25
+4442: Ident           "self" at 407:25-407:29
+4443: Colon           ":" at 407:29-407:30
+4444: Ident           "int32" at 407:31-407:36 (leading: Space)
+4445: Comma           "," at 407:36-407:37
+4446: Ident           "other" at 407:38-407:43 (leading: Space)
+4447: Colon           ":" at 407:43-407:44
+4448: Ident           "int32" at 407:45-407:50 (leading: Space)
+4449: RParen          ")" at 407:50-407:51
+4450: Arrow           "->" at 407:52-407:54 (leading: Space)
+4451: Ident           "int32" at 407:55-407:60 (leading: Space)
+4452: Semicolon       ";" at 407:60-407:61
+4453: At              "@" at 408:5-408:6 (leading: Newline, Space)
+4454: Ident           "intrinsic" at 408:6-408:15
+4455: KwFn            "fn" at 408:16-408:18 (leading: Space)
+4456: Ident           "__mod" at 408:19-408:24 (leading: Space)
+4457: LParen          "(" at 408:24-408:25
+4458: Ident           "self" at 408:25-408:29
+4459: Colon           ":" at 408:29-408:30
+4460: Ident           "int32" at 408:31-408:36 (leading: Space)
+4461: Comma           "," at 408:36-408:37
+4462: Ident           "other" at 408:38-408:43 (leading: Space)
+4463: Colon           ":" at 408:43-408:44
+4464: Ident           "int32" at 408:45-408:50 (leading: Space)
+4465: RParen          ")" at 408:50-408:51
+4466: Arrow           "->" at 408:52-408:54 (leading: Space)
+4467: Ident           "int32" at 408:55-408:60 (leading: Space)
+4468: Semicolon       ";" at 408:60-408:61
+4469: At              "@" at 409:5-409:6 (leading: Newline, Space)
+4470: Ident           "intrinsic" at 409:6-409:15
+4471: KwFn            "fn" at 409:16-409:18 (leading: Space)
+4472: Ident           "__bit_and" at 409:19-409:28 (leading: Space)
+4473: LParen          "(" at 409:28-409:29
+4474: Ident           "self" at 409:29-409:33
+4475: Colon           ":" at 409:33-409:34
+4476: Ident           "int32" at 409:35-409:40 (leading: Space)
+4477: Comma           "," at 409:40-409:41
+4478: Ident           "other" at 409:42-409:47 (leading: Space)
+4479: Colon           ":" at 409:47-409:48
+4480: Ident           "int32" at 409:49-409:54 (leading: Space)
+4481: RParen          ")" at 409:54-409:55
+4482: Arrow           "->" at 409:56-409:58 (leading: Space)
+4483: Ident           "int32" at 409:59-409:64 (leading: Space)
+4484: Semicolon       ";" at 409:64-409:65
+4485: At              "@" at 410:5-410:6 (leading: Newline, Space)
+4486: Ident           "intrinsic" at 410:6-410:15
+4487: KwFn            "fn" at 410:16-410:18 (leading: Space)
+4488: Ident           "__bit_or" at 410:19-410:27 (leading: Space)
+4489: LParen          "(" at 410:27-410:28
+4490: Ident           "self" at 410:28-410:32
+4491: Colon           ":" at 410:32-410:33
+4492: Ident           "int32" at 410:34-410:39 (leading: Space)
+4493: Comma           "," at 410:39-410:40
+4494: Ident           "other" at 410:41-410:46 (leading: Space)
+4495: Colon           ":" at 410:46-410:47
+4496: Ident           "int32" at 410:48-410:53 (leading: Space)
+4497: RParen          ")" at 410:53-410:54
+4498: Arrow           "->" at 410:55-410:57 (leading: Space)
+4499: Ident           "int32" at 410:58-410:63 (leading: Space)
+4500: Semicolon       ";" at 410:63-410:64
+4501: At              "@" at 411:5-411:6 (leading: Newline, Space)
+4502: Ident           "intrinsic" at 411:6-411:15
+4503: KwFn            "fn" at 411:16-411:18 (leading: Space)
+4504: Ident           "__bit_xor" at 411:19-411:28 (leading: Space)
+4505: LParen          "(" at 411:28-411:29
+4506: Ident           "self" at 411:29-411:33
+4507: Colon           ":" at 411:33-411:34
+4508: Ident           "int32" at 411:35-411:40 (leading: Space)
+4509: Comma           "," at 411:40-411:41
+4510: Ident           "other" at 411:42-411:47 (leading: Space)
+4511: Colon           ":" at 411:47-411:48
+4512: Ident           "int32" at 411:49-411:54 (leading: Space)
+4513: RParen          ")" at 411:54-411:55
+4514: Arrow           "->" at 411:56-411:58 (leading: Space)
+4515: Ident           "int32" at 411:59-411:64 (leading: Space)
+4516: Semicolon       ";" at 411:64-411:65
+4517: At              "@" at 412:5-412:6 (leading: Newline, Space)
+4518: Ident           "intrinsic" at 412:6-412:15
+4519: KwFn            "fn" at 412:16-412:18 (leading: Space)
+4520: Ident           "__shl" at 412:19-412:24 (leading: Space)
+4521: LParen          "(" at 412:24-412:25
+4522: Ident           "self" at 412:25-412:29
+4523: Colon           ":" at 412:29-412:30
+4524: Ident           "int32" at 412:31-412:36 (leading: Space)
+4525: Comma           "," at 412:36-412:37
+4526: Ident           "other" at 412:38-412:43 (leading: Space)
+4527: Colon           ":" at 412:43-412:44
+4528: Ident           "int32" at 412:45-412:50 (leading: Space)
+4529: RParen          ")" at 412:50-412:51
+4530: Arrow           "->" at 412:52-412:54 (leading: Space)
+4531: Ident           "int32" at 412:55-412:60 (leading: Space)
+4532: Semicolon       ";" at 412:60-412:61
+4533: At              "@" at 413:5-413:6 (leading: Newline, Space)
+4534: Ident           "intrinsic" at 413:6-413:15
+4535: KwFn            "fn" at 413:16-413:18 (leading: Space)
+4536: Ident           "__shr" at 413:19-413:24 (leading: Space)
+4537: LParen          "(" at 413:24-413:25
+4538: Ident           "self" at 413:25-413:29
+4539: Colon           ":" at 413:29-413:30
+4540: Ident           "int32" at 413:31-413:36 (leading: Space)
+4541: Comma           "," at 413:36-413:37
+4542: Ident           "other" at 413:38-413:43 (leading: Space)
+4543: Colon           ":" at 413:43-413:44
+4544: Ident           "int32" at 413:45-413:50 (leading: Space)
+4545: RParen          ")" at 413:50-413:51
+4546: Arrow           "->" at 413:52-413:54 (leading: Space)
+4547: Ident           "int32" at 413:55-413:60 (leading: Space)
+4548: Semicolon       ";" at 413:60-413:61
+4549: At              "@" at 414:5-414:6 (leading: Newline, Space)
+4550: Ident           "intrinsic" at 414:6-414:15
+4551: KwFn            "fn" at 414:16-414:18 (leading: Space)
+4552: Ident           "__lt" at 414:19-414:23 (leading: Space)
+4553: LParen          "(" at 414:23-414:24
+4554: Ident           "self" at 414:24-414:28
+4555: Colon           ":" at 414:28-414:29
+4556: Ident           "int32" at 414:30-414:35 (leading: Space)
+4557: Comma           "," at 414:35-414:36
+4558: Ident           "other" at 414:37-414:42 (leading: Space)
+4559: Colon           ":" at 414:42-414:43
+4560: Ident           "int32" at 414:44-414:49 (leading: Space)
+4561: RParen          ")" at 414:49-414:50
+4562: Arrow           "->" at 414:51-414:53 (leading: Space)
+4563: Ident           "bool" at 414:54-414:58 (leading: Space)
+4564: Semicolon       ";" at 414:58-414:59
+4565: At              "@" at 415:5-415:6 (leading: Newline, Space)
+4566: Ident           "intrinsic" at 415:6-415:15
+4567: KwFn            "fn" at 415:16-415:18 (leading: Space)
+4568: Ident           "__le" at 415:19-415:23 (leading: Space)
+4569: LParen          "(" at 415:23-415:24
+4570: Ident           "self" at 415:24-415:28
+4571: Colon           ":" at 415:28-415:29
+4572: Ident           "int32" at 415:30-415:35 (leading: Space)
+4573: Comma           "," at 415:35-415:36
+4574: Ident           "other" at 415:37-415:42 (leading: Space)
+4575: Colon           ":" at 415:42-415:43
+4576: Ident           "int32" at 415:44-415:49 (leading: Space)
+4577: RParen          ")" at 415:49-415:50
+4578: Arrow           "->" at 415:51-415:53 (leading: Space)
+4579: Ident           "bool" at 415:54-415:58 (leading: Space)
+4580: Semicolon       ";" at 415:58-415:59
+4581: At              "@" at 416:5-416:6 (leading: Newline, Space)
+4582: Ident           "intrinsic" at 416:6-416:15
+4583: KwFn            "fn" at 416:16-416:18 (leading: Space)
+4584: Ident           "__eq" at 416:19-416:23 (leading: Space)
+4585: LParen          "(" at 416:23-416:24
+4586: Ident           "self" at 416:24-416:28
+4587: Colon           ":" at 416:28-416:29
+4588: Ident           "int32" at 416:30-416:35 (leading: Space)
+4589: Comma           "," at 416:35-416:36
+4590: Ident           "other" at 416:37-416:42 (leading: Space)
+4591: Colon           ":" at 416:42-416:43
+4592: Ident           "int32" at 416:44-416:49 (leading: Space)
+4593: RParen          ")" at 416:49-416:50
+4594: Arrow           "->" at 416:51-416:53 (leading: Space)
+4595: Ident           "bool" at 416:54-416:58 (leading: Space)
+4596: Semicolon       ";" at 416:58-416:59
+4597: At              "@" at 417:5-417:6 (leading: Newline, Space)
+4598: Ident           "intrinsic" at 417:6-417:15
+4599: KwFn            "fn" at 417:16-417:18 (leading: Space)
+4600: Ident           "__ne" at 417:19-417:23 (leading: Space)
+4601: LParen          "(" at 417:23-417:24
+4602: Ident           "self" at 417:24-417:28
+4603: Colon           ":" at 417:28-417:29
+4604: Ident           "int32" at 417:30-417:35 (leading: Space)
+4605: Comma           "," at 417:35-417:36
+4606: Ident           "other" at 417:37-417:42 (leading: Space)
+4607: Colon           ":" at 417:42-417:43
+4608: Ident           "int32" at 417:44-417:49 (leading: Space)
+4609: RParen          ")" at 417:49-417:50
+4610: Arrow           "->" at 417:51-417:53 (leading: Space)
+4611: Ident           "bool" at 417:54-417:58 (leading: Space)
+4612: Semicolon       ";" at 417:58-417:59
+4613: At              "@" at 418:5-418:6 (leading: Newline, Space)
+4614: Ident           "intrinsic" at 418:6-418:15
+4615: KwFn            "fn" at 418:16-418:18 (leading: Space)
+4616: Ident           "__ge" at 418:19-418:23 (leading: Space)
+4617: LParen          "(" at 418:23-418:24
+4618: Ident           "self" at 418:24-418:28
+4619: Colon           ":" at 418:28-418:29
+4620: Ident           "int32" at 418:30-418:35 (leading: Space)
+4621: Comma           "," at 418:35-418:36
+4622: Ident           "other" at 418:37-418:42 (leading: Space)
+4623: Colon           ":" at 418:42-418:43
+4624: Ident           "int32" at 418:44-418:49 (leading: Space)
+4625: RParen          ")" at 418:49-418:50
+4626: Arrow           "->" at 418:51-418:53 (leading: Space)
+4627: Ident           "bool" at 418:54-418:58 (leading: Space)
+4628: Semicolon       ";" at 418:58-418:59
+4629: At              "@" at 419:5-419:6 (leading: Newline, Space)
+4630: Ident           "intrinsic" at 419:6-419:15
+4631: KwFn            "fn" at 419:16-419:18 (leading: Space)
+4632: Ident           "__gt" at 419:19-419:23 (leading: Space)
+4633: LParen          "(" at 419:23-419:24
+4634: Ident           "self" at 419:24-419:28
+4635: Colon           ":" at 419:28-419:29
+4636: Ident           "int32" at 419:30-419:35 (leading: Space)
+4637: Comma           "," at 419:35-419:36
+4638: Ident           "other" at 419:37-419:42 (leading: Space)
+4639: Colon           ":" at 419:42-419:43
+4640: Ident           "int32" at 419:44-419:49 (leading: Space)
+4641: RParen          ")" at 419:49-419:50
+4642: Arrow           "->" at 419:51-419:53 (leading: Space)
+4643: Ident           "bool" at 419:54-419:58 (leading: Space)
+4644: Semicolon       ";" at 419:58-419:59
+4645: At              "@" at 420:5-420:6 (leading: Newline, Space)
+4646: Ident           "intrinsic" at 420:6-420:15
+4647: KwFn            "fn" at 420:16-420:18 (leading: Space)
+4648: Ident           "__pos" at 420:19-420:24 (leading: Space)
+4649: LParen          "(" at 420:24-420:25
+4650: Ident           "self" at 420:25-420:29
+4651: Colon           ":" at 420:29-420:30
+4652: Ident           "int32" at 420:31-420:36 (leading: Space)
+4653: RParen          ")" at 420:36-420:37
+4654: Arrow           "->" at 420:38-420:40 (leading: Space)
+4655: Ident           "int32" at 420:41-420:46 (leading: Space)
+4656: Semicolon       ";" at 420:46-420:47
+4657: At              "@" at 421:5-421:6 (leading: Newline, Space)
+4658: Ident           "intrinsic" at 421:6-421:15
+4659: KwFn            "fn" at 421:16-421:18 (leading: Space)
+4660: Ident           "__neg" at 421:19-421:24 (leading: Space)
+4661: LParen          "(" at 421:24-421:25
+4662: Ident           "self" at 421:25-421:29
+4663: Colon           ":" at 421:29-421:30
+4664: Ident           "int32" at 421:31-421:36 (leading: Space)
+4665: RParen          ")" at 421:36-421:37
+4666: Arrow           "->" at 421:38-421:40 (leading: Space)
+4667: Ident           "int32" at 421:41-421:46 (leading: Space)
+4668: Semicolon       ";" at 421:46-421:47
+4669: At              "@" at 422:5-422:6 (leading: Newline, Space)
+4670: Ident           "intrinsic" at 422:6-422:15
+4671: KwFn            "fn" at 422:16-422:18 (leading: Space)
+4672: Ident           "__abs" at 422:19-422:24 (leading: Space)
+4673: LParen          "(" at 422:24-422:25
+4674: Ident           "self" at 422:25-422:29
+4675: Colon           ":" at 422:29-422:30
+4676: Ident           "int32" at 422:31-422:36 (leading: Space)
+4677: RParen          ")" at 422:36-422:37
+4678: Arrow           "->" at 422:38-422:40 (leading: Space)
+4679: Ident           "int32" at 422:41-422:46 (leading: Space)
+4680: Semicolon       ";" at 422:46-422:47
+4681: At              "@" at 423:5-423:6 (leading: Newline, Space)
+4682: Ident           "intrinsic" at 423:6-423:15
+4683: KwFn            "fn" at 423:16-423:18 (leading: Space)
+4684: Ident           "__to" at 423:19-423:23 (leading: Space)
+4685: LParen          "(" at 423:23-423:24
+4686: Ident           "self" at 423:24-423:28
+4687: Colon           ":" at 423:28-423:29
+4688: Ident           "int32" at 423:30-423:35 (leading: Space)
+4689: Comma           "," at 423:35-423:36
+4690: Ident           "target" at 423:37-423:43 (leading: Space)
+4691: Colon           ":" at 423:43-423:44
+4692: Ident           "int" at 423:45-423:48 (leading: Space)
+4693: RParen          ")" at 423:48-423:49
+4694: Arrow           "->" at 423:50-423:52 (leading: Space)
+4695: Ident           "int" at 423:53-423:56 (leading: Space)
+4696: Semicolon       ";" at 423:56-423:57
+4697: At              "@" at 424:5-424:6 (leading: Newline, Space)
+4698: Ident           "intrinsic" at 424:6-424:15
+4699: At              "@" at 424:16-424:17 (leading: Space)
+4700: Ident           "overload" at 424:17-424:25
+4701: KwFn            "fn" at 424:26-424:28 (leading: Space)
+4702: Ident           "__to" at 424:29-424:33 (leading: Space)
+4703: LParen          "(" at 424:33-424:34
+4704: Ident           "self" at 424:34-424:38
+4705: Colon           ":" at 424:38-424:39
+4706: Ident           "int32" at 424:40-424:45 (leading: Space)
+4707: Comma           "," at 424:45-424:46
+4708: Ident           "target" at 424:47-424:53 (leading: Space)
+4709: Colon           ":" at 424:53-424:54
+4710: Ident           "int8" at 424:55-424:59 (leading: Space)
+4711: RParen          ")" at 424:59-424:60
+4712: Arrow           "->" at 424:61-424:63 (leading: Space)
+4713: Ident           "int8" at 424:64-424:68 (leading: Space)
+4714: Semicolon       ";" at 424:68-424:69
+4715: At              "@" at 425:5-425:6 (leading: Newline, Space)
+4716: Ident           "intrinsic" at 425:6-425:15
+4717: At              "@" at 425:16-425:17 (leading: Space)
+4718: Ident           "overload" at 425:17-425:25
+4719: KwFn            "fn" at 425:26-425:28 (leading: Space)
+4720: Ident           "__to" at 425:29-425:33 (leading: Space)
+4721: LParen          "(" at 425:33-425:34
+4722: Ident           "self" at 425:34-425:38
+4723: Colon           ":" at 425:38-425:39
+4724: Ident           "int32" at 425:40-425:45 (leading: Space)
+4725: Comma           "," at 425:45-425:46
+4726: Ident           "target" at 425:47-425:53 (leading: Space)
+4727: Colon           ":" at 425:53-425:54
+4728: Ident           "int16" at 425:55-425:60 (leading: Space)
+4729: RParen          ")" at 425:60-425:61
+4730: Arrow           "->" at 425:62-425:64 (leading: Space)
+4731: Ident           "int16" at 425:65-425:70 (leading: Space)
+4732: Semicolon       ";" at 425:70-425:71
+4733: At              "@" at 426:5-426:6 (leading: Newline, Space)
+4734: Ident           "intrinsic" at 426:6-426:15
+4735: At              "@" at 426:16-426:17 (leading: Space)
+4736: Ident           "overload" at 426:17-426:25
+4737: KwFn            "fn" at 426:26-426:28 (leading: Space)
+4738: Ident           "__to" at 426:29-426:33 (leading: Space)
+4739: LParen          "(" at 426:33-426:34
+4740: Ident           "self" at 426:34-426:38
+4741: Colon           ":" at 426:38-426:39
+4742: Ident           "int32" at 426:40-426:45 (leading: Space)
+4743: Comma           "," at 426:45-426:46
+4744: Ident           "target" at 426:47-426:53 (leading: Space)
+4745: Colon           ":" at 426:53-426:54
+4746: Ident           "int64" at 426:55-426:60 (leading: Space)
+4747: RParen          ")" at 426:60-426:61
+4748: Arrow           "->" at 426:62-426:64 (leading: Space)
+4749: Ident           "int64" at 426:65-426:70 (leading: Space)
+4750: Semicolon       ";" at 426:70-426:71
+4751: At              "@" at 427:5-427:6 (leading: Newline, Space)
+4752: Ident           "intrinsic" at 427:6-427:15
+4753: KwPub           "pub" at 427:16-427:19 (leading: Space)
+4754: KwFn            "fn" at 427:20-427:22 (leading: Space)
+4755: Ident           "from_str" at 427:23-427:31 (leading: Space)
+4756: LParen          "(" at 427:31-427:32
+4757: Ident           "s" at 427:32-427:33
+4758: Colon           ":" at 427:33-427:34
+4759: Amp             "&" at 427:35-427:36 (leading: Space)
+4760: Ident           "string" at 427:36-427:42
+4761: RParen          ")" at 427:42-427:43
+4762: Arrow           "->" at 427:44-427:46 (leading: Space)
+4763: Ident           "Erring" at 427:47-427:53 (leading: Space)
+4764: Lt              "<" at 427:53-427:54
+4765: Ident           "int32" at 427:54-427:59
+4766: Comma           "," at 427:59-427:60
+4767: Ident           "Error" at 427:61-427:66 (leading: Space)
+4768: Gt              ">" at 427:66-427:67
+4769: Semicolon       ";" at 427:67-427:68
+4770: RBrace          "}" at 428:1-428:2 (leading: Newline)
+4771: KwExtern        "extern" at 430:1-430:7 (leading: Newline)
+4772: Lt              "<" at 430:7-430:8
+4773: Ident           "int64" at 430:8-430:13
+4774: Gt              ">" at 430:13-430:14
+4775: LBrace          "{" at 430:15-430:16 (leading: Space)
+4776: KwPub           "pub" at 431:5-431:8 (leading: Newline, Space)
+4777: KwFn            "fn" at 431:9-431:11 (leading: Space)
+4778: Ident           "__min_value" at 431:12-431:23 (leading: Space)
+4779: LParen          "(" at 431:23-431:24
+4780: RParen          ")" at 431:24-431:25
+4781: Arrow           "->" at 431:26-431:28 (leading: Space)
+4782: Ident           "int64" at 431:29-431:34 (leading: Space)
+4783: LBrace          "{" at 431:35-431:36 (leading: Space)
+4784: KwReturn        "return" at 431:37-431:43 (leading: Space)
+4785: LParen          "(" at 431:44-431:45 (leading: Space)
+4786: Minus           "-" at 431:45-431:46
+4787: IntLit          "9_223_372_036_854_775_808" at 431:46-431:71
+4788: RParen          ")" at 431:71-431:72
+4789: Colon           ":" at 431:72-431:73
+4790: Ident           "int64" at 431:73-431:78
+4791: Semicolon       ";" at 431:78-431:79
+4792: RBrace          "}" at 431:80-431:81 (leading: Space)
+4793: KwPub           "pub" at 432:5-432:8 (leading: Newline, Space)
+4794: KwFn            "fn" at 432:9-432:11 (leading: Space)
+4795: Ident           "__max_value" at 432:12-432:23 (leading: Space)
+4796: LParen          "(" at 432:23-432:24
+4797: RParen          ")" at 432:24-432:25
+4798: Arrow           "->" at 432:26-432:28 (leading: Space)
+4799: Ident           "int64" at 432:29-432:34 (leading: Space)
+4800: LBrace          "{" at 432:35-432:36 (leading: Space)
+4801: KwReturn        "return" at 432:37-432:43 (leading: Space)
+4802: LParen          "(" at 432:44-432:45 (leading: Space)
+4803: IntLit          "9_223_372_036_854_775_807" at 432:45-432:70
+4804: RParen          ")" at 432:70-432:71
+4805: Colon           ":" at 432:71-432:72
+4806: Ident           "int64" at 432:72-432:77
+4807: Semicolon       ";" at 432:77-432:78
+4808: RBrace          "}" at 432:79-432:80 (leading: Space)
+4809: At              "@" at 433:5-433:6 (leading: Newline, Space)
+4810: Ident           "intrinsic" at 433:6-433:15
+4811: KwFn            "fn" at 433:16-433:18 (leading: Space)
+4812: Ident           "__add" at 433:19-433:24 (leading: Space)
+4813: LParen          "(" at 433:24-433:25
+4814: Ident           "self" at 433:25-433:29
+4815: Colon           ":" at 433:29-433:30
+4816: Ident           "int64" at 433:31-433:36 (leading: Space)
+4817: Comma           "," at 433:36-433:37
+4818: Ident           "other" at 433:38-433:43 (leading: Space)
+4819: Colon           ":" at 433:43-433:44
+4820: Ident           "int64" at 433:45-433:50 (leading: Space)
+4821: RParen          ")" at 433:50-433:51
+4822: Arrow           "->" at 433:52-433:54 (leading: Space)
+4823: Ident           "int64" at 433:55-433:60 (leading: Space)
+4824: Semicolon       ";" at 433:60-433:61
+4825: At              "@" at 434:5-434:6 (leading: Newline, Space)
+4826: Ident           "intrinsic" at 434:6-434:15
+4827: KwFn            "fn" at 434:16-434:18 (leading: Space)
+4828: Ident           "__sub" at 434:19-434:24 (leading: Space)
+4829: LParen          "(" at 434:24-434:25
+4830: Ident           "self" at 434:25-434:29
+4831: Colon           ":" at 434:29-434:30
+4832: Ident           "int64" at 434:31-434:36 (leading: Space)
+4833: Comma           "," at 434:36-434:37
+4834: Ident           "other" at 434:38-434:43 (leading: Space)
+4835: Colon           ":" at 434:43-434:44
+4836: Ident           "int64" at 434:45-434:50 (leading: Space)
+4837: RParen          ")" at 434:50-434:51
+4838: Arrow           "->" at 434:52-434:54 (leading: Space)
+4839: Ident           "int64" at 434:55-434:60 (leading: Space)
+4840: Semicolon       ";" at 434:60-434:61
+4841: At              "@" at 435:5-435:6 (leading: Newline, Space)
+4842: Ident           "intrinsic" at 435:6-435:15
+4843: KwFn            "fn" at 435:16-435:18 (leading: Space)
+4844: Ident           "__mul" at 435:19-435:24 (leading: Space)
+4845: LParen          "(" at 435:24-435:25
+4846: Ident           "self" at 435:25-435:29
+4847: Colon           ":" at 435:29-435:30
+4848: Ident           "int64" at 435:31-435:36 (leading: Space)
+4849: Comma           "," at 435:36-435:37
+4850: Ident           "other" at 435:38-435:43 (leading: Space)
+4851: Colon           ":" at 435:43-435:44
+4852: Ident           "int64" at 435:45-435:50 (leading: Space)
+4853: RParen          ")" at 435:50-435:51
+4854: Arrow           "->" at 435:52-435:54 (leading: Space)
+4855: Ident           "int64" at 435:55-435:60 (leading: Space)
+4856: Semicolon       ";" at 435:60-435:61
+4857: At              "@" at 436:5-436:6 (leading: Newline, Space)
+4858: Ident           "intrinsic" at 436:6-436:15
+4859: KwFn            "fn" at 436:16-436:18 (leading: Space)
+4860: Ident           "__div" at 436:19-436:24 (leading: Space)
+4861: LParen          "(" at 436:24-436:25
+4862: Ident           "self" at 436:25-436:29
+4863: Colon           ":" at 436:29-436:30
+4864: Ident           "int64" at 436:31-436:36 (leading: Space)
+4865: Comma           "," at 436:36-436:37
+4866: Ident           "other" at 436:38-436:43 (leading: Space)
+4867: Colon           ":" at 436:43-436:44
+4868: Ident           "int64" at 436:45-436:50 (leading: Space)
+4869: RParen          ")" at 436:50-436:51
+4870: Arrow           "->" at 436:52-436:54 (leading: Space)
+4871: Ident           "int64" at 436:55-436:60 (leading: Space)
+4872: Semicolon       ";" at 436:60-436:61
+4873: At              "@" at 437:5-437:6 (leading: Newline, Space)
+4874: Ident           "intrinsic" at 437:6-437:15
+4875: KwFn            "fn" at 437:16-437:18 (leading: Space)
+4876: Ident           "__mod" at 437:19-437:24 (leading: Space)
+4877: LParen          "(" at 437:24-437:25
+4878: Ident           "self" at 437:25-437:29
+4879: Colon           ":" at 437:29-437:30
+4880: Ident           "int64" at 437:31-437:36 (leading: Space)
+4881: Comma           "," at 437:36-437:37
+4882: Ident           "other" at 437:38-437:43 (leading: Space)
+4883: Colon           ":" at 437:43-437:44
+4884: Ident           "int64" at 437:45-437:50 (leading: Space)
+4885: RParen          ")" at 437:50-437:51
+4886: Arrow           "->" at 437:52-437:54 (leading: Space)
+4887: Ident           "int64" at 437:55-437:60 (leading: Space)
+4888: Semicolon       ";" at 437:60-437:61
+4889: At              "@" at 438:5-438:6 (leading: Newline, Space)
+4890: Ident           "intrinsic" at 438:6-438:15
+4891: KwFn            "fn" at 438:16-438:18 (leading: Space)
+4892: Ident           "__bit_and" at 438:19-438:28 (leading: Space)
+4893: LParen          "(" at 438:28-438:29
+4894: Ident           "self" at 438:29-438:33
+4895: Colon           ":" at 438:33-438:34
+4896: Ident           "int64" at 438:35-438:40 (leading: Space)
+4897: Comma           "," at 438:40-438:41
+4898: Ident           "other" at 438:42-438:47 (leading: Space)
+4899: Colon           ":" at 438:47-438:48
+4900: Ident           "int64" at 438:49-438:54 (leading: Space)
+4901: RParen          ")" at 438:54-438:55
+4902: Arrow           "->" at 438:56-438:58 (leading: Space)
+4903: Ident           "int64" at 438:59-438:64 (leading: Space)
+4904: Semicolon       ";" at 438:64-438:65
+4905: At              "@" at 439:5-439:6 (leading: Newline, Space)
+4906: Ident           "intrinsic" at 439:6-439:15
+4907: KwFn            "fn" at 439:16-439:18 (leading: Space)
+4908: Ident           "__bit_or" at 439:19-439:27 (leading: Space)
+4909: LParen          "(" at 439:27-439:28
+4910: Ident           "self" at 439:28-439:32
+4911: Colon           ":" at 439:32-439:33
+4912: Ident           "int64" at 439:34-439:39 (leading: Space)
+4913: Comma           "," at 439:39-439:40
+4914: Ident           "other" at 439:41-439:46 (leading: Space)
+4915: Colon           ":" at 439:46-439:47
+4916: Ident           "int64" at 439:48-439:53 (leading: Space)
+4917: RParen          ")" at 439:53-439:54
+4918: Arrow           "->" at 439:55-439:57 (leading: Space)
+4919: Ident           "int64" at 439:58-439:63 (leading: Space)
+4920: Semicolon       ";" at 439:63-439:64
+4921: At              "@" at 440:5-440:6 (leading: Newline, Space)
+4922: Ident           "intrinsic" at 440:6-440:15
+4923: KwFn            "fn" at 440:16-440:18 (leading: Space)
+4924: Ident           "__bit_xor" at 440:19-440:28 (leading: Space)
+4925: LParen          "(" at 440:28-440:29
+4926: Ident           "self" at 440:29-440:33
+4927: Colon           ":" at 440:33-440:34
+4928: Ident           "int64" at 440:35-440:40 (leading: Space)
+4929: Comma           "," at 440:40-440:41
+4930: Ident           "other" at 440:42-440:47 (leading: Space)
+4931: Colon           ":" at 440:47-440:48
+4932: Ident           "int64" at 440:49-440:54 (leading: Space)
+4933: RParen          ")" at 440:54-440:55
+4934: Arrow           "->" at 440:56-440:58 (leading: Space)
+4935: Ident           "int64" at 440:59-440:64 (leading: Space)
+4936: Semicolon       ";" at 440:64-440:65
+4937: At              "@" at 441:5-441:6 (leading: Newline, Space)
+4938: Ident           "intrinsic" at 441:6-441:15
+4939: KwFn            "fn" at 441:16-441:18 (leading: Space)
+4940: Ident           "__shl" at 441:19-441:24 (leading: Space)
+4941: LParen          "(" at 441:24-441:25
+4942: Ident           "self" at 441:25-441:29
+4943: Colon           ":" at 441:29-441:30
+4944: Ident           "int64" at 441:31-441:36 (leading: Space)
+4945: Comma           "," at 441:36-441:37
+4946: Ident           "other" at 441:38-441:43 (leading: Space)
+4947: Colon           ":" at 441:43-441:44
+4948: Ident           "int64" at 441:45-441:50 (leading: Space)
+4949: RParen          ")" at 441:50-441:51
+4950: Arrow           "->" at 441:52-441:54 (leading: Space)
+4951: Ident           "int64" at 441:55-441:60 (leading: Space)
+4952: Semicolon       ";" at 441:60-441:61
+4953: At              "@" at 442:5-442:6 (leading: Newline, Space)
+4954: Ident           "intrinsic" at 442:6-442:15
+4955: KwFn            "fn" at 442:16-442:18 (leading: Space)
+4956: Ident           "__shr" at 442:19-442:24 (leading: Space)
+4957: LParen          "(" at 442:24-442:25
+4958: Ident           "self" at 442:25-442:29
+4959: Colon           ":" at 442:29-442:30
+4960: Ident           "int64" at 442:31-442:36 (leading: Space)
+4961: Comma           "," at 442:36-442:37
+4962: Ident           "other" at 442:38-442:43 (leading: Space)
+4963: Colon           ":" at 442:43-442:44
+4964: Ident           "int64" at 442:45-442:50 (leading: Space)
+4965: RParen          ")" at 442:50-442:51
+4966: Arrow           "->" at 442:52-442:54 (leading: Space)
+4967: Ident           "int64" at 442:55-442:60 (leading: Space)
+4968: Semicolon       ";" at 442:60-442:61
+4969: At              "@" at 443:5-443:6 (leading: Newline, Space)
+4970: Ident           "intrinsic" at 443:6-443:15
+4971: KwFn            "fn" at 443:16-443:18 (leading: Space)
+4972: Ident           "__lt" at 443:19-443:23 (leading: Space)
+4973: LParen          "(" at 443:23-443:24
+4974: Ident           "self" at 443:24-443:28
+4975: Colon           ":" at 443:28-443:29
+4976: Ident           "int64" at 443:30-443:35 (leading: Space)
+4977: Comma           "," at 443:35-443:36
+4978: Ident           "other" at 443:37-443:42 (leading: Space)
+4979: Colon           ":" at 443:42-443:43
+4980: Ident           "int64" at 443:44-443:49 (leading: Space)
+4981: RParen          ")" at 443:49-443:50
+4982: Arrow           "->" at 443:51-443:53 (leading: Space)
+4983: Ident           "bool" at 443:54-443:58 (leading: Space)
+4984: Semicolon       ";" at 443:58-443:59
+4985: At              "@" at 444:5-444:6 (leading: Newline, Space)
+4986: Ident           "intrinsic" at 444:6-444:15
+4987: KwFn            "fn" at 444:16-444:18 (leading: Space)
+4988: Ident           "__le" at 444:19-444:23 (leading: Space)
+4989: LParen          "(" at 444:23-444:24
+4990: Ident           "self" at 444:24-444:28
+4991: Colon           ":" at 444:28-444:29
+4992: Ident           "int64" at 444:30-444:35 (leading: Space)
+4993: Comma           "," at 444:35-444:36
+4994: Ident           "other" at 444:37-444:42 (leading: Space)
+4995: Colon           ":" at 444:42-444:43
+4996: Ident           "int64" at 444:44-444:49 (leading: Space)
+4997: RParen          ")" at 444:49-444:50
+4998: Arrow           "->" at 444:51-444:53 (leading: Space)
+4999: Ident           "bool" at 444:54-444:58 (leading: Space)
+5000: Semicolon       ";" at 444:58-444:59
+5001: At              "@" at 445:5-445:6 (leading: Newline, Space)
+5002: Ident           "intrinsic" at 445:6-445:15
+5003: KwFn            "fn" at 445:16-445:18 (leading: Space)
+5004: Ident           "__eq" at 445:19-445:23 (leading: Space)
+5005: LParen          "(" at 445:23-445:24
+5006: Ident           "self" at 445:24-445:28
+5007: Colon           ":" at 445:28-445:29
+5008: Ident           "int64" at 445:30-445:35 (leading: Space)
+5009: Comma           "," at 445:35-445:36
+5010: Ident           "other" at 445:37-445:42 (leading: Space)
+5011: Colon           ":" at 445:42-445:43
+5012: Ident           "int64" at 445:44-445:49 (leading: Space)
+5013: RParen          ")" at 445:49-445:50
+5014: Arrow           "->" at 445:51-445:53 (leading: Space)
+5015: Ident           "bool" at 445:54-445:58 (leading: Space)
+5016: Semicolon       ";" at 445:58-445:59
+5017: At              "@" at 446:5-446:6 (leading: Newline, Space)
+5018: Ident           "intrinsic" at 446:6-446:15
+5019: KwFn            "fn" at 446:16-446:18 (leading: Space)
+5020: Ident           "__ne" at 446:19-446:23 (leading: Space)
+5021: LParen          "(" at 446:23-446:24
+5022: Ident           "self" at 446:24-446:28
+5023: Colon           ":" at 446:28-446:29
+5024: Ident           "int64" at 446:30-446:35 (leading: Space)
+5025: Comma           "," at 446:35-446:36
+5026: Ident           "other" at 446:37-446:42 (leading: Space)
+5027: Colon           ":" at 446:42-446:43
+5028: Ident           "int64" at 446:44-446:49 (leading: Space)
+5029: RParen          ")" at 446:49-446:50
+5030: Arrow           "->" at 446:51-446:53 (leading: Space)
+5031: Ident           "bool" at 446:54-446:58 (leading: Space)
+5032: Semicolon       ";" at 446:58-446:59
+5033: At              "@" at 447:5-447:6 (leading: Newline, Space)
+5034: Ident           "intrinsic" at 447:6-447:15
+5035: KwFn            "fn" at 447:16-447:18 (leading: Space)
+5036: Ident           "__ge" at 447:19-447:23 (leading: Space)
+5037: LParen          "(" at 447:23-447:24
+5038: Ident           "self" at 447:24-447:28
+5039: Colon           ":" at 447:28-447:29
+5040: Ident           "int64" at 447:30-447:35 (leading: Space)
+5041: Comma           "," at 447:35-447:36
+5042: Ident           "other" at 447:37-447:42 (leading: Space)
+5043: Colon           ":" at 447:42-447:43
+5044: Ident           "int64" at 447:44-447:49 (leading: Space)
+5045: RParen          ")" at 447:49-447:50
+5046: Arrow           "->" at 447:51-447:53 (leading: Space)
+5047: Ident           "bool" at 447:54-447:58 (leading: Space)
+5048: Semicolon       ";" at 447:58-447:59
+5049: At              "@" at 448:5-448:6 (leading: Newline, Space)
+5050: Ident           "intrinsic" at 448:6-448:15
+5051: KwFn            "fn" at 448:16-448:18 (leading: Space)
+5052: Ident           "__gt" at 448:19-448:23 (leading: Space)
+5053: LParen          "(" at 448:23-448:24
+5054: Ident           "self" at 448:24-448:28
+5055: Colon           ":" at 448:28-448:29
+5056: Ident           "int64" at 448:30-448:35 (leading: Space)
+5057: Comma           "," at 448:35-448:36
+5058: Ident           "other" at 448:37-448:42 (leading: Space)
+5059: Colon           ":" at 448:42-448:43
+5060: Ident           "int64" at 448:44-448:49 (leading: Space)
+5061: RParen          ")" at 448:49-448:50
+5062: Arrow           "->" at 448:51-448:53 (leading: Space)
+5063: Ident           "bool" at 448:54-448:58 (leading: Space)
+5064: Semicolon       ";" at 448:58-448:59
+5065: At              "@" at 449:5-449:6 (leading: Newline, Space)
+5066: Ident           "intrinsic" at 449:6-449:15
+5067: KwFn            "fn" at 449:16-449:18 (leading: Space)
+5068: Ident           "__pos" at 449:19-449:24 (leading: Space)
+5069: LParen          "(" at 449:24-449:25
+5070: Ident           "self" at 449:25-449:29
+5071: Colon           ":" at 449:29-449:30
+5072: Ident           "int64" at 449:31-449:36 (leading: Space)
+5073: RParen          ")" at 449:36-449:37
+5074: Arrow           "->" at 449:38-449:40 (leading: Space)
+5075: Ident           "int64" at 449:41-449:46 (leading: Space)
+5076: Semicolon       ";" at 449:46-449:47
+5077: At              "@" at 450:5-450:6 (leading: Newline, Space)
+5078: Ident           "intrinsic" at 450:6-450:15
+5079: KwFn            "fn" at 450:16-450:18 (leading: Space)
+5080: Ident           "__neg" at 450:19-450:24 (leading: Space)
+5081: LParen          "(" at 450:24-450:25
+5082: Ident           "self" at 450:25-450:29
+5083: Colon           ":" at 450:29-450:30
+5084: Ident           "int64" at 450:31-450:36 (leading: Space)
+5085: RParen          ")" at 450:36-450:37
+5086: Arrow           "->" at 450:38-450:40 (leading: Space)
+5087: Ident           "int64" at 450:41-450:46 (leading: Space)
+5088: Semicolon       ";" at 450:46-450:47
+5089: At              "@" at 451:5-451:6 (leading: Newline, Space)
+5090: Ident           "intrinsic" at 451:6-451:15
+5091: KwFn            "fn" at 451:16-451:18 (leading: Space)
+5092: Ident           "__abs" at 451:19-451:24 (leading: Space)
+5093: LParen          "(" at 451:24-451:25
+5094: Ident           "self" at 451:25-451:29
+5095: Colon           ":" at 451:29-451:30
+5096: Ident           "int64" at 451:31-451:36 (leading: Space)
+5097: RParen          ")" at 451:36-451:37
+5098: Arrow           "->" at 451:38-451:40 (leading: Space)
+5099: Ident           "int64" at 451:41-451:46 (leading: Space)
+5100: Semicolon       ";" at 451:46-451:47
+5101: At              "@" at 452:5-452:6 (leading: Newline, Space)
+5102: Ident           "intrinsic" at 452:6-452:15
+5103: KwFn            "fn" at 452:16-452:18 (leading: Space)
+5104: Ident           "__to" at 452:19-452:23 (leading: Space)
+5105: LParen          "(" at 452:23-452:24
+5106: Ident           "self" at 452:24-452:28
+5107: Colon           ":" at 452:28-452:29
+5108: Ident           "int64" at 452:30-452:35 (leading: Space)
+5109: Comma           "," at 452:35-452:36
+5110: Ident           "target" at 452:37-452:43 (leading: Space)
+5111: Colon           ":" at 452:43-452:44
+5112: Ident           "int" at 452:45-452:48 (leading: Space)
+5113: RParen          ")" at 452:48-452:49
+5114: Arrow           "->" at 452:50-452:52 (leading: Space)
+5115: Ident           "int" at 452:53-452:56 (leading: Space)
+5116: Semicolon       ";" at 452:56-452:57
+5117: At              "@" at 453:5-453:6 (leading: Newline, Space)
+5118: Ident           "intrinsic" at 453:6-453:15
+5119: At              "@" at 453:16-453:17 (leading: Space)
+5120: Ident           "overload" at 453:17-453:25
+5121: KwFn            "fn" at 453:26-453:28 (leading: Space)
+5122: Ident           "__to" at 453:29-453:33 (leading: Space)
+5123: LParen          "(" at 453:33-453:34
+5124: Ident           "self" at 453:34-453:38
+5125: Colon           ":" at 453:38-453:39
+5126: Ident           "int64" at 453:40-453:45 (leading: Space)
+5127: Comma           "," at 453:45-453:46
+5128: Ident           "target" at 453:47-453:53 (leading: Space)
+5129: Colon           ":" at 453:53-453:54
+5130: Ident           "int8" at 453:55-453:59 (leading: Space)
+5131: RParen          ")" at 453:59-453:60
+5132: Arrow           "->" at 453:61-453:63 (leading: Space)
+5133: Ident           "int8" at 453:64-453:68 (leading: Space)
+5134: Semicolon       ";" at 453:68-453:69
+5135: At              "@" at 454:5-454:6 (leading: Newline, Space)
+5136: Ident           "intrinsic" at 454:6-454:15
+5137: At              "@" at 454:16-454:17 (leading: Space)
+5138: Ident           "overload" at 454:17-454:25
+5139: KwFn            "fn" at 454:26-454:28 (leading: Space)
+5140: Ident           "__to" at 454:29-454:33 (leading: Space)
+5141: LParen          "(" at 454:33-454:34
+5142: Ident           "self" at 454:34-454:38
+5143: Colon           ":" at 454:38-454:39
+5144: Ident           "int64" at 454:40-454:45 (leading: Space)
+5145: Comma           "," at 454:45-454:46
+5146: Ident           "target" at 454:47-454:53 (leading: Space)
+5147: Colon           ":" at 454:53-454:54
+5148: Ident           "int16" at 454:55-454:60 (leading: Space)
+5149: RParen          ")" at 454:60-454:61
+5150: Arrow           "->" at 454:62-454:64 (leading: Space)
+5151: Ident           "int16" at 454:65-454:70 (leading: Space)
+5152: Semicolon       ";" at 454:70-454:71
+5153: At              "@" at 455:5-455:6 (leading: Newline, Space)
+5154: Ident           "intrinsic" at 455:6-455:15
+5155: At              "@" at 455:16-455:17 (leading: Space)
+5156: Ident           "overload" at 455:17-455:25
+5157: KwFn            "fn" at 455:26-455:28 (leading: Space)
+5158: Ident           "__to" at 455:29-455:33 (leading: Space)
+5159: LParen          "(" at 455:33-455:34
+5160: Ident           "self" at 455:34-455:38
+5161: Colon           ":" at 455:38-455:39
+5162: Ident           "int64" at 455:40-455:45 (leading: Space)
+5163: Comma           "," at 455:45-455:46
+5164: Ident           "target" at 455:47-455:53 (leading: Space)
+5165: Colon           ":" at 455:53-455:54
+5166: Ident           "int32" at 455:55-455:60 (leading: Space)
+5167: RParen          ")" at 455:60-455:61
+5168: Arrow           "->" at 455:62-455:64 (leading: Space)
+5169: Ident           "int32" at 455:65-455:70 (leading: Space)
+5170: Semicolon       ";" at 455:70-455:71
+5171: At              "@" at 456:5-456:6 (leading: Newline, Space)
+5172: Ident           "intrinsic" at 456:6-456:15
+5173: KwPub           "pub" at 456:16-456:19 (leading: Space)
+5174: KwFn            "fn" at 456:20-456:22 (leading: Space)
+5175: Ident           "from_str" at 456:23-456:31 (leading: Space)
+5176: LParen          "(" at 456:31-456:32
+5177: Ident           "s" at 456:32-456:33
+5178: Colon           ":" at 456:33-456:34
+5179: Amp             "&" at 456:35-456:36 (leading: Space)
+5180: Ident           "string" at 456:36-456:42
+5181: RParen          ")" at 456:42-456:43
+5182: Arrow           "->" at 456:44-456:46 (leading: Space)
+5183: Ident           "Erring" at 456:47-456:53 (leading: Space)
+5184: Lt              "<" at 456:53-456:54
+5185: Ident           "int64" at 456:54-456:59
+5186: Comma           "," at 456:59-456:60
+5187: Ident           "Error" at 456:61-456:66 (leading: Space)
+5188: Gt              ">" at 456:66-456:67
+5189: Semicolon       ";" at 456:67-456:68
+5190: RBrace          "}" at 457:1-457:2 (leading: Newline)
+5191: KwExtern        "extern" at 459:1-459:7 (leading: Newline)
+5192: Lt              "<" at 459:7-459:8
+5193: Ident           "uint8" at 459:8-459:13
+5194: Gt              ">" at 459:13-459:14
+5195: LBrace          "{" at 459:15-459:16 (leading: Space)
+5196: KwPub           "pub" at 460:5-460:8 (leading: Newline, Space)
+5197: KwFn            "fn" at 460:9-460:11 (leading: Space)
+5198: Ident           "__min_value" at 460:12-460:23 (leading: Space)
+5199: LParen          "(" at 460:23-460:24
+5200: RParen          ")" at 460:24-460:25
+5201: Arrow           "->" at 460:26-460:28 (leading: Space)
+5202: Ident           "uint8" at 460:29-460:34 (leading: Space)
+5203: LBrace          "{" at 460:35-460:36 (leading: Space)
+5204: KwReturn        "return" at 460:37-460:43 (leading: Space)
+5205: LParen          "(" at 460:44-460:45 (leading: Space)
+5206: IntLit          "0" at 460:45-460:46
+5207: RParen          ")" at 460:46-460:47
+5208: Colon           ":" at 460:47-460:48
+5209: Ident           "uint8" at 460:48-460:53
+5210: Semicolon       ";" at 460:53-460:54
+5211: RBrace          "}" at 460:55-460:56 (leading: Space)
+5212: KwPub           "pub" at 461:5-461:8 (leading: Newline, Space)
+5213: KwFn            "fn" at 461:9-461:11 (leading: Space)
+5214: Ident           "__max_value" at 461:12-461:23 (leading: Space)
+5215: LParen          "(" at 461:23-461:24
+5216: RParen          ")" at 461:24-461:25
+5217: Arrow           "->" at 461:26-461:28 (leading: Space)
+5218: Ident           "uint8" at 461:29-461:34 (leading: Space)
+5219: LBrace          "{" at 461:35-461:36 (leading: Space)
+5220: KwReturn        "return" at 461:37-461:43 (leading: Space)
+5221: LParen          "(" at 461:44-461:45 (leading: Space)
+5222: IntLit          "255" at 461:45-461:48
+5223: RParen          ")" at 461:48-461:49
+5224: Colon           ":" at 461:49-461:50
+5225: Ident           "uint8" at 461:50-461:55
+5226: Semicolon       ";" at 461:55-461:56
+5227: RBrace          "}" at 461:57-461:58 (leading: Space)
+5228: At              "@" at 462:5-462:6 (leading: Newline, Space)
+5229: Ident           "intrinsic" at 462:6-462:15
+5230: KwFn            "fn" at 462:16-462:18 (leading: Space)
+5231: Ident           "__add" at 462:19-462:24 (leading: Space)
+5232: LParen          "(" at 462:24-462:25
+5233: Ident           "self" at 462:25-462:29
+5234: Colon           ":" at 462:29-462:30
+5235: Ident           "uint8" at 462:31-462:36 (leading: Space)
+5236: Comma           "," at 462:36-462:37
+5237: Ident           "other" at 462:38-462:43 (leading: Space)
+5238: Colon           ":" at 462:43-462:44
+5239: Ident           "uint8" at 462:45-462:50 (leading: Space)
+5240: RParen          ")" at 462:50-462:51
+5241: Arrow           "->" at 462:52-462:54 (leading: Space)
+5242: Ident           "uint8" at 462:55-462:60 (leading: Space)
+5243: Semicolon       ";" at 462:60-462:61
+5244: At              "@" at 463:5-463:6 (leading: Newline, Space)
+5245: Ident           "intrinsic" at 463:6-463:15
+5246: KwFn            "fn" at 463:16-463:18 (leading: Space)
+5247: Ident           "__sub" at 463:19-463:24 (leading: Space)
+5248: LParen          "(" at 463:24-463:25
+5249: Ident           "self" at 463:25-463:29
+5250: Colon           ":" at 463:29-463:30
+5251: Ident           "uint8" at 463:31-463:36 (leading: Space)
+5252: Comma           "," at 463:36-463:37
+5253: Ident           "other" at 463:38-463:43 (leading: Space)
+5254: Colon           ":" at 463:43-463:44
+5255: Ident           "uint8" at 463:45-463:50 (leading: Space)
+5256: RParen          ")" at 463:50-463:51
+5257: Arrow           "->" at 463:52-463:54 (leading: Space)
+5258: Ident           "uint8" at 463:55-463:60 (leading: Space)
+5259: Semicolon       ";" at 463:60-463:61
+5260: At              "@" at 464:5-464:6 (leading: Newline, Space)
+5261: Ident           "intrinsic" at 464:6-464:15
+5262: KwFn            "fn" at 464:16-464:18 (leading: Space)
+5263: Ident           "__mul" at 464:19-464:24 (leading: Space)
+5264: LParen          "(" at 464:24-464:25
+5265: Ident           "self" at 464:25-464:29
+5266: Colon           ":" at 464:29-464:30
+5267: Ident           "uint8" at 464:31-464:36 (leading: Space)
+5268: Comma           "," at 464:36-464:37
+5269: Ident           "other" at 464:38-464:43 (leading: Space)
+5270: Colon           ":" at 464:43-464:44
+5271: Ident           "uint8" at 464:45-464:50 (leading: Space)
+5272: RParen          ")" at 464:50-464:51
+5273: Arrow           "->" at 464:52-464:54 (leading: Space)
+5274: Ident           "uint8" at 464:55-464:60 (leading: Space)
+5275: Semicolon       ";" at 464:60-464:61
+5276: At              "@" at 465:5-465:6 (leading: Newline, Space)
+5277: Ident           "intrinsic" at 465:6-465:15
+5278: KwFn            "fn" at 465:16-465:18 (leading: Space)
+5279: Ident           "__div" at 465:19-465:24 (leading: Space)
+5280: LParen          "(" at 465:24-465:25
+5281: Ident           "self" at 465:25-465:29
+5282: Colon           ":" at 465:29-465:30
+5283: Ident           "uint8" at 465:31-465:36 (leading: Space)
+5284: Comma           "," at 465:36-465:37
+5285: Ident           "other" at 465:38-465:43 (leading: Space)
+5286: Colon           ":" at 465:43-465:44
+5287: Ident           "uint8" at 465:45-465:50 (leading: Space)
+5288: RParen          ")" at 465:50-465:51
+5289: Arrow           "->" at 465:52-465:54 (leading: Space)
+5290: Ident           "uint8" at 465:55-465:60 (leading: Space)
+5291: Semicolon       ";" at 465:60-465:61
+5292: At              "@" at 466:5-466:6 (leading: Newline, Space)
+5293: Ident           "intrinsic" at 466:6-466:15
+5294: KwFn            "fn" at 466:16-466:18 (leading: Space)
+5295: Ident           "__mod" at 466:19-466:24 (leading: Space)
+5296: LParen          "(" at 466:24-466:25
+5297: Ident           "self" at 466:25-466:29
+5298: Colon           ":" at 466:29-466:30
+5299: Ident           "uint8" at 466:31-466:36 (leading: Space)
+5300: Comma           "," at 466:36-466:37
+5301: Ident           "other" at 466:38-466:43 (leading: Space)
+5302: Colon           ":" at 466:43-466:44
+5303: Ident           "uint8" at 466:45-466:50 (leading: Space)
+5304: RParen          ")" at 466:50-466:51
+5305: Arrow           "->" at 466:52-466:54 (leading: Space)
+5306: Ident           "uint8" at 466:55-466:60 (leading: Space)
+5307: Semicolon       ";" at 466:60-466:61
+5308: At              "@" at 467:5-467:6 (leading: Newline, Space)
+5309: Ident           "intrinsic" at 467:6-467:15
+5310: KwFn            "fn" at 467:16-467:18 (leading: Space)
+5311: Ident           "__bit_and" at 467:19-467:28 (leading: Space)
+5312: LParen          "(" at 467:28-467:29
+5313: Ident           "self" at 467:29-467:33
+5314: Colon           ":" at 467:33-467:34
+5315: Ident           "uint8" at 467:35-467:40 (leading: Space)
+5316: Comma           "," at 467:40-467:41
+5317: Ident           "other" at 467:42-467:47 (leading: Space)
+5318: Colon           ":" at 467:47-467:48
+5319: Ident           "uint8" at 467:49-467:54 (leading: Space)
+5320: RParen          ")" at 467:54-467:55
+5321: Arrow           "->" at 467:56-467:58 (leading: Space)
+5322: Ident           "uint8" at 467:59-467:64 (leading: Space)
+5323: Semicolon       ";" at 467:64-467:65
+5324: At              "@" at 468:5-468:6 (leading: Newline, Space)
+5325: Ident           "intrinsic" at 468:6-468:15
+5326: KwFn            "fn" at 468:16-468:18 (leading: Space)
+5327: Ident           "__bit_or" at 468:19-468:27 (leading: Space)
+5328: LParen          "(" at 468:27-468:28
+5329: Ident           "self" at 468:28-468:32
+5330: Colon           ":" at 468:32-468:33
+5331: Ident           "uint8" at 468:34-468:39 (leading: Space)
+5332: Comma           "," at 468:39-468:40
+5333: Ident           "other" at 468:41-468:46 (leading: Space)
+5334: Colon           ":" at 468:46-468:47
+5335: Ident           "uint8" at 468:48-468:53 (leading: Space)
+5336: RParen          ")" at 468:53-468:54
+5337: Arrow           "->" at 468:55-468:57 (leading: Space)
+5338: Ident           "uint8" at 468:58-468:63 (leading: Space)
+5339: Semicolon       ";" at 468:63-468:64
+5340: At              "@" at 469:5-469:6 (leading: Newline, Space)
+5341: Ident           "intrinsic" at 469:6-469:15
+5342: KwFn            "fn" at 469:16-469:18 (leading: Space)
+5343: Ident           "__bit_xor" at 469:19-469:28 (leading: Space)
+5344: LParen          "(" at 469:28-469:29
+5345: Ident           "self" at 469:29-469:33
+5346: Colon           ":" at 469:33-469:34
+5347: Ident           "uint8" at 469:35-469:40 (leading: Space)
+5348: Comma           "," at 469:40-469:41
+5349: Ident           "other" at 469:42-469:47 (leading: Space)
+5350: Colon           ":" at 469:47-469:48
+5351: Ident           "uint8" at 469:49-469:54 (leading: Space)
+5352: RParen          ")" at 469:54-469:55
+5353: Arrow           "->" at 469:56-469:58 (leading: Space)
+5354: Ident           "uint8" at 469:59-469:64 (leading: Space)
+5355: Semicolon       ";" at 469:64-469:65
+5356: At              "@" at 470:5-470:6 (leading: Newline, Space)
+5357: Ident           "intrinsic" at 470:6-470:15
+5358: KwFn            "fn" at 470:16-470:18 (leading: Space)
+5359: Ident           "__shl" at 470:19-470:24 (leading: Space)
+5360: LParen          "(" at 470:24-470:25
+5361: Ident           "self" at 470:25-470:29
+5362: Colon           ":" at 470:29-470:30
+5363: Ident           "uint8" at 470:31-470:36 (leading: Space)
+5364: Comma           "," at 470:36-470:37
+5365: Ident           "other" at 470:38-470:43 (leading: Space)
+5366: Colon           ":" at 470:43-470:44
+5367: Ident           "uint8" at 470:45-470:50 (leading: Space)
+5368: RParen          ")" at 470:50-470:51
+5369: Arrow           "->" at 470:52-470:54 (leading: Space)
+5370: Ident           "uint8" at 470:55-470:60 (leading: Space)
+5371: Semicolon       ";" at 470:60-470:61
+5372: At              "@" at 471:5-471:6 (leading: Newline, Space)
+5373: Ident           "intrinsic" at 471:6-471:15
+5374: KwFn            "fn" at 471:16-471:18 (leading: Space)
+5375: Ident           "__shr" at 471:19-471:24 (leading: Space)
+5376: LParen          "(" at 471:24-471:25
+5377: Ident           "self" at 471:25-471:29
+5378: Colon           ":" at 471:29-471:30
+5379: Ident           "uint8" at 471:31-471:36 (leading: Space)
+5380: Comma           "," at 471:36-471:37
+5381: Ident           "other" at 471:38-471:43 (leading: Space)
+5382: Colon           ":" at 471:43-471:44
+5383: Ident           "uint8" at 471:45-471:50 (leading: Space)
+5384: RParen          ")" at 471:50-471:51
+5385: Arrow           "->" at 471:52-471:54 (leading: Space)
+5386: Ident           "uint8" at 471:55-471:60 (leading: Space)
+5387: Semicolon       ";" at 471:60-471:61
+5388: At              "@" at 472:5-472:6 (leading: Newline, Space)
+5389: Ident           "intrinsic" at 472:6-472:15
+5390: KwFn            "fn" at 472:16-472:18 (leading: Space)
+5391: Ident           "__lt" at 472:19-472:23 (leading: Space)
+5392: LParen          "(" at 472:23-472:24
+5393: Ident           "self" at 472:24-472:28
+5394: Colon           ":" at 472:28-472:29
+5395: Ident           "uint8" at 472:30-472:35 (leading: Space)
+5396: Comma           "," at 472:35-472:36
+5397: Ident           "other" at 472:37-472:42 (leading: Space)
+5398: Colon           ":" at 472:42-472:43
+5399: Ident           "uint8" at 472:44-472:49 (leading: Space)
+5400: RParen          ")" at 472:49-472:50
+5401: Arrow           "->" at 472:51-472:53 (leading: Space)
+5402: Ident           "bool" at 472:54-472:58 (leading: Space)
+5403: Semicolon       ";" at 472:58-472:59
+5404: At              "@" at 473:5-473:6 (leading: Newline, Space)
+5405: Ident           "intrinsic" at 473:6-473:15
+5406: KwFn            "fn" at 473:16-473:18 (leading: Space)
+5407: Ident           "__le" at 473:19-473:23 (leading: Space)
+5408: LParen          "(" at 473:23-473:24
+5409: Ident           "self" at 473:24-473:28
+5410: Colon           ":" at 473:28-473:29
+5411: Ident           "uint8" at 473:30-473:35 (leading: Space)
+5412: Comma           "," at 473:35-473:36
+5413: Ident           "other" at 473:37-473:42 (leading: Space)
+5414: Colon           ":" at 473:42-473:43
+5415: Ident           "uint8" at 473:44-473:49 (leading: Space)
+5416: RParen          ")" at 473:49-473:50
+5417: Arrow           "->" at 473:51-473:53 (leading: Space)
+5418: Ident           "bool" at 473:54-473:58 (leading: Space)
+5419: Semicolon       ";" at 473:58-473:59
+5420: At              "@" at 474:5-474:6 (leading: Newline, Space)
+5421: Ident           "intrinsic" at 474:6-474:15
+5422: KwFn            "fn" at 474:16-474:18 (leading: Space)
+5423: Ident           "__eq" at 474:19-474:23 (leading: Space)
+5424: LParen          "(" at 474:23-474:24
+5425: Ident           "self" at 474:24-474:28
+5426: Colon           ":" at 474:28-474:29
+5427: Ident           "uint8" at 474:30-474:35 (leading: Space)
+5428: Comma           "," at 474:35-474:36
+5429: Ident           "other" at 474:37-474:42 (leading: Space)
+5430: Colon           ":" at 474:42-474:43
+5431: Ident           "uint8" at 474:44-474:49 (leading: Space)
+5432: RParen          ")" at 474:49-474:50
+5433: Arrow           "->" at 474:51-474:53 (leading: Space)
+5434: Ident           "bool" at 474:54-474:58 (leading: Space)
+5435: Semicolon       ";" at 474:58-474:59
+5436: At              "@" at 475:5-475:6 (leading: Newline, Space)
+5437: Ident           "intrinsic" at 475:6-475:15
+5438: KwFn            "fn" at 475:16-475:18 (leading: Space)
+5439: Ident           "__ne" at 475:19-475:23 (leading: Space)
+5440: LParen          "(" at 475:23-475:24
+5441: Ident           "self" at 475:24-475:28
+5442: Colon           ":" at 475:28-475:29
+5443: Ident           "uint8" at 475:30-475:35 (leading: Space)
+5444: Comma           "," at 475:35-475:36
+5445: Ident           "other" at 475:37-475:42 (leading: Space)
+5446: Colon           ":" at 475:42-475:43
+5447: Ident           "uint8" at 475:44-475:49 (leading: Space)
+5448: RParen          ")" at 475:49-475:50
+5449: Arrow           "->" at 475:51-475:53 (leading: Space)
+5450: Ident           "bool" at 475:54-475:58 (leading: Space)
+5451: Semicolon       ";" at 475:58-475:59
+5452: At              "@" at 476:5-476:6 (leading: Newline, Space)
+5453: Ident           "intrinsic" at 476:6-476:15
+5454: KwFn            "fn" at 476:16-476:18 (leading: Space)
+5455: Ident           "__ge" at 476:19-476:23 (leading: Space)
+5456: LParen          "(" at 476:23-476:24
+5457: Ident           "self" at 476:24-476:28
+5458: Colon           ":" at 476:28-476:29
+5459: Ident           "uint8" at 476:30-476:35 (leading: Space)
+5460: Comma           "," at 476:35-476:36
+5461: Ident           "other" at 476:37-476:42 (leading: Space)
+5462: Colon           ":" at 476:42-476:43
+5463: Ident           "uint8" at 476:44-476:49 (leading: Space)
+5464: RParen          ")" at 476:49-476:50
+5465: Arrow           "->" at 476:51-476:53 (leading: Space)
+5466: Ident           "bool" at 476:54-476:58 (leading: Space)
+5467: Semicolon       ";" at 476:58-476:59
+5468: At              "@" at 477:5-477:6 (leading: Newline, Space)
+5469: Ident           "intrinsic" at 477:6-477:15
+5470: KwFn            "fn" at 477:16-477:18 (leading: Space)
+5471: Ident           "__gt" at 477:19-477:23 (leading: Space)
+5472: LParen          "(" at 477:23-477:24
+5473: Ident           "self" at 477:24-477:28
+5474: Colon           ":" at 477:28-477:29
+5475: Ident           "uint8" at 477:30-477:35 (leading: Space)
+5476: Comma           "," at 477:35-477:36
+5477: Ident           "other" at 477:37-477:42 (leading: Space)
+5478: Colon           ":" at 477:42-477:43
+5479: Ident           "uint8" at 477:44-477:49 (leading: Space)
+5480: RParen          ")" at 477:49-477:50
+5481: Arrow           "->" at 477:51-477:53 (leading: Space)
+5482: Ident           "bool" at 477:54-477:58 (leading: Space)
+5483: Semicolon       ";" at 477:58-477:59
+5484: At              "@" at 478:5-478:6 (leading: Newline, Space)
+5485: Ident           "intrinsic" at 478:6-478:15
+5486: KwFn            "fn" at 478:16-478:18 (leading: Space)
+5487: Ident           "__pos" at 478:19-478:24 (leading: Space)
+5488: LParen          "(" at 478:24-478:25
+5489: Ident           "self" at 478:25-478:29
+5490: Colon           ":" at 478:29-478:30
+5491: Ident           "uint8" at 478:31-478:36 (leading: Space)
+5492: RParen          ")" at 478:36-478:37
+5493: Arrow           "->" at 478:38-478:40 (leading: Space)
+5494: Ident           "uint8" at 478:41-478:46 (leading: Space)
+5495: Semicolon       ";" at 478:46-478:47
+5496: At              "@" at 479:5-479:6 (leading: Newline, Space)
+5497: Ident           "intrinsic" at 479:6-479:15
+5498: KwFn            "fn" at 479:16-479:18 (leading: Space)
+5499: Ident           "__abs" at 479:19-479:24 (leading: Space)
+5500: LParen          "(" at 479:24-479:25
+5501: Ident           "self" at 479:25-479:29
+5502: Colon           ":" at 479:29-479:30
+5503: Ident           "uint8" at 479:31-479:36 (leading: Space)
+5504: RParen          ")" at 479:36-479:37
+5505: Arrow           "->" at 479:38-479:40 (leading: Space)
+5506: Ident           "uint8" at 479:41-479:46 (leading: Space)
+5507: Semicolon       ";" at 479:46-479:47
+5508: At              "@" at 480:5-480:6 (leading: Newline, Space)
+5509: Ident           "intrinsic" at 480:6-480:15
+5510: KwFn            "fn" at 480:16-480:18 (leading: Space)
+5511: Ident           "__to" at 480:19-480:23 (leading: Space)
+5512: LParen          "(" at 480:23-480:24
+5513: Ident           "self" at 480:24-480:28
+5514: Colon           ":" at 480:28-480:29
+5515: Ident           "uint8" at 480:30-480:35 (leading: Space)
+5516: Comma           "," at 480:35-480:36
+5517: Ident           "target" at 480:37-480:43 (leading: Space)
+5518: Colon           ":" at 480:43-480:44
+5519: Ident           "uint" at 480:45-480:49 (leading: Space)
+5520: RParen          ")" at 480:49-480:50
+5521: Arrow           "->" at 480:51-480:53 (leading: Space)
+5522: Ident           "uint" at 480:54-480:58 (leading: Space)
+5523: Semicolon       ";" at 480:58-480:59
+5524: At              "@" at 481:5-481:6 (leading: Newline, Space)
+5525: Ident           "intrinsic" at 481:6-481:15
+5526: At              "@" at 481:16-481:17 (leading: Space)
+5527: Ident           "overload" at 481:17-481:25
+5528: KwFn            "fn" at 481:26-481:28 (leading: Space)
+5529: Ident           "__to" at 481:29-481:33 (leading: Space)
+5530: LParen          "(" at 481:33-481:34
+5531: Ident           "self" at 481:34-481:38
+5532: Colon           ":" at 481:38-481:39
+5533: Ident           "uint8" at 481:40-481:45 (leading: Space)
+5534: Comma           "," at 481:45-481:46
+5535: Ident           "target" at 481:47-481:53 (leading: Space)
+5536: Colon           ":" at 481:53-481:54
+5537: Ident           "uint16" at 481:55-481:61 (leading: Space)
+5538: RParen          ")" at 481:61-481:62
+5539: Arrow           "->" at 481:63-481:65 (leading: Space)
+5540: Ident           "uint16" at 481:66-481:72 (leading: Space)
+5541: Semicolon       ";" at 481:72-481:73
+5542: At              "@" at 482:5-482:6 (leading: Newline, Space)
+5543: Ident           "intrinsic" at 482:6-482:15
+5544: At              "@" at 482:16-482:17 (leading: Space)
+5545: Ident           "overload" at 482:17-482:25
+5546: KwFn            "fn" at 482:26-482:28 (leading: Space)
+5547: Ident           "__to" at 482:29-482:33 (leading: Space)
+5548: LParen          "(" at 482:33-482:34
+5549: Ident           "self" at 482:34-482:38
+5550: Colon           ":" at 482:38-482:39
+5551: Ident           "uint8" at 482:40-482:45 (leading: Space)
+5552: Comma           "," at 482:45-482:46
+5553: Ident           "target" at 482:47-482:53 (leading: Space)
+5554: Colon           ":" at 482:53-482:54
+5555: Ident           "uint32" at 482:55-482:61 (leading: Space)
+5556: RParen          ")" at 482:61-482:62
+5557: Arrow           "->" at 482:63-482:65 (leading: Space)
+5558: Ident           "uint32" at 482:66-482:72 (leading: Space)
+5559: Semicolon       ";" at 482:72-482:73
+5560: At              "@" at 483:5-483:6 (leading: Newline, Space)
+5561: Ident           "intrinsic" at 483:6-483:15
+5562: At              "@" at 483:16-483:17 (leading: Space)
+5563: Ident           "overload" at 483:17-483:25
+5564: KwFn            "fn" at 483:26-483:28 (leading: Space)
+5565: Ident           "__to" at 483:29-483:33 (leading: Space)
+5566: LParen          "(" at 483:33-483:34
+5567: Ident           "self" at 483:34-483:38
+5568: Colon           ":" at 483:38-483:39
+5569: Ident           "uint8" at 483:40-483:45 (leading: Space)
+5570: Comma           "," at 483:45-483:46
+5571: Ident           "target" at 483:47-483:53 (leading: Space)
+5572: Colon           ":" at 483:53-483:54
+5573: Ident           "uint64" at 483:55-483:61 (leading: Space)
+5574: RParen          ")" at 483:61-483:62
+5575: Arrow           "->" at 483:63-483:65 (leading: Space)
+5576: Ident           "uint64" at 483:66-483:72 (leading: Space)
+5577: Semicolon       ";" at 483:72-483:73
+5578: At              "@" at 484:5-484:6 (leading: Newline, Space)
+5579: Ident           "intrinsic" at 484:6-484:15
+5580: KwPub           "pub" at 484:16-484:19 (leading: Space)
+5581: KwFn            "fn" at 484:20-484:22 (leading: Space)
+5582: Ident           "from_str" at 484:23-484:31 (leading: Space)
+5583: LParen          "(" at 484:31-484:32
+5584: Ident           "s" at 484:32-484:33
+5585: Colon           ":" at 484:33-484:34
+5586: Amp             "&" at 484:35-484:36 (leading: Space)
+5587: Ident           "string" at 484:36-484:42
+5588: RParen          ")" at 484:42-484:43
+5589: Arrow           "->" at 484:44-484:46 (leading: Space)
+5590: Ident           "Erring" at 484:47-484:53 (leading: Space)
+5591: Lt              "<" at 484:53-484:54
+5592: Ident           "uint8" at 484:54-484:59
+5593: Comma           "," at 484:59-484:60
+5594: Ident           "Error" at 484:61-484:66 (leading: Space)
+5595: Gt              ">" at 484:66-484:67
+5596: Semicolon       ";" at 484:67-484:68
+5597: RBrace          "}" at 485:1-485:2 (leading: Newline)
+5598: KwExtern        "extern" at 487:1-487:7 (leading: Newline)
+5599: Lt              "<" at 487:7-487:8
+5600: Ident           "uint16" at 487:8-487:14
+5601: Gt              ">" at 487:14-487:15
+5602: LBrace          "{" at 487:16-487:17 (leading: Space)
+5603: KwPub           "pub" at 488:5-488:8 (leading: Newline, Space)
+5604: KwFn            "fn" at 488:9-488:11 (leading: Space)
+5605: Ident           "__min_value" at 488:12-488:23 (leading: Space)
+5606: LParen          "(" at 488:23-488:24
+5607: RParen          ")" at 488:24-488:25
+5608: Arrow           "->" at 488:26-488:28 (leading: Space)
+5609: Ident           "uint16" at 488:29-488:35 (leading: Space)
+5610: LBrace          "{" at 488:36-488:37 (leading: Space)
+5611: KwReturn        "return" at 488:38-488:44 (leading: Space)
+5612: LParen          "(" at 488:45-488:46 (leading: Space)
+5613: IntLit          "0" at 488:46-488:47
+5614: RParen          ")" at 488:47-488:48
+5615: Colon           ":" at 488:48-488:49
+5616: Ident           "uint16" at 488:49-488:55
+5617: Semicolon       ";" at 488:55-488:56
+5618: RBrace          "}" at 488:57-488:58 (leading: Space)
+5619: KwPub           "pub" at 489:5-489:8 (leading: Newline, Space)
+5620: KwFn            "fn" at 489:9-489:11 (leading: Space)
+5621: Ident           "__max_value" at 489:12-489:23 (leading: Space)
+5622: LParen          "(" at 489:23-489:24
+5623: RParen          ")" at 489:24-489:25
+5624: Arrow           "->" at 489:26-489:28 (leading: Space)
+5625: Ident           "uint16" at 489:29-489:35 (leading: Space)
+5626: LBrace          "{" at 489:36-489:37 (leading: Space)
+5627: KwReturn        "return" at 489:38-489:44 (leading: Space)
+5628: LParen          "(" at 489:45-489:46 (leading: Space)
+5629: IntLit          "65_535" at 489:46-489:52
+5630: RParen          ")" at 489:52-489:53
+5631: Colon           ":" at 489:53-489:54
+5632: Ident           "uint16" at 489:54-489:60
+5633: Semicolon       ";" at 489:60-489:61
+5634: RBrace          "}" at 489:62-489:63 (leading: Space)
+5635: At              "@" at 490:5-490:6 (leading: Newline, Space)
+5636: Ident           "intrinsic" at 490:6-490:15
+5637: KwFn            "fn" at 490:16-490:18 (leading: Space)
+5638: Ident           "__add" at 490:19-490:24 (leading: Space)
+5639: LParen          "(" at 490:24-490:25
+5640: Ident           "self" at 490:25-490:29
+5641: Colon           ":" at 490:29-490:30
+5642: Ident           "uint16" at 490:31-490:37 (leading: Space)
+5643: Comma           "," at 490:37-490:38
+5644: Ident           "other" at 490:39-490:44 (leading: Space)
+5645: Colon           ":" at 490:44-490:45
+5646: Ident           "uint16" at 490:46-490:52 (leading: Space)
+5647: RParen          ")" at 490:52-490:53
+5648: Arrow           "->" at 490:54-490:56 (leading: Space)
+5649: Ident           "uint16" at 490:57-490:63 (leading: Space)
+5650: Semicolon       ";" at 490:63-490:64
+5651: At              "@" at 491:5-491:6 (leading: Newline, Space)
+5652: Ident           "intrinsic" at 491:6-491:15
+5653: KwFn            "fn" at 491:16-491:18 (leading: Space)
+5654: Ident           "__sub" at 491:19-491:24 (leading: Space)
+5655: LParen          "(" at 491:24-491:25
+5656: Ident           "self" at 491:25-491:29
+5657: Colon           ":" at 491:29-491:30
+5658: Ident           "uint16" at 491:31-491:37 (leading: Space)
+5659: Comma           "," at 491:37-491:38
+5660: Ident           "other" at 491:39-491:44 (leading: Space)
+5661: Colon           ":" at 491:44-491:45
+5662: Ident           "uint16" at 491:46-491:52 (leading: Space)
+5663: RParen          ")" at 491:52-491:53
+5664: Arrow           "->" at 491:54-491:56 (leading: Space)
+5665: Ident           "uint16" at 491:57-491:63 (leading: Space)
+5666: Semicolon       ";" at 491:63-491:64
+5667: At              "@" at 492:5-492:6 (leading: Newline, Space)
+5668: Ident           "intrinsic" at 492:6-492:15
+5669: KwFn            "fn" at 492:16-492:18 (leading: Space)
+5670: Ident           "__mul" at 492:19-492:24 (leading: Space)
+5671: LParen          "(" at 492:24-492:25
+5672: Ident           "self" at 492:25-492:29
+5673: Colon           ":" at 492:29-492:30
+5674: Ident           "uint16" at 492:31-492:37 (leading: Space)
+5675: Comma           "," at 492:37-492:38
+5676: Ident           "other" at 492:39-492:44 (leading: Space)
+5677: Colon           ":" at 492:44-492:45
+5678: Ident           "uint16" at 492:46-492:52 (leading: Space)
+5679: RParen          ")" at 492:52-492:53
+5680: Arrow           "->" at 492:54-492:56 (leading: Space)
+5681: Ident           "uint16" at 492:57-492:63 (leading: Space)
+5682: Semicolon       ";" at 492:63-492:64
+5683: At              "@" at 493:5-493:6 (leading: Newline, Space)
+5684: Ident           "intrinsic" at 493:6-493:15
+5685: KwFn            "fn" at 493:16-493:18 (leading: Space)
+5686: Ident           "__div" at 493:19-493:24 (leading: Space)
+5687: LParen          "(" at 493:24-493:25
+5688: Ident           "self" at 493:25-493:29
+5689: Colon           ":" at 493:29-493:30
+5690: Ident           "uint16" at 493:31-493:37 (leading: Space)
+5691: Comma           "," at 493:37-493:38
+5692: Ident           "other" at 493:39-493:44 (leading: Space)
+5693: Colon           ":" at 493:44-493:45
+5694: Ident           "uint16" at 493:46-493:52 (leading: Space)
+5695: RParen          ")" at 493:52-493:53
+5696: Arrow           "->" at 493:54-493:56 (leading: Space)
+5697: Ident           "uint16" at 493:57-493:63 (leading: Space)
+5698: Semicolon       ";" at 493:63-493:64
+5699: At              "@" at 494:5-494:6 (leading: Newline, Space)
+5700: Ident           "intrinsic" at 494:6-494:15
+5701: KwFn            "fn" at 494:16-494:18 (leading: Space)
+5702: Ident           "__mod" at 494:19-494:24 (leading: Space)
+5703: LParen          "(" at 494:24-494:25
+5704: Ident           "self" at 494:25-494:29
+5705: Colon           ":" at 494:29-494:30
+5706: Ident           "uint16" at 494:31-494:37 (leading: Space)
+5707: Comma           "," at 494:37-494:38
+5708: Ident           "other" at 494:39-494:44 (leading: Space)
+5709: Colon           ":" at 494:44-494:45
+5710: Ident           "uint16" at 494:46-494:52 (leading: Space)
+5711: RParen          ")" at 494:52-494:53
+5712: Arrow           "->" at 494:54-494:56 (leading: Space)
+5713: Ident           "uint16" at 494:57-494:63 (leading: Space)
+5714: Semicolon       ";" at 494:63-494:64
+5715: At              "@" at 495:5-495:6 (leading: Newline, Space)
+5716: Ident           "intrinsic" at 495:6-495:15
+5717: KwFn            "fn" at 495:16-495:18 (leading: Space)
+5718: Ident           "__bit_and" at 495:19-495:28 (leading: Space)
+5719: LParen          "(" at 495:28-495:29
+5720: Ident           "self" at 495:29-495:33
+5721: Colon           ":" at 495:33-495:34
+5722: Ident           "uint16" at 495:35-495:41 (leading: Space)
+5723: Comma           "," at 495:41-495:42
+5724: Ident           "other" at 495:43-495:48 (leading: Space)
+5725: Colon           ":" at 495:48-495:49
+5726: Ident           "uint16" at 495:50-495:56 (leading: Space)
+5727: RParen          ")" at 495:56-495:57
+5728: Arrow           "->" at 495:58-495:60 (leading: Space)
+5729: Ident           "uint16" at 495:61-495:67 (leading: Space)
+5730: Semicolon       ";" at 495:67-495:68
+5731: At              "@" at 496:5-496:6 (leading: Newline, Space)
+5732: Ident           "intrinsic" at 496:6-496:15
+5733: KwFn            "fn" at 496:16-496:18 (leading: Space)
+5734: Ident           "__bit_or" at 496:19-496:27 (leading: Space)
+5735: LParen          "(" at 496:27-496:28
+5736: Ident           "self" at 496:28-496:32
+5737: Colon           ":" at 496:32-496:33
+5738: Ident           "uint16" at 496:34-496:40 (leading: Space)
+5739: Comma           "," at 496:40-496:41
+5740: Ident           "other" at 496:42-496:47 (leading: Space)
+5741: Colon           ":" at 496:47-496:48
+5742: Ident           "uint16" at 496:49-496:55 (leading: Space)
+5743: RParen          ")" at 496:55-496:56
+5744: Arrow           "->" at 496:57-496:59 (leading: Space)
+5745: Ident           "uint16" at 496:60-496:66 (leading: Space)
+5746: Semicolon       ";" at 496:66-496:67
+5747: At              "@" at 497:5-497:6 (leading: Newline, Space)
+5748: Ident           "intrinsic" at 497:6-497:15
+5749: KwFn            "fn" at 497:16-497:18 (leading: Space)
+5750: Ident           "__bit_xor" at 497:19-497:28 (leading: Space)
+5751: LParen          "(" at 497:28-497:29
+5752: Ident           "self" at 497:29-497:33
+5753: Colon           ":" at 497:33-497:34
+5754: Ident           "uint16" at 497:35-497:41 (leading: Space)
+5755: Comma           "," at 497:41-497:42
+5756: Ident           "other" at 497:43-497:48 (leading: Space)
+5757: Colon           ":" at 497:48-497:49
+5758: Ident           "uint16" at 497:50-497:56 (leading: Space)
+5759: RParen          ")" at 497:56-497:57
+5760: Arrow           "->" at 497:58-497:60 (leading: Space)
+5761: Ident           "uint16" at 497:61-497:67 (leading: Space)
+5762: Semicolon       ";" at 497:67-497:68
+5763: At              "@" at 498:5-498:6 (leading: Newline, Space)
+5764: Ident           "intrinsic" at 498:6-498:15
+5765: KwFn            "fn" at 498:16-498:18 (leading: Space)
+5766: Ident           "__shl" at 498:19-498:24 (leading: Space)
+5767: LParen          "(" at 498:24-498:25
+5768: Ident           "self" at 498:25-498:29
+5769: Colon           ":" at 498:29-498:30
+5770: Ident           "uint16" at 498:31-498:37 (leading: Space)
+5771: Comma           "," at 498:37-498:38
+5772: Ident           "other" at 498:39-498:44 (leading: Space)
+5773: Colon           ":" at 498:44-498:45
+5774: Ident           "uint16" at 498:46-498:52 (leading: Space)
+5775: RParen          ")" at 498:52-498:53
+5776: Arrow           "->" at 498:54-498:56 (leading: Space)
+5777: Ident           "uint16" at 498:57-498:63 (leading: Space)
+5778: Semicolon       ";" at 498:63-498:64
+5779: At              "@" at 499:5-499:6 (leading: Newline, Space)
+5780: Ident           "intrinsic" at 499:6-499:15
+5781: KwFn            "fn" at 499:16-499:18 (leading: Space)
+5782: Ident           "__shr" at 499:19-499:24 (leading: Space)
+5783: LParen          "(" at 499:24-499:25
+5784: Ident           "self" at 499:25-499:29
+5785: Colon           ":" at 499:29-499:30
+5786: Ident           "uint16" at 499:31-499:37 (leading: Space)
+5787: Comma           "," at 499:37-499:38
+5788: Ident           "other" at 499:39-499:44 (leading: Space)
+5789: Colon           ":" at 499:44-499:45
+5790: Ident           "uint16" at 499:46-499:52 (leading: Space)
+5791: RParen          ")" at 499:52-499:53
+5792: Arrow           "->" at 499:54-499:56 (leading: Space)
+5793: Ident           "uint16" at 499:57-499:63 (leading: Space)
+5794: Semicolon       ";" at 499:63-499:64
+5795: At              "@" at 500:5-500:6 (leading: Newline, Space)
+5796: Ident           "intrinsic" at 500:6-500:15
+5797: KwFn            "fn" at 500:16-500:18 (leading: Space)
+5798: Ident           "__lt" at 500:19-500:23 (leading: Space)
+5799: LParen          "(" at 500:23-500:24
+5800: Ident           "self" at 500:24-500:28
+5801: Colon           ":" at 500:28-500:29
+5802: Ident           "uint16" at 500:30-500:36 (leading: Space)
+5803: Comma           "," at 500:36-500:37
+5804: Ident           "other" at 500:38-500:43 (leading: Space)
+5805: Colon           ":" at 500:43-500:44
+5806: Ident           "uint16" at 500:45-500:51 (leading: Space)
+5807: RParen          ")" at 500:51-500:52
+5808: Arrow           "->" at 500:53-500:55 (leading: Space)
+5809: Ident           "bool" at 500:56-500:60 (leading: Space)
+5810: Semicolon       ";" at 500:60-500:61
+5811: At              "@" at 501:5-501:6 (leading: Newline, Space)
+5812: Ident           "intrinsic" at 501:6-501:15
+5813: KwFn            "fn" at 501:16-501:18 (leading: Space)
+5814: Ident           "__le" at 501:19-501:23 (leading: Space)
+5815: LParen          "(" at 501:23-501:24
+5816: Ident           "self" at 501:24-501:28
+5817: Colon           ":" at 501:28-501:29
+5818: Ident           "uint16" at 501:30-501:36 (leading: Space)
+5819: Comma           "," at 501:36-501:37
+5820: Ident           "other" at 501:38-501:43 (leading: Space)
+5821: Colon           ":" at 501:43-501:44
+5822: Ident           "uint16" at 501:45-501:51 (leading: Space)
+5823: RParen          ")" at 501:51-501:52
+5824: Arrow           "->" at 501:53-501:55 (leading: Space)
+5825: Ident           "bool" at 501:56-501:60 (leading: Space)
+5826: Semicolon       ";" at 501:60-501:61
+5827: At              "@" at 502:5-502:6 (leading: Newline, Space)
+5828: Ident           "intrinsic" at 502:6-502:15
+5829: KwFn            "fn" at 502:16-502:18 (leading: Space)
+5830: Ident           "__eq" at 502:19-502:23 (leading: Space)
+5831: LParen          "(" at 502:23-502:24
+5832: Ident           "self" at 502:24-502:28
+5833: Colon           ":" at 502:28-502:29
+5834: Ident           "uint16" at 502:30-502:36 (leading: Space)
+5835: Comma           "," at 502:36-502:37
+5836: Ident           "other" at 502:38-502:43 (leading: Space)
+5837: Colon           ":" at 502:43-502:44
+5838: Ident           "uint16" at 502:45-502:51 (leading: Space)
+5839: RParen          ")" at 502:51-502:52
+5840: Arrow           "->" at 502:53-502:55 (leading: Space)
+5841: Ident           "bool" at 502:56-502:60 (leading: Space)
+5842: Semicolon       ";" at 502:60-502:61
+5843: At              "@" at 503:5-503:6 (leading: Newline, Space)
+5844: Ident           "intrinsic" at 503:6-503:15
+5845: KwFn            "fn" at 503:16-503:18 (leading: Space)
+5846: Ident           "__ne" at 503:19-503:23 (leading: Space)
+5847: LParen          "(" at 503:23-503:24
+5848: Ident           "self" at 503:24-503:28
+5849: Colon           ":" at 503:28-503:29
+5850: Ident           "uint16" at 503:30-503:36 (leading: Space)
+5851: Comma           "," at 503:36-503:37
+5852: Ident           "other" at 503:38-503:43 (leading: Space)
+5853: Colon           ":" at 503:43-503:44
+5854: Ident           "uint16" at 503:45-503:51 (leading: Space)
+5855: RParen          ")" at 503:51-503:52
+5856: Arrow           "->" at 503:53-503:55 (leading: Space)
+5857: Ident           "bool" at 503:56-503:60 (leading: Space)
+5858: Semicolon       ";" at 503:60-503:61
+5859: At              "@" at 504:5-504:6 (leading: Newline, Space)
+5860: Ident           "intrinsic" at 504:6-504:15
+5861: KwFn            "fn" at 504:16-504:18 (leading: Space)
+5862: Ident           "__ge" at 504:19-504:23 (leading: Space)
+5863: LParen          "(" at 504:23-504:24
+5864: Ident           "self" at 504:24-504:28
+5865: Colon           ":" at 504:28-504:29
+5866: Ident           "uint16" at 504:30-504:36 (leading: Space)
+5867: Comma           "," at 504:36-504:37
+5868: Ident           "other" at 504:38-504:43 (leading: Space)
+5869: Colon           ":" at 504:43-504:44
+5870: Ident           "uint16" at 504:45-504:51 (leading: Space)
+5871: RParen          ")" at 504:51-504:52
+5872: Arrow           "->" at 504:53-504:55 (leading: Space)
+5873: Ident           "bool" at 504:56-504:60 (leading: Space)
+5874: Semicolon       ";" at 504:60-504:61
+5875: At              "@" at 505:5-505:6 (leading: Newline, Space)
+5876: Ident           "intrinsic" at 505:6-505:15
+5877: KwFn            "fn" at 505:16-505:18 (leading: Space)
+5878: Ident           "__gt" at 505:19-505:23 (leading: Space)
+5879: LParen          "(" at 505:23-505:24
+5880: Ident           "self" at 505:24-505:28
+5881: Colon           ":" at 505:28-505:29
+5882: Ident           "uint16" at 505:30-505:36 (leading: Space)
+5883: Comma           "," at 505:36-505:37
+5884: Ident           "other" at 505:38-505:43 (leading: Space)
+5885: Colon           ":" at 505:43-505:44
+5886: Ident           "uint16" at 505:45-505:51 (leading: Space)
+5887: RParen          ")" at 505:51-505:52
+5888: Arrow           "->" at 505:53-505:55 (leading: Space)
+5889: Ident           "bool" at 505:56-505:60 (leading: Space)
+5890: Semicolon       ";" at 505:60-505:61
+5891: At              "@" at 506:5-506:6 (leading: Newline, Space)
+5892: Ident           "intrinsic" at 506:6-506:15
+5893: KwFn            "fn" at 506:16-506:18 (leading: Space)
+5894: Ident           "__pos" at 506:19-506:24 (leading: Space)
+5895: LParen          "(" at 506:24-506:25
+5896: Ident           "self" at 506:25-506:29
+5897: Colon           ":" at 506:29-506:30
+5898: Ident           "uint16" at 506:31-506:37 (leading: Space)
+5899: RParen          ")" at 506:37-506:38
+5900: Arrow           "->" at 506:39-506:41 (leading: Space)
+5901: Ident           "uint16" at 506:42-506:48 (leading: Space)
+5902: Semicolon       ";" at 506:48-506:49
+5903: At              "@" at 507:5-507:6 (leading: Newline, Space)
+5904: Ident           "intrinsic" at 507:6-507:15
+5905: KwFn            "fn" at 507:16-507:18 (leading: Space)
+5906: Ident           "__abs" at 507:19-507:24 (leading: Space)
+5907: LParen          "(" at 507:24-507:25
+5908: Ident           "self" at 507:25-507:29
+5909: Colon           ":" at 507:29-507:30
+5910: Ident           "uint16" at 507:31-507:37 (leading: Space)
+5911: RParen          ")" at 507:37-507:38
+5912: Arrow           "->" at 507:39-507:41 (leading: Space)
+5913: Ident           "uint16" at 507:42-507:48 (leading: Space)
+5914: Semicolon       ";" at 507:48-507:49
+5915: At              "@" at 508:5-508:6 (leading: Newline, Space)
+5916: Ident           "intrinsic" at 508:6-508:15
+5917: KwFn            "fn" at 508:16-508:18 (leading: Space)
+5918: Ident           "__to" at 508:19-508:23 (leading: Space)
+5919: LParen          "(" at 508:23-508:24
+5920: Ident           "self" at 508:24-508:28
+5921: Colon           ":" at 508:28-508:29
+5922: Ident           "uint16" at 508:30-508:36 (leading: Space)
+5923: Comma           "," at 508:36-508:37
+5924: Ident           "target" at 508:38-508:44 (leading: Space)
+5925: Colon           ":" at 508:44-508:45
+5926: Ident           "uint" at 508:46-508:50 (leading: Space)
+5927: RParen          ")" at 508:50-508:51
+5928: Arrow           "->" at 508:52-508:54 (leading: Space)
+5929: Ident           "uint" at 508:55-508:59 (leading: Space)
+5930: Semicolon       ";" at 508:59-508:60
+5931: At              "@" at 509:5-509:6 (leading: Newline, Space)
+5932: Ident           "intrinsic" at 509:6-509:15
+5933: At              "@" at 509:16-509:17 (leading: Space)
+5934: Ident           "overload" at 509:17-509:25
+5935: KwFn            "fn" at 509:26-509:28 (leading: Space)
+5936: Ident           "__to" at 509:29-509:33 (leading: Space)
+5937: LParen          "(" at 509:33-509:34
+5938: Ident           "self" at 509:34-509:38
+5939: Colon           ":" at 509:38-509:39
+5940: Ident           "uint16" at 509:40-509:46 (leading: Space)
+5941: Comma           "," at 509:46-509:47
+5942: Ident           "target" at 509:48-509:54 (leading: Space)
+5943: Colon           ":" at 509:54-509:55
+5944: Ident           "uint8" at 509:56-509:61 (leading: Space)
+5945: RParen          ")" at 509:61-509:62
+5946: Arrow           "->" at 509:63-509:65 (leading: Space)
+5947: Ident           "uint8" at 509:66-509:71 (leading: Space)
+5948: Semicolon       ";" at 509:71-509:72
+5949: At              "@" at 510:5-510:6 (leading: Newline, Space)
+5950: Ident           "intrinsic" at 510:6-510:15
+5951: At              "@" at 510:16-510:17 (leading: Space)
+5952: Ident           "overload" at 510:17-510:25
+5953: KwFn            "fn" at 510:26-510:28 (leading: Space)
+5954: Ident           "__to" at 510:29-510:33 (leading: Space)
+5955: LParen          "(" at 510:33-510:34
+5956: Ident           "self" at 510:34-510:38
+5957: Colon           ":" at 510:38-510:39
+5958: Ident           "uint16" at 510:40-510:46 (leading: Space)
+5959: Comma           "," at 510:46-510:47
+5960: Ident           "target" at 510:48-510:54 (leading: Space)
+5961: Colon           ":" at 510:54-510:55
+5962: Ident           "uint32" at 510:56-510:62 (leading: Space)
+5963: RParen          ")" at 510:62-510:63
+5964: Arrow           "->" at 510:64-510:66 (leading: Space)
+5965: Ident           "uint32" at 510:67-510:73 (leading: Space)
+5966: Semicolon       ";" at 510:73-510:74
+5967: At              "@" at 511:5-511:6 (leading: Newline, Space)
+5968: Ident           "intrinsic" at 511:6-511:15
+5969: At              "@" at 511:16-511:17 (leading: Space)
+5970: Ident           "overload" at 511:17-511:25
+5971: KwFn            "fn" at 511:26-511:28 (leading: Space)
+5972: Ident           "__to" at 511:29-511:33 (leading: Space)
+5973: LParen          "(" at 511:33-511:34
+5974: Ident           "self" at 511:34-511:38
+5975: Colon           ":" at 511:38-511:39
+5976: Ident           "uint16" at 511:40-511:46 (leading: Space)
+5977: Comma           "," at 511:46-511:47
+5978: Ident           "target" at 511:48-511:54 (leading: Space)
+5979: Colon           ":" at 511:54-511:55
+5980: Ident           "uint64" at 511:56-511:62 (leading: Space)
+5981: RParen          ")" at 511:62-511:63
+5982: Arrow           "->" at 511:64-511:66 (leading: Space)
+5983: Ident           "uint64" at 511:67-511:73 (leading: Space)
+5984: Semicolon       ";" at 511:73-511:74
+5985: At              "@" at 512:5-512:6 (leading: Newline, Space)
+5986: Ident           "intrinsic" at 512:6-512:15
+5987: KwPub           "pub" at 512:16-512:19 (leading: Space)
+5988: KwFn            "fn" at 512:20-512:22 (leading: Space)
+5989: Ident           "from_str" at 512:23-512:31 (leading: Space)
+5990: LParen          "(" at 512:31-512:32
+5991: Ident           "s" at 512:32-512:33
+5992: Colon           ":" at 512:33-512:34
+5993: Amp             "&" at 512:35-512:36 (leading: Space)
+5994: Ident           "string" at 512:36-512:42
+5995: RParen          ")" at 512:42-512:43
+5996: Arrow           "->" at 512:44-512:46 (leading: Space)
+5997: Ident           "Erring" at 512:47-512:53 (leading: Space)
+5998: Lt              "<" at 512:53-512:54
+5999: Ident           "uint16" at 512:54-512:60
+6000: Comma           "," at 512:60-512:61
+6001: Ident           "Error" at 512:62-512:67 (leading: Space)
+6002: Gt              ">" at 512:67-512:68
+6003: Semicolon       ";" at 512:68-512:69
+6004: RBrace          "}" at 513:1-513:2 (leading: Newline)
+6005: KwExtern        "extern" at 515:1-515:7 (leading: Newline)
+6006: Lt              "<" at 515:7-515:8
+6007: Ident           "uint32" at 515:8-515:14
+6008: Gt              ">" at 515:14-515:15
+6009: LBrace          "{" at 515:16-515:17 (leading: Space)
+6010: KwPub           "pub" at 516:5-516:8 (leading: Newline, Space)
+6011: KwFn            "fn" at 516:9-516:11 (leading: Space)
+6012: Ident           "__min_value" at 516:12-516:23 (leading: Space)
+6013: LParen          "(" at 516:23-516:24
+6014: RParen          ")" at 516:24-516:25
+6015: Arrow           "->" at 516:26-516:28 (leading: Space)
+6016: Ident           "uint32" at 516:29-516:35 (leading: Space)
+6017: LBrace          "{" at 516:36-516:37 (leading: Space)
+6018: KwReturn        "return" at 516:38-516:44 (leading: Space)
+6019: LParen          "(" at 516:45-516:46 (leading: Space)
+6020: IntLit          "0" at 516:46-516:47
+6021: RParen          ")" at 516:47-516:48
+6022: Colon           ":" at 516:48-516:49
+6023: Ident           "uint32" at 516:49-516:55
+6024: Semicolon       ";" at 516:55-516:56
+6025: RBrace          "}" at 516:57-516:58 (leading: Space)
+6026: KwPub           "pub" at 517:5-517:8 (leading: Newline, Space)
+6027: KwFn            "fn" at 517:9-517:11 (leading: Space)
+6028: Ident           "__max_value" at 517:12-517:23 (leading: Space)
+6029: LParen          "(" at 517:23-517:24
+6030: RParen          ")" at 517:24-517:25
+6031: Arrow           "->" at 517:26-517:28 (leading: Space)
+6032: Ident           "uint32" at 517:29-517:35 (leading: Space)
+6033: LBrace          "{" at 517:36-517:37 (leading: Space)
+6034: KwReturn        "return" at 517:38-517:44 (leading: Space)
+6035: LParen          "(" at 517:45-517:46 (leading: Space)
+6036: IntLit          "4_294_967_295" at 517:46-517:59
+6037: RParen          ")" at 517:59-517:60
+6038: Colon           ":" at 517:60-517:61
+6039: Ident           "uint32" at 517:61-517:67
+6040: Semicolon       ";" at 517:67-517:68
+6041: RBrace          "}" at 517:69-517:70 (leading: Space)
+6042: At              "@" at 518:5-518:6 (leading: Newline, Space)
+6043: Ident           "intrinsic" at 518:6-518:15
+6044: KwFn            "fn" at 518:16-518:18 (leading: Space)
+6045: Ident           "__add" at 518:19-518:24 (leading: Space)
+6046: LParen          "(" at 518:24-518:25
+6047: Ident           "self" at 518:25-518:29
+6048: Colon           ":" at 518:29-518:30
+6049: Ident           "uint32" at 518:31-518:37 (leading: Space)
+6050: Comma           "," at 518:37-518:38
+6051: Ident           "other" at 518:39-518:44 (leading: Space)
+6052: Colon           ":" at 518:44-518:45
+6053: Ident           "uint32" at 518:46-518:52 (leading: Space)
+6054: RParen          ")" at 518:52-518:53
+6055: Arrow           "->" at 518:54-518:56 (leading: Space)
+6056: Ident           "uint32" at 518:57-518:63 (leading: Space)
+6057: Semicolon       ";" at 518:63-518:64
+6058: At              "@" at 519:5-519:6 (leading: Newline, Space)
+6059: Ident           "intrinsic" at 519:6-519:15
+6060: KwFn            "fn" at 519:16-519:18 (leading: Space)
+6061: Ident           "__sub" at 519:19-519:24 (leading: Space)
+6062: LParen          "(" at 519:24-519:25
+6063: Ident           "self" at 519:25-519:29
+6064: Colon           ":" at 519:29-519:30
+6065: Ident           "uint32" at 519:31-519:37 (leading: Space)
+6066: Comma           "," at 519:37-519:38
+6067: Ident           "other" at 519:39-519:44 (leading: Space)
+6068: Colon           ":" at 519:44-519:45
+6069: Ident           "uint32" at 519:46-519:52 (leading: Space)
+6070: RParen          ")" at 519:52-519:53
+6071: Arrow           "->" at 519:54-519:56 (leading: Space)
+6072: Ident           "uint32" at 519:57-519:63 (leading: Space)
+6073: Semicolon       ";" at 519:63-519:64
+6074: At              "@" at 520:5-520:6 (leading: Newline, Space)
+6075: Ident           "intrinsic" at 520:6-520:15
+6076: KwFn            "fn" at 520:16-520:18 (leading: Space)
+6077: Ident           "__mul" at 520:19-520:24 (leading: Space)
+6078: LParen          "(" at 520:24-520:25
+6079: Ident           "self" at 520:25-520:29
+6080: Colon           ":" at 520:29-520:30
+6081: Ident           "uint32" at 520:31-520:37 (leading: Space)
+6082: Comma           "," at 520:37-520:38
+6083: Ident           "other" at 520:39-520:44 (leading: Space)
+6084: Colon           ":" at 520:44-520:45
+6085: Ident           "uint32" at 520:46-520:52 (leading: Space)
+6086: RParen          ")" at 520:52-520:53
+6087: Arrow           "->" at 520:54-520:56 (leading: Space)
+6088: Ident           "uint32" at 520:57-520:63 (leading: Space)
+6089: Semicolon       ";" at 520:63-520:64
+6090: At              "@" at 521:5-521:6 (leading: Newline, Space)
+6091: Ident           "intrinsic" at 521:6-521:15
+6092: KwFn            "fn" at 521:16-521:18 (leading: Space)
+6093: Ident           "__div" at 521:19-521:24 (leading: Space)
+6094: LParen          "(" at 521:24-521:25
+6095: Ident           "self" at 521:25-521:29
+6096: Colon           ":" at 521:29-521:30
+6097: Ident           "uint32" at 521:31-521:37 (leading: Space)
+6098: Comma           "," at 521:37-521:38
+6099: Ident           "other" at 521:39-521:44 (leading: Space)
+6100: Colon           ":" at 521:44-521:45
+6101: Ident           "uint32" at 521:46-521:52 (leading: Space)
+6102: RParen          ")" at 521:52-521:53
+6103: Arrow           "->" at 521:54-521:56 (leading: Space)
+6104: Ident           "uint32" at 521:57-521:63 (leading: Space)
+6105: Semicolon       ";" at 521:63-521:64
+6106: At              "@" at 522:5-522:6 (leading: Newline, Space)
+6107: Ident           "intrinsic" at 522:6-522:15
+6108: KwFn            "fn" at 522:16-522:18 (leading: Space)
+6109: Ident           "__mod" at 522:19-522:24 (leading: Space)
+6110: LParen          "(" at 522:24-522:25
+6111: Ident           "self" at 522:25-522:29
+6112: Colon           ":" at 522:29-522:30
+6113: Ident           "uint32" at 522:31-522:37 (leading: Space)
+6114: Comma           "," at 522:37-522:38
+6115: Ident           "other" at 522:39-522:44 (leading: Space)
+6116: Colon           ":" at 522:44-522:45
+6117: Ident           "uint32" at 522:46-522:52 (leading: Space)
+6118: RParen          ")" at 522:52-522:53
+6119: Arrow           "->" at 522:54-522:56 (leading: Space)
+6120: Ident           "uint32" at 522:57-522:63 (leading: Space)
+6121: Semicolon       ";" at 522:63-522:64
+6122: At              "@" at 523:5-523:6 (leading: Newline, Space)
+6123: Ident           "intrinsic" at 523:6-523:15
+6124: KwFn            "fn" at 523:16-523:18 (leading: Space)
+6125: Ident           "__bit_and" at 523:19-523:28 (leading: Space)
+6126: LParen          "(" at 523:28-523:29
+6127: Ident           "self" at 523:29-523:33
+6128: Colon           ":" at 523:33-523:34
+6129: Ident           "uint32" at 523:35-523:41 (leading: Space)
+6130: Comma           "," at 523:41-523:42
+6131: Ident           "other" at 523:43-523:48 (leading: Space)
+6132: Colon           ":" at 523:48-523:49
+6133: Ident           "uint32" at 523:50-523:56 (leading: Space)
+6134: RParen          ")" at 523:56-523:57
+6135: Arrow           "->" at 523:58-523:60 (leading: Space)
+6136: Ident           "uint32" at 523:61-523:67 (leading: Space)
+6137: Semicolon       ";" at 523:67-523:68
+6138: At              "@" at 524:5-524:6 (leading: Newline, Space)
+6139: Ident           "intrinsic" at 524:6-524:15
+6140: KwFn            "fn" at 524:16-524:18 (leading: Space)
+6141: Ident           "__bit_or" at 524:19-524:27 (leading: Space)
+6142: LParen          "(" at 524:27-524:28
+6143: Ident           "self" at 524:28-524:32
+6144: Colon           ":" at 524:32-524:33
+6145: Ident           "uint32" at 524:34-524:40 (leading: Space)
+6146: Comma           "," at 524:40-524:41
+6147: Ident           "other" at 524:42-524:47 (leading: Space)
+6148: Colon           ":" at 524:47-524:48
+6149: Ident           "uint32" at 524:49-524:55 (leading: Space)
+6150: RParen          ")" at 524:55-524:56
+6151: Arrow           "->" at 524:57-524:59 (leading: Space)
+6152: Ident           "uint32" at 524:60-524:66 (leading: Space)
+6153: Semicolon       ";" at 524:66-524:67
+6154: At              "@" at 525:5-525:6 (leading: Newline, Space)
+6155: Ident           "intrinsic" at 525:6-525:15
+6156: KwFn            "fn" at 525:16-525:18 (leading: Space)
+6157: Ident           "__bit_xor" at 525:19-525:28 (leading: Space)
+6158: LParen          "(" at 525:28-525:29
+6159: Ident           "self" at 525:29-525:33
+6160: Colon           ":" at 525:33-525:34
+6161: Ident           "uint32" at 525:35-525:41 (leading: Space)
+6162: Comma           "," at 525:41-525:42
+6163: Ident           "other" at 525:43-525:48 (leading: Space)
+6164: Colon           ":" at 525:48-525:49
+6165: Ident           "uint32" at 525:50-525:56 (leading: Space)
+6166: RParen          ")" at 525:56-525:57
+6167: Arrow           "->" at 525:58-525:60 (leading: Space)
+6168: Ident           "uint32" at 525:61-525:67 (leading: Space)
+6169: Semicolon       ";" at 525:67-525:68
+6170: At              "@" at 526:5-526:6 (leading: Newline, Space)
+6171: Ident           "intrinsic" at 526:6-526:15
+6172: KwFn            "fn" at 526:16-526:18 (leading: Space)
+6173: Ident           "__shl" at 526:19-526:24 (leading: Space)
+6174: LParen          "(" at 526:24-526:25
+6175: Ident           "self" at 526:25-526:29
+6176: Colon           ":" at 526:29-526:30
+6177: Ident           "uint32" at 526:31-526:37 (leading: Space)
+6178: Comma           "," at 526:37-526:38
+6179: Ident           "other" at 526:39-526:44 (leading: Space)
+6180: Colon           ":" at 526:44-526:45
+6181: Ident           "uint32" at 526:46-526:52 (leading: Space)
+6182: RParen          ")" at 526:52-526:53
+6183: Arrow           "->" at 526:54-526:56 (leading: Space)
+6184: Ident           "uint32" at 526:57-526:63 (leading: Space)
+6185: Semicolon       ";" at 526:63-526:64
+6186: At              "@" at 527:5-527:6 (leading: Newline, Space)
+6187: Ident           "intrinsic" at 527:6-527:15
+6188: KwFn            "fn" at 527:16-527:18 (leading: Space)
+6189: Ident           "__shr" at 527:19-527:24 (leading: Space)
+6190: LParen          "(" at 527:24-527:25
+6191: Ident           "self" at 527:25-527:29
+6192: Colon           ":" at 527:29-527:30
+6193: Ident           "uint32" at 527:31-527:37 (leading: Space)
+6194: Comma           "," at 527:37-527:38
+6195: Ident           "other" at 527:39-527:44 (leading: Space)
+6196: Colon           ":" at 527:44-527:45
+6197: Ident           "uint32" at 527:46-527:52 (leading: Space)
+6198: RParen          ")" at 527:52-527:53
+6199: Arrow           "->" at 527:54-527:56 (leading: Space)
+6200: Ident           "uint32" at 527:57-527:63 (leading: Space)
+6201: Semicolon       ";" at 527:63-527:64
+6202: At              "@" at 528:5-528:6 (leading: Newline, Space)
+6203: Ident           "intrinsic" at 528:6-528:15
+6204: KwFn            "fn" at 528:16-528:18 (leading: Space)
+6205: Ident           "__lt" at 528:19-528:23 (leading: Space)
+6206: LParen          "(" at 528:23-528:24
+6207: Ident           "self" at 528:24-528:28
+6208: Colon           ":" at 528:28-528:29
+6209: Ident           "uint32" at 528:30-528:36 (leading: Space)
+6210: Comma           "," at 528:36-528:37
+6211: Ident           "other" at 528:38-528:43 (leading: Space)
+6212: Colon           ":" at 528:43-528:44
+6213: Ident           "uint32" at 528:45-528:51 (leading: Space)
+6214: RParen          ")" at 528:51-528:52
+6215: Arrow           "->" at 528:53-528:55 (leading: Space)
+6216: Ident           "bool" at 528:56-528:60 (leading: Space)
+6217: Semicolon       ";" at 528:60-528:61
+6218: At              "@" at 529:5-529:6 (leading: Newline, Space)
+6219: Ident           "intrinsic" at 529:6-529:15
+6220: KwFn            "fn" at 529:16-529:18 (leading: Space)
+6221: Ident           "__le" at 529:19-529:23 (leading: Space)
+6222: LParen          "(" at 529:23-529:24
+6223: Ident           "self" at 529:24-529:28
+6224: Colon           ":" at 529:28-529:29
+6225: Ident           "uint32" at 529:30-529:36 (leading: Space)
+6226: Comma           "," at 529:36-529:37
+6227: Ident           "other" at 529:38-529:43 (leading: Space)
+6228: Colon           ":" at 529:43-529:44
+6229: Ident           "uint32" at 529:45-529:51 (leading: Space)
+6230: RParen          ")" at 529:51-529:52
+6231: Arrow           "->" at 529:53-529:55 (leading: Space)
+6232: Ident           "bool" at 529:56-529:60 (leading: Space)
+6233: Semicolon       ";" at 529:60-529:61
+6234: At              "@" at 530:5-530:6 (leading: Newline, Space)
+6235: Ident           "intrinsic" at 530:6-530:15
+6236: KwFn            "fn" at 530:16-530:18 (leading: Space)
+6237: Ident           "__eq" at 530:19-530:23 (leading: Space)
+6238: LParen          "(" at 530:23-530:24
+6239: Ident           "self" at 530:24-530:28
+6240: Colon           ":" at 530:28-530:29
+6241: Ident           "uint32" at 530:30-530:36 (leading: Space)
+6242: Comma           "," at 530:36-530:37
+6243: Ident           "other" at 530:38-530:43 (leading: Space)
+6244: Colon           ":" at 530:43-530:44
+6245: Ident           "uint32" at 530:45-530:51 (leading: Space)
+6246: RParen          ")" at 530:51-530:52
+6247: Arrow           "->" at 530:53-530:55 (leading: Space)
+6248: Ident           "bool" at 530:56-530:60 (leading: Space)
+6249: Semicolon       ";" at 530:60-530:61
+6250: At              "@" at 531:5-531:6 (leading: Newline, Space)
+6251: Ident           "intrinsic" at 531:6-531:15
+6252: KwFn            "fn" at 531:16-531:18 (leading: Space)
+6253: Ident           "__ne" at 531:19-531:23 (leading: Space)
+6254: LParen          "(" at 531:23-531:24
+6255: Ident           "self" at 531:24-531:28
+6256: Colon           ":" at 531:28-531:29
+6257: Ident           "uint32" at 531:30-531:36 (leading: Space)
+6258: Comma           "," at 531:36-531:37
+6259: Ident           "other" at 531:38-531:43 (leading: Space)
+6260: Colon           ":" at 531:43-531:44
+6261: Ident           "uint32" at 531:45-531:51 (leading: Space)
+6262: RParen          ")" at 531:51-531:52
+6263: Arrow           "->" at 531:53-531:55 (leading: Space)
+6264: Ident           "bool" at 531:56-531:60 (leading: Space)
+6265: Semicolon       ";" at 531:60-531:61
+6266: At              "@" at 532:5-532:6 (leading: Newline, Space)
+6267: Ident           "intrinsic" at 532:6-532:15
+6268: KwFn            "fn" at 532:16-532:18 (leading: Space)
+6269: Ident           "__ge" at 532:19-532:23 (leading: Space)
+6270: LParen          "(" at 532:23-532:24
+6271: Ident           "self" at 532:24-532:28
+6272: Colon           ":" at 532:28-532:29
+6273: Ident           "uint32" at 532:30-532:36 (leading: Space)
+6274: Comma           "," at 532:36-532:37
+6275: Ident           "other" at 532:38-532:43 (leading: Space)
+6276: Colon           ":" at 532:43-532:44
+6277: Ident           "uint32" at 532:45-532:51 (leading: Space)
+6278: RParen          ")" at 532:51-532:52
+6279: Arrow           "->" at 532:53-532:55 (leading: Space)
+6280: Ident           "bool" at 532:56-532:60 (leading: Space)
+6281: Semicolon       ";" at 532:60-532:61
+6282: At              "@" at 533:5-533:6 (leading: Newline, Space)
+6283: Ident           "intrinsic" at 533:6-533:15
+6284: KwFn            "fn" at 533:16-533:18 (leading: Space)
+6285: Ident           "__gt" at 533:19-533:23 (leading: Space)
+6286: LParen          "(" at 533:23-533:24
+6287: Ident           "self" at 533:24-533:28
+6288: Colon           ":" at 533:28-533:29
+6289: Ident           "uint32" at 533:30-533:36 (leading: Space)
+6290: Comma           "," at 533:36-533:37
+6291: Ident           "other" at 533:38-533:43 (leading: Space)
+6292: Colon           ":" at 533:43-533:44
+6293: Ident           "uint32" at 533:45-533:51 (leading: Space)
+6294: RParen          ")" at 533:51-533:52
+6295: Arrow           "->" at 533:53-533:55 (leading: Space)
+6296: Ident           "bool" at 533:56-533:60 (leading: Space)
+6297: Semicolon       ";" at 533:60-533:61
+6298: At              "@" at 534:5-534:6 (leading: Newline, Space)
+6299: Ident           "intrinsic" at 534:6-534:15
+6300: KwFn            "fn" at 534:16-534:18 (leading: Space)
+6301: Ident           "__pos" at 534:19-534:24 (leading: Space)
+6302: LParen          "(" at 534:24-534:25
+6303: Ident           "self" at 534:25-534:29
+6304: Colon           ":" at 534:29-534:30
+6305: Ident           "uint32" at 534:31-534:37 (leading: Space)
+6306: RParen          ")" at 534:37-534:38
+6307: Arrow           "->" at 534:39-534:41 (leading: Space)
+6308: Ident           "uint32" at 534:42-534:48 (leading: Space)
+6309: Semicolon       ";" at 534:48-534:49
+6310: At              "@" at 535:5-535:6 (leading: Newline, Space)
+6311: Ident           "intrinsic" at 535:6-535:15
+6312: KwFn            "fn" at 535:16-535:18 (leading: Space)
+6313: Ident           "__abs" at 535:19-535:24 (leading: Space)
+6314: LParen          "(" at 535:24-535:25
+6315: Ident           "self" at 535:25-535:29
+6316: Colon           ":" at 535:29-535:30
+6317: Ident           "uint32" at 535:31-535:37 (leading: Space)
+6318: RParen          ")" at 535:37-535:38
+6319: Arrow           "->" at 535:39-535:41 (leading: Space)
+6320: Ident           "uint32" at 535:42-535:48 (leading: Space)
+6321: Semicolon       ";" at 535:48-535:49
+6322: At              "@" at 536:5-536:6 (leading: Newline, Space)
+6323: Ident           "intrinsic" at 536:6-536:15
+6324: KwFn            "fn" at 536:16-536:18 (leading: Space)
+6325: Ident           "__to" at 536:19-536:23 (leading: Space)
+6326: LParen          "(" at 536:23-536:24
+6327: Ident           "self" at 536:24-536:28
+6328: Colon           ":" at 536:28-536:29
+6329: Ident           "uint32" at 536:30-536:36 (leading: Space)
+6330: Comma           "," at 536:36-536:37
+6331: Ident           "target" at 536:38-536:44 (leading: Space)
+6332: Colon           ":" at 536:44-536:45
+6333: Ident           "uint" at 536:46-536:50 (leading: Space)
+6334: RParen          ")" at 536:50-536:51
+6335: Arrow           "->" at 536:52-536:54 (leading: Space)
+6336: Ident           "uint" at 536:55-536:59 (leading: Space)
+6337: Semicolon       ";" at 536:59-536:60
+6338: At              "@" at 537:5-537:6 (leading: Newline, Space)
+6339: Ident           "intrinsic" at 537:6-537:15
+6340: At              "@" at 537:16-537:17 (leading: Space)
+6341: Ident           "overload" at 537:17-537:25
+6342: KwFn            "fn" at 537:26-537:28 (leading: Space)
+6343: Ident           "__to" at 537:29-537:33 (leading: Space)
+6344: LParen          "(" at 537:33-537:34
+6345: Ident           "self" at 537:34-537:38
+6346: Colon           ":" at 537:38-537:39
+6347: Ident           "uint32" at 537:40-537:46 (leading: Space)
+6348: Comma           "," at 537:46-537:47
+6349: Ident           "target" at 537:48-537:54 (leading: Space)
+6350: Colon           ":" at 537:54-537:55
+6351: Ident           "uint8" at 537:56-537:61 (leading: Space)
+6352: RParen          ")" at 537:61-537:62
+6353: Arrow           "->" at 537:63-537:65 (leading: Space)
+6354: Ident           "uint8" at 537:66-537:71 (leading: Space)
+6355: Semicolon       ";" at 537:71-537:72
+6356: At              "@" at 538:5-538:6 (leading: Newline, Space)
+6357: Ident           "intrinsic" at 538:6-538:15
+6358: At              "@" at 538:16-538:17 (leading: Space)
+6359: Ident           "overload" at 538:17-538:25
+6360: KwFn            "fn" at 538:26-538:28 (leading: Space)
+6361: Ident           "__to" at 538:29-538:33 (leading: Space)
+6362: LParen          "(" at 538:33-538:34
+6363: Ident           "self" at 538:34-538:38
+6364: Colon           ":" at 538:38-538:39
+6365: Ident           "uint32" at 538:40-538:46 (leading: Space)
+6366: Comma           "," at 538:46-538:47
+6367: Ident           "target" at 538:48-538:54 (leading: Space)
+6368: Colon           ":" at 538:54-538:55
+6369: Ident           "uint16" at 538:56-538:62 (leading: Space)
+6370: RParen          ")" at 538:62-538:63
+6371: Arrow           "->" at 538:64-538:66 (leading: Space)
+6372: Ident           "uint16" at 538:67-538:73 (leading: Space)
+6373: Semicolon       ";" at 538:73-538:74
+6374: At              "@" at 539:5-539:6 (leading: Newline, Space)
+6375: Ident           "intrinsic" at 539:6-539:15
+6376: At              "@" at 539:16-539:17 (leading: Space)
+6377: Ident           "overload" at 539:17-539:25
+6378: KwFn            "fn" at 539:26-539:28 (leading: Space)
+6379: Ident           "__to" at 539:29-539:33 (leading: Space)
+6380: LParen          "(" at 539:33-539:34
+6381: Ident           "self" at 539:34-539:38
+6382: Colon           ":" at 539:38-539:39
+6383: Ident           "uint32" at 539:40-539:46 (leading: Space)
+6384: Comma           "," at 539:46-539:47
+6385: Ident           "target" at 539:48-539:54 (leading: Space)
+6386: Colon           ":" at 539:54-539:55
+6387: Ident           "uint64" at 539:56-539:62 (leading: Space)
+6388: RParen          ")" at 539:62-539:63
+6389: Arrow           "->" at 539:64-539:66 (leading: Space)
+6390: Ident           "uint64" at 539:67-539:73 (leading: Space)
+6391: Semicolon       ";" at 539:73-539:74
+6392: At              "@" at 540:5-540:6 (leading: Newline, Space)
+6393: Ident           "intrinsic" at 540:6-540:15
+6394: KwPub           "pub" at 540:16-540:19 (leading: Space)
+6395: KwFn            "fn" at 540:20-540:22 (leading: Space)
+6396: Ident           "from_str" at 540:23-540:31 (leading: Space)
+6397: LParen          "(" at 540:31-540:32
+6398: Ident           "s" at 540:32-540:33
+6399: Colon           ":" at 540:33-540:34
+6400: Amp             "&" at 540:35-540:36 (leading: Space)
+6401: Ident           "string" at 540:36-540:42
+6402: RParen          ")" at 540:42-540:43
+6403: Arrow           "->" at 540:44-540:46 (leading: Space)
+6404: Ident           "Erring" at 540:47-540:53 (leading: Space)
+6405: Lt              "<" at 540:53-540:54
+6406: Ident           "uint32" at 540:54-540:60
+6407: Comma           "," at 540:60-540:61
+6408: Ident           "Error" at 540:62-540:67 (leading: Space)
+6409: Gt              ">" at 540:67-540:68
+6410: Semicolon       ";" at 540:68-540:69
+6411: RBrace          "}" at 541:1-541:2 (leading: Newline)
+6412: KwExtern        "extern" at 543:1-543:7 (leading: Newline)
+6413: Lt              "<" at 543:7-543:8
+6414: Ident           "uint64" at 543:8-543:14
+6415: Gt              ">" at 543:14-543:15
+6416: LBrace          "{" at 543:16-543:17 (leading: Space)
+6417: KwPub           "pub" at 544:5-544:8 (leading: Newline, Space)
+6418: KwFn            "fn" at 544:9-544:11 (leading: Space)
+6419: Ident           "__min_value" at 544:12-544:23 (leading: Space)
+6420: LParen          "(" at 544:23-544:24
+6421: RParen          ")" at 544:24-544:25
+6422: Arrow           "->" at 544:26-544:28 (leading: Space)
+6423: Ident           "uint64" at 544:29-544:35 (leading: Space)
+6424: LBrace          "{" at 544:36-544:37 (leading: Space)
+6425: KwReturn        "return" at 544:38-544:44 (leading: Space)
+6426: LParen          "(" at 544:45-544:46 (leading: Space)
+6427: IntLit          "0" at 544:46-544:47
+6428: RParen          ")" at 544:47-544:48
+6429: Colon           ":" at 544:48-544:49
+6430: Ident           "uint64" at 544:49-544:55
+6431: Semicolon       ";" at 544:55-544:56
+6432: RBrace          "}" at 544:57-544:58 (leading: Space)
+6433: KwPub           "pub" at 545:5-545:8 (leading: Newline, Space)
+6434: KwFn            "fn" at 545:9-545:11 (leading: Space)
+6435: Ident           "__max_value" at 545:12-545:23 (leading: Space)
+6436: LParen          "(" at 545:23-545:24
+6437: RParen          ")" at 545:24-545:25
+6438: Arrow           "->" at 545:26-545:28 (leading: Space)
+6439: Ident           "uint64" at 545:29-545:35 (leading: Space)
+6440: LBrace          "{" at 545:36-545:37 (leading: Space)
+6441: KwReturn        "return" at 545:38-545:44 (leading: Space)
+6442: LParen          "(" at 545:45-545:46 (leading: Space)
+6443: IntLit          "18_446_744_073_709_551_615" at 545:46-545:72
+6444: RParen          ")" at 545:72-545:73
+6445: Colon           ":" at 545:73-545:74
+6446: Ident           "uint64" at 545:74-545:80
+6447: Semicolon       ";" at 545:80-545:81
+6448: RBrace          "}" at 545:82-545:83 (leading: Space)
+6449: At              "@" at 546:5-546:6 (leading: Newline, Space)
+6450: Ident           "intrinsic" at 546:6-546:15
+6451: KwFn            "fn" at 546:16-546:18 (leading: Space)
+6452: Ident           "__add" at 546:19-546:24 (leading: Space)
+6453: LParen          "(" at 546:24-546:25
+6454: Ident           "self" at 546:25-546:29
+6455: Colon           ":" at 546:29-546:30
+6456: Ident           "uint64" at 546:31-546:37 (leading: Space)
+6457: Comma           "," at 546:37-546:38
+6458: Ident           "other" at 546:39-546:44 (leading: Space)
+6459: Colon           ":" at 546:44-546:45
+6460: Ident           "uint64" at 546:46-546:52 (leading: Space)
+6461: RParen          ")" at 546:52-546:53
+6462: Arrow           "->" at 546:54-546:56 (leading: Space)
+6463: Ident           "uint64" at 546:57-546:63 (leading: Space)
+6464: Semicolon       ";" at 546:63-546:64
+6465: At              "@" at 547:5-547:6 (leading: Newline, Space)
+6466: Ident           "intrinsic" at 547:6-547:15
+6467: KwFn            "fn" at 547:16-547:18 (leading: Space)
+6468: Ident           "__sub" at 547:19-547:24 (leading: Space)
+6469: LParen          "(" at 547:24-547:25
+6470: Ident           "self" at 547:25-547:29
+6471: Colon           ":" at 547:29-547:30
+6472: Ident           "uint64" at 547:31-547:37 (leading: Space)
+6473: Comma           "," at 547:37-547:38
+6474: Ident           "other" at 547:39-547:44 (leading: Space)
+6475: Colon           ":" at 547:44-547:45
+6476: Ident           "uint64" at 547:46-547:52 (leading: Space)
+6477: RParen          ")" at 547:52-547:53
+6478: Arrow           "->" at 547:54-547:56 (leading: Space)
+6479: Ident           "uint64" at 547:57-547:63 (leading: Space)
+6480: Semicolon       ";" at 547:63-547:64
+6481: At              "@" at 548:5-548:6 (leading: Newline, Space)
+6482: Ident           "intrinsic" at 548:6-548:15
+6483: KwFn            "fn" at 548:16-548:18 (leading: Space)
+6484: Ident           "__mul" at 548:19-548:24 (leading: Space)
+6485: LParen          "(" at 548:24-548:25
+6486: Ident           "self" at 548:25-548:29
+6487: Colon           ":" at 548:29-548:30
+6488: Ident           "uint64" at 548:31-548:37 (leading: Space)
+6489: Comma           "," at 548:37-548:38
+6490: Ident           "other" at 548:39-548:44 (leading: Space)
+6491: Colon           ":" at 548:44-548:45
+6492: Ident           "uint64" at 548:46-548:52 (leading: Space)
+6493: RParen          ")" at 548:52-548:53
+6494: Arrow           "->" at 548:54-548:56 (leading: Space)
+6495: Ident           "uint64" at 548:57-548:63 (leading: Space)
+6496: Semicolon       ";" at 548:63-548:64
+6497: At              "@" at 549:5-549:6 (leading: Newline, Space)
+6498: Ident           "intrinsic" at 549:6-549:15
+6499: KwFn            "fn" at 549:16-549:18 (leading: Space)
+6500: Ident           "__div" at 549:19-549:24 (leading: Space)
+6501: LParen          "(" at 549:24-549:25
+6502: Ident           "self" at 549:25-549:29
+6503: Colon           ":" at 549:29-549:30
+6504: Ident           "uint64" at 549:31-549:37 (leading: Space)
+6505: Comma           "," at 549:37-549:38
+6506: Ident           "other" at 549:39-549:44 (leading: Space)
+6507: Colon           ":" at 549:44-549:45
+6508: Ident           "uint64" at 549:46-549:52 (leading: Space)
+6509: RParen          ")" at 549:52-549:53
+6510: Arrow           "->" at 549:54-549:56 (leading: Space)
+6511: Ident           "uint64" at 549:57-549:63 (leading: Space)
+6512: Semicolon       ";" at 549:63-549:64
+6513: At              "@" at 550:5-550:6 (leading: Newline, Space)
+6514: Ident           "intrinsic" at 550:6-550:15
+6515: KwFn            "fn" at 550:16-550:18 (leading: Space)
+6516: Ident           "__mod" at 550:19-550:24 (leading: Space)
+6517: LParen          "(" at 550:24-550:25
+6518: Ident           "self" at 550:25-550:29
+6519: Colon           ":" at 550:29-550:30
+6520: Ident           "uint64" at 550:31-550:37 (leading: Space)
+6521: Comma           "," at 550:37-550:38
+6522: Ident           "other" at 550:39-550:44 (leading: Space)
+6523: Colon           ":" at 550:44-550:45
+6524: Ident           "uint64" at 550:46-550:52 (leading: Space)
+6525: RParen          ")" at 550:52-550:53
+6526: Arrow           "->" at 550:54-550:56 (leading: Space)
+6527: Ident           "uint64" at 550:57-550:63 (leading: Space)
+6528: Semicolon       ";" at 550:63-550:64
+6529: At              "@" at 551:5-551:6 (leading: Newline, Space)
+6530: Ident           "intrinsic" at 551:6-551:15
+6531: KwFn            "fn" at 551:16-551:18 (leading: Space)
+6532: Ident           "__bit_and" at 551:19-551:28 (leading: Space)
+6533: LParen          "(" at 551:28-551:29
+6534: Ident           "self" at 551:29-551:33
+6535: Colon           ":" at 551:33-551:34
+6536: Ident           "uint64" at 551:35-551:41 (leading: Space)
+6537: Comma           "," at 551:41-551:42
+6538: Ident           "other" at 551:43-551:48 (leading: Space)
+6539: Colon           ":" at 551:48-551:49
+6540: Ident           "uint64" at 551:50-551:56 (leading: Space)
+6541: RParen          ")" at 551:56-551:57
+6542: Arrow           "->" at 551:58-551:60 (leading: Space)
+6543: Ident           "uint64" at 551:61-551:67 (leading: Space)
+6544: Semicolon       ";" at 551:67-551:68
+6545: At              "@" at 552:5-552:6 (leading: Newline, Space)
+6546: Ident           "intrinsic" at 552:6-552:15
+6547: KwFn            "fn" at 552:16-552:18 (leading: Space)
+6548: Ident           "__bit_or" at 552:19-552:27 (leading: Space)
+6549: LParen          "(" at 552:27-552:28
+6550: Ident           "self" at 552:28-552:32
+6551: Colon           ":" at 552:32-552:33
+6552: Ident           "uint64" at 552:34-552:40 (leading: Space)
+6553: Comma           "," at 552:40-552:41
+6554: Ident           "other" at 552:42-552:47 (leading: Space)
+6555: Colon           ":" at 552:47-552:48
+6556: Ident           "uint64" at 552:49-552:55 (leading: Space)
+6557: RParen          ")" at 552:55-552:56
+6558: Arrow           "->" at 552:57-552:59 (leading: Space)
+6559: Ident           "uint64" at 552:60-552:66 (leading: Space)
+6560: Semicolon       ";" at 552:66-552:67
+6561: At              "@" at 553:5-553:6 (leading: Newline, Space)
+6562: Ident           "intrinsic" at 553:6-553:15
+6563: KwFn            "fn" at 553:16-553:18 (leading: Space)
+6564: Ident           "__bit_xor" at 553:19-553:28 (leading: Space)
+6565: LParen          "(" at 553:28-553:29
+6566: Ident           "self" at 553:29-553:33
+6567: Colon           ":" at 553:33-553:34
+6568: Ident           "uint64" at 553:35-553:41 (leading: Space)
+6569: Comma           "," at 553:41-553:42
+6570: Ident           "other" at 553:43-553:48 (leading: Space)
+6571: Colon           ":" at 553:48-553:49
+6572: Ident           "uint64" at 553:50-553:56 (leading: Space)
+6573: RParen          ")" at 553:56-553:57
+6574: Arrow           "->" at 553:58-553:60 (leading: Space)
+6575: Ident           "uint64" at 553:61-553:67 (leading: Space)
+6576: Semicolon       ";" at 553:67-553:68
+6577: At              "@" at 554:5-554:6 (leading: Newline, Space)
+6578: Ident           "intrinsic" at 554:6-554:15
+6579: KwFn            "fn" at 554:16-554:18 (leading: Space)
+6580: Ident           "__shl" at 554:19-554:24 (leading: Space)
+6581: LParen          "(" at 554:24-554:25
+6582: Ident           "self" at 554:25-554:29
+6583: Colon           ":" at 554:29-554:30
+6584: Ident           "uint64" at 554:31-554:37 (leading: Space)
+6585: Comma           "," at 554:37-554:38
+6586: Ident           "other" at 554:39-554:44 (leading: Space)
+6587: Colon           ":" at 554:44-554:45
+6588: Ident           "uint64" at 554:46-554:52 (leading: Space)
+6589: RParen          ")" at 554:52-554:53
+6590: Arrow           "->" at 554:54-554:56 (leading: Space)
+6591: Ident           "uint64" at 554:57-554:63 (leading: Space)
+6592: Semicolon       ";" at 554:63-554:64
+6593: At              "@" at 555:5-555:6 (leading: Newline, Space)
+6594: Ident           "intrinsic" at 555:6-555:15
+6595: KwFn            "fn" at 555:16-555:18 (leading: Space)
+6596: Ident           "__shr" at 555:19-555:24 (leading: Space)
+6597: LParen          "(" at 555:24-555:25
+6598: Ident           "self" at 555:25-555:29
+6599: Colon           ":" at 555:29-555:30
+6600: Ident           "uint64" at 555:31-555:37 (leading: Space)
+6601: Comma           "," at 555:37-555:38
+6602: Ident           "other" at 555:39-555:44 (leading: Space)
+6603: Colon           ":" at 555:44-555:45
+6604: Ident           "uint64" at 555:46-555:52 (leading: Space)
+6605: RParen          ")" at 555:52-555:53
+6606: Arrow           "->" at 555:54-555:56 (leading: Space)
+6607: Ident           "uint64" at 555:57-555:63 (leading: Space)
+6608: Semicolon       ";" at 555:63-555:64
+6609: At              "@" at 556:5-556:6 (leading: Newline, Space)
+6610: Ident           "intrinsic" at 556:6-556:15
+6611: KwFn            "fn" at 556:16-556:18 (leading: Space)
+6612: Ident           "__lt" at 556:19-556:23 (leading: Space)
+6613: LParen          "(" at 556:23-556:24
+6614: Ident           "self" at 556:24-556:28
+6615: Colon           ":" at 556:28-556:29
+6616: Ident           "uint64" at 556:30-556:36 (leading: Space)
+6617: Comma           "," at 556:36-556:37
+6618: Ident           "other" at 556:38-556:43 (leading: Space)
+6619: Colon           ":" at 556:43-556:44
+6620: Ident           "uint64" at 556:45-556:51 (leading: Space)
+6621: RParen          ")" at 556:51-556:52
+6622: Arrow           "->" at 556:53-556:55 (leading: Space)
+6623: Ident           "bool" at 556:56-556:60 (leading: Space)
+6624: Semicolon       ";" at 556:60-556:61
+6625: At              "@" at 557:5-557:6 (leading: Newline, Space)
+6626: Ident           "intrinsic" at 557:6-557:15
+6627: KwFn            "fn" at 557:16-557:18 (leading: Space)
+6628: Ident           "__le" at 557:19-557:23 (leading: Space)
+6629: LParen          "(" at 557:23-557:24
+6630: Ident           "self" at 557:24-557:28
+6631: Colon           ":" at 557:28-557:29
+6632: Ident           "uint64" at 557:30-557:36 (leading: Space)
+6633: Comma           "," at 557:36-557:37
+6634: Ident           "other" at 557:38-557:43 (leading: Space)
+6635: Colon           ":" at 557:43-557:44
+6636: Ident           "uint64" at 557:45-557:51 (leading: Space)
+6637: RParen          ")" at 557:51-557:52
+6638: Arrow           "->" at 557:53-557:55 (leading: Space)
+6639: Ident           "bool" at 557:56-557:60 (leading: Space)
+6640: Semicolon       ";" at 557:60-557:61
+6641: At              "@" at 558:5-558:6 (leading: Newline, Space)
+6642: Ident           "intrinsic" at 558:6-558:15
+6643: KwFn            "fn" at 558:16-558:18 (leading: Space)
+6644: Ident           "__eq" at 558:19-558:23 (leading: Space)
+6645: LParen          "(" at 558:23-558:24
+6646: Ident           "self" at 558:24-558:28
+6647: Colon           ":" at 558:28-558:29
+6648: Ident           "uint64" at 558:30-558:36 (leading: Space)
+6649: Comma           "," at 558:36-558:37
+6650: Ident           "other" at 558:38-558:43 (leading: Space)
+6651: Colon           ":" at 558:43-558:44
+6652: Ident           "uint64" at 558:45-558:51 (leading: Space)
+6653: RParen          ")" at 558:51-558:52
+6654: Arrow           "->" at 558:53-558:55 (leading: Space)
+6655: Ident           "bool" at 558:56-558:60 (leading: Space)
+6656: Semicolon       ";" at 558:60-558:61
+6657: At              "@" at 559:5-559:6 (leading: Newline, Space)
+6658: Ident           "intrinsic" at 559:6-559:15
+6659: KwFn            "fn" at 559:16-559:18 (leading: Space)
+6660: Ident           "__ne" at 559:19-559:23 (leading: Space)
+6661: LParen          "(" at 559:23-559:24
+6662: Ident           "self" at 559:24-559:28
+6663: Colon           ":" at 559:28-559:29
+6664: Ident           "uint64" at 559:30-559:36 (leading: Space)
+6665: Comma           "," at 559:36-559:37
+6666: Ident           "other" at 559:38-559:43 (leading: Space)
+6667: Colon           ":" at 559:43-559:44
+6668: Ident           "uint64" at 559:45-559:51 (leading: Space)
+6669: RParen          ")" at 559:51-559:52
+6670: Arrow           "->" at 559:53-559:55 (leading: Space)
+6671: Ident           "bool" at 559:56-559:60 (leading: Space)
+6672: Semicolon       ";" at 559:60-559:61
+6673: At              "@" at 560:5-560:6 (leading: Newline, Space)
+6674: Ident           "intrinsic" at 560:6-560:15
+6675: KwFn            "fn" at 560:16-560:18 (leading: Space)
+6676: Ident           "__ge" at 560:19-560:23 (leading: Space)
+6677: LParen          "(" at 560:23-560:24
+6678: Ident           "self" at 560:24-560:28
+6679: Colon           ":" at 560:28-560:29
+6680: Ident           "uint64" at 560:30-560:36 (leading: Space)
+6681: Comma           "," at 560:36-560:37
+6682: Ident           "other" at 560:38-560:43 (leading: Space)
+6683: Colon           ":" at 560:43-560:44
+6684: Ident           "uint64" at 560:45-560:51 (leading: Space)
+6685: RParen          ")" at 560:51-560:52
+6686: Arrow           "->" at 560:53-560:55 (leading: Space)
+6687: Ident           "bool" at 560:56-560:60 (leading: Space)
+6688: Semicolon       ";" at 560:60-560:61
+6689: At              "@" at 561:5-561:6 (leading: Newline, Space)
+6690: Ident           "intrinsic" at 561:6-561:15
+6691: KwFn            "fn" at 561:16-561:18 (leading: Space)
+6692: Ident           "__gt" at 561:19-561:23 (leading: Space)
+6693: LParen          "(" at 561:23-561:24
+6694: Ident           "self" at 561:24-561:28
+6695: Colon           ":" at 561:28-561:29
+6696: Ident           "uint64" at 561:30-561:36 (leading: Space)
+6697: Comma           "," at 561:36-561:37
+6698: Ident           "other" at 561:38-561:43 (leading: Space)
+6699: Colon           ":" at 561:43-561:44
+6700: Ident           "uint64" at 561:45-561:51 (leading: Space)
+6701: RParen          ")" at 561:51-561:52
+6702: Arrow           "->" at 561:53-561:55 (leading: Space)
+6703: Ident           "bool" at 561:56-561:60 (leading: Space)
+6704: Semicolon       ";" at 561:60-561:61
+6705: At              "@" at 562:5-562:6 (leading: Newline, Space)
+6706: Ident           "intrinsic" at 562:6-562:15
+6707: KwFn            "fn" at 562:16-562:18 (leading: Space)
+6708: Ident           "__pos" at 562:19-562:24 (leading: Space)
+6709: LParen          "(" at 562:24-562:25
+6710: Ident           "self" at 562:25-562:29
+6711: Colon           ":" at 562:29-562:30
+6712: Ident           "uint64" at 562:31-562:37 (leading: Space)
+6713: RParen          ")" at 562:37-562:38
+6714: Arrow           "->" at 562:39-562:41 (leading: Space)
+6715: Ident           "uint64" at 562:42-562:48 (leading: Space)
+6716: Semicolon       ";" at 562:48-562:49
+6717: At              "@" at 563:5-563:6 (leading: Newline, Space)
+6718: Ident           "intrinsic" at 563:6-563:15
+6719: KwFn            "fn" at 563:16-563:18 (leading: Space)
+6720: Ident           "__abs" at 563:19-563:24 (leading: Space)
+6721: LParen          "(" at 563:24-563:25
+6722: Ident           "self" at 563:25-563:29
+6723: Colon           ":" at 563:29-563:30
+6724: Ident           "uint64" at 563:31-563:37 (leading: Space)
+6725: RParen          ")" at 563:37-563:38
+6726: Arrow           "->" at 563:39-563:41 (leading: Space)
+6727: Ident           "uint64" at 563:42-563:48 (leading: Space)
+6728: Semicolon       ";" at 563:48-563:49
+6729: At              "@" at 564:5-564:6 (leading: Newline, Space)
+6730: Ident           "intrinsic" at 564:6-564:15
+6731: KwFn            "fn" at 564:16-564:18 (leading: Space)
+6732: Ident           "__to" at 564:19-564:23 (leading: Space)
+6733: LParen          "(" at 564:23-564:24
+6734: Ident           "self" at 564:24-564:28
+6735: Colon           ":" at 564:28-564:29
+6736: Ident           "uint64" at 564:30-564:36 (leading: Space)
+6737: Comma           "," at 564:36-564:37
+6738: Ident           "target" at 564:38-564:44 (leading: Space)
+6739: Colon           ":" at 564:44-564:45
+6740: Ident           "uint" at 564:46-564:50 (leading: Space)
+6741: RParen          ")" at 564:50-564:51
+6742: Arrow           "->" at 564:52-564:54 (leading: Space)
+6743: Ident           "uint" at 564:55-564:59 (leading: Space)
+6744: Semicolon       ";" at 564:59-564:60
+6745: At              "@" at 565:5-565:6 (leading: Newline, Space)
+6746: Ident           "intrinsic" at 565:6-565:15
+6747: At              "@" at 565:16-565:17 (leading: Space)
+6748: Ident           "overload" at 565:17-565:25
+6749: KwFn            "fn" at 565:26-565:28 (leading: Space)
+6750: Ident           "__to" at 565:29-565:33 (leading: Space)
+6751: LParen          "(" at 565:33-565:34
+6752: Ident           "self" at 565:34-565:38
+6753: Colon           ":" at 565:38-565:39
+6754: Ident           "uint64" at 565:40-565:46 (leading: Space)
+6755: Comma           "," at 565:46-565:47
+6756: Ident           "target" at 565:48-565:54 (leading: Space)
+6757: Colon           ":" at 565:54-565:55
+6758: Ident           "uint8" at 565:56-565:61 (leading: Space)
+6759: RParen          ")" at 565:61-565:62
+6760: Arrow           "->" at 565:63-565:65 (leading: Space)
+6761: Ident           "uint8" at 565:66-565:71 (leading: Space)
+6762: Semicolon       ";" at 565:71-565:72
+6763: At              "@" at 566:5-566:6 (leading: Newline, Space)
+6764: Ident           "intrinsic" at 566:6-566:15
+6765: At              "@" at 566:16-566:17 (leading: Space)
+6766: Ident           "overload" at 566:17-566:25
+6767: KwFn            "fn" at 566:26-566:28 (leading: Space)
+6768: Ident           "__to" at 566:29-566:33 (leading: Space)
+6769: LParen          "(" at 566:33-566:34
+6770: Ident           "self" at 566:34-566:38
+6771: Colon           ":" at 566:38-566:39
+6772: Ident           "uint64" at 566:40-566:46 (leading: Space)
+6773: Comma           "," at 566:46-566:47
+6774: Ident           "target" at 566:48-566:54 (leading: Space)
+6775: Colon           ":" at 566:54-566:55
+6776: Ident           "uint16" at 566:56-566:62 (leading: Space)
+6777: RParen          ")" at 566:62-566:63
+6778: Arrow           "->" at 566:64-566:66 (leading: Space)
+6779: Ident           "uint16" at 566:67-566:73 (leading: Space)
+6780: Semicolon       ";" at 566:73-566:74
+6781: At              "@" at 567:5-567:6 (leading: Newline, Space)
+6782: Ident           "intrinsic" at 567:6-567:15
+6783: At              "@" at 567:16-567:17 (leading: Space)
+6784: Ident           "overload" at 567:17-567:25
+6785: KwFn            "fn" at 567:26-567:28 (leading: Space)
+6786: Ident           "__to" at 567:29-567:33 (leading: Space)
+6787: LParen          "(" at 567:33-567:34
+6788: Ident           "self" at 567:34-567:38
+6789: Colon           ":" at 567:38-567:39
+6790: Ident           "uint64" at 567:40-567:46 (leading: Space)
+6791: Comma           "," at 567:46-567:47
+6792: Ident           "target" at 567:48-567:54 (leading: Space)
+6793: Colon           ":" at 567:54-567:55
+6794: Ident           "uint32" at 567:56-567:62 (leading: Space)
+6795: RParen          ")" at 567:62-567:63
+6796: Arrow           "->" at 567:64-567:66 (leading: Space)
+6797: Ident           "uint32" at 567:67-567:73 (leading: Space)
+6798: Semicolon       ";" at 567:73-567:74
+6799: At              "@" at 568:5-568:6 (leading: Newline, Space)
+6800: Ident           "intrinsic" at 568:6-568:15
+6801: KwPub           "pub" at 568:16-568:19 (leading: Space)
+6802: KwFn            "fn" at 568:20-568:22 (leading: Space)
+6803: Ident           "from_str" at 568:23-568:31 (leading: Space)
+6804: LParen          "(" at 568:31-568:32
+6805: Ident           "s" at 568:32-568:33
+6806: Colon           ":" at 568:33-568:34
+6807: Amp             "&" at 568:35-568:36 (leading: Space)
+6808: Ident           "string" at 568:36-568:42
+6809: RParen          ")" at 568:42-568:43
+6810: Arrow           "->" at 568:44-568:46 (leading: Space)
+6811: Ident           "Erring" at 568:47-568:53 (leading: Space)
+6812: Lt              "<" at 568:53-568:54
+6813: Ident           "uint64" at 568:54-568:60
+6814: Comma           "," at 568:60-568:61
+6815: Ident           "Error" at 568:62-568:67 (leading: Space)
+6816: Gt              ">" at 568:67-568:68
+6817: Semicolon       ";" at 568:68-568:69
+6818: RBrace          "}" at 569:1-569:2 (leading: Newline)
+6819: KwExtern        "extern" at 571:1-571:7 (leading: Newline)
+6820: Lt              "<" at 571:7-571:8
+6821: Ident           "float16" at 571:8-571:15
+6822: Gt              ">" at 571:15-571:16
+6823: LBrace          "{" at 571:17-571:18 (leading: Space)
+6824: KwPub           "pub" at 572:5-572:8 (leading: Newline, Space)
+6825: KwFn            "fn" at 572:9-572:11 (leading: Space)
+6826: Ident           "__min_value" at 572:12-572:23 (leading: Space)
+6827: LParen          "(" at 572:23-572:24
+6828: RParen          ")" at 572:24-572:25
+6829: Arrow           "->" at 572:26-572:28 (leading: Space)
+6830: Ident           "float16" at 572:29-572:36 (leading: Space)
+6831: LBrace          "{" at 572:37-572:38 (leading: Space)
+6832: KwReturn        "return" at 572:39-572:45 (leading: Space)
+6833: LParen          "(" at 572:46-572:47 (leading: Space)
+6834: Minus           "-" at 572:47-572:48
+6835: FloatLit        "65504.0" at 572:48-572:55
+6836: RParen          ")" at 572:55-572:56
+6837: Colon           ":" at 572:56-572:57
+6838: Ident           "float16" at 572:57-572:64
+6839: Semicolon       ";" at 572:64-572:65
+6840: RBrace          "}" at 572:66-572:67 (leading: Space)
+6841: KwPub           "pub" at 573:5-573:8 (leading: Newline, Space)
+6842: KwFn            "fn" at 573:9-573:11 (leading: Space)
+6843: Ident           "__max_value" at 573:12-573:23 (leading: Space)
+6844: LParen          "(" at 573:23-573:24
+6845: RParen          ")" at 573:24-573:25
+6846: Arrow           "->" at 573:26-573:28 (leading: Space)
+6847: Ident           "float16" at 573:29-573:36 (leading: Space)
+6848: LBrace          "{" at 573:37-573:38 (leading: Space)
+6849: KwReturn        "return" at 573:39-573:45 (leading: Space)
+6850: LParen          "(" at 573:46-573:47 (leading: Space)
+6851: FloatLit        "65504.0" at 573:47-573:54
+6852: RParen          ")" at 573:54-573:55
+6853: Colon           ":" at 573:55-573:56
+6854: Ident           "float16" at 573:56-573:63
+6855: Semicolon       ";" at 573:63-573:64
+6856: RBrace          "}" at 573:65-573:66 (leading: Space)
+6857: At              "@" at 574:5-574:6 (leading: Newline, Space)
+6858: Ident           "intrinsic" at 574:6-574:15
+6859: KwFn            "fn" at 574:16-574:18 (leading: Space)
+6860: Ident           "__add" at 574:19-574:24 (leading: Space)
+6861: LParen          "(" at 574:24-574:25
+6862: Ident           "self" at 574:25-574:29
+6863: Colon           ":" at 574:29-574:30
+6864: Ident           "float16" at 574:31-574:38 (leading: Space)
+6865: Comma           "," at 574:38-574:39
+6866: Ident           "other" at 574:40-574:45 (leading: Space)
+6867: Colon           ":" at 574:45-574:46
+6868: Ident           "float16" at 574:47-574:54 (leading: Space)
+6869: RParen          ")" at 574:54-574:55
+6870: Arrow           "->" at 574:56-574:58 (leading: Space)
+6871: Ident           "float16" at 574:59-574:66 (leading: Space)
+6872: Semicolon       ";" at 574:66-574:67
+6873: At              "@" at 575:5-575:6 (leading: Newline, Space)
+6874: Ident           "intrinsic" at 575:6-575:15
+6875: KwFn            "fn" at 575:16-575:18 (leading: Space)
+6876: Ident           "__sub" at 575:19-575:24 (leading: Space)
+6877: LParen          "(" at 575:24-575:25
+6878: Ident           "self" at 575:25-575:29
+6879: Colon           ":" at 575:29-575:30
+6880: Ident           "float16" at 575:31-575:38 (leading: Space)
+6881: Comma           "," at 575:38-575:39
+6882: Ident           "other" at 575:40-575:45 (leading: Space)
+6883: Colon           ":" at 575:45-575:46
+6884: Ident           "float16" at 575:47-575:54 (leading: Space)
+6885: RParen          ")" at 575:54-575:55
+6886: Arrow           "->" at 575:56-575:58 (leading: Space)
+6887: Ident           "float16" at 575:59-575:66 (leading: Space)
+6888: Semicolon       ";" at 575:66-575:67
+6889: At              "@" at 576:5-576:6 (leading: Newline, Space)
+6890: Ident           "intrinsic" at 576:6-576:15
+6891: KwFn            "fn" at 576:16-576:18 (leading: Space)
+6892: Ident           "__mul" at 576:19-576:24 (leading: Space)
+6893: LParen          "(" at 576:24-576:25
+6894: Ident           "self" at 576:25-576:29
+6895: Colon           ":" at 576:29-576:30
+6896: Ident           "float16" at 576:31-576:38 (leading: Space)
+6897: Comma           "," at 576:38-576:39
+6898: Ident           "other" at 576:40-576:45 (leading: Space)
+6899: Colon           ":" at 576:45-576:46
+6900: Ident           "float16" at 576:47-576:54 (leading: Space)
+6901: RParen          ")" at 576:54-576:55
+6902: Arrow           "->" at 576:56-576:58 (leading: Space)
+6903: Ident           "float16" at 576:59-576:66 (leading: Space)
+6904: Semicolon       ";" at 576:66-576:67
+6905: At              "@" at 577:5-577:6 (leading: Newline, Space)
+6906: Ident           "intrinsic" at 577:6-577:15
+6907: KwFn            "fn" at 577:16-577:18 (leading: Space)
+6908: Ident           "__div" at 577:19-577:24 (leading: Space)
+6909: LParen          "(" at 577:24-577:25
+6910: Ident           "self" at 577:25-577:29
+6911: Colon           ":" at 577:29-577:30
+6912: Ident           "float16" at 577:31-577:38 (leading: Space)
+6913: Comma           "," at 577:38-577:39
+6914: Ident           "other" at 577:40-577:45 (leading: Space)
+6915: Colon           ":" at 577:45-577:46
+6916: Ident           "float16" at 577:47-577:54 (leading: Space)
+6917: RParen          ")" at 577:54-577:55
+6918: Arrow           "->" at 577:56-577:58 (leading: Space)
+6919: Ident           "float16" at 577:59-577:66 (leading: Space)
+6920: Semicolon       ";" at 577:66-577:67
+6921: At              "@" at 578:5-578:6 (leading: Newline, Space)
+6922: Ident           "intrinsic" at 578:6-578:15
+6923: KwFn            "fn" at 578:16-578:18 (leading: Space)
+6924: Ident           "__mod" at 578:19-578:24 (leading: Space)
+6925: LParen          "(" at 578:24-578:25
+6926: Ident           "self" at 578:25-578:29
+6927: Colon           ":" at 578:29-578:30
+6928: Ident           "float16" at 578:31-578:38 (leading: Space)
+6929: Comma           "," at 578:38-578:39
+6930: Ident           "other" at 578:40-578:45 (leading: Space)
+6931: Colon           ":" at 578:45-578:46
+6932: Ident           "float16" at 578:47-578:54 (leading: Space)
+6933: RParen          ")" at 578:54-578:55
+6934: Arrow           "->" at 578:56-578:58 (leading: Space)
+6935: Ident           "float16" at 578:59-578:66 (leading: Space)
+6936: Semicolon       ";" at 578:66-578:67
+6937: At              "@" at 579:5-579:6 (leading: Newline, Space)
+6938: Ident           "intrinsic" at 579:6-579:15
+6939: KwFn            "fn" at 579:16-579:18 (leading: Space)
+6940: Ident           "__lt" at 579:19-579:23 (leading: Space)
+6941: LParen          "(" at 579:23-579:24
+6942: Ident           "self" at 579:24-579:28
+6943: Colon           ":" at 579:28-579:29
+6944: Ident           "float16" at 579:30-579:37 (leading: Space)
+6945: Comma           "," at 579:37-579:38
+6946: Ident           "other" at 579:39-579:44 (leading: Space)
+6947: Colon           ":" at 579:44-579:45
+6948: Ident           "float16" at 579:46-579:53 (leading: Space)
+6949: RParen          ")" at 579:53-579:54
+6950: Arrow           "->" at 579:55-579:57 (leading: Space)
+6951: Ident           "bool" at 579:58-579:62 (leading: Space)
+6952: Semicolon       ";" at 579:62-579:63
+6953: At              "@" at 580:5-580:6 (leading: Newline, Space)
+6954: Ident           "intrinsic" at 580:6-580:15
+6955: KwFn            "fn" at 580:16-580:18 (leading: Space)
+6956: Ident           "__le" at 580:19-580:23 (leading: Space)
+6957: LParen          "(" at 580:23-580:24
+6958: Ident           "self" at 580:24-580:28
+6959: Colon           ":" at 580:28-580:29
+6960: Ident           "float16" at 580:30-580:37 (leading: Space)
+6961: Comma           "," at 580:37-580:38
+6962: Ident           "other" at 580:39-580:44 (leading: Space)
+6963: Colon           ":" at 580:44-580:45
+6964: Ident           "float16" at 580:46-580:53 (leading: Space)
+6965: RParen          ")" at 580:53-580:54
+6966: Arrow           "->" at 580:55-580:57 (leading: Space)
+6967: Ident           "bool" at 580:58-580:62 (leading: Space)
+6968: Semicolon       ";" at 580:62-580:63
+6969: At              "@" at 581:5-581:6 (leading: Newline, Space)
+6970: Ident           "intrinsic" at 581:6-581:15
+6971: KwFn            "fn" at 581:16-581:18 (leading: Space)
+6972: Ident           "__eq" at 581:19-581:23 (leading: Space)
+6973: LParen          "(" at 581:23-581:24
+6974: Ident           "self" at 581:24-581:28
+6975: Colon           ":" at 581:28-581:29
+6976: Ident           "float16" at 581:30-581:37 (leading: Space)
+6977: Comma           "," at 581:37-581:38
+6978: Ident           "other" at 581:39-581:44 (leading: Space)
+6979: Colon           ":" at 581:44-581:45
+6980: Ident           "float16" at 581:46-581:53 (leading: Space)
+6981: RParen          ")" at 581:53-581:54
+6982: Arrow           "->" at 581:55-581:57 (leading: Space)
+6983: Ident           "bool" at 581:58-581:62 (leading: Space)
+6984: Semicolon       ";" at 581:62-581:63
+6985: At              "@" at 582:5-582:6 (leading: Newline, Space)
+6986: Ident           "intrinsic" at 582:6-582:15
+6987: KwFn            "fn" at 582:16-582:18 (leading: Space)
+6988: Ident           "__ne" at 582:19-582:23 (leading: Space)
+6989: LParen          "(" at 582:23-582:24
+6990: Ident           "self" at 582:24-582:28
+6991: Colon           ":" at 582:28-582:29
+6992: Ident           "float16" at 582:30-582:37 (leading: Space)
+6993: Comma           "," at 582:37-582:38
+6994: Ident           "other" at 582:39-582:44 (leading: Space)
+6995: Colon           ":" at 582:44-582:45
+6996: Ident           "float16" at 582:46-582:53 (leading: Space)
+6997: RParen          ")" at 582:53-582:54
+6998: Arrow           "->" at 582:55-582:57 (leading: Space)
+6999: Ident           "bool" at 582:58-582:62 (leading: Space)
+7000: Semicolon       ";" at 582:62-582:63
+7001: At              "@" at 583:5-583:6 (leading: Newline, Space)
+7002: Ident           "intrinsic" at 583:6-583:15
+7003: KwFn            "fn" at 583:16-583:18 (leading: Space)
+7004: Ident           "__ge" at 583:19-583:23 (leading: Space)
+7005: LParen          "(" at 583:23-583:24
+7006: Ident           "self" at 583:24-583:28
+7007: Colon           ":" at 583:28-583:29
+7008: Ident           "float16" at 583:30-583:37 (leading: Space)
+7009: Comma           "," at 583:37-583:38
+7010: Ident           "other" at 583:39-583:44 (leading: Space)
+7011: Colon           ":" at 583:44-583:45
+7012: Ident           "float16" at 583:46-583:53 (leading: Space)
+7013: RParen          ")" at 583:53-583:54
+7014: Arrow           "->" at 583:55-583:57 (leading: Space)
+7015: Ident           "bool" at 583:58-583:62 (leading: Space)
+7016: Semicolon       ";" at 583:62-583:63
+7017: At              "@" at 584:5-584:6 (leading: Newline, Space)
+7018: Ident           "intrinsic" at 584:6-584:15
+7019: KwFn            "fn" at 584:16-584:18 (leading: Space)
+7020: Ident           "__gt" at 584:19-584:23 (leading: Space)
+7021: LParen          "(" at 584:23-584:24
+7022: Ident           "self" at 584:24-584:28
+7023: Colon           ":" at 584:28-584:29
+7024: Ident           "float16" at 584:30-584:37 (leading: Space)
+7025: Comma           "," at 584:37-584:38
+7026: Ident           "other" at 584:39-584:44 (leading: Space)
+7027: Colon           ":" at 584:44-584:45
+7028: Ident           "float16" at 584:46-584:53 (leading: Space)
+7029: RParen          ")" at 584:53-584:54
+7030: Arrow           "->" at 584:55-584:57 (leading: Space)
+7031: Ident           "bool" at 584:58-584:62 (leading: Space)
+7032: Semicolon       ";" at 584:62-584:63
+7033: At              "@" at 585:5-585:6 (leading: Newline, Space)
+7034: Ident           "intrinsic" at 585:6-585:15
+7035: KwFn            "fn" at 585:16-585:18 (leading: Space)
+7036: Ident           "__pos" at 585:19-585:24 (leading: Space)
+7037: LParen          "(" at 585:24-585:25
+7038: Ident           "self" at 585:25-585:29
+7039: Colon           ":" at 585:29-585:30
+7040: Ident           "float16" at 585:31-585:38 (leading: Space)
+7041: RParen          ")" at 585:38-585:39
+7042: Arrow           "->" at 585:40-585:42 (leading: Space)
+7043: Ident           "float16" at 585:43-585:50 (leading: Space)
+7044: Semicolon       ";" at 585:50-585:51
+7045: At              "@" at 586:5-586:6 (leading: Newline, Space)
+7046: Ident           "intrinsic" at 586:6-586:15
+7047: KwFn            "fn" at 586:16-586:18 (leading: Space)
+7048: Ident           "__neg" at 586:19-586:24 (leading: Space)
+7049: LParen          "(" at 586:24-586:25
+7050: Ident           "self" at 586:25-586:29
+7051: Colon           ":" at 586:29-586:30
+7052: Ident           "float16" at 586:31-586:38 (leading: Space)
+7053: RParen          ")" at 586:38-586:39
+7054: Arrow           "->" at 586:40-586:42 (leading: Space)
+7055: Ident           "float16" at 586:43-586:50 (leading: Space)
+7056: Semicolon       ";" at 586:50-586:51
+7057: At              "@" at 587:5-587:6 (leading: Newline, Space)
+7058: Ident           "intrinsic" at 587:6-587:15
+7059: KwFn            "fn" at 587:16-587:18 (leading: Space)
+7060: Ident           "__abs" at 587:19-587:24 (leading: Space)
+7061: LParen          "(" at 587:24-587:25
+7062: Ident           "self" at 587:25-587:29
+7063: Colon           ":" at 587:29-587:30
+7064: Ident           "float16" at 587:31-587:38 (leading: Space)
+7065: RParen          ")" at 587:38-587:39
+7066: Arrow           "->" at 587:40-587:42 (leading: Space)
+7067: Ident           "float16" at 587:43-587:50 (leading: Space)
+7068: Semicolon       ";" at 587:50-587:51
+7069: At              "@" at 588:5-588:6 (leading: Newline, Space)
+7070: Ident           "intrinsic" at 588:6-588:15
+7071: KwFn            "fn" at 588:16-588:18 (leading: Space)
+7072: Ident           "__to" at 588:19-588:23 (leading: Space)
+7073: LParen          "(" at 588:23-588:24
+7074: Ident           "self" at 588:24-588:28
+7075: Colon           ":" at 588:28-588:29
+7076: Ident           "float16" at 588:30-588:37 (leading: Space)
+7077: Comma           "," at 588:37-588:38
+7078: Ident           "target" at 588:39-588:45 (leading: Space)
+7079: Colon           ":" at 588:45-588:46
+7080: Ident           "float" at 588:47-588:52 (leading: Space)
+7081: RParen          ")" at 588:52-588:53
+7082: Arrow           "->" at 588:54-588:56 (leading: Space)
+7083: Ident           "float" at 588:57-588:62 (leading: Space)
+7084: Semicolon       ";" at 588:62-588:63
+7085: At              "@" at 589:5-589:6 (leading: Newline, Space)
+7086: Ident           "intrinsic" at 589:6-589:15
+7087: At              "@" at 589:16-589:17 (leading: Space)
+7088: Ident           "overload" at 589:17-589:25
+7089: KwFn            "fn" at 589:26-589:28 (leading: Space)
+7090: Ident           "__to" at 589:29-589:33 (leading: Space)
+7091: LParen          "(" at 589:33-589:34
+7092: Ident           "self" at 589:34-589:38
+7093: Colon           ":" at 589:38-589:39
+7094: Ident           "float16" at 589:40-589:47 (leading: Space)
+7095: Comma           "," at 589:47-589:48
+7096: Ident           "target" at 589:49-589:55 (leading: Space)
+7097: Colon           ":" at 589:55-589:56
+7098: Ident           "float32" at 589:57-589:64 (leading: Space)
+7099: RParen          ")" at 589:64-589:65
+7100: Arrow           "->" at 589:66-589:68 (leading: Space)
+7101: Ident           "float32" at 589:69-589:76 (leading: Space)
+7102: Semicolon       ";" at 589:76-589:77
+7103: At              "@" at 590:5-590:6 (leading: Newline, Space)
+7104: Ident           "intrinsic" at 590:6-590:15
+7105: At              "@" at 590:16-590:17 (leading: Space)
+7106: Ident           "overload" at 590:17-590:25
+7107: KwFn            "fn" at 590:26-590:28 (leading: Space)
+7108: Ident           "__to" at 590:29-590:33 (leading: Space)
+7109: LParen          "(" at 590:33-590:34
+7110: Ident           "self" at 590:34-590:38
+7111: Colon           ":" at 590:38-590:39
+7112: Ident           "float16" at 590:40-590:47 (leading: Space)
+7113: Comma           "," at 590:47-590:48
+7114: Ident           "target" at 590:49-590:55 (leading: Space)
+7115: Colon           ":" at 590:55-590:56
+7116: Ident           "float64" at 590:57-590:64 (leading: Space)
+7117: RParen          ")" at 590:64-590:65
+7118: Arrow           "->" at 590:66-590:68 (leading: Space)
+7119: Ident           "float64" at 590:69-590:76 (leading: Space)
+7120: Semicolon       ";" at 590:76-590:77
+7121: At              "@" at 591:5-591:6 (leading: Newline, Space)
+7122: Ident           "intrinsic" at 591:6-591:15
+7123: KwPub           "pub" at 591:16-591:19 (leading: Space)
+7124: KwFn            "fn" at 591:20-591:22 (leading: Space)
+7125: Ident           "from_str" at 591:23-591:31 (leading: Space)
+7126: LParen          "(" at 591:31-591:32
+7127: Ident           "s" at 591:32-591:33
+7128: Colon           ":" at 591:33-591:34
+7129: Amp             "&" at 591:35-591:36 (leading: Space)
+7130: Ident           "string" at 591:36-591:42
+7131: RParen          ")" at 591:42-591:43
+7132: Arrow           "->" at 591:44-591:46 (leading: Space)
+7133: Ident           "Erring" at 591:47-591:53 (leading: Space)
+7134: Lt              "<" at 591:53-591:54
+7135: Ident           "float16" at 591:54-591:61
+7136: Comma           "," at 591:61-591:62
+7137: Ident           "Error" at 591:63-591:68 (leading: Space)
+7138: Gt              ">" at 591:68-591:69
+7139: Semicolon       ";" at 591:69-591:70
+7140: RBrace          "}" at 592:1-592:2 (leading: Newline)
+7141: KwExtern        "extern" at 594:1-594:7 (leading: Newline)
+7142: Lt              "<" at 594:7-594:8
+7143: Ident           "float32" at 594:8-594:15
+7144: Gt              ">" at 594:15-594:16
+7145: LBrace          "{" at 594:17-594:18 (leading: Space)
+7146: KwPub           "pub" at 595:5-595:8 (leading: Newline, Space)
+7147: KwFn            "fn" at 595:9-595:11 (leading: Space)
+7148: Ident           "__min_value" at 595:12-595:23 (leading: Space)
+7149: LParen          "(" at 595:23-595:24
+7150: RParen          ")" at 595:24-595:25
+7151: Arrow           "->" at 595:26-595:28 (leading: Space)
+7152: Ident           "float32" at 595:29-595:36 (leading: Space)
+7153: LBrace          "{" at 595:37-595:38 (leading: Space)
+7154: KwReturn        "return" at 595:39-595:45 (leading: Space)
+7155: LParen          "(" at 595:46-595:47 (leading: Space)
+7156: Minus           "-" at 595:47-595:48
+7157: FloatLit        "3.402_823_466_385_2886e+38" at 595:48-595:74
+7158: RParen          ")" at 595:74-595:75
+7159: Colon           ":" at 595:75-595:76
+7160: Ident           "float32" at 595:76-595:83
+7161: Semicolon       ";" at 595:83-595:84
+7162: RBrace          "}" at 595:85-595:86 (leading: Space)
+7163: KwPub           "pub" at 596:5-596:8 (leading: Newline, Space)
+7164: KwFn            "fn" at 596:9-596:11 (leading: Space)
+7165: Ident           "__max_value" at 596:12-596:23 (leading: Space)
+7166: LParen          "(" at 596:23-596:24
+7167: RParen          ")" at 596:24-596:25
+7168: Arrow           "->" at 596:26-596:28 (leading: Space)
+7169: Ident           "float32" at 596:29-596:36 (leading: Space)
+7170: LBrace          "{" at 596:37-596:38 (leading: Space)
+7171: KwReturn        "return" at 596:39-596:45 (leading: Space)
+7172: LParen          "(" at 596:46-596:47 (leading: Space)
+7173: FloatLit        "3.402_823_466_385_2886e+38" at 596:47-596:73
+7174: RParen          ")" at 596:73-596:74
+7175: Colon           ":" at 596:74-596:75
+7176: Ident           "float32" at 596:75-596:82
+7177: Semicolon       ";" at 596:82-596:83
+7178: RBrace          "}" at 596:84-596:85 (leading: Space)
+7179: At              "@" at 597:5-597:6 (leading: Newline, Space)
+7180: Ident           "intrinsic" at 597:6-597:15
+7181: KwFn            "fn" at 597:16-597:18 (leading: Space)
+7182: Ident           "__add" at 597:19-597:24 (leading: Space)
+7183: LParen          "(" at 597:24-597:25
+7184: Ident           "self" at 597:25-597:29
+7185: Colon           ":" at 597:29-597:30
+7186: Ident           "float32" at 597:31-597:38 (leading: Space)
+7187: Comma           "," at 597:38-597:39
+7188: Ident           "other" at 597:40-597:45 (leading: Space)
+7189: Colon           ":" at 597:45-597:46
+7190: Ident           "float32" at 597:47-597:54 (leading: Space)
+7191: RParen          ")" at 597:54-597:55
+7192: Arrow           "->" at 597:56-597:58 (leading: Space)
+7193: Ident           "float32" at 597:59-597:66 (leading: Space)
+7194: Semicolon       ";" at 597:66-597:67
+7195: At              "@" at 598:5-598:6 (leading: Newline, Space)
+7196: Ident           "intrinsic" at 598:6-598:15
+7197: KwFn            "fn" at 598:16-598:18 (leading: Space)
+7198: Ident           "__sub" at 598:19-598:24 (leading: Space)
+7199: LParen          "(" at 598:24-598:25
+7200: Ident           "self" at 598:25-598:29
+7201: Colon           ":" at 598:29-598:30
+7202: Ident           "float32" at 598:31-598:38 (leading: Space)
+7203: Comma           "," at 598:38-598:39
+7204: Ident           "other" at 598:40-598:45 (leading: Space)
+7205: Colon           ":" at 598:45-598:46
+7206: Ident           "float32" at 598:47-598:54 (leading: Space)
+7207: RParen          ")" at 598:54-598:55
+7208: Arrow           "->" at 598:56-598:58 (leading: Space)
+7209: Ident           "float32" at 598:59-598:66 (leading: Space)
+7210: Semicolon       ";" at 598:66-598:67
+7211: At              "@" at 599:5-599:6 (leading: Newline, Space)
+7212: Ident           "intrinsic" at 599:6-599:15
+7213: KwFn            "fn" at 599:16-599:18 (leading: Space)
+7214: Ident           "__mul" at 599:19-599:24 (leading: Space)
+7215: LParen          "(" at 599:24-599:25
+7216: Ident           "self" at 599:25-599:29
+7217: Colon           ":" at 599:29-599:30
+7218: Ident           "float32" at 599:31-599:38 (leading: Space)
+7219: Comma           "," at 599:38-599:39
+7220: Ident           "other" at 599:40-599:45 (leading: Space)
+7221: Colon           ":" at 599:45-599:46
+7222: Ident           "float32" at 599:47-599:54 (leading: Space)
+7223: RParen          ")" at 599:54-599:55
+7224: Arrow           "->" at 599:56-599:58 (leading: Space)
+7225: Ident           "float32" at 599:59-599:66 (leading: Space)
+7226: Semicolon       ";" at 599:66-599:67
+7227: At              "@" at 600:5-600:6 (leading: Newline, Space)
+7228: Ident           "intrinsic" at 600:6-600:15
+7229: KwFn            "fn" at 600:16-600:18 (leading: Space)
+7230: Ident           "__div" at 600:19-600:24 (leading: Space)
+7231: LParen          "(" at 600:24-600:25
+7232: Ident           "self" at 600:25-600:29
+7233: Colon           ":" at 600:29-600:30
+7234: Ident           "float32" at 600:31-600:38 (leading: Space)
+7235: Comma           "," at 600:38-600:39
+7236: Ident           "other" at 600:40-600:45 (leading: Space)
+7237: Colon           ":" at 600:45-600:46
+7238: Ident           "float32" at 600:47-600:54 (leading: Space)
+7239: RParen          ")" at 600:54-600:55
+7240: Arrow           "->" at 600:56-600:58 (leading: Space)
+7241: Ident           "float32" at 600:59-600:66 (leading: Space)
+7242: Semicolon       ";" at 600:66-600:67
+7243: At              "@" at 601:5-601:6 (leading: Newline, Space)
+7244: Ident           "intrinsic" at 601:6-601:15
+7245: KwFn            "fn" at 601:16-601:18 (leading: Space)
+7246: Ident           "__mod" at 601:19-601:24 (leading: Space)
+7247: LParen          "(" at 601:24-601:25
+7248: Ident           "self" at 601:25-601:29
+7249: Colon           ":" at 601:29-601:30
+7250: Ident           "float32" at 601:31-601:38 (leading: Space)
+7251: Comma           "," at 601:38-601:39
+7252: Ident           "other" at 601:40-601:45 (leading: Space)
+7253: Colon           ":" at 601:45-601:46
+7254: Ident           "float32" at 601:47-601:54 (leading: Space)
+7255: RParen          ")" at 601:54-601:55
+7256: Arrow           "->" at 601:56-601:58 (leading: Space)
+7257: Ident           "float32" at 601:59-601:66 (leading: Space)
+7258: Semicolon       ";" at 601:66-601:67
+7259: At              "@" at 602:5-602:6 (leading: Newline, Space)
+7260: Ident           "intrinsic" at 602:6-602:15
+7261: KwFn            "fn" at 602:16-602:18 (leading: Space)
+7262: Ident           "__lt" at 602:19-602:23 (leading: Space)
+7263: LParen          "(" at 602:23-602:24
+7264: Ident           "self" at 602:24-602:28
+7265: Colon           ":" at 602:28-602:29
+7266: Ident           "float32" at 602:30-602:37 (leading: Space)
+7267: Comma           "," at 602:37-602:38
+7268: Ident           "other" at 602:39-602:44 (leading: Space)
+7269: Colon           ":" at 602:44-602:45
+7270: Ident           "float32" at 602:46-602:53 (leading: Space)
+7271: RParen          ")" at 602:53-602:54
+7272: Arrow           "->" at 602:55-602:57 (leading: Space)
+7273: Ident           "bool" at 602:58-602:62 (leading: Space)
+7274: Semicolon       ";" at 602:62-602:63
+7275: At              "@" at 603:5-603:6 (leading: Newline, Space)
+7276: Ident           "intrinsic" at 603:6-603:15
+7277: KwFn            "fn" at 603:16-603:18 (leading: Space)
+7278: Ident           "__le" at 603:19-603:23 (leading: Space)
+7279: LParen          "(" at 603:23-603:24
+7280: Ident           "self" at 603:24-603:28
+7281: Colon           ":" at 603:28-603:29
+7282: Ident           "float32" at 603:30-603:37 (leading: Space)
+7283: Comma           "," at 603:37-603:38
+7284: Ident           "other" at 603:39-603:44 (leading: Space)
+7285: Colon           ":" at 603:44-603:45
+7286: Ident           "float32" at 603:46-603:53 (leading: Space)
+7287: RParen          ")" at 603:53-603:54
+7288: Arrow           "->" at 603:55-603:57 (leading: Space)
+7289: Ident           "bool" at 603:58-603:62 (leading: Space)
+7290: Semicolon       ";" at 603:62-603:63
+7291: At              "@" at 604:5-604:6 (leading: Newline, Space)
+7292: Ident           "intrinsic" at 604:6-604:15
+7293: KwFn            "fn" at 604:16-604:18 (leading: Space)
+7294: Ident           "__eq" at 604:19-604:23 (leading: Space)
+7295: LParen          "(" at 604:23-604:24
+7296: Ident           "self" at 604:24-604:28
+7297: Colon           ":" at 604:28-604:29
+7298: Ident           "float32" at 604:30-604:37 (leading: Space)
+7299: Comma           "," at 604:37-604:38
+7300: Ident           "other" at 604:39-604:44 (leading: Space)
+7301: Colon           ":" at 604:44-604:45
+7302: Ident           "float32" at 604:46-604:53 (leading: Space)
+7303: RParen          ")" at 604:53-604:54
+7304: Arrow           "->" at 604:55-604:57 (leading: Space)
+7305: Ident           "bool" at 604:58-604:62 (leading: Space)
+7306: Semicolon       ";" at 604:62-604:63
+7307: At              "@" at 605:5-605:6 (leading: Newline, Space)
+7308: Ident           "intrinsic" at 605:6-605:15
+7309: KwFn            "fn" at 605:16-605:18 (leading: Space)
+7310: Ident           "__ne" at 605:19-605:23 (leading: Space)
+7311: LParen          "(" at 605:23-605:24
+7312: Ident           "self" at 605:24-605:28
+7313: Colon           ":" at 605:28-605:29
+7314: Ident           "float32" at 605:30-605:37 (leading: Space)
+7315: Comma           "," at 605:37-605:38
+7316: Ident           "other" at 605:39-605:44 (leading: Space)
+7317: Colon           ":" at 605:44-605:45
+7318: Ident           "float32" at 605:46-605:53 (leading: Space)
+7319: RParen          ")" at 605:53-605:54
+7320: Arrow           "->" at 605:55-605:57 (leading: Space)
+7321: Ident           "bool" at 605:58-605:62 (leading: Space)
+7322: Semicolon       ";" at 605:62-605:63
+7323: At              "@" at 606:5-606:6 (leading: Newline, Space)
+7324: Ident           "intrinsic" at 606:6-606:15
+7325: KwFn            "fn" at 606:16-606:18 (leading: Space)
+7326: Ident           "__ge" at 606:19-606:23 (leading: Space)
+7327: LParen          "(" at 606:23-606:24
+7328: Ident           "self" at 606:24-606:28
+7329: Colon           ":" at 606:28-606:29
+7330: Ident           "float32" at 606:30-606:37 (leading: Space)
+7331: Comma           "," at 606:37-606:38
+7332: Ident           "other" at 606:39-606:44 (leading: Space)
+7333: Colon           ":" at 606:44-606:45
+7334: Ident           "float32" at 606:46-606:53 (leading: Space)
+7335: RParen          ")" at 606:53-606:54
+7336: Arrow           "->" at 606:55-606:57 (leading: Space)
+7337: Ident           "bool" at 606:58-606:62 (leading: Space)
+7338: Semicolon       ";" at 606:62-606:63
+7339: At              "@" at 607:5-607:6 (leading: Newline, Space)
+7340: Ident           "intrinsic" at 607:6-607:15
+7341: KwFn            "fn" at 607:16-607:18 (leading: Space)
+7342: Ident           "__gt" at 607:19-607:23 (leading: Space)
+7343: LParen          "(" at 607:23-607:24
+7344: Ident           "self" at 607:24-607:28
+7345: Colon           ":" at 607:28-607:29
+7346: Ident           "float32" at 607:30-607:37 (leading: Space)
+7347: Comma           "," at 607:37-607:38
+7348: Ident           "other" at 607:39-607:44 (leading: Space)
+7349: Colon           ":" at 607:44-607:45
+7350: Ident           "float32" at 607:46-607:53 (leading: Space)
+7351: RParen          ")" at 607:53-607:54
+7352: Arrow           "->" at 607:55-607:57 (leading: Space)
+7353: Ident           "bool" at 607:58-607:62 (leading: Space)
+7354: Semicolon       ";" at 607:62-607:63
+7355: At              "@" at 608:5-608:6 (leading: Newline, Space)
+7356: Ident           "intrinsic" at 608:6-608:15
+7357: KwFn            "fn" at 608:16-608:18 (leading: Space)
+7358: Ident           "__pos" at 608:19-608:24 (leading: Space)
+7359: LParen          "(" at 608:24-608:25
+7360: Ident           "self" at 608:25-608:29
+7361: Colon           ":" at 608:29-608:30
+7362: Ident           "float32" at 608:31-608:38 (leading: Space)
+7363: RParen          ")" at 608:38-608:39
+7364: Arrow           "->" at 608:40-608:42 (leading: Space)
+7365: Ident           "float32" at 608:43-608:50 (leading: Space)
+7366: Semicolon       ";" at 608:50-608:51
+7367: At              "@" at 609:5-609:6 (leading: Newline, Space)
+7368: Ident           "intrinsic" at 609:6-609:15
+7369: KwFn            "fn" at 609:16-609:18 (leading: Space)
+7370: Ident           "__neg" at 609:19-609:24 (leading: Space)
+7371: LParen          "(" at 609:24-609:25
+7372: Ident           "self" at 609:25-609:29
+7373: Colon           ":" at 609:29-609:30
+7374: Ident           "float32" at 609:31-609:38 (leading: Space)
+7375: RParen          ")" at 609:38-609:39
+7376: Arrow           "->" at 609:40-609:42 (leading: Space)
+7377: Ident           "float32" at 609:43-609:50 (leading: Space)
+7378: Semicolon       ";" at 609:50-609:51
+7379: At              "@" at 610:5-610:6 (leading: Newline, Space)
+7380: Ident           "intrinsic" at 610:6-610:15
+7381: KwFn            "fn" at 610:16-610:18 (leading: Space)
+7382: Ident           "__abs" at 610:19-610:24 (leading: Space)
+7383: LParen          "(" at 610:24-610:25
+7384: Ident           "self" at 610:25-610:29
+7385: Colon           ":" at 610:29-610:30
+7386: Ident           "float32" at 610:31-610:38 (leading: Space)
+7387: RParen          ")" at 610:38-610:39
+7388: Arrow           "->" at 610:40-610:42 (leading: Space)
+7389: Ident           "float32" at 610:43-610:50 (leading: Space)
+7390: Semicolon       ";" at 610:50-610:51
+7391: At              "@" at 611:5-611:6 (leading: Newline, Space)
+7392: Ident           "intrinsic" at 611:6-611:15
+7393: KwFn            "fn" at 611:16-611:18 (leading: Space)
+7394: Ident           "__to" at 611:19-611:23 (leading: Space)
+7395: LParen          "(" at 611:23-611:24
+7396: Ident           "self" at 611:24-611:28
+7397: Colon           ":" at 611:28-611:29
+7398: Ident           "float32" at 611:30-611:37 (leading: Space)
+7399: Comma           "," at 611:37-611:38
+7400: Ident           "target" at 611:39-611:45 (leading: Space)
+7401: Colon           ":" at 611:45-611:46
+7402: Ident           "float" at 611:47-611:52 (leading: Space)
+7403: RParen          ")" at 611:52-611:53
+7404: Arrow           "->" at 611:54-611:56 (leading: Space)
+7405: Ident           "float" at 611:57-611:62 (leading: Space)
+7406: Semicolon       ";" at 611:62-611:63
+7407: At              "@" at 612:5-612:6 (leading: Newline, Space)
+7408: Ident           "intrinsic" at 612:6-612:15
+7409: At              "@" at 612:16-612:17 (leading: Space)
+7410: Ident           "overload" at 612:17-612:25
+7411: KwFn            "fn" at 612:26-612:28 (leading: Space)
+7412: Ident           "__to" at 612:29-612:33 (leading: Space)
+7413: LParen          "(" at 612:33-612:34
+7414: Ident           "self" at 612:34-612:38
+7415: Colon           ":" at 612:38-612:39
+7416: Ident           "float32" at 612:40-612:47 (leading: Space)
+7417: Comma           "," at 612:47-612:48
+7418: Ident           "target" at 612:49-612:55 (leading: Space)
+7419: Colon           ":" at 612:55-612:56
+7420: Ident           "float16" at 612:57-612:64 (leading: Space)
+7421: RParen          ")" at 612:64-612:65
+7422: Arrow           "->" at 612:66-612:68 (leading: Space)
+7423: Ident           "float16" at 612:69-612:76 (leading: Space)
+7424: Semicolon       ";" at 612:76-612:77
+7425: At              "@" at 613:5-613:6 (leading: Newline, Space)
+7426: Ident           "intrinsic" at 613:6-613:15
+7427: At              "@" at 613:16-613:17 (leading: Space)
+7428: Ident           "overload" at 613:17-613:25
+7429: KwFn            "fn" at 613:26-613:28 (leading: Space)
+7430: Ident           "__to" at 613:29-613:33 (leading: Space)
+7431: LParen          "(" at 613:33-613:34
+7432: Ident           "self" at 613:34-613:38
+7433: Colon           ":" at 613:38-613:39
+7434: Ident           "float32" at 613:40-613:47 (leading: Space)
+7435: Comma           "," at 613:47-613:48
+7436: Ident           "target" at 613:49-613:55 (leading: Space)
+7437: Colon           ":" at 613:55-613:56
+7438: Ident           "float64" at 613:57-613:64 (leading: Space)
+7439: RParen          ")" at 613:64-613:65
+7440: Arrow           "->" at 613:66-613:68 (leading: Space)
+7441: Ident           "float64" at 613:69-613:76 (leading: Space)
+7442: Semicolon       ";" at 613:76-613:77
+7443: At              "@" at 614:5-614:6 (leading: Newline, Space)
+7444: Ident           "intrinsic" at 614:6-614:15
+7445: KwPub           "pub" at 614:16-614:19 (leading: Space)
+7446: KwFn            "fn" at 614:20-614:22 (leading: Space)
+7447: Ident           "from_str" at 614:23-614:31 (leading: Space)
+7448: LParen          "(" at 614:31-614:32
+7449: Ident           "s" at 614:32-614:33
+7450: Colon           ":" at 614:33-614:34
+7451: Amp             "&" at 614:35-614:36 (leading: Space)
+7452: Ident           "string" at 614:36-614:42
+7453: RParen          ")" at 614:42-614:43
+7454: Arrow           "->" at 614:44-614:46 (leading: Space)
+7455: Ident           "Erring" at 614:47-614:53 (leading: Space)
+7456: Lt              "<" at 614:53-614:54
+7457: Ident           "float32" at 614:54-614:61
+7458: Comma           "," at 614:61-614:62
+7459: Ident           "Error" at 614:63-614:68 (leading: Space)
+7460: Gt              ">" at 614:68-614:69
+7461: Semicolon       ";" at 614:69-614:70
+7462: RBrace          "}" at 615:1-615:2 (leading: Newline)
+7463: KwExtern        "extern" at 617:1-617:7 (leading: Newline)
+7464: Lt              "<" at 617:7-617:8
+7465: Ident           "float64" at 617:8-617:15
+7466: Gt              ">" at 617:15-617:16
+7467: LBrace          "{" at 617:17-617:18 (leading: Space)
+7468: KwPub           "pub" at 618:5-618:8 (leading: Newline, Space)
+7469: KwFn            "fn" at 618:9-618:11 (leading: Space)
+7470: Ident           "__min_value" at 618:12-618:23 (leading: Space)
+7471: LParen          "(" at 618:23-618:24
+7472: RParen          ")" at 618:24-618:25
+7473: Arrow           "->" at 618:26-618:28 (leading: Space)
+7474: Ident           "float64" at 618:29-618:36 (leading: Space)
+7475: LBrace          "{" at 618:37-618:38 (leading: Space)
+7476: KwReturn        "return" at 618:39-618:45 (leading: Space)
+7477: LParen          "(" at 618:46-618:47 (leading: Space)
+7478: Minus           "-" at 618:47-618:48
+7479: FloatLit        "1.797_693_134_862_3157e+308" at 618:48-618:75
+7480: RParen          ")" at 618:75-618:76
+7481: Colon           ":" at 618:76-618:77
+7482: Ident           "float64" at 618:77-618:84
+7483: Semicolon       ";" at 618:84-618:85
+7484: RBrace          "}" at 618:86-618:87 (leading: Space)
+7485: KwPub           "pub" at 619:5-619:8 (leading: Newline, Space)
+7486: KwFn            "fn" at 619:9-619:11 (leading: Space)
+7487: Ident           "__max_value" at 619:12-619:23 (leading: Space)
+7488: LParen          "(" at 619:23-619:24
+7489: RParen          ")" at 619:24-619:25
+7490: Arrow           "->" at 619:26-619:28 (leading: Space)
+7491: Ident           "float64" at 619:29-619:36 (leading: Space)
+7492: LBrace          "{" at 619:37-619:38 (leading: Space)
+7493: KwReturn        "return" at 619:39-619:45 (leading: Space)
+7494: LParen          "(" at 619:46-619:47 (leading: Space)
+7495: FloatLit        "1.797_693_134_862_3157e+308" at 619:47-619:74
+7496: RParen          ")" at 619:74-619:75
+7497: Colon           ":" at 619:75-619:76
+7498: Ident           "float64" at 619:76-619:83
+7499: Semicolon       ";" at 619:83-619:84
+7500: RBrace          "}" at 619:85-619:86 (leading: Space)
+7501: At              "@" at 620:5-620:6 (leading: Newline, Space)
+7502: Ident           "intrinsic" at 620:6-620:15
+7503: KwFn            "fn" at 620:16-620:18 (leading: Space)
+7504: Ident           "__add" at 620:19-620:24 (leading: Space)
+7505: LParen          "(" at 620:24-620:25
+7506: Ident           "self" at 620:25-620:29
+7507: Colon           ":" at 620:29-620:30
+7508: Ident           "float64" at 620:31-620:38 (leading: Space)
+7509: Comma           "," at 620:38-620:39
+7510: Ident           "other" at 620:40-620:45 (leading: Space)
+7511: Colon           ":" at 620:45-620:46
+7512: Ident           "float64" at 620:47-620:54 (leading: Space)
+7513: RParen          ")" at 620:54-620:55
+7514: Arrow           "->" at 620:56-620:58 (leading: Space)
+7515: Ident           "float64" at 620:59-620:66 (leading: Space)
+7516: Semicolon       ";" at 620:66-620:67
+7517: At              "@" at 621:5-621:6 (leading: Newline, Space)
+7518: Ident           "intrinsic" at 621:6-621:15
+7519: KwFn            "fn" at 621:16-621:18 (leading: Space)
+7520: Ident           "__sub" at 621:19-621:24 (leading: Space)
+7521: LParen          "(" at 621:24-621:25
+7522: Ident           "self" at 621:25-621:29
+7523: Colon           ":" at 621:29-621:30
+7524: Ident           "float64" at 621:31-621:38 (leading: Space)
+7525: Comma           "," at 621:38-621:39
+7526: Ident           "other" at 621:40-621:45 (leading: Space)
+7527: Colon           ":" at 621:45-621:46
+7528: Ident           "float64" at 621:47-621:54 (leading: Space)
+7529: RParen          ")" at 621:54-621:55
+7530: Arrow           "->" at 621:56-621:58 (leading: Space)
+7531: Ident           "float64" at 621:59-621:66 (leading: Space)
+7532: Semicolon       ";" at 621:66-621:67
+7533: At              "@" at 622:5-622:6 (leading: Newline, Space)
+7534: Ident           "intrinsic" at 622:6-622:15
+7535: KwFn            "fn" at 622:16-622:18 (leading: Space)
+7536: Ident           "__mul" at 622:19-622:24 (leading: Space)
+7537: LParen          "(" at 622:24-622:25
+7538: Ident           "self" at 622:25-622:29
+7539: Colon           ":" at 622:29-622:30
+7540: Ident           "float64" at 622:31-622:38 (leading: Space)
+7541: Comma           "," at 622:38-622:39
+7542: Ident           "other" at 622:40-622:45 (leading: Space)
+7543: Colon           ":" at 622:45-622:46
+7544: Ident           "float64" at 622:47-622:54 (leading: Space)
+7545: RParen          ")" at 622:54-622:55
+7546: Arrow           "->" at 622:56-622:58 (leading: Space)
+7547: Ident           "float64" at 622:59-622:66 (leading: Space)
+7548: Semicolon       ";" at 622:66-622:67
+7549: At              "@" at 623:5-623:6 (leading: Newline, Space)
+7550: Ident           "intrinsic" at 623:6-623:15
+7551: KwFn            "fn" at 623:16-623:18 (leading: Space)
+7552: Ident           "__div" at 623:19-623:24 (leading: Space)
+7553: LParen          "(" at 623:24-623:25
+7554: Ident           "self" at 623:25-623:29
+7555: Colon           ":" at 623:29-623:30
+7556: Ident           "float64" at 623:31-623:38 (leading: Space)
+7557: Comma           "," at 623:38-623:39
+7558: Ident           "other" at 623:40-623:45 (leading: Space)
+7559: Colon           ":" at 623:45-623:46
+7560: Ident           "float64" at 623:47-623:54 (leading: Space)
+7561: RParen          ")" at 623:54-623:55
+7562: Arrow           "->" at 623:56-623:58 (leading: Space)
+7563: Ident           "float64" at 623:59-623:66 (leading: Space)
+7564: Semicolon       ";" at 623:66-623:67
+7565: At              "@" at 624:5-624:6 (leading: Newline, Space)
+7566: Ident           "intrinsic" at 624:6-624:15
+7567: KwFn            "fn" at 624:16-624:18 (leading: Space)
+7568: Ident           "__mod" at 624:19-624:24 (leading: Space)
+7569: LParen          "(" at 624:24-624:25
+7570: Ident           "self" at 624:25-624:29
+7571: Colon           ":" at 624:29-624:30
+7572: Ident           "float64" at 624:31-624:38 (leading: Space)
+7573: Comma           "," at 624:38-624:39
+7574: Ident           "other" at 624:40-624:45 (leading: Space)
+7575: Colon           ":" at 624:45-624:46
+7576: Ident           "float64" at 624:47-624:54 (leading: Space)
+7577: RParen          ")" at 624:54-624:55
+7578: Arrow           "->" at 624:56-624:58 (leading: Space)
+7579: Ident           "float64" at 624:59-624:66 (leading: Space)
+7580: Semicolon       ";" at 624:66-624:67
+7581: At              "@" at 625:5-625:6 (leading: Newline, Space)
+7582: Ident           "intrinsic" at 625:6-625:15
+7583: KwFn            "fn" at 625:16-625:18 (leading: Space)
+7584: Ident           "__lt" at 625:19-625:23 (leading: Space)
+7585: LParen          "(" at 625:23-625:24
+7586: Ident           "self" at 625:24-625:28
+7587: Colon           ":" at 625:28-625:29
+7588: Ident           "float64" at 625:30-625:37 (leading: Space)
+7589: Comma           "," at 625:37-625:38
+7590: Ident           "other" at 625:39-625:44 (leading: Space)
+7591: Colon           ":" at 625:44-625:45
+7592: Ident           "float64" at 625:46-625:53 (leading: Space)
+7593: RParen          ")" at 625:53-625:54
+7594: Arrow           "->" at 625:55-625:57 (leading: Space)
+7595: Ident           "bool" at 625:58-625:62 (leading: Space)
+7596: Semicolon       ";" at 625:62-625:63
+7597: At              "@" at 626:5-626:6 (leading: Newline, Space)
+7598: Ident           "intrinsic" at 626:6-626:15
+7599: KwFn            "fn" at 626:16-626:18 (leading: Space)
+7600: Ident           "__le" at 626:19-626:23 (leading: Space)
+7601: LParen          "(" at 626:23-626:24
+7602: Ident           "self" at 626:24-626:28
+7603: Colon           ":" at 626:28-626:29
+7604: Ident           "float64" at 626:30-626:37 (leading: Space)
+7605: Comma           "," at 626:37-626:38
+7606: Ident           "other" at 626:39-626:44 (leading: Space)
+7607: Colon           ":" at 626:44-626:45
+7608: Ident           "float64" at 626:46-626:53 (leading: Space)
+7609: RParen          ")" at 626:53-626:54
+7610: Arrow           "->" at 626:55-626:57 (leading: Space)
+7611: Ident           "bool" at 626:58-626:62 (leading: Space)
+7612: Semicolon       ";" at 626:62-626:63
+7613: At              "@" at 627:5-627:6 (leading: Newline, Space)
+7614: Ident           "intrinsic" at 627:6-627:15
+7615: KwFn            "fn" at 627:16-627:18 (leading: Space)
+7616: Ident           "__eq" at 627:19-627:23 (leading: Space)
+7617: LParen          "(" at 627:23-627:24
+7618: Ident           "self" at 627:24-627:28
+7619: Colon           ":" at 627:28-627:29
+7620: Ident           "float64" at 627:30-627:37 (leading: Space)
+7621: Comma           "," at 627:37-627:38
+7622: Ident           "other" at 627:39-627:44 (leading: Space)
+7623: Colon           ":" at 627:44-627:45
+7624: Ident           "float64" at 627:46-627:53 (leading: Space)
+7625: RParen          ")" at 627:53-627:54
+7626: Arrow           "->" at 627:55-627:57 (leading: Space)
+7627: Ident           "bool" at 627:58-627:62 (leading: Space)
+7628: Semicolon       ";" at 627:62-627:63
+7629: At              "@" at 628:5-628:6 (leading: Newline, Space)
+7630: Ident           "intrinsic" at 628:6-628:15
+7631: KwFn            "fn" at 628:16-628:18 (leading: Space)
+7632: Ident           "__ne" at 628:19-628:23 (leading: Space)
+7633: LParen          "(" at 628:23-628:24
+7634: Ident           "self" at 628:24-628:28
+7635: Colon           ":" at 628:28-628:29
+7636: Ident           "float64" at 628:30-628:37 (leading: Space)
+7637: Comma           "," at 628:37-628:38
+7638: Ident           "other" at 628:39-628:44 (leading: Space)
+7639: Colon           ":" at 628:44-628:45
+7640: Ident           "float64" at 628:46-628:53 (leading: Space)
+7641: RParen          ")" at 628:53-628:54
+7642: Arrow           "->" at 628:55-628:57 (leading: Space)
+7643: Ident           "bool" at 628:58-628:62 (leading: Space)
+7644: Semicolon       ";" at 628:62-628:63
+7645: At              "@" at 629:5-629:6 (leading: Newline, Space)
+7646: Ident           "intrinsic" at 629:6-629:15
+7647: KwFn            "fn" at 629:16-629:18 (leading: Space)
+7648: Ident           "__ge" at 629:19-629:23 (leading: Space)
+7649: LParen          "(" at 629:23-629:24
+7650: Ident           "self" at 629:24-629:28
+7651: Colon           ":" at 629:28-629:29
+7652: Ident           "float64" at 629:30-629:37 (leading: Space)
+7653: Comma           "," at 629:37-629:38
+7654: Ident           "other" at 629:39-629:44 (leading: Space)
+7655: Colon           ":" at 629:44-629:45
+7656: Ident           "float64" at 629:46-629:53 (leading: Space)
+7657: RParen          ")" at 629:53-629:54
+7658: Arrow           "->" at 629:55-629:57 (leading: Space)
+7659: Ident           "bool" at 629:58-629:62 (leading: Space)
+7660: Semicolon       ";" at 629:62-629:63
+7661: At              "@" at 630:5-630:6 (leading: Newline, Space)
+7662: Ident           "intrinsic" at 630:6-630:15
+7663: KwFn            "fn" at 630:16-630:18 (leading: Space)
+7664: Ident           "__gt" at 630:19-630:23 (leading: Space)
+7665: LParen          "(" at 630:23-630:24
+7666: Ident           "self" at 630:24-630:28
+7667: Colon           ":" at 630:28-630:29
+7668: Ident           "float64" at 630:30-630:37 (leading: Space)
+7669: Comma           "," at 630:37-630:38
+7670: Ident           "other" at 630:39-630:44 (leading: Space)
+7671: Colon           ":" at 630:44-630:45
+7672: Ident           "float64" at 630:46-630:53 (leading: Space)
+7673: RParen          ")" at 630:53-630:54
+7674: Arrow           "->" at 630:55-630:57 (leading: Space)
+7675: Ident           "bool" at 630:58-630:62 (leading: Space)
+7676: Semicolon       ";" at 630:62-630:63
+7677: At              "@" at 631:5-631:6 (leading: Newline, Space)
+7678: Ident           "intrinsic" at 631:6-631:15
+7679: KwFn            "fn" at 631:16-631:18 (leading: Space)
+7680: Ident           "__pos" at 631:19-631:24 (leading: Space)
+7681: LParen          "(" at 631:24-631:25
+7682: Ident           "self" at 631:25-631:29
+7683: Colon           ":" at 631:29-631:30
+7684: Ident           "float64" at 631:31-631:38 (leading: Space)
+7685: RParen          ")" at 631:38-631:39
+7686: Arrow           "->" at 631:40-631:42 (leading: Space)
+7687: Ident           "float64" at 631:43-631:50 (leading: Space)
+7688: Semicolon       ";" at 631:50-631:51
+7689: At              "@" at 632:5-632:6 (leading: Newline, Space)
+7690: Ident           "intrinsic" at 632:6-632:15
+7691: KwFn            "fn" at 632:16-632:18 (leading: Space)
+7692: Ident           "__neg" at 632:19-632:24 (leading: Space)
+7693: LParen          "(" at 632:24-632:25
+7694: Ident           "self" at 632:25-632:29
+7695: Colon           ":" at 632:29-632:30
+7696: Ident           "float64" at 632:31-632:38 (leading: Space)
+7697: RParen          ")" at 632:38-632:39
+7698: Arrow           "->" at 632:40-632:42 (leading: Space)
+7699: Ident           "float64" at 632:43-632:50 (leading: Space)
+7700: Semicolon       ";" at 632:50-632:51
+7701: At              "@" at 633:5-633:6 (leading: Newline, Space)
+7702: Ident           "intrinsic" at 633:6-633:15
+7703: KwFn            "fn" at 633:16-633:18 (leading: Space)
+7704: Ident           "__abs" at 633:19-633:24 (leading: Space)
+7705: LParen          "(" at 633:24-633:25
+7706: Ident           "self" at 633:25-633:29
+7707: Colon           ":" at 633:29-633:30
+7708: Ident           "float64" at 633:31-633:38 (leading: Space)
+7709: RParen          ")" at 633:38-633:39
+7710: Arrow           "->" at 633:40-633:42 (leading: Space)
+7711: Ident           "float64" at 633:43-633:50 (leading: Space)
+7712: Semicolon       ";" at 633:50-633:51
+7713: At              "@" at 634:5-634:6 (leading: Newline, Space)
+7714: Ident           "intrinsic" at 634:6-634:15
+7715: KwFn            "fn" at 634:16-634:18 (leading: Space)
+7716: Ident           "__to" at 634:19-634:23 (leading: Space)
+7717: LParen          "(" at 634:23-634:24
+7718: Ident           "self" at 634:24-634:28
+7719: Colon           ":" at 634:28-634:29
+7720: Ident           "float64" at 634:30-634:37 (leading: Space)
+7721: Comma           "," at 634:37-634:38
+7722: Ident           "target" at 634:39-634:45 (leading: Space)
+7723: Colon           ":" at 634:45-634:46
+7724: Ident           "float" at 634:47-634:52 (leading: Space)
+7725: RParen          ")" at 634:52-634:53
+7726: Arrow           "->" at 634:54-634:56 (leading: Space)
+7727: Ident           "float" at 634:57-634:62 (leading: Space)
+7728: Semicolon       ";" at 634:62-634:63
+7729: At              "@" at 635:5-635:6 (leading: Newline, Space)
+7730: Ident           "intrinsic" at 635:6-635:15
+7731: At              "@" at 635:16-635:17 (leading: Space)
+7732: Ident           "overload" at 635:17-635:25
+7733: KwFn            "fn" at 635:26-635:28 (leading: Space)
+7734: Ident           "__to" at 635:29-635:33 (leading: Space)
+7735: LParen          "(" at 635:33-635:34
+7736: Ident           "self" at 635:34-635:38
+7737: Colon           ":" at 635:38-635:39
+7738: Ident           "float64" at 635:40-635:47 (leading: Space)
+7739: Comma           "," at 635:47-635:48
+7740: Ident           "target" at 635:49-635:55 (leading: Space)
+7741: Colon           ":" at 635:55-635:56
+7742: Ident           "float16" at 635:57-635:64 (leading: Space)
+7743: RParen          ")" at 635:64-635:65
+7744: Arrow           "->" at 635:66-635:68 (leading: Space)
+7745: Ident           "float16" at 635:69-635:76 (leading: Space)
+7746: Semicolon       ";" at 635:76-635:77
+7747: At              "@" at 636:5-636:6 (leading: Newline, Space)
+7748: Ident           "intrinsic" at 636:6-636:15
+7749: At              "@" at 636:16-636:17 (leading: Space)
+7750: Ident           "overload" at 636:17-636:25
+7751: KwFn            "fn" at 636:26-636:28 (leading: Space)
+7752: Ident           "__to" at 636:29-636:33 (leading: Space)
+7753: LParen          "(" at 636:33-636:34
+7754: Ident           "self" at 636:34-636:38
+7755: Colon           ":" at 636:38-636:39
+7756: Ident           "float64" at 636:40-636:47 (leading: Space)
+7757: Comma           "," at 636:47-636:48
+7758: Ident           "target" at 636:49-636:55 (leading: Space)
+7759: Colon           ":" at 636:55-636:56
+7760: Ident           "float32" at 636:57-636:64 (leading: Space)
+7761: RParen          ")" at 636:64-636:65
+7762: Arrow           "->" at 636:66-636:68 (leading: Space)
+7763: Ident           "float32" at 636:69-636:76 (leading: Space)
+7764: Semicolon       ";" at 636:76-636:77
+7765: At              "@" at 637:5-637:6 (leading: Newline, Space)
+7766: Ident           "intrinsic" at 637:6-637:15
+7767: KwPub           "pub" at 637:16-637:19 (leading: Space)
+7768: KwFn            "fn" at 637:20-637:22 (leading: Space)
+7769: Ident           "from_str" at 637:23-637:31 (leading: Space)
+7770: LParen          "(" at 637:31-637:32
+7771: Ident           "s" at 637:32-637:33
+7772: Colon           ":" at 637:33-637:34
+7773: Amp             "&" at 637:35-637:36 (leading: Space)
+7774: Ident           "string" at 637:36-637:42
+7775: RParen          ")" at 637:42-637:43
+7776: Arrow           "->" at 637:44-637:46 (leading: Space)
+7777: Ident           "Erring" at 637:47-637:53 (leading: Space)
+7778: Lt              "<" at 637:53-637:54
+7779: Ident           "float64" at 637:54-637:61
+7780: Comma           "," at 637:61-637:62
+7781: Ident           "Error" at 637:63-637:68 (leading: Space)
+7782: Gt              ">" at 637:68-637:69
+7783: Semicolon       ";" at 637:69-637:70
+7784: RBrace          "}" at 638:1-638:2 (leading: Newline)
+7785: KwExtern        "extern" at 640:1-640:7 (leading: Newline)
+7786: Lt              "<" at 640:7-640:8
+7787: Ident           "float" at 640:8-640:13
+7788: Gt              ">" at 640:13-640:14
+7789: LBrace          "{" at 640:15-640:16 (leading: Space)
+7790: At              "@" at 641:5-641:6 (leading: Newline, Space)
+7791: Ident           "intrinsic" at 641:6-641:15
+7792: KwFn            "fn" at 641:16-641:18 (leading: Space)
+7793: Ident           "__add" at 641:19-641:24 (leading: Space)
+7794: LParen          "(" at 641:24-641:25
+7795: Ident           "self" at 641:25-641:29
+7796: Colon           ":" at 641:29-641:30
+7797: Ident           "float" at 641:31-641:36 (leading: Space)
+7798: Comma           "," at 641:36-641:37
+7799: Ident           "other" at 641:38-641:43 (leading: Space)
+7800: Colon           ":" at 641:43-641:44
+7801: Ident           "float" at 641:45-641:50 (leading: Space)
+7802: RParen          ")" at 641:50-641:51
+7803: Arrow           "->" at 641:52-641:54 (leading: Space)
+7804: Ident           "float" at 641:55-641:60 (leading: Space)
+7805: Semicolon       ";" at 641:60-641:61
+7806: At              "@" at 642:5-642:6 (leading: Newline, Space)
+7807: Ident           "intrinsic" at 642:6-642:15
+7808: KwFn            "fn" at 642:16-642:18 (leading: Space)
+7809: Ident           "__sub" at 642:19-642:24 (leading: Space)
+7810: LParen          "(" at 642:24-642:25
+7811: Ident           "self" at 642:25-642:29
+7812: Colon           ":" at 642:29-642:30
+7813: Ident           "float" at 642:31-642:36 (leading: Space)
+7814: Comma           "," at 642:36-642:37
+7815: Ident           "other" at 642:38-642:43 (leading: Space)
+7816: Colon           ":" at 642:43-642:44
+7817: Ident           "float" at 642:45-642:50 (leading: Space)
+7818: RParen          ")" at 642:50-642:51
+7819: Arrow           "->" at 642:52-642:54 (leading: Space)
+7820: Ident           "float" at 642:55-642:60 (leading: Space)
+7821: Semicolon       ";" at 642:60-642:61
+7822: At              "@" at 643:5-643:6 (leading: Newline, Space)
+7823: Ident           "intrinsic" at 643:6-643:15
+7824: KwFn            "fn" at 643:16-643:18 (leading: Space)
+7825: Ident           "__mul" at 643:19-643:24 (leading: Space)
+7826: LParen          "(" at 643:24-643:25
+7827: Ident           "self" at 643:25-643:29
+7828: Colon           ":" at 643:29-643:30
+7829: Ident           "float" at 643:31-643:36 (leading: Space)
+7830: Comma           "," at 643:36-643:37
+7831: Ident           "other" at 643:38-643:43 (leading: Space)
+7832: Colon           ":" at 643:43-643:44
+7833: Ident           "float" at 643:45-643:50 (leading: Space)
+7834: RParen          ")" at 643:50-643:51
+7835: Arrow           "->" at 643:52-643:54 (leading: Space)
+7836: Ident           "float" at 643:55-643:60 (leading: Space)
+7837: Semicolon       ";" at 643:60-643:61
+7838: At              "@" at 644:5-644:6 (leading: Newline, Space)
+7839: Ident           "intrinsic" at 644:6-644:15
+7840: KwFn            "fn" at 644:16-644:18 (leading: Space)
+7841: Ident           "__div" at 644:19-644:24 (leading: Space)
+7842: LParen          "(" at 644:24-644:25
+7843: Ident           "self" at 644:25-644:29
+7844: Colon           ":" at 644:29-644:30
+7845: Ident           "float" at 644:31-644:36 (leading: Space)
+7846: Comma           "," at 644:36-644:37
+7847: Ident           "other" at 644:38-644:43 (leading: Space)
+7848: Colon           ":" at 644:43-644:44
+7849: Ident           "float" at 644:45-644:50 (leading: Space)
+7850: RParen          ")" at 644:50-644:51
+7851: Arrow           "->" at 644:52-644:54 (leading: Space)
+7852: Ident           "float" at 644:55-644:60 (leading: Space)
+7853: Semicolon       ";" at 644:60-644:61
+7854: At              "@" at 645:5-645:6 (leading: Newline, Space)
+7855: Ident           "intrinsic" at 645:6-645:15
+7856: KwFn            "fn" at 645:16-645:18 (leading: Space)
+7857: Ident           "__mod" at 645:19-645:24 (leading: Space)
+7858: LParen          "(" at 645:24-645:25
+7859: Ident           "self" at 645:25-645:29
+7860: Colon           ":" at 645:29-645:30
+7861: Ident           "float" at 645:31-645:36 (leading: Space)
+7862: Comma           "," at 645:36-645:37
+7863: Ident           "other" at 645:38-645:43 (leading: Space)
+7864: Colon           ":" at 645:43-645:44
+7865: Ident           "float" at 645:45-645:50 (leading: Space)
+7866: RParen          ")" at 645:50-645:51
+7867: Arrow           "->" at 645:52-645:54 (leading: Space)
+7868: Ident           "float" at 645:55-645:60 (leading: Space)
+7869: Semicolon       ";" at 645:60-645:61
+7870: At              "@" at 646:5-646:6 (leading: Newline, Space)
+7871: Ident           "intrinsic" at 646:6-646:15
+7872: KwFn            "fn" at 646:16-646:18 (leading: Space)
+7873: Ident           "__lt" at 646:19-646:23 (leading: Space)
+7874: LParen          "(" at 646:23-646:24
+7875: Ident           "self" at 646:24-646:28
+7876: Colon           ":" at 646:28-646:29
+7877: Ident           "float" at 646:30-646:35 (leading: Space)
+7878: Comma           "," at 646:35-646:36
+7879: Ident           "other" at 646:37-646:42 (leading: Space)
+7880: Colon           ":" at 646:42-646:43
+7881: Ident           "float" at 646:44-646:49 (leading: Space)
+7882: RParen          ")" at 646:49-646:50
+7883: Arrow           "->" at 646:51-646:53 (leading: Space)
+7884: Ident           "bool" at 646:54-646:58 (leading: Space)
+7885: Semicolon       ";" at 646:58-646:59
+7886: At              "@" at 647:5-647:6 (leading: Newline, Space)
+7887: Ident           "intrinsic" at 647:6-647:15
+7888: KwFn            "fn" at 647:16-647:18 (leading: Space)
+7889: Ident           "__le" at 647:19-647:23 (leading: Space)
+7890: LParen          "(" at 647:23-647:24
+7891: Ident           "self" at 647:24-647:28
+7892: Colon           ":" at 647:28-647:29
+7893: Ident           "float" at 647:30-647:35 (leading: Space)
+7894: Comma           "," at 647:35-647:36
+7895: Ident           "other" at 647:37-647:42 (leading: Space)
+7896: Colon           ":" at 647:42-647:43
+7897: Ident           "float" at 647:44-647:49 (leading: Space)
+7898: RParen          ")" at 647:49-647:50
+7899: Arrow           "->" at 647:51-647:53 (leading: Space)
+7900: Ident           "bool" at 647:54-647:58 (leading: Space)
+7901: Semicolon       ";" at 647:58-647:59
+7902: At              "@" at 648:5-648:6 (leading: Newline, Space)
+7903: Ident           "intrinsic" at 648:6-648:15
+7904: KwFn            "fn" at 648:16-648:18 (leading: Space)
+7905: Ident           "__eq" at 648:19-648:23 (leading: Space)
+7906: LParen          "(" at 648:23-648:24
+7907: Ident           "self" at 648:24-648:28
+7908: Colon           ":" at 648:28-648:29
+7909: Ident           "float" at 648:30-648:35 (leading: Space)
+7910: Comma           "," at 648:35-648:36
+7911: Ident           "other" at 648:37-648:42 (leading: Space)
+7912: Colon           ":" at 648:42-648:43
+7913: Ident           "float" at 648:44-648:49 (leading: Space)
+7914: RParen          ")" at 648:49-648:50
+7915: Arrow           "->" at 648:51-648:53 (leading: Space)
+7916: Ident           "bool" at 648:54-648:58 (leading: Space)
+7917: Semicolon       ";" at 648:58-648:59
+7918: At              "@" at 649:5-649:6 (leading: Newline, Space)
+7919: Ident           "intrinsic" at 649:6-649:15
+7920: KwFn            "fn" at 649:16-649:18 (leading: Space)
+7921: Ident           "__ne" at 649:19-649:23 (leading: Space)
+7922: LParen          "(" at 649:23-649:24
+7923: Ident           "self" at 649:24-649:28
+7924: Colon           ":" at 649:28-649:29
+7925: Ident           "float" at 649:30-649:35 (leading: Space)
+7926: Comma           "," at 649:35-649:36
+7927: Ident           "other" at 649:37-649:42 (leading: Space)
+7928: Colon           ":" at 649:42-649:43
+7929: Ident           "float" at 649:44-649:49 (leading: Space)
+7930: RParen          ")" at 649:49-649:50
+7931: Arrow           "->" at 649:51-649:53 (leading: Space)
+7932: Ident           "bool" at 649:54-649:58 (leading: Space)
+7933: Semicolon       ";" at 649:58-649:59
+7934: At              "@" at 650:5-650:6 (leading: Newline, Space)
+7935: Ident           "intrinsic" at 650:6-650:15
+7936: KwFn            "fn" at 650:16-650:18 (leading: Space)
+7937: Ident           "__ge" at 650:19-650:23 (leading: Space)
+7938: LParen          "(" at 650:23-650:24
+7939: Ident           "self" at 650:24-650:28
+7940: Colon           ":" at 650:28-650:29
+7941: Ident           "float" at 650:30-650:35 (leading: Space)
+7942: Comma           "," at 650:35-650:36
+7943: Ident           "other" at 650:37-650:42 (leading: Space)
+7944: Colon           ":" at 650:42-650:43
+7945: Ident           "float" at 650:44-650:49 (leading: Space)
+7946: RParen          ")" at 650:49-650:50
+7947: Arrow           "->" at 650:51-650:53 (leading: Space)
+7948: Ident           "bool" at 650:54-650:58 (leading: Space)
+7949: Semicolon       ";" at 650:58-650:59
+7950: At              "@" at 651:5-651:6 (leading: Newline, Space)
+7951: Ident           "intrinsic" at 651:6-651:15
+7952: KwFn            "fn" at 651:16-651:18 (leading: Space)
+7953: Ident           "__gt" at 651:19-651:23 (leading: Space)
+7954: LParen          "(" at 651:23-651:24
+7955: Ident           "self" at 651:24-651:28
+7956: Colon           ":" at 651:28-651:29
+7957: Ident           "float" at 651:30-651:35 (leading: Space)
+7958: Comma           "," at 651:35-651:36
+7959: Ident           "other" at 651:37-651:42 (leading: Space)
+7960: Colon           ":" at 651:42-651:43
+7961: Ident           "float" at 651:44-651:49 (leading: Space)
+7962: RParen          ")" at 651:49-651:50
+7963: Arrow           "->" at 651:51-651:53 (leading: Space)
+7964: Ident           "bool" at 651:54-651:58 (leading: Space)
+7965: Semicolon       ";" at 651:58-651:59
+7966: At              "@" at 652:5-652:6 (leading: Newline, Space)
+7967: Ident           "intrinsic" at 652:6-652:15
+7968: KwFn            "fn" at 652:16-652:18 (leading: Space)
+7969: Ident           "__pos" at 652:19-652:24 (leading: Space)
+7970: LParen          "(" at 652:24-652:25
+7971: Ident           "self" at 652:25-652:29
+7972: Colon           ":" at 652:29-652:30
+7973: Ident           "float" at 652:31-652:36 (leading: Space)
+7974: RParen          ")" at 652:36-652:37
+7975: Arrow           "->" at 652:38-652:40 (leading: Space)
+7976: Ident           "float" at 652:41-652:46 (leading: Space)
+7977: Semicolon       ";" at 652:46-652:47
+7978: At              "@" at 653:5-653:6 (leading: Newline, Space)
+7979: Ident           "intrinsic" at 653:6-653:15
+7980: KwFn            "fn" at 653:16-653:18 (leading: Space)
+7981: Ident           "__neg" at 653:19-653:24 (leading: Space)
+7982: LParen          "(" at 653:24-653:25
+7983: Ident           "self" at 653:25-653:29
+7984: Colon           ":" at 653:29-653:30
+7985: Ident           "float" at 653:31-653:36 (leading: Space)
+7986: RParen          ")" at 653:36-653:37
+7987: Arrow           "->" at 653:38-653:40 (leading: Space)
+7988: Ident           "float" at 653:41-653:46 (leading: Space)
+7989: Semicolon       ";" at 653:46-653:47
+7990: At              "@" at 654:5-654:6 (leading: Newline, Space)
+7991: Ident           "intrinsic" at 654:6-654:15
+7992: KwFn            "fn" at 654:16-654:18 (leading: Space)
+7993: Ident           "__abs" at 654:19-654:24 (leading: Space)
+7994: LParen          "(" at 654:24-654:25
+7995: Ident           "self" at 654:25-654:29
+7996: Colon           ":" at 654:29-654:30
+7997: Ident           "float" at 654:31-654:36 (leading: Space)
+7998: RParen          ")" at 654:36-654:37
+7999: Arrow           "->" at 654:38-654:40 (leading: Space)
+8000: Ident           "float" at 654:41-654:46 (leading: Space)
+8001: Semicolon       ";" at 654:46-654:47
+8002: At              "@" at 655:5-655:6 (leading: Newline, Space)
+8003: Ident           "intrinsic" at 655:6-655:15
+8004: KwFn            "fn" at 655:16-655:18 (leading: Space)
+8005: Ident           "__to" at 655:19-655:23 (leading: Space)
+8006: LParen          "(" at 655:23-655:24
+8007: Ident           "self" at 655:24-655:28
+8008: Colon           ":" at 655:28-655:29
+8009: Ident           "float" at 655:30-655:35 (leading: Space)
+8010: Comma           "," at 655:35-655:36
+8011: Ident           "target" at 655:37-655:43 (leading: Space)
+8012: Colon           ":" at 655:43-655:44
+8013: Ident           "string" at 655:45-655:51 (leading: Space)
+8014: RParen          ")" at 655:51-655:52
+8015: Arrow           "->" at 655:53-655:55 (leading: Space)
+8016: Ident           "string" at 655:56-655:62 (leading: Space)
+8017: Semicolon       ";" at 655:62-655:63
+8018: At              "@" at 656:5-656:6 (leading: Newline, Space)
+8019: Ident           "overload" at 656:6-656:14
+8020: KwPub           "pub" at 656:15-656:18 (leading: Space)
+8021: KwFn            "fn" at 656:19-656:21 (leading: Space)
+8022: Ident           "__to" at 656:22-656:26 (leading: Space)
+8023: LParen          "(" at 656:26-656:27
+8024: Ident           "self" at 656:27-656:31
+8025: Colon           ":" at 656:31-656:32
+8026: Amp             "&" at 656:33-656:34 (leading: Space)
+8027: Ident           "float" at 656:34-656:39
+8028: Comma           "," at 656:39-656:40
+8029: Underscore      "_" at 656:41-656:42 (leading: Space)
+8030: Colon           ":" at 656:42-656:43
+8031: Ident           "string" at 656:44-656:50 (leading: Space)
+8032: RParen          ")" at 656:50-656:51
+8033: Arrow           "->" at 656:52-656:54 (leading: Space)
+8034: Ident           "string" at 656:55-656:61 (leading: Space)
+8035: LBrace          "{" at 656:62-656:63 (leading: Space)
+8036: KwReturn        "return" at 657:9-657:15 (leading: Newline, Space)
+8037: LParen          "(" at 657:16-657:17 (leading: Space)
+8038: Star            "*" at 657:17-657:18
+8039: Ident           "self" at 657:18-657:22
+8040: RParen          ")" at 657:22-657:23
+8041: KwTo            "to" at 657:24-657:26 (leading: Space)
+8042: Ident           "string" at 657:27-657:33 (leading: Space)
+8043: Semicolon       ";" at 657:33-657:34
+8044: RBrace          "}" at 658:5-658:6 (leading: Newline, Space)
+8045: At              "@" at 659:5-659:6 (leading: Newline, Space)
+8046: Ident           "intrinsic" at 659:6-659:15
+8047: At              "@" at 659:16-659:17 (leading: Space)
+8048: Ident           "overload" at 659:17-659:25
+8049: KwFn            "fn" at 659:26-659:28 (leading: Space)
+8050: Ident           "__to" at 659:29-659:33 (leading: Space)
+8051: LParen          "(" at 659:33-659:34
+8052: Ident           "self" at 659:34-659:38
+8053: Colon           ":" at 659:38-659:39
+8054: Ident           "float" at 659:40-659:45 (leading: Space)
+8055: Comma           "," at 659:45-659:46
+8056: Ident           "target" at 659:47-659:53 (leading: Space)
+8057: Colon           ":" at 659:53-659:54
+8058: Ident           "int" at 659:55-659:58 (leading: Space)
+8059: RParen          ")" at 659:58-659:59
+8060: Arrow           "->" at 659:60-659:62 (leading: Space)
+8061: Ident           "int" at 659:63-659:66 (leading: Space)
+8062: Semicolon       ";" at 659:66-659:67
+8063: At              "@" at 660:5-660:6 (leading: Newline, Space)
+8064: Ident           "intrinsic" at 660:6-660:15
+8065: At              "@" at 660:16-660:17 (leading: Space)
+8066: Ident           "overload" at 660:17-660:25
+8067: KwFn            "fn" at 660:26-660:28 (leading: Space)
+8068: Ident           "__to" at 660:29-660:33 (leading: Space)
+8069: LParen          "(" at 660:33-660:34
+8070: Ident           "self" at 660:34-660:38
+8071: Colon           ":" at 660:38-660:39
+8072: Ident           "float" at 660:40-660:45 (leading: Space)
+8073: Comma           "," at 660:45-660:46
+8074: Ident           "target" at 660:47-660:53 (leading: Space)
+8075: Colon           ":" at 660:53-660:54
+8076: Ident           "uint" at 660:55-660:59 (leading: Space)
+8077: RParen          ")" at 660:59-660:60
+8078: Arrow           "->" at 660:61-660:63 (leading: Space)
+8079: Ident           "uint" at 660:64-660:68 (leading: Space)
+8080: Semicolon       ";" at 660:68-660:69
+8081: At              "@" at 661:5-661:6 (leading: Newline, Space)
+8082: Ident           "intrinsic" at 661:6-661:15
+8083: At              "@" at 661:16-661:17 (leading: Space)
+8084: Ident           "overload" at 661:17-661:25
+8085: KwFn            "fn" at 661:26-661:28 (leading: Space)
+8086: Ident           "__to" at 661:29-661:33 (leading: Space)
+8087: LParen          "(" at 661:33-661:34
+8088: Ident           "self" at 661:34-661:38
+8089: Colon           ":" at 661:38-661:39
+8090: Ident           "float" at 661:40-661:45 (leading: Space)
+8091: Comma           "," at 661:45-661:46
+8092: Ident           "target" at 661:47-661:53 (leading: Space)
+8093: Colon           ":" at 661:53-661:54
+8094: Ident           "int8" at 661:55-661:59 (leading: Space)
+8095: RParen          ")" at 661:59-661:60
+8096: Arrow           "->" at 661:61-661:63 (leading: Space)
+8097: Ident           "int8" at 661:64-661:68 (leading: Space)
+8098: Semicolon       ";" at 661:68-661:69
+8099: At              "@" at 662:5-662:6 (leading: Newline, Space)
+8100: Ident           "intrinsic" at 662:6-662:15
+8101: At              "@" at 662:16-662:17 (leading: Space)
+8102: Ident           "overload" at 662:17-662:25
+8103: KwFn            "fn" at 662:26-662:28 (leading: Space)
+8104: Ident           "__to" at 662:29-662:33 (leading: Space)
+8105: LParen          "(" at 662:33-662:34
+8106: Ident           "self" at 662:34-662:38
+8107: Colon           ":" at 662:38-662:39
+8108: Ident           "float" at 662:40-662:45 (leading: Space)
+8109: Comma           "," at 662:45-662:46
+8110: Ident           "target" at 662:47-662:53 (leading: Space)
+8111: Colon           ":" at 662:53-662:54
+8112: Ident           "int16" at 662:55-662:60 (leading: Space)
+8113: RParen          ")" at 662:60-662:61
+8114: Arrow           "->" at 662:62-662:64 (leading: Space)
+8115: Ident           "int16" at 662:65-662:70 (leading: Space)
+8116: Semicolon       ";" at 662:70-662:71
+8117: At              "@" at 663:5-663:6 (leading: Newline, Space)
+8118: Ident           "intrinsic" at 663:6-663:15
+8119: At              "@" at 663:16-663:17 (leading: Space)
+8120: Ident           "overload" at 663:17-663:25
+8121: KwFn            "fn" at 663:26-663:28 (leading: Space)
+8122: Ident           "__to" at 663:29-663:33 (leading: Space)
+8123: LParen          "(" at 663:33-663:34
+8124: Ident           "self" at 663:34-663:38
+8125: Colon           ":" at 663:38-663:39
+8126: Ident           "float" at 663:40-663:45 (leading: Space)
+8127: Comma           "," at 663:45-663:46
+8128: Ident           "target" at 663:47-663:53 (leading: Space)
+8129: Colon           ":" at 663:53-663:54
+8130: Ident           "int32" at 663:55-663:60 (leading: Space)
+8131: RParen          ")" at 663:60-663:61
+8132: Arrow           "->" at 663:62-663:64 (leading: Space)
+8133: Ident           "int32" at 663:65-663:70 (leading: Space)
+8134: Semicolon       ";" at 663:70-663:71
+8135: At              "@" at 664:5-664:6 (leading: Newline, Space)
+8136: Ident           "intrinsic" at 664:6-664:15
+8137: At              "@" at 664:16-664:17 (leading: Space)
+8138: Ident           "overload" at 664:17-664:25
+8139: KwFn            "fn" at 664:26-664:28 (leading: Space)
+8140: Ident           "__to" at 664:29-664:33 (leading: Space)
+8141: LParen          "(" at 664:33-664:34
+8142: Ident           "self" at 664:34-664:38
+8143: Colon           ":" at 664:38-664:39
+8144: Ident           "float" at 664:40-664:45 (leading: Space)
+8145: Comma           "," at 664:45-664:46
+8146: Ident           "target" at 664:47-664:53 (leading: Space)
+8147: Colon           ":" at 664:53-664:54
+8148: Ident           "int64" at 664:55-664:60 (leading: Space)
+8149: RParen          ")" at 664:60-664:61
+8150: Arrow           "->" at 664:62-664:64 (leading: Space)
+8151: Ident           "int64" at 664:65-664:70 (leading: Space)
+8152: Semicolon       ";" at 664:70-664:71
+8153: At              "@" at 665:5-665:6 (leading: Newline, Space)
+8154: Ident           "intrinsic" at 665:6-665:15
+8155: At              "@" at 665:16-665:17 (leading: Space)
+8156: Ident           "overload" at 665:17-665:25
+8157: KwFn            "fn" at 665:26-665:28 (leading: Space)
+8158: Ident           "__to" at 665:29-665:33 (leading: Space)
+8159: LParen          "(" at 665:33-665:34
+8160: Ident           "self" at 665:34-665:38
+8161: Colon           ":" at 665:38-665:39
+8162: Ident           "float" at 665:40-665:45 (leading: Space)
+8163: Comma           "," at 665:45-665:46
+8164: Ident           "target" at 665:47-665:53 (leading: Space)
+8165: Colon           ":" at 665:53-665:54
+8166: Ident           "uint8" at 665:55-665:60 (leading: Space)
+8167: RParen          ")" at 665:60-665:61
+8168: Arrow           "->" at 665:62-665:64 (leading: Space)
+8169: Ident           "uint8" at 665:65-665:70 (leading: Space)
+8170: Semicolon       ";" at 665:70-665:71
+8171: At              "@" at 666:5-666:6 (leading: Newline, Space)
+8172: Ident           "intrinsic" at 666:6-666:15
+8173: At              "@" at 666:16-666:17 (leading: Space)
+8174: Ident           "overload" at 666:17-666:25
+8175: KwFn            "fn" at 666:26-666:28 (leading: Space)
+8176: Ident           "__to" at 666:29-666:33 (leading: Space)
+8177: LParen          "(" at 666:33-666:34
+8178: Ident           "self" at 666:34-666:38
+8179: Colon           ":" at 666:38-666:39
+8180: Ident           "float" at 666:40-666:45 (leading: Space)
+8181: Comma           "," at 666:45-666:46
+8182: Ident           "target" at 666:47-666:53 (leading: Space)
+8183: Colon           ":" at 666:53-666:54
+8184: Ident           "uint16" at 666:55-666:61 (leading: Space)
+8185: RParen          ")" at 666:61-666:62
+8186: Arrow           "->" at 666:63-666:65 (leading: Space)
+8187: Ident           "uint16" at 666:66-666:72 (leading: Space)
+8188: Semicolon       ";" at 666:72-666:73
+8189: At              "@" at 667:5-667:6 (leading: Newline, Space)
+8190: Ident           "intrinsic" at 667:6-667:15
+8191: At              "@" at 667:16-667:17 (leading: Space)
+8192: Ident           "overload" at 667:17-667:25
+8193: KwFn            "fn" at 667:26-667:28 (leading: Space)
+8194: Ident           "__to" at 667:29-667:33 (leading: Space)
+8195: LParen          "(" at 667:33-667:34
+8196: Ident           "self" at 667:34-667:38
+8197: Colon           ":" at 667:38-667:39
+8198: Ident           "float" at 667:40-667:45 (leading: Space)
+8199: Comma           "," at 667:45-667:46
+8200: Ident           "target" at 667:47-667:53 (leading: Space)
+8201: Colon           ":" at 667:53-667:54
+8202: Ident           "uint32" at 667:55-667:61 (leading: Space)
+8203: RParen          ")" at 667:61-667:62
+8204: Arrow           "->" at 667:63-667:65 (leading: Space)
+8205: Ident           "uint32" at 667:66-667:72 (leading: Space)
+8206: Semicolon       ";" at 667:72-667:73
+8207: At              "@" at 668:5-668:6 (leading: Newline, Space)
+8208: Ident           "intrinsic" at 668:6-668:15
+8209: At              "@" at 668:16-668:17 (leading: Space)
+8210: Ident           "overload" at 668:17-668:25
+8211: KwFn            "fn" at 668:26-668:28 (leading: Space)
+8212: Ident           "__to" at 668:29-668:33 (leading: Space)
+8213: LParen          "(" at 668:33-668:34
+8214: Ident           "self" at 668:34-668:38
+8215: Colon           ":" at 668:38-668:39
+8216: Ident           "float" at 668:40-668:45 (leading: Space)
+8217: Comma           "," at 668:45-668:46
+8218: Ident           "target" at 668:47-668:53 (leading: Space)
+8219: Colon           ":" at 668:53-668:54
+8220: Ident           "uint64" at 668:55-668:61 (leading: Space)
+8221: RParen          ")" at 668:61-668:62
+8222: Arrow           "->" at 668:63-668:65 (leading: Space)
+8223: Ident           "uint64" at 668:66-668:72 (leading: Space)
+8224: Semicolon       ";" at 668:72-668:73
+8225: At              "@" at 669:5-669:6 (leading: Newline, Space)
+8226: Ident           "intrinsic" at 669:6-669:15
+8227: At              "@" at 669:16-669:17 (leading: Space)
+8228: Ident           "overload" at 669:17-669:25
+8229: KwFn            "fn" at 669:26-669:28 (leading: Space)
+8230: Ident           "__to" at 669:29-669:33 (leading: Space)
+8231: LParen          "(" at 669:33-669:34
+8232: Ident           "self" at 669:34-669:38
+8233: Colon           ":" at 669:38-669:39
+8234: Ident           "float" at 669:40-669:45 (leading: Space)
+8235: Comma           "," at 669:45-669:46
+8236: Ident           "target" at 669:47-669:53 (leading: Space)
+8237: Colon           ":" at 669:53-669:54
+8238: Ident           "float16" at 669:55-669:62 (leading: Space)
+8239: RParen          ")" at 669:62-669:63
+8240: Arrow           "->" at 669:64-669:66 (leading: Space)
+8241: Ident           "float16" at 669:67-669:74 (leading: Space)
+8242: Semicolon       ";" at 669:74-669:75
+8243: At              "@" at 670:5-670:6 (leading: Newline, Space)
+8244: Ident           "intrinsic" at 670:6-670:15
+8245: At              "@" at 670:16-670:17 (leading: Space)
+8246: Ident           "overload" at 670:17-670:25
+8247: KwFn            "fn" at 670:26-670:28 (leading: Space)
+8248: Ident           "__to" at 670:29-670:33 (leading: Space)
+8249: LParen          "(" at 670:33-670:34
+8250: Ident           "self" at 670:34-670:38
+8251: Colon           ":" at 670:38-670:39
+8252: Ident           "float" at 670:40-670:45 (leading: Space)
+8253: Comma           "," at 670:45-670:46
+8254: Ident           "target" at 670:47-670:53 (leading: Space)
+8255: Colon           ":" at 670:53-670:54
+8256: Ident           "float32" at 670:55-670:62 (leading: Space)
+8257: RParen          ")" at 670:62-670:63
+8258: Arrow           "->" at 670:64-670:66 (leading: Space)
+8259: Ident           "float32" at 670:67-670:74 (leading: Space)
+8260: Semicolon       ";" at 670:74-670:75
+8261: At              "@" at 671:5-671:6 (leading: Newline, Space)
+8262: Ident           "intrinsic" at 671:6-671:15
+8263: At              "@" at 671:16-671:17 (leading: Space)
+8264: Ident           "overload" at 671:17-671:25
+8265: KwFn            "fn" at 671:26-671:28 (leading: Space)
+8266: Ident           "__to" at 671:29-671:33 (leading: Space)
+8267: LParen          "(" at 671:33-671:34
+8268: Ident           "self" at 671:34-671:38
+8269: Colon           ":" at 671:38-671:39
+8270: Ident           "float" at 671:40-671:45 (leading: Space)
+8271: Comma           "," at 671:45-671:46
+8272: Ident           "target" at 671:47-671:53 (leading: Space)
+8273: Colon           ":" at 671:53-671:54
+8274: Ident           "float64" at 671:55-671:62 (leading: Space)
+8275: RParen          ")" at 671:62-671:63
+8276: Arrow           "->" at 671:64-671:66 (leading: Space)
+8277: Ident           "float64" at 671:67-671:74 (leading: Space)
+8278: Semicolon       ";" at 671:74-671:75
+8279: At              "@" at 673:5-673:6 (leading: Newline, Space, LineComment, Newline, Space)
+8280: Ident           "intrinsic" at 673:6-673:15
+8281: KwPub           "pub" at 673:16-673:19 (leading: Space)
+8282: KwFn            "fn" at 673:20-673:22 (leading: Space)
+8283: Ident           "from_str" at 673:23-673:31 (leading: Space)
+8284: LParen          "(" at 673:31-673:32
+8285: Ident           "s" at 673:32-673:33
+8286: Colon           ":" at 673:33-673:34
+8287: Amp             "&" at 673:35-673:36 (leading: Space)
+8288: Ident           "string" at 673:36-673:42
+8289: RParen          ")" at 673:42-673:43
+8290: Arrow           "->" at 673:44-673:46 (leading: Space)
+8291: Ident           "Erring" at 673:47-673:53 (leading: Space)
+8292: Lt              "<" at 673:53-673:54
+8293: Ident           "float" at 673:54-673:59
+8294: Comma           "," at 673:59-673:60
+8295: Ident           "Error" at 673:61-673:66 (leading: Space)
+8296: Gt              ">" at 673:66-673:67
+8297: Semicolon       ";" at 673:67-673:68
+8298: RBrace          "}" at 674:1-674:2 (leading: Newline)
+8299: KwExtern        "extern" at 676:1-676:7 (leading: Newline)
+8300: Lt              "<" at 676:7-676:8
+8301: Ident           "string" at 676:8-676:14
+8302: Gt              ">" at 676:14-676:15
+8303: LBrace          "{" at 676:16-676:17 (leading: Space)
+8304: At              "@" at 677:5-677:6 (leading: Newline, Space)
+8305: Ident           "intrinsic" at 677:6-677:15
+8306: KwFn            "fn" at 677:16-677:18 (leading: Space)
+8307: Ident           "__add" at 677:19-677:24 (leading: Space)
+8308: LParen          "(" at 677:24-677:25
+8309: Ident           "self" at 677:25-677:29
+8310: Colon           ":" at 677:29-677:30
+8311: Amp             "&" at 677:31-677:32 (leading: Space)
+8312: Ident           "string" at 677:32-677:38
+8313: Comma           "," at 677:38-677:39
+8314: Ident           "other" at 677:40-677:45 (leading: Space)
+8315: Colon           ":" at 677:45-677:46
+8316: Amp             "&" at 677:47-677:48 (leading: Space)
+8317: Ident           "string" at 677:48-677:54
+8318: RParen          ")" at 677:54-677:55
+8319: Arrow           "->" at 677:56-677:58 (leading: Space)
+8320: Ident           "string" at 677:59-677:65 (leading: Space)
+8321: Semicolon       ";" at 677:65-677:66
+8322: At              "@" at 678:5-678:6 (leading: Newline, Space)
+8323: Ident           "intrinsic" at 678:6-678:15
+8324: KwFn            "fn" at 678:16-678:18 (leading: Space)
+8325: Ident           "__mul" at 678:19-678:24 (leading: Space)
+8326: LParen          "(" at 678:24-678:25
+8327: Ident           "self" at 678:25-678:29
+8328: Colon           ":" at 678:29-678:30
+8329: Amp             "&" at 678:31-678:32 (leading: Space)
+8330: Ident           "string" at 678:32-678:38
+8331: Comma           "," at 678:38-678:39
+8332: Ident           "other" at 678:40-678:45 (leading: Space)
+8333: Colon           ":" at 678:45-678:46
+8334: Ident           "int" at 678:47-678:50 (leading: Space)
+8335: RParen          ")" at 678:50-678:51
+8336: Arrow           "->" at 678:52-678:54 (leading: Space)
+8337: Ident           "string" at 678:55-678:61 (leading: Space)
+8338: Semicolon       ";" at 678:61-678:62
+8339: At              "@" at 679:5-679:6 (leading: Newline, Space)
+8340: Ident           "overload" at 679:6-679:14
+8341: KwPub           "pub" at 679:15-679:18 (leading: Space)
+8342: KwFn            "fn" at 679:19-679:21 (leading: Space)
+8343: Ident           "__mul" at 679:22-679:27 (leading: Space)
+8344: LParen          "(" at 679:27-679:28
+8345: Ident           "self" at 679:28-679:32
+8346: Colon           ":" at 679:32-679:33
+8347: Amp             "&" at 679:34-679:35 (leading: Space)
+8348: Ident           "string" at 679:35-679:41
+8349: Comma           "," at 679:41-679:42
+8350: Ident           "other" at 679:43-679:48 (leading: Space)
+8351: Colon           ":" at 679:48-679:49
+8352: Ident           "uint" at 679:50-679:54 (leading: Space)
+8353: RParen          ")" at 679:54-679:55
+8354: Arrow           "->" at 679:56-679:58 (leading: Space)
+8355: Ident           "string" at 679:59-679:65 (leading: Space)
+8356: LBrace          "{" at 679:66-679:67 (leading: Space)
+8357: KwReturn        "return" at 680:9-680:15 (leading: Newline, Space)
+8358: Ident           "self" at 680:16-680:20 (leading: Space)
+8359: Star            "*" at 680:21-680:22 (leading: Space)
+8360: LParen          "(" at 680:23-680:24 (leading: Space)
+8361: Ident           "other" at 680:24-680:29
+8362: KwTo            "to" at 680:30-680:32 (leading: Space)
+8363: Ident           "int" at 680:33-680:36 (leading: Space)
+8364: RParen          ")" at 680:36-680:37
+8365: Semicolon       ";" at 680:37-680:38
+8366: RBrace          "}" at 681:5-681:6 (leading: Newline, Space)
+8367: At              "@" at 682:5-682:6 (leading: Newline, Space)
+8368: Ident           "intrinsic" at 682:6-682:15
+8369: KwFn            "fn" at 682:16-682:18 (leading: Space)
+8370: Ident           "__eq" at 682:19-682:23 (leading: Space)
+8371: LParen          "(" at 682:23-682:24
+8372: Ident           "self" at 682:24-682:28
+8373: Colon           ":" at 682:28-682:29
+8374: Amp             "&" at 682:30-682:31 (leading: Space)
+8375: Ident           "string" at 682:31-682:37
+8376: Comma           "," at 682:37-682:38
+8377: Ident           "other" at 682:39-682:44 (leading: Space)
+8378: Colon           ":" at 682:44-682:45
+8379: Amp             "&" at 682:46-682:47 (leading: Space)
+8380: Ident           "string" at 682:47-682:53
+8381: RParen          ")" at 682:53-682:54
+8382: Arrow           "->" at 682:55-682:57 (leading: Space)
+8383: Ident           "bool" at 682:58-682:62 (leading: Space)
+8384: Semicolon       ";" at 682:62-682:63
+8385: At              "@" at 683:5-683:6 (leading: Newline, Space)
+8386: Ident           "intrinsic" at 683:6-683:15
+8387: KwFn            "fn" at 683:16-683:18 (leading: Space)
+8388: Ident           "__ne" at 683:19-683:23 (leading: Space)
+8389: LParen          "(" at 683:23-683:24
+8390: Ident           "self" at 683:24-683:28
+8391: Colon           ":" at 683:28-683:29
+8392: Amp             "&" at 683:30-683:31 (leading: Space)
+8393: Ident           "string" at 683:31-683:37
+8394: Comma           "," at 683:37-683:38
+8395: Ident           "other" at 683:39-683:44 (leading: Space)
+8396: Colon           ":" at 683:44-683:45
+8397: Amp             "&" at 683:46-683:47 (leading: Space)
+8398: Ident           "string" at 683:47-683:53
+8399: RParen          ")" at 683:53-683:54
+8400: Arrow           "->" at 683:55-683:57 (leading: Space)
+8401: Ident           "bool" at 683:58-683:62 (leading: Space)
+8402: Semicolon       ";" at 683:62-683:63
+8403: At              "@" at 684:5-684:6 (leading: Newline, Space)
+8404: Ident           "intrinsic" at 684:6-684:15
+8405: KwFn            "fn" at 684:16-684:18 (leading: Space)
+8406: Ident           "__to" at 684:19-684:23 (leading: Space)
+8407: LParen          "(" at 684:23-684:24
+8408: Ident           "self" at 684:24-684:28
+8409: Colon           ":" at 684:28-684:29
+8410: Amp             "&" at 684:30-684:31 (leading: Space)
+8411: Ident           "string" at 684:31-684:37
+8412: Comma           "," at 684:37-684:38
+8413: Ident           "target" at 684:39-684:45 (leading: Space)
+8414: Colon           ":" at 684:45-684:46
+8415: Ident           "int" at 684:47-684:50 (leading: Space)
+8416: RParen          ")" at 684:50-684:51
+8417: Arrow           "->" at 684:52-684:54 (leading: Space)
+8418: Ident           "int" at 684:55-684:58 (leading: Space)
+8419: Semicolon       ";" at 684:58-684:59
+8420: At              "@" at 685:5-685:6 (leading: Newline, Space)
+8421: Ident           "intrinsic" at 685:6-685:15
+8422: At              "@" at 685:16-685:17 (leading: Space)
+8423: Ident           "overload" at 685:17-685:25
+8424: KwFn            "fn" at 685:26-685:28 (leading: Space)
+8425: Ident           "__to" at 685:29-685:33 (leading: Space)
+8426: LParen          "(" at 685:33-685:34
+8427: Ident           "self" at 685:34-685:38
+8428: Colon           ":" at 685:38-685:39
+8429: Amp             "&" at 685:40-685:41 (leading: Space)
+8430: Ident           "string" at 685:41-685:47
+8431: Comma           "," at 685:47-685:48
+8432: Ident           "target" at 685:49-685:55 (leading: Space)
+8433: Colon           ":" at 685:55-685:56
+8434: Ident           "uint" at 685:57-685:61 (leading: Space)
+8435: RParen          ")" at 685:61-685:62
+8436: Arrow           "->" at 685:63-685:65 (leading: Space)
+8437: Ident           "uint" at 685:66-685:70 (leading: Space)
+8438: Semicolon       ";" at 685:70-685:71
+8439: At              "@" at 686:5-686:6 (leading: Newline, Space)
+8440: Ident           "intrinsic" at 686:6-686:15
+8441: At              "@" at 686:16-686:17 (leading: Space)
+8442: Ident           "overload" at 686:17-686:25
+8443: KwFn            "fn" at 686:26-686:28 (leading: Space)
+8444: Ident           "__to" at 686:29-686:33 (leading: Space)
+8445: LParen          "(" at 686:33-686:34
+8446: Ident           "self" at 686:34-686:38
+8447: Colon           ":" at 686:38-686:39
+8448: Amp             "&" at 686:40-686:41 (leading: Space)
+8449: Ident           "string" at 686:41-686:47
+8450: Comma           "," at 686:47-686:48
+8451: Ident           "target" at 686:49-686:55 (leading: Space)
+8452: Colon           ":" at 686:55-686:56
+8453: Ident           "float" at 686:57-686:62 (leading: Space)
+8454: RParen          ")" at 686:62-686:63
+8455: Arrow           "->" at 686:64-686:66 (leading: Space)
+8456: Ident           "float" at 686:67-686:72 (leading: Space)
+8457: Semicolon       ";" at 686:72-686:73
+8458: At              "@" at 687:5-687:6 (leading: Newline, Space)
+8459: Ident           "overload" at 687:6-687:14
+8460: KwPub           "pub" at 687:15-687:18 (leading: Space)
+8461: KwFn            "fn" at 687:19-687:21 (leading: Space)
+8462: Ident           "__to" at 687:22-687:26 (leading: Space)
+8463: LParen          "(" at 687:26-687:27
+8464: Ident           "self" at 687:27-687:31
+8465: Colon           ":" at 687:31-687:32
+8466: Amp             "&" at 687:33-687:34 (leading: Space)
+8467: Ident           "string" at 687:34-687:40
+8468: Comma           "," at 687:40-687:41
+8469: Underscore      "_" at 687:42-687:43 (leading: Space)
+8470: Colon           ":" at 687:43-687:44
+8471: Ident           "string" at 687:45-687:51 (leading: Space)
+8472: RParen          ")" at 687:51-687:52
+8473: Arrow           "->" at 687:53-687:55 (leading: Space)
+8474: Ident           "string" at 687:56-687:62 (leading: Space)
+8475: LBrace          "{" at 687:63-687:64 (leading: Space)
+8476: KwReturn        "return" at 688:9-688:15 (leading: Newline, Space)
+8477: Ident           "self" at 688:16-688:20 (leading: Space)
+8478: Dot             "." at 688:20-688:21
+8479: Ident           "__clone" at 688:21-688:28
+8480: LParen          "(" at 688:28-688:29
+8481: RParen          ")" at 688:29-688:30
+8482: Semicolon       ";" at 688:30-688:31
+8483: RBrace          "}" at 689:5-689:6 (leading: Newline, Space)
+8484: At              "@" at 690:5-690:6 (leading: Newline, Space)
+8485: Ident           "overload" at 690:6-690:14
+8486: KwPub           "pub" at 691:5-691:8 (leading: Newline, Space)
+8487: KwFn            "fn" at 691:9-691:11 (leading: Space)
+8488: Ident           "__to" at 691:12-691:16 (leading: Space)
+8489: LParen          "(" at 691:16-691:17
+8490: Ident           "self" at 691:17-691:21
+8491: Colon           ":" at 691:21-691:22
+8492: Amp             "&" at 691:23-691:24 (leading: Space)
+8493: Ident           "string" at 691:24-691:30
+8494: Comma           "," at 691:30-691:31
+8495: Underscore      "_" at 691:32-691:33 (leading: Space)
+8496: Colon           ":" at 691:33-691:34
+8497: Ident           "byte" at 691:35-691:39 (leading: Space)
+8498: LBracket        "[" at 691:39-691:40
+8499: RBracket        "]" at 691:40-691:41
+8500: RParen          ")" at 691:41-691:42
+8501: Arrow           "->" at 691:43-691:45 (leading: Space)
+8502: Ident           "byte" at 691:46-691:50 (leading: Space)
+8503: LBracket        "[" at 691:50-691:51
+8504: RBracket        "]" at 691:51-691:52
+8505: LBrace          "{" at 691:53-691:54 (leading: Space)
+8506: KwLet           "let" at 692:9-692:12 (leading: Newline, Space)
+8507: KwMut           "mut" at 692:13-692:16 (leading: Space)
+8508: Ident           "out" at 692:17-692:20 (leading: Space)
+8509: Colon           ":" at 692:20-692:21
+8510: Ident           "byte" at 692:22-692:26 (leading: Space)
+8511: LBracket        "[" at 692:26-692:27
+8512: RBracket        "]" at 692:27-692:28
+8513: Assign          "=" at 692:29-692:30 (leading: Space)
+8514: LBracket        "[" at 692:31-692:32 (leading: Space)
+8515: RBracket        "]" at 692:32-692:33
+8516: Semicolon       ";" at 692:33-692:34
+8517: Ident           "rt_array_append_raw_bytes" at 693:9-693:34 (leading: Newline, Space)
+8518: LParen          "(" at 693:34-693:35
+8519: Amp             "&" at 693:35-693:36
+8520: KwMut           "mut" at 693:36-693:39
+8521: Ident           "out" at 693:40-693:43 (leading: Space)
+8522: Comma           "," at 693:43-693:44
+8523: Ident           "rt_string_ptr" at 693:45-693:58 (leading: Space)
+8524: LParen          "(" at 693:58-693:59
+8525: Ident           "self" at 693:59-693:63
+8526: RParen          ")" at 693:63-693:64
+8527: Comma           "," at 693:64-693:65
+8528: Ident           "rt_string_len_bytes" at 693:66-693:85 (leading: Space)
+8529: LParen          "(" at 693:85-693:86
+8530: Ident           "self" at 693:86-693:90
+8531: RParen          ")" at 693:90-693:91
+8532: KwTo            "to" at 693:92-693:94 (leading: Space)
+8533: Ident           "uint64" at 693:95-693:101 (leading: Space)
+8534: RParen          ")" at 693:101-693:102
+8535: Semicolon       ";" at 693:102-693:103
+8536: KwReturn        "return" at 694:9-694:15 (leading: Newline, Space)
+8537: Ident           "out" at 694:16-694:19 (leading: Space)
+8538: Semicolon       ";" at 694:19-694:20
+8539: RBrace          "}" at 695:5-695:6 (leading: Newline, Space)
+8540: At              "@" at 696:5-696:6 (leading: Newline, Space)
+8541: Ident           "intrinsic" at 696:6-696:15
+8542: KwFn            "fn" at 696:16-696:18 (leading: Space)
+8543: Ident           "__len" at 696:19-696:24 (leading: Space)
+8544: LParen          "(" at 696:24-696:25
+8545: Ident           "self" at 696:25-696:29
+8546: Colon           ":" at 696:29-696:30
+8547: Amp             "&" at 696:31-696:32 (leading: Space)
+8548: Ident           "string" at 696:32-696:38
+8549: RParen          ")" at 696:38-696:39
+8550: Arrow           "->" at 696:40-696:42 (leading: Space)
+8551: Ident           "uint" at 696:43-696:47 (leading: Space)
+8552: Semicolon       ";" at 696:47-696:48
+8553: At              "@" at 697:5-697:6 (leading: Newline, Space)
+8554: Ident           "intrinsic" at 697:6-697:15
+8555: KwFn            "fn" at 697:16-697:18 (leading: Space)
+8556: Ident           "__clone" at 697:19-697:26 (leading: Space)
+8557: LParen          "(" at 697:26-697:27
+8558: Ident           "self" at 697:27-697:31
+8559: Colon           ":" at 697:31-697:32
+8560: Amp             "&" at 697:33-697:34 (leading: Space)
+8561: Ident           "string" at 697:34-697:40
+8562: RParen          ")" at 697:40-697:41
+8563: Arrow           "->" at 697:42-697:44 (leading: Space)
+8564: Ident           "string" at 697:45-697:51 (leading: Space)
+8565: Semicolon       ";" at 697:51-697:52
+8566: At              "@" at 698:5-698:6 (leading: Newline, Space)
+8567: Ident           "intrinsic" at 698:6-698:15
+8568: At              "@" at 698:16-698:17 (leading: Space)
+8569: Ident           "overload" at 698:17-698:25
+8570: KwFn            "fn" at 698:26-698:28 (leading: Space)
+8571: Ident           "__index" at 698:29-698:36 (leading: Space)
+8572: LParen          "(" at 698:36-698:37
+8573: Ident           "self" at 698:37-698:41
+8574: Colon           ":" at 698:41-698:42
+8575: Amp             "&" at 698:43-698:44 (leading: Space)
+8576: Ident           "string" at 698:44-698:50
+8577: Comma           "," at 698:50-698:51
+8578: Ident           "index" at 698:52-698:57 (leading: Space)
+8579: Colon           ":" at 698:57-698:58
+8580: Ident           "int" at 698:59-698:62 (leading: Space)
+8581: RParen          ")" at 698:62-698:63
+8582: Arrow           "->" at 698:64-698:66 (leading: Space)
+8583: Ident           "uint32" at 698:67-698:73 (leading: Space)
+8584: Semicolon       ";" at 698:73-698:74
+8585: At              "@" at 699:5-699:6 (leading: Newline, Space)
+8586: Ident           "intrinsic" at 699:6-699:15
+8587: At              "@" at 699:16-699:17 (leading: Space)
+8588: Ident           "overload" at 699:17-699:25
+8589: KwFn            "fn" at 699:26-699:28 (leading: Space)
+8590: Ident           "__index" at 699:29-699:36 (leading: Space)
+8591: LParen          "(" at 699:36-699:37
+8592: Ident           "self" at 699:37-699:41
+8593: Colon           ":" at 699:41-699:42
+8594: Amp             "&" at 699:43-699:44 (leading: Space)
+8595: Ident           "string" at 699:44-699:50
+8596: Comma           "," at 699:50-699:51
+8597: Ident           "index" at 699:52-699:57 (leading: Space)
+8598: Colon           ":" at 699:57-699:58
+8599: Ident           "Range" at 699:59-699:64 (leading: Space)
+8600: Lt              "<" at 699:64-699:65
+8601: Ident           "int" at 699:65-699:68
+8602: Gt              ">" at 699:68-699:69
+8603: RParen          ")" at 699:69-699:70
+8604: Arrow           "->" at 699:71-699:73 (leading: Space)
+8605: Ident           "string" at 699:74-699:80 (leading: Space)
+8606: Semicolon       ";" at 699:80-699:81
+8607: RBrace          "}" at 700:1-700:2 (leading: Newline)
+8608: At              "@" at 702:1-702:2 (leading: Newline)
+8609: Ident           "intrinsic" at 702:2-702:11
+8610: KwPub           "pub" at 703:1-703:4 (leading: Newline)
+8611: KwType          "type" at 703:5-703:9 (leading: Space)
+8612: Ident           "BytesView" at 703:10-703:19 (leading: Space)
+8613: Assign          "=" at 703:20-703:21 (leading: Space)
+8614: LBrace          "{" at 703:22-703:23 (leading: Space)
+8615: Ident           "owner" at 704:5-704:10 (leading: Newline, Space)
+8616: Colon           ":" at 704:10-704:11
+8617: Ident           "string" at 704:12-704:18 (leading: Space)
+8618: Comma           "," at 704:18-704:19
+8619: Ident           "ptr" at 705:5-705:8 (leading: Newline, Space)
+8620: Colon           ":" at 705:8-705:9
+8621: Star            "*" at 705:10-705:11 (leading: Space)
+8622: Ident           "byte" at 705:11-705:15
+8623: Comma           "," at 705:15-705:16
+8624: Ident           "len" at 706:5-706:8 (leading: Newline, Space)
+8625: Colon           ":" at 706:8-706:9
+8626: Ident           "uint" at 706:10-706:14 (leading: Space)
+8627: Comma           "," at 706:14-706:15
+8628: RBrace          "}" at 707:1-707:2 (leading: Newline)
+8629: Semicolon       ";" at 707:2-707:3
+8630: KwExtern        "extern" at 709:1-709:7 (leading: Newline)
+8631: Lt              "<" at 709:7-709:8
+8632: Ident           "BytesView" at 709:8-709:17
+8633: Gt              ">" at 709:17-709:18
+8634: LBrace          "{" at 709:19-709:20 (leading: Space)
+8635: At              "@" at 710:5-710:6 (leading: Newline, Space)
+8636: Ident           "intrinsic" at 710:6-710:15
+8637: KwFn            "fn" at 710:16-710:18 (leading: Space)
+8638: Ident           "__len" at 710:19-710:24 (leading: Space)
+8639: LParen          "(" at 710:24-710:25
+8640: Ident           "self" at 710:25-710:29
+8641: Colon           ":" at 710:29-710:30
+8642: Amp             "&" at 710:31-710:32 (leading: Space)
+8643: Ident           "BytesView" at 710:32-710:41
+8644: RParen          ")" at 710:41-710:42
+8645: Arrow           "->" at 710:43-710:45 (leading: Space)
+8646: Ident           "uint" at 710:46-710:50 (leading: Space)
+8647: Semicolon       ";" at 710:50-710:51
+8648: At              "@" at 711:5-711:6 (leading: Newline, Space)
+8649: Ident           "intrinsic" at 711:6-711:15
+8650: KwFn            "fn" at 711:16-711:18 (leading: Space)
+8651: Ident           "__index" at 711:19-711:26 (leading: Space)
+8652: LParen          "(" at 711:26-711:27
+8653: Ident           "self" at 711:27-711:31
+8654: Colon           ":" at 711:31-711:32
+8655: Amp             "&" at 711:33-711:34 (leading: Space)
+8656: Ident           "BytesView" at 711:34-711:43
+8657: Comma           "," at 711:43-711:44
+8658: Ident           "index" at 711:45-711:50 (leading: Space)
+8659: Colon           ":" at 711:50-711:51
+8660: Ident           "int" at 711:52-711:55 (leading: Space)
+8661: RParen          ")" at 711:55-711:56
+8662: Arrow           "->" at 711:57-711:59 (leading: Space)
+8663: Ident           "uint8" at 711:60-711:65 (leading: Space)
+8664: Semicolon       ";" at 711:65-711:66
+8665: At              "@" at 712:5-712:6 (leading: Newline, Space)
+8666: Ident           "intrinsic" at 712:6-712:15
+8667: At              "@" at 712:16-712:17 (leading: Space)
+8668: Ident           "overload" at 712:17-712:25
+8669: KwFn            "fn" at 712:26-712:28 (leading: Space)
+8670: Ident           "__index" at 712:29-712:36 (leading: Space)
+8671: LParen          "(" at 712:36-712:37
+8672: Ident           "self" at 712:37-712:41
+8673: Colon           ":" at 712:41-712:42
+8674: Amp             "&" at 712:43-712:44 (leading: Space)
+8675: Ident           "BytesView" at 712:44-712:53
+8676: Comma           "," at 712:53-712:54
+8677: Ident           "index" at 712:55-712:60 (leading: Space)
+8678: Colon           ":" at 712:60-712:61
+8679: Ident           "int64" at 712:62-712:67 (leading: Space)
+8680: RParen          ")" at 712:67-712:68
+8681: Arrow           "->" at 712:69-712:71 (leading: Space)
+8682: Ident           "uint8" at 712:72-712:77 (leading: Space)
+8683: Semicolon       ";" at 712:77-712:78
+8684: RBrace          "}" at 713:1-713:2 (leading: Newline)
+8685: KwExtern        "extern" at 715:1-715:7 (leading: Newline)
+8686: Lt              "<" at 715:7-715:8
+8687: Ident           "bool" at 715:8-715:12
+8688: Gt              ">" at 715:12-715:13
+8689: LBrace          "{" at 715:14-715:15 (leading: Space)
+8690: At              "@" at 716:5-716:6 (leading: Newline, Space)
+8691: Ident           "intrinsic" at 716:6-716:15
+8692: KwFn            "fn" at 716:16-716:18 (leading: Space)
+8693: Ident           "__eq" at 716:19-716:23 (leading: Space)
+8694: LParen          "(" at 716:23-716:24
+8695: Ident           "self" at 716:24-716:28
+8696: Colon           ":" at 716:28-716:29
+8697: Ident           "bool" at 716:30-716:34 (leading: Space)
+8698: Comma           "," at 716:34-716:35
+8699: Ident           "other" at 716:36-716:41 (leading: Space)
+8700: Colon           ":" at 716:41-716:42
+8701: Ident           "bool" at 716:43-716:47 (leading: Space)
+8702: RParen          ")" at 716:47-716:48
+8703: Arrow           "->" at 716:49-716:51 (leading: Space)
+8704: Ident           "bool" at 716:52-716:56 (leading: Space)
+8705: Semicolon       ";" at 716:56-716:57
+8706: At              "@" at 717:5-717:6 (leading: Newline, Space)
+8707: Ident           "intrinsic" at 717:6-717:15
+8708: KwFn            "fn" at 717:16-717:18 (leading: Space)
+8709: Ident           "__ne" at 717:19-717:23 (leading: Space)
+8710: LParen          "(" at 717:23-717:24
+8711: Ident           "self" at 717:24-717:28
+8712: Colon           ":" at 717:28-717:29
+8713: Ident           "bool" at 717:30-717:34 (leading: Space)
+8714: Comma           "," at 717:34-717:35
+8715: Ident           "other" at 717:36-717:41 (leading: Space)
+8716: Colon           ":" at 717:41-717:42
+8717: Ident           "bool" at 717:43-717:47 (leading: Space)
+8718: RParen          ")" at 717:47-717:48
+8719: Arrow           "->" at 717:49-717:51 (leading: Space)
+8720: Ident           "bool" at 717:52-717:56 (leading: Space)
+8721: Semicolon       ";" at 717:56-717:57
+8722: At              "@" at 718:5-718:6 (leading: Newline, Space)
+8723: Ident           "intrinsic" at 718:6-718:15
+8724: KwFn            "fn" at 718:16-718:18 (leading: Space)
+8725: Ident           "__not" at 718:19-718:24 (leading: Space)
+8726: LParen          "(" at 718:24-718:25
+8727: Ident           "self" at 718:25-718:29
+8728: Colon           ":" at 718:29-718:30
+8729: Ident           "bool" at 718:31-718:35 (leading: Space)
+8730: RParen          ")" at 718:35-718:36
+8731: Arrow           "->" at 718:37-718:39 (leading: Space)
+8732: Ident           "bool" at 718:40-718:44 (leading: Space)
+8733: Semicolon       ";" at 718:44-718:45
+8734: At              "@" at 719:5-719:6 (leading: Newline, Space)
+8735: Ident           "intrinsic" at 719:6-719:15
+8736: KwFn            "fn" at 719:16-719:18 (leading: Space)
+8737: Ident           "__to" at 719:19-719:23 (leading: Space)
+8738: LParen          "(" at 719:23-719:24
+8739: Ident           "self" at 719:24-719:28
+8740: Colon           ":" at 719:28-719:29
+8741: Ident           "bool" at 719:30-719:34 (leading: Space)
+8742: Comma           "," at 719:34-719:35
+8743: Ident           "target" at 719:36-719:42 (leading: Space)
+8744: Colon           ":" at 719:42-719:43
+8745: Ident           "string" at 719:44-719:50 (leading: Space)
+8746: RParen          ")" at 719:50-719:51
+8747: Arrow           "->" at 719:52-719:54 (leading: Space)
+8748: Ident           "string" at 719:55-719:61 (leading: Space)
+8749: Semicolon       ";" at 719:61-719:62
+8750: At              "@" at 720:5-720:6 (leading: Newline, Space)
+8751: Ident           "overload" at 720:6-720:14
+8752: KwPub           "pub" at 720:15-720:18 (leading: Space)
+8753: KwFn            "fn" at 720:19-720:21 (leading: Space)
+8754: Ident           "__to" at 720:22-720:26 (leading: Space)
+8755: LParen          "(" at 720:26-720:27
+8756: Ident           "self" at 720:27-720:31
+8757: Colon           ":" at 720:31-720:32
+8758: Amp             "&" at 720:33-720:34 (leading: Space)
+8759: Ident           "bool" at 720:34-720:38
+8760: Comma           "," at 720:38-720:39
+8761: Underscore      "_" at 720:40-720:41 (leading: Space)
+8762: Colon           ":" at 720:41-720:42
+8763: Ident           "string" at 720:43-720:49 (leading: Space)
+8764: RParen          ")" at 720:49-720:50
+8765: Arrow           "->" at 720:51-720:53 (leading: Space)
+8766: Ident           "string" at 720:54-720:60 (leading: Space)
+8767: LBrace          "{" at 720:61-720:62 (leading: Space)
+8768: KwReturn        "return" at 721:9-721:15 (leading: Newline, Space)
+8769: LParen          "(" at 721:16-721:17 (leading: Space)
+8770: Star            "*" at 721:17-721:18
+8771: Ident           "self" at 721:18-721:22
+8772: RParen          ")" at 721:22-721:23
+8773: KwTo            "to" at 721:24-721:26 (leading: Space)
+8774: Ident           "string" at 721:27-721:33 (leading: Space)
+8775: Semicolon       ";" at 721:33-721:34
+8776: RBrace          "}" at 722:5-722:6 (leading: Newline, Space)
+8777: At              "@" at 723:5-723:6 (leading: Newline, Space)
+8778: Ident           "intrinsic" at 723:6-723:15
+8779: At              "@" at 723:16-723:17 (leading: Space)
+8780: Ident           "overload" at 723:17-723:25
+8781: KwFn            "fn" at 723:26-723:28 (leading: Space)
+8782: Ident           "__to" at 723:29-723:33 (leading: Space)
+8783: LParen          "(" at 723:33-723:34
+8784: Ident           "self" at 723:34-723:38
+8785: Colon           ":" at 723:38-723:39
+8786: Ident           "bool" at 723:40-723:44 (leading: Space)
+8787: Comma           "," at 723:44-723:45
+8788: Ident           "target" at 723:46-723:52 (leading: Space)
+8789: Colon           ":" at 723:52-723:53
+8790: Ident           "int" at 723:54-723:57 (leading: Space)
+8791: RParen          ")" at 723:57-723:58
+8792: Arrow           "->" at 723:59-723:61 (leading: Space)
+8793: Ident           "int" at 723:62-723:65 (leading: Space)
+8794: Semicolon       ";" at 723:65-723:66
+8795: At              "@" at 725:5-725:6 (leading: Newline, Space, LineComment, Newline, Space)
+8796: Ident           "intrinsic" at 725:6-725:15
+8797: KwPub           "pub" at 725:16-725:19 (leading: Space)
+8798: KwFn            "fn" at 725:20-725:22 (leading: Space)
+8799: Ident           "from_str" at 725:23-725:31 (leading: Space)
+8800: LParen          "(" at 725:31-725:32
+8801: Ident           "s" at 725:32-725:33
+8802: Colon           ":" at 725:33-725:34
+8803: Amp             "&" at 725:35-725:36 (leading: Space)
+8804: Ident           "string" at 725:36-725:42
+8805: RParen          ")" at 725:42-725:43
+8806: Arrow           "->" at 725:44-725:46 (leading: Space)
+8807: Ident           "Erring" at 725:47-725:53 (leading: Space)
+8808: Lt              "<" at 725:53-725:54
+8809: Ident           "bool" at 725:54-725:58
+8810: Comma           "," at 725:58-725:59
+8811: Ident           "Error" at 725:60-725:65 (leading: Space)
+8812: Gt              ">" at 725:65-725:66
+8813: Semicolon       ";" at 725:66-725:67
+8814: RBrace          "}" at 726:1-726:2 (leading: Newline)
+8815: KwExtern        "extern" at 728:1-728:7 (leading: Newline)
+8816: Lt              "<" at 728:7-728:8
+8817: Ident           "Array" at 728:8-728:13
+8818: Lt              "<" at 728:13-728:14
+8819: Ident           "T" at 728:14-728:15
+8820: Shr             ">>" at 728:15-728:17
+8821: LBrace          "{" at 728:18-728:19 (leading: Space)
+8822: At              "@" at 729:5-729:6 (leading: Newline, Space)
+8823: Ident           "intrinsic" at 729:6-729:15
+8824: KwFn            "fn" at 729:16-729:18 (leading: Space)
+8825: Ident           "__add" at 729:19-729:24 (leading: Space)
+8826: LParen          "(" at 729:24-729:25
+8827: Ident           "self" at 729:25-729:29
+8828: Colon           ":" at 729:29-729:30
+8829: Amp             "&" at 729:31-729:32 (leading: Space)
+8830: Ident           "Array" at 729:32-729:37
+8831: Lt              "<" at 729:37-729:38
+8832: Ident           "T" at 729:38-729:39
+8833: Gt              ">" at 729:39-729:40
+8834: Comma           "," at 729:40-729:41
+8835: Ident           "other" at 729:42-729:47 (leading: Space)
+8836: Colon           ":" at 729:47-729:48
+8837: Amp             "&" at 729:49-729:50 (leading: Space)
+8838: Ident           "Array" at 729:50-729:55
+8839: Lt              "<" at 729:55-729:56
+8840: Ident           "T" at 729:56-729:57
+8841: Gt              ">" at 729:57-729:58
+8842: RParen          ")" at 729:58-729:59
+8843: Arrow           "->" at 729:60-729:62 (leading: Space)
+8844: Ident           "Array" at 729:63-729:68 (leading: Space)
+8845: Lt              "<" at 729:68-729:69
+8846: Ident           "T" at 729:69-729:70
+8847: Gt              ">" at 729:70-729:71
+8848: Semicolon       ";" at 729:71-729:72
+8849: At              "@" at 730:5-730:6 (leading: Newline, Space)
+8850: Ident           "intrinsic" at 730:6-730:15
+8851: KwFn            "fn" at 730:16-730:18 (leading: Space)
+8852: Ident           "__index" at 730:19-730:26 (leading: Space)
+8853: LParen          "(" at 730:26-730:27
+8854: Ident           "self" at 730:27-730:31
+8855: Colon           ":" at 730:31-730:32
+8856: Amp             "&" at 730:33-730:34 (leading: Space)
+8857: Ident           "Array" at 730:34-730:39
+8858: Lt              "<" at 730:39-730:40
+8859: Ident           "T" at 730:40-730:41
+8860: Gt              ">" at 730:41-730:42
+8861: Comma           "," at 730:42-730:43
+8862: Ident           "index" at 730:44-730:49 (leading: Space)
+8863: Colon           ":" at 730:49-730:50
+8864: Ident           "int" at 730:51-730:54 (leading: Space)
+8865: RParen          ")" at 730:54-730:55
+8866: Arrow           "->" at 730:56-730:58 (leading: Space)
+8867: Amp             "&" at 730:59-730:60 (leading: Space)
+8868: Ident           "T" at 730:60-730:61
+8869: Semicolon       ";" at 730:61-730:62
+8870: At              "@" at 731:5-731:6 (leading: Newline, Space)
+8871: Ident           "intrinsic" at 731:6-731:15
+8872: At              "@" at 731:16-731:17 (leading: Space)
+8873: Ident           "overload" at 731:17-731:25
+8874: KwFn            "fn" at 731:26-731:28 (leading: Space)
+8875: Ident           "__index" at 731:29-731:36 (leading: Space)
+8876: LParen          "(" at 731:36-731:37
+8877: Ident           "self" at 731:37-731:41
+8878: Colon           ":" at 731:41-731:42
+8879: Amp             "&" at 731:43-731:44 (leading: Space)
+8880: Ident           "Array" at 731:44-731:49
+8881: Lt              "<" at 731:49-731:50
+8882: Ident           "T" at 731:50-731:51
+8883: Gt              ">" at 731:51-731:52
+8884: Comma           "," at 731:52-731:53
+8885: Ident           "index" at 731:54-731:59 (leading: Space)
+8886: Colon           ":" at 731:59-731:60
+8887: Ident           "Range" at 731:61-731:66 (leading: Space)
+8888: Lt              "<" at 731:66-731:67
+8889: Ident           "int" at 731:67-731:70
+8890: Gt              ">" at 731:70-731:71
+8891: RParen          ")" at 731:71-731:72
+8892: Arrow           "->" at 731:73-731:75 (leading: Space)
+8893: Ident           "Array" at 731:76-731:81 (leading: Space)
+8894: Lt              "<" at 731:81-731:82
+8895: Ident           "T" at 731:82-731:83
+8896: Gt              ">" at 731:83-731:84
+8897: Semicolon       ";" at 731:84-731:85
+8898: At              "@" at 732:5-732:6 (leading: Newline, Space)
+8899: Ident           "intrinsic" at 732:6-732:15
+8900: KwFn            "fn" at 732:16-732:18 (leading: Space)
+8901: Ident           "__index_set" at 732:19-732:30 (leading: Space)
+8902: LParen          "(" at 732:30-732:31
+8903: Ident           "self" at 732:31-732:35
+8904: Colon           ":" at 732:35-732:36
+8905: Amp             "&" at 732:37-732:38 (leading: Space)
+8906: KwMut           "mut" at 732:38-732:41
+8907: Ident           "Array" at 732:42-732:47 (leading: Space)
+8908: Lt              "<" at 732:47-732:48
+8909: Ident           "T" at 732:48-732:49
+8910: Gt              ">" at 732:49-732:50
+8911: Comma           "," at 732:50-732:51
+8912: Ident           "index" at 732:52-732:57 (leading: Space)
+8913: Colon           ":" at 732:57-732:58
+8914: Ident           "int" at 732:59-732:62 (leading: Space)
+8915: Comma           "," at 732:62-732:63
+8916: Ident           "value" at 732:64-732:69 (leading: Space)
+8917: Colon           ":" at 732:69-732:70
+8918: Ident           "T" at 732:71-732:72 (leading: Space)
+8919: RParen          ")" at 732:72-732:73
+8920: Arrow           "->" at 732:74-732:76 (leading: Space)
+8921: NothingLit      "nothing" at 732:77-732:84 (leading: Space)
+8922: Semicolon       ";" at 732:84-732:85
+8923: At              "@" at 733:5-733:6 (leading: Newline, Space)
+8924: Ident           "intrinsic" at 733:6-733:15
+8925: KwFn            "fn" at 733:16-733:18 (leading: Space)
+8926: Ident           "__range" at 733:19-733:26 (leading: Space)
+8927: LParen          "(" at 733:26-733:27
+8928: Ident           "self" at 733:27-733:31
+8929: Colon           ":" at 733:31-733:32
+8930: Amp             "&" at 733:33-733:34 (leading: Space)
+8931: Ident           "Array" at 733:34-733:39
+8932: Lt              "<" at 733:39-733:40
+8933: Ident           "T" at 733:40-733:41
+8934: Gt              ">" at 733:41-733:42
+8935: RParen          ")" at 733:42-733:43
+8936: Arrow           "->" at 733:44-733:46 (leading: Space)
+8937: Ident           "Range" at 733:47-733:52 (leading: Space)
+8938: Lt              "<" at 733:52-733:53
+8939: Ident           "T" at 733:53-733:54
+8940: Gt              ">" at 733:54-733:55
+8941: Semicolon       ";" at 733:55-733:56
+8942: At              "@" at 734:5-734:6 (leading: Newline, Space)
+8943: Ident           "intrinsic" at 734:6-734:15
+8944: KwFn            "fn" at 734:16-734:18 (leading: Space)
+8945: Ident           "__len" at 734:19-734:24 (leading: Space)
+8946: LParen          "(" at 734:24-734:25
+8947: Ident           "self" at 734:25-734:29
+8948: Colon           ":" at 734:29-734:30
+8949: Amp             "&" at 734:31-734:32 (leading: Space)
+8950: Ident           "Array" at 734:32-734:37
+8951: Lt              "<" at 734:37-734:38
+8952: Ident           "T" at 734:38-734:39
+8953: Gt              ">" at 734:39-734:40
+8954: RParen          ")" at 734:40-734:41
+8955: Arrow           "->" at 734:42-734:44 (leading: Space)
+8956: Ident           "uint" at 734:45-734:49 (leading: Space)
+8957: Semicolon       ";" at 734:49-734:50
+8958: RBrace          "}" at 735:1-735:2 (leading: Newline)
+8959: KwExtern        "extern" at 737:1-737:7 (leading: Newline)
+8960: Lt              "<" at 737:7-737:8
+8961: Ident           "ArrayFixed" at 737:8-737:18
+8962: Lt              "<" at 737:18-737:19
+8963: Ident           "T" at 737:19-737:20
+8964: Comma           "," at 737:20-737:21
+8965: Ident           "N" at 737:22-737:23 (leading: Space)
+8966: Shr             ">>" at 737:23-737:25
+8967: LBrace          "{" at 737:26-737:27 (leading: Space)
+8968: At              "@" at 738:5-738:6 (leading: Newline, Space)
+8969: Ident           "intrinsic" at 738:6-738:15
+8970: KwFn            "fn" at 738:16-738:18 (leading: Space)
+8971: Ident           "__add" at 738:19-738:24 (leading: Space)
+8972: LParen          "(" at 738:24-738:25
+8973: Ident           "self" at 738:25-738:29
+8974: Colon           ":" at 738:29-738:30
+8975: Amp             "&" at 738:31-738:32 (leading: Space)
+8976: Ident           "ArrayFixed" at 738:32-738:42
+8977: Lt              "<" at 738:42-738:43
+8978: Ident           "T" at 738:43-738:44
+8979: Comma           "," at 738:44-738:45
+8980: Ident           "N" at 738:46-738:47 (leading: Space)
+8981: Gt              ">" at 738:47-738:48
+8982: Comma           "," at 738:48-738:49
+8983: Ident           "other" at 738:50-738:55 (leading: Space)
+8984: Colon           ":" at 738:55-738:56
+8985: Amp             "&" at 738:57-738:58 (leading: Space)
+8986: Ident           "ArrayFixed" at 738:58-738:68
+8987: Lt              "<" at 738:68-738:69
+8988: Ident           "T" at 738:69-738:70
+8989: Comma           "," at 738:70-738:71
+8990: Ident           "N" at 738:72-738:73 (leading: Space)
+8991: Gt              ">" at 738:73-738:74
+8992: RParen          ")" at 738:74-738:75
+8993: Arrow           "->" at 738:76-738:78 (leading: Space)
+8994: Ident           "ArrayFixed" at 738:79-738:89 (leading: Space)
+8995: Lt              "<" at 738:89-738:90
+8996: Ident           "T" at 738:90-738:91
+8997: Comma           "," at 738:91-738:92
+8998: Ident           "N" at 738:93-738:94 (leading: Space)
+8999: Gt              ">" at 738:94-738:95
+9000: Semicolon       ";" at 738:95-738:96
+9001: At              "@" at 739:5-739:6 (leading: Newline, Space)
+9002: Ident           "intrinsic" at 739:6-739:15
+9003: KwFn            "fn" at 739:16-739:18 (leading: Space)
+9004: Ident           "__index" at 739:19-739:26 (leading: Space)
+9005: LParen          "(" at 739:26-739:27
+9006: Ident           "self" at 739:27-739:31
+9007: Colon           ":" at 739:31-739:32
+9008: Amp             "&" at 739:33-739:34 (leading: Space)
+9009: Ident           "ArrayFixed" at 739:34-739:44
+9010: Lt              "<" at 739:44-739:45
+9011: Ident           "T" at 739:45-739:46
+9012: Comma           "," at 739:46-739:47
+9013: Ident           "N" at 739:48-739:49 (leading: Space)
+9014: Gt              ">" at 739:49-739:50
+9015: Comma           "," at 739:50-739:51
+9016: Ident           "index" at 739:52-739:57 (leading: Space)
+9017: Colon           ":" at 739:57-739:58
+9018: Ident           "int" at 739:59-739:62 (leading: Space)
+9019: RParen          ")" at 739:62-739:63
+9020: Arrow           "->" at 739:64-739:66 (leading: Space)
+9021: Amp             "&" at 739:67-739:68 (leading: Space)
+9022: Ident           "T" at 739:68-739:69
+9023: Semicolon       ";" at 739:69-739:70
+9024: At              "@" at 740:5-740:6 (leading: Newline, Space)
+9025: Ident           "intrinsic" at 740:6-740:15
+9026: At              "@" at 740:16-740:17 (leading: Space)
+9027: Ident           "overload" at 740:17-740:25
+9028: KwFn            "fn" at 740:26-740:28 (leading: Space)
+9029: Ident           "__index" at 740:29-740:36 (leading: Space)
+9030: LParen          "(" at 740:36-740:37
+9031: Ident           "self" at 740:37-740:41
+9032: Colon           ":" at 740:41-740:42
+9033: Amp             "&" at 740:43-740:44 (leading: Space)
+9034: Ident           "ArrayFixed" at 740:44-740:54
+9035: Lt              "<" at 740:54-740:55
+9036: Ident           "T" at 740:55-740:56
+9037: Comma           "," at 740:56-740:57
+9038: Ident           "N" at 740:58-740:59 (leading: Space)
+9039: Gt              ">" at 740:59-740:60
+9040: Comma           "," at 740:60-740:61
+9041: Ident           "index" at 740:62-740:67 (leading: Space)
+9042: Colon           ":" at 740:67-740:68
+9043: Ident           "Range" at 740:69-740:74 (leading: Space)
+9044: Lt              "<" at 740:74-740:75
+9045: Ident           "int" at 740:75-740:78
+9046: Gt              ">" at 740:78-740:79
+9047: RParen          ")" at 740:79-740:80
+9048: Arrow           "->" at 740:81-740:83 (leading: Space)
+9049: Ident           "Array" at 740:84-740:89 (leading: Space)
+9050: Lt              "<" at 740:89-740:90
+9051: Ident           "T" at 740:90-740:91
+9052: Gt              ">" at 740:91-740:92
+9053: Semicolon       ";" at 740:92-740:93
+9054: At              "@" at 741:5-741:6 (leading: Newline, Space)
+9055: Ident           "intrinsic" at 741:6-741:15
+9056: KwFn            "fn" at 741:16-741:18 (leading: Space)
+9057: Ident           "__index_set" at 741:19-741:30 (leading: Space)
+9058: LParen          "(" at 741:30-741:31
+9059: Ident           "self" at 741:31-741:35
+9060: Colon           ":" at 741:35-741:36
+9061: Amp             "&" at 741:37-741:38 (leading: Space)
+9062: KwMut           "mut" at 741:38-741:41
+9063: Ident           "ArrayFixed" at 741:42-741:52 (leading: Space)
+9064: Lt              "<" at 741:52-741:53
+9065: Ident           "T" at 741:53-741:54
+9066: Comma           "," at 741:54-741:55
+9067: Ident           "N" at 741:56-741:57 (leading: Space)
+9068: Gt              ">" at 741:57-741:58
+9069: Comma           "," at 741:58-741:59
+9070: Ident           "index" at 741:60-741:65 (leading: Space)
+9071: Colon           ":" at 741:65-741:66
+9072: Ident           "int" at 741:67-741:70 (leading: Space)
+9073: Comma           "," at 741:70-741:71
+9074: Ident           "value" at 741:72-741:77 (leading: Space)
+9075: Colon           ":" at 741:77-741:78
+9076: Ident           "T" at 741:79-741:80 (leading: Space)
+9077: RParen          ")" at 741:80-741:81
+9078: Arrow           "->" at 741:82-741:84 (leading: Space)
+9079: NothingLit      "nothing" at 741:85-741:92 (leading: Space)
+9080: Semicolon       ";" at 741:92-741:93
+9081: At              "@" at 742:5-742:6 (leading: Newline, Space)
+9082: Ident           "intrinsic" at 742:6-742:15
+9083: KwFn            "fn" at 742:16-742:18 (leading: Space)
+9084: Ident           "__range" at 742:19-742:26 (leading: Space)
+9085: LParen          "(" at 742:26-742:27
+9086: Ident           "self" at 742:27-742:31
+9087: Colon           ":" at 742:31-742:32
+9088: Amp             "&" at 742:33-742:34 (leading: Space)
+9089: Ident           "ArrayFixed" at 742:34-742:44
+9090: Lt              "<" at 742:44-742:45
+9091: Ident           "T" at 742:45-742:46
+9092: Comma           "," at 742:46-742:47
+9093: Ident           "N" at 742:48-742:49 (leading: Space)
+9094: Gt              ">" at 742:49-742:50
+9095: RParen          ")" at 742:50-742:51
+9096: Arrow           "->" at 742:52-742:54 (leading: Space)
+9097: Ident           "Range" at 742:55-742:60 (leading: Space)
+9098: Lt              "<" at 742:60-742:61
+9099: Ident           "T" at 742:61-742:62
+9100: Gt              ">" at 742:62-742:63
+9101: Semicolon       ";" at 742:63-742:64
+9102: At              "@" at 743:5-743:6 (leading: Newline, Space)
+9103: Ident           "intrinsic" at 743:6-743:15
+9104: KwFn            "fn" at 743:16-743:18 (leading: Space)
+9105: Ident           "__len" at 743:19-743:24 (leading: Space)
+9106: LParen          "(" at 743:24-743:25
+9107: Ident           "self" at 743:25-743:29
+9108: Colon           ":" at 743:29-743:30
+9109: Amp             "&" at 743:31-743:32 (leading: Space)
+9110: Ident           "ArrayFixed" at 743:32-743:42
+9111: Lt              "<" at 743:42-743:43
+9112: Ident           "T" at 743:43-743:44
+9113: Comma           "," at 743:44-743:45
+9114: Ident           "N" at 743:46-743:47 (leading: Space)
+9115: Gt              ">" at 743:47-743:48
+9116: RParen          ")" at 743:48-743:49
+9117: Arrow           "->" at 743:50-743:52 (leading: Space)
+9118: Ident           "uint" at 743:53-743:57 (leading: Space)
+9119: Semicolon       ";" at 743:57-743:58
+9120: RBrace          "}" at 744:1-744:2 (leading: Newline)
+9121: At              "@" at 746:1-746:2 (leading: Newline)
+9122: Ident           "intrinsic" at 746:2-746:11
+9123: KwPub           "pub" at 747:1-747:4 (leading: Newline)
+9124: KwFn            "fn" at 747:5-747:7 (leading: Space)
+9125: Ident           "default" at 747:8-747:15 (leading: Space)
+9126: Lt              "<" at 747:15-747:16
+9127: Ident           "T" at 747:16-747:17
+9128: Gt              ">" at 747:17-747:18
+9129: LParen          "(" at 747:18-747:19
+9130: RParen          ")" at 747:19-747:20
+9131: Arrow           "->" at 747:21-747:23 (leading: Space)
+9132: Ident           "T" at 747:24-747:25 (leading: Space)
+9133: Semicolon       ";" at 747:25-747:26
+9134: At              "@" at 749:1-749:2 (leading: Newline)
+9135: Ident           "intrinsic" at 749:2-749:11
+9136: KwPub           "pub" at 750:1-750:4 (leading: Newline)
+9137: KwFn            "fn" at 750:5-750:7 (leading: Space)
+9138: Ident           "size_of" at 750:8-750:15 (leading: Space)
+9139: Lt              "<" at 750:15-750:16
+9140: Ident           "T" at 750:16-750:17
+9141: Gt              ">" at 750:17-750:18
+9142: LParen          "(" at 750:18-750:19
+9143: RParen          ")" at 750:19-750:20
+9144: Arrow           "->" at 750:21-750:23 (leading: Space)
+9145: Ident           "uint" at 750:24-750:28 (leading: Space)
+9146: Semicolon       ";" at 750:28-750:29
+9147: At              "@" at 752:1-752:2 (leading: Newline)
+9148: Ident           "intrinsic" at 752:2-752:11
+9149: KwPub           "pub" at 753:1-753:4 (leading: Newline)
+9150: KwFn            "fn" at 753:5-753:7 (leading: Space)
+9151: Ident           "align_of" at 753:8-753:16 (leading: Space)
+9152: Lt              "<" at 753:16-753:17
+9153: Ident           "T" at 753:17-753:18
+9154: Gt              ">" at 753:18-753:19
+9155: LParen          "(" at 753:19-753:20
+9156: RParen          ")" at 753:20-753:21
+9157: Arrow           "->" at 753:22-753:24 (leading: Space)
+9158: Ident           "uint" at 753:25-753:29 (leading: Space)
+9159: Semicolon       ";" at 753:29-753:30
+9160: KwPub           "pub" at 755:1-755:4 (leading: Newline)
+9161: KwContract      "contract" at 755:5-755:13 (leading: Space)
+9162: Ident           "ErrorLike" at 755:14-755:23 (leading: Space)
+9163: LBrace          "{" at 755:23-755:24
+9164: KwField         "field" at 756:5-756:10 (leading: Newline, Space)
+9165: Ident           "message" at 756:11-756:18 (leading: Space)
+9166: Colon           ":" at 756:18-756:19
+9167: Ident           "string" at 756:20-756:26 (leading: Space)
+9168: Semicolon       ";" at 756:26-756:27
+9169: KwField         "field" at 757:5-757:10 (leading: Newline, Space)
+9170: Ident           "code" at 757:11-757:15 (leading: Space)
+9171: Colon           ":" at 757:15-757:16
+9172: Ident           "uint" at 757:17-757:21 (leading: Space)
+9173: Semicolon       ";" at 757:21-757:22
+9174: RBrace          "}" at 758:1-758:2 (leading: Newline)
+9175: At              "@" at 760:1-760:2 (leading: Newline)
+9176: Ident           "intrinsic" at 760:2-760:11
+9177: KwPub           "pub" at 761:1-761:4 (leading: Newline)
+9178: KwFn            "fn" at 761:5-761:7 (leading: Space)
+9179: Ident           "exit" at 761:8-761:12 (leading: Space)
+9180: Lt              "<" at 761:12-761:13
+9181: Ident           "E" at 761:13-761:14
+9182: Colon           ":" at 761:14-761:15
+9183: Ident           "ErrorLike" at 761:16-761:25 (leading: Space)
+9184: Gt              ">" at 761:25-761:26
+9185: LParen          "(" at 761:26-761:27
+9186: Ident           "e" at 761:27-761:28
+9187: Colon           ":" at 761:28-761:29
+9188: Ident           "E" at 761:30-761:31 (leading: Space)
+9189: RParen          ")" at 761:31-761:32
+9190: Arrow           "->" at 761:33-761:35 (leading: Space)
+9191: NothingLit      "nothing" at 761:36-761:43 (leading: Space)
+9192: Semicolon       ";" at 761:43-761:44
+9193: At              "@" at 763:1-763:2 (leading: Newline)
+9194: Ident           "intrinsic" at 763:2-763:11
+9195: KwPub           "pub" at 764:1-764:4 (leading: Newline)
+9196: KwFn            "fn" at 764:5-764:7 (leading: Space)
+9197: Ident           "rt_panic" at 764:8-764:16 (leading: Space)
+9198: LParen          "(" at 764:16-764:17
+9199: Ident           "ptr" at 764:17-764:20
+9200: Colon           ":" at 764:20-764:21
+9201: Star            "*" at 764:22-764:23 (leading: Space)
+9202: Ident           "byte" at 764:23-764:27
+9203: Comma           "," at 764:27-764:28
+9204: Ident           "length" at 764:29-764:35 (leading: Space)
+9205: Colon           ":" at 764:35-764:36
+9206: Ident           "uint" at 764:37-764:41 (leading: Space)
+9207: RParen          ")" at 764:41-764:42
+9208: Arrow           "->" at 764:43-764:45 (leading: Space)
+9209: NothingLit      "nothing" at 764:46-764:53 (leading: Space)
+9210: Semicolon       ";" at 764:53-764:54
+9211: KwPub           "pub" at 766:1-766:4 (leading: Newline)
+9212: KwFn            "fn" at 766:5-766:7 (leading: Space)
+9213: Ident           "panic" at 766:8-766:13 (leading: Space)
+9214: LParen          "(" at 766:13-766:14
+9215: Ident           "msg" at 766:14-766:17
+9216: Colon           ":" at 766:17-766:18
+9217: Ident           "string" at 766:19-766:25 (leading: Space)
+9218: RParen          ")" at 766:25-766:26
+9219: Arrow           "->" at 766:27-766:29 (leading: Space)
+9220: NothingLit      "nothing" at 766:30-766:37 (leading: Space)
+9221: LBrace          "{" at 766:38-766:39 (leading: Space)
+9222: KwLet           "let" at 767:5-767:8 (leading: Newline, Space)
+9223: Ident           "ptr" at 767:9-767:12 (leading: Space)
+9224: Assign          "=" at 767:13-767:14 (leading: Space)
+9225: Ident           "rt_string_ptr" at 767:15-767:28 (leading: Space)
+9226: LParen          "(" at 767:28-767:29
+9227: Amp             "&" at 767:29-767:30
+9228: Ident           "msg" at 767:30-767:33
+9229: RParen          ")" at 767:33-767:34
+9230: Semicolon       ";" at 767:34-767:35
+9231: KwLet           "let" at 768:5-768:8 (leading: Newline, Space)
+9232: Ident           "length" at 768:9-768:15 (leading: Space)
+9233: Assign          "=" at 768:16-768:17 (leading: Space)
+9234: Ident           "rt_string_len_bytes" at 768:18-768:37 (leading: Space)
+9235: LParen          "(" at 768:37-768:38
+9236: Amp             "&" at 768:38-768:39
+9237: Ident           "msg" at 768:39-768:42
+9238: RParen          ")" at 768:42-768:43
+9239: Semicolon       ";" at 768:43-768:44
+9240: Ident           "rt_panic" at 769:5-769:13 (leading: Newline, Space)
+9241: LParen          "(" at 769:13-769:14
+9242: Ident           "ptr" at 769:14-769:17
+9243: Comma           "," at 769:17-769:18
+9244: Ident           "length" at 769:19-769:25 (leading: Space)
+9245: RParen          ")" at 769:25-769:26
+9246: Semicolon       ";" at 769:26-769:27
+9247: RBrace          "}" at 770:1-770:2 (leading: Newline)
+9248: At              "@" at 772:1-772:2 (leading: Newline)
+9249: Ident           "intrinsic" at 772:2-772:11
+9250: KwPub           "pub" at 773:1-773:4 (leading: Newline)
+9251: KwType          "type" at 773:5-773:9 (leading: Space)
+9252: Ident           "RwLock" at 773:10-773:16 (leading: Space)
+9253: Assign          "=" at 773:17-773:18 (leading: Space)
+9254: LBrace          "{" at 773:19-773:20 (leading: Space)
+9255: Ident           "__opaque" at 774:5-774:13 (leading: Newline, Space)
+9256: Colon           ":" at 774:13-774:14
+9257: Star            "*" at 774:15-774:16 (leading: Space)
+9258: Ident           "byte" at 774:16-774:20
+9259: Comma           "," at 774:20-774:21
+9260: RBrace          "}" at 775:1-775:2 (leading: Newline)
+9261: Semicolon       ";" at 775:2-775:3
+9262: KwExtern        "extern" at 777:1-777:7 (leading: Newline)
+9263: Lt              "<" at 777:7-777:8
+9264: Ident           "RwLock" at 777:8-777:14
+9265: Gt              ">" at 777:14-777:15
+9266: LBrace          "{" at 777:16-777:17 (leading: Space)
+9267: At              "@" at 778:5-778:6 (leading: Newline, Space)
+9268: Ident           "intrinsic" at 778:6-778:15
+9269: KwPub           "pub" at 778:16-778:19 (leading: Space)
+9270: KwFn            "fn" at 778:20-778:22 (leading: Space)
+9271: Ident           "new" at 778:23-778:26 (leading: Space)
+9272: LParen          "(" at 778:26-778:27
+9273: RParen          ")" at 778:27-778:28
+9274: Arrow           "->" at 778:29-778:31 (leading: Space)
+9275: Ident           "RwLock" at 778:32-778:38 (leading: Space)
+9276: Semicolon       ";" at 778:38-778:39
+9277: At              "@" at 779:5-779:6 (leading: Newline, Space)
+9278: Ident           "intrinsic" at 779:6-779:15
+9279: KwPub           "pub" at 779:16-779:19 (leading: Space)
+9280: KwFn            "fn" at 779:20-779:22 (leading: Space)
+9281: Ident           "read_lock" at 779:23-779:32 (leading: Space)
+9282: LParen          "(" at 779:32-779:33
+9283: Ident           "self" at 779:33-779:37
+9284: Colon           ":" at 779:37-779:38
+9285: Amp             "&" at 779:39-779:40 (leading: Space)
+9286: KwMut           "mut" at 779:40-779:43
+9287: Ident           "RwLock" at 779:44-779:50 (leading: Space)
+9288: RParen          ")" at 779:50-779:51
+9289: Arrow           "->" at 779:52-779:54 (leading: Space)
+9290: NothingLit      "nothing" at 779:55-779:62 (leading: Space)
+9291: Semicolon       ";" at 779:62-779:63
+9292: At              "@" at 780:5-780:6 (leading: Newline, Space)
+9293: Ident           "intrinsic" at 780:6-780:15
+9294: KwPub           "pub" at 780:16-780:19 (leading: Space)
+9295: KwFn            "fn" at 780:20-780:22 (leading: Space)
+9296: Ident           "read_unlock" at 780:23-780:34 (leading: Space)
+9297: LParen          "(" at 780:34-780:35
+9298: Ident           "self" at 780:35-780:39
+9299: Colon           ":" at 780:39-780:40
+9300: Amp             "&" at 780:41-780:42 (leading: Space)
+9301: KwMut           "mut" at 780:42-780:45
+9302: Ident           "RwLock" at 780:46-780:52 (leading: Space)
+9303: RParen          ")" at 780:52-780:53
+9304: Arrow           "->" at 780:54-780:56 (leading: Space)
+9305: NothingLit      "nothing" at 780:57-780:64 (leading: Space)
+9306: Semicolon       ";" at 780:64-780:65
+9307: At              "@" at 781:5-781:6 (leading: Newline, Space)
+9308: Ident           "intrinsic" at 781:6-781:15
+9309: KwPub           "pub" at 781:16-781:19 (leading: Space)
+9310: KwFn            "fn" at 781:20-781:22 (leading: Space)
+9311: Ident           "write_lock" at 781:23-781:33 (leading: Space)
+9312: LParen          "(" at 781:33-781:34
+9313: Ident           "self" at 781:34-781:38
+9314: Colon           ":" at 781:38-781:39
+9315: Amp             "&" at 781:40-781:41 (leading: Space)
+9316: KwMut           "mut" at 781:41-781:44
+9317: Ident           "RwLock" at 781:45-781:51 (leading: Space)
+9318: RParen          ")" at 781:51-781:52
+9319: Arrow           "->" at 781:53-781:55 (leading: Space)
+9320: NothingLit      "nothing" at 781:56-781:63 (leading: Space)
+9321: Semicolon       ";" at 781:63-781:64
+9322: At              "@" at 782:5-782:6 (leading: Newline, Space)
+9323: Ident           "intrinsic" at 782:6-782:15
+9324: KwPub           "pub" at 782:16-782:19 (leading: Space)
+9325: KwFn            "fn" at 782:20-782:22 (leading: Space)
+9326: Ident           "write_unlock" at 782:23-782:35 (leading: Space)
+9327: LParen          "(" at 782:35-782:36
+9328: Ident           "self" at 782:36-782:40
+9329: Colon           ":" at 782:40-782:41
+9330: Amp             "&" at 782:42-782:43 (leading: Space)
+9331: KwMut           "mut" at 782:43-782:46
+9332: Ident           "RwLock" at 782:47-782:53 (leading: Space)
+9333: RParen          ")" at 782:53-782:54
+9334: Arrow           "->" at 782:55-782:57 (leading: Space)
+9335: NothingLit      "nothing" at 782:58-782:65 (leading: Space)
+9336: Semicolon       ";" at 782:65-782:66
+9337: At              "@" at 783:5-783:6 (leading: Newline, Space)
+9338: Ident           "intrinsic" at 783:6-783:15
+9339: KwPub           "pub" at 783:16-783:19 (leading: Space)
+9340: KwFn            "fn" at 783:20-783:22 (leading: Space)
+9341: Ident           "try_read_lock" at 783:23-783:36 (leading: Space)
+9342: LParen          "(" at 783:36-783:37
+9343: Ident           "self" at 783:37-783:41
+9344: Colon           ":" at 783:41-783:42
+9345: Amp             "&" at 783:43-783:44 (leading: Space)
+9346: KwMut           "mut" at 783:44-783:47
+9347: Ident           "RwLock" at 783:48-783:54 (leading: Space)
+9348: RParen          ")" at 783:54-783:55
+9349: Arrow           "->" at 783:56-783:58 (leading: Space)
+9350: Ident           "bool" at 783:59-783:63 (leading: Space)
+9351: Semicolon       ";" at 783:63-783:64
+9352: At              "@" at 784:5-784:6 (leading: Newline, Space)
+9353: Ident           "intrinsic" at 784:6-784:15
+9354: KwPub           "pub" at 784:16-784:19 (leading: Space)
+9355: KwFn            "fn" at 784:20-784:22 (leading: Space)
+9356: Ident           "try_write_lock" at 784:23-784:37 (leading: Space)
+9357: LParen          "(" at 784:37-784:38
+9358: Ident           "self" at 784:38-784:42
+9359: Colon           ":" at 784:42-784:43
+9360: Amp             "&" at 784:44-784:45 (leading: Space)
+9361: KwMut           "mut" at 784:45-784:48
+9362: Ident           "RwLock" at 784:49-784:55 (leading: Space)
+9363: RParen          ")" at 784:55-784:56
+9364: Arrow           "->" at 784:57-784:59 (leading: Space)
+9365: Ident           "bool" at 784:60-784:64 (leading: Space)
+9366: Semicolon       ";" at 784:64-784:65
+9367: RBrace          "}" at 785:1-785:2 (leading: Newline)
+9368: At              "@" at 793:1-793:2 (leading: Newline, LineComment, Newline, LineComment, Newline, LineComment, Newline, LineComment, Newline, LineComment, Newline)
+9369: Ident           "intrinsic" at 793:2-793:11
+9370: KwPub           "pub" at 794:1-794:4 (leading: Newline)
+9371: KwFn            "fn" at 794:5-794:7 (leading: Space)
+9372: Ident           "atomic_load" at 794:8-794:19 (leading: Space)
+9373: LParen          "(" at 794:19-794:20
+9374: Ident           "ptr" at 794:20-794:23
+9375: Colon           ":" at 794:23-794:24
+9376: Amp             "&" at 794:25-794:26 (leading: Space)
+9377: Ident           "int" at 794:26-794:29
+9378: RParen          ")" at 794:29-794:30
+9379: Arrow           "->" at 794:31-794:33 (leading: Space)
+9380: Ident           "int" at 794:34-794:37 (leading: Space)
+9381: Semicolon       ";" at 794:37-794:38
+9382: At              "@" at 796:1-796:2 (leading: Newline)
+9383: Ident           "intrinsic" at 796:2-796:11
+9384: At              "@" at 797:1-797:2 (leading: Newline)
+9385: Ident           "overload" at 797:2-797:10
+9386: KwPub           "pub" at 798:1-798:4 (leading: Newline)
+9387: KwFn            "fn" at 798:5-798:7 (leading: Space)
+9388: Ident           "atomic_load" at 798:8-798:19 (leading: Space)
+9389: LParen          "(" at 798:19-798:20
+9390: Ident           "ptr" at 798:20-798:23
+9391: Colon           ":" at 798:23-798:24
+9392: Amp             "&" at 798:25-798:26 (leading: Space)
+9393: Ident           "uint" at 798:26-798:30
+9394: RParen          ")" at 798:30-798:31
+9395: Arrow           "->" at 798:32-798:34 (leading: Space)
+9396: Ident           "uint" at 798:35-798:39 (leading: Space)
+9397: Semicolon       ";" at 798:39-798:40
+9398: At              "@" at 800:1-800:2 (leading: Newline)
+9399: Ident           "intrinsic" at 800:2-800:11
+9400: At              "@" at 801:1-801:2 (leading: Newline)
+9401: Ident           "overload" at 801:2-801:10
+9402: KwPub           "pub" at 802:1-802:4 (leading: Newline)
+9403: KwFn            "fn" at 802:5-802:7 (leading: Space)
+9404: Ident           "atomic_load" at 802:8-802:19 (leading: Space)
+9405: LParen          "(" at 802:19-802:20
+9406: Ident           "ptr" at 802:20-802:23
+9407: Colon           ":" at 802:23-802:24
+9408: Amp             "&" at 802:25-802:26 (leading: Space)
+9409: Ident           "bool" at 802:26-802:30
+9410: RParen          ")" at 802:30-802:31
+9411: Arrow           "->" at 802:32-802:34 (leading: Space)
+9412: Ident           "bool" at 802:35-802:39 (leading: Space)
+9413: Semicolon       ";" at 802:39-802:40
+9414: At              "@" at 805:1-805:2 (leading: Newline, LineComment, Newline)
+9415: Ident           "intrinsic" at 805:2-805:11
+9416: KwPub           "pub" at 806:1-806:4 (leading: Newline)
+9417: KwFn            "fn" at 806:5-806:7 (leading: Space)
+9418: Ident           "atomic_store" at 806:8-806:20 (leading: Space)
+9419: LParen          "(" at 806:20-806:21
+9420: Ident           "ptr" at 806:21-806:24
+9421: Colon           ":" at 806:24-806:25
+9422: Amp             "&" at 806:26-806:27 (leading: Space)
+9423: KwMut           "mut" at 806:27-806:30
+9424: Ident           "int" at 806:31-806:34 (leading: Space)
+9425: Comma           "," at 806:34-806:35
+9426: Ident           "value" at 806:36-806:41 (leading: Space)
+9427: Colon           ":" at 806:41-806:42
+9428: Ident           "int" at 806:43-806:46 (leading: Space)
+9429: RParen          ")" at 806:46-806:47
+9430: Arrow           "->" at 806:48-806:50 (leading: Space)
+9431: NothingLit      "nothing" at 806:51-806:58 (leading: Space)
+9432: Semicolon       ";" at 806:58-806:59
+9433: At              "@" at 808:1-808:2 (leading: Newline)
+9434: Ident           "intrinsic" at 808:2-808:11
+9435: At              "@" at 809:1-809:2 (leading: Newline)
+9436: Ident           "overload" at 809:2-809:10
+9437: KwPub           "pub" at 810:1-810:4 (leading: Newline)
+9438: KwFn            "fn" at 810:5-810:7 (leading: Space)
+9439: Ident           "atomic_store" at 810:8-810:20 (leading: Space)
+9440: LParen          "(" at 810:20-810:21
+9441: Ident           "ptr" at 810:21-810:24
+9442: Colon           ":" at 810:24-810:25
+9443: Amp             "&" at 810:26-810:27 (leading: Space)
+9444: KwMut           "mut" at 810:27-810:30
+9445: Ident           "uint" at 810:31-810:35 (leading: Space)
+9446: Comma           "," at 810:35-810:36
+9447: Ident           "value" at 810:37-810:42 (leading: Space)
+9448: Colon           ":" at 810:42-810:43
+9449: Ident           "uint" at 810:44-810:48 (leading: Space)
+9450: RParen          ")" at 810:48-810:49
+9451: Arrow           "->" at 810:50-810:52 (leading: Space)
+9452: NothingLit      "nothing" at 810:53-810:60 (leading: Space)
+9453: Semicolon       ";" at 810:60-810:61
+9454: At              "@" at 812:1-812:2 (leading: Newline)
+9455: Ident           "intrinsic" at 812:2-812:11
+9456: At              "@" at 813:1-813:2 (leading: Newline)
+9457: Ident           "overload" at 813:2-813:10
+9458: KwPub           "pub" at 814:1-814:4 (leading: Newline)
+9459: KwFn            "fn" at 814:5-814:7 (leading: Space)
+9460: Ident           "atomic_store" at 814:8-814:20 (leading: Space)
+9461: LParen          "(" at 814:20-814:21
+9462: Ident           "ptr" at 814:21-814:24
+9463: Colon           ":" at 814:24-814:25
+9464: Amp             "&" at 814:26-814:27 (leading: Space)
+9465: KwMut           "mut" at 814:27-814:30
+9466: Ident           "bool" at 814:31-814:35 (leading: Space)
+9467: Comma           "," at 814:35-814:36
+9468: Ident           "value" at 814:37-814:42 (leading: Space)
+9469: Colon           ":" at 814:42-814:43
+9470: Ident           "bool" at 814:44-814:48 (leading: Space)
+9471: RParen          ")" at 814:48-814:49
+9472: Arrow           "->" at 814:50-814:52 (leading: Space)
+9473: NothingLit      "nothing" at 814:53-814:60 (leading: Space)
+9474: Semicolon       ";" at 814:60-814:61
+9475: At              "@" at 817:1-817:2 (leading: Newline, LineComment, Newline)
+9476: Ident           "intrinsic" at 817:2-817:11
+9477: KwPub           "pub" at 818:1-818:4 (leading: Newline)
+9478: KwFn            "fn" at 818:5-818:7 (leading: Space)
+9479: Ident           "atomic_exchange" at 818:8-818:23 (leading: Space)
+9480: LParen          "(" at 818:23-818:24
+9481: Ident           "ptr" at 818:24-818:27
+9482: Colon           ":" at 818:27-818:28
+9483: Amp             "&" at 818:29-818:30 (leading: Space)
+9484: KwMut           "mut" at 818:30-818:33
+9485: Ident           "int" at 818:34-818:37 (leading: Space)
+9486: Comma           "," at 818:37-818:38
+9487: Ident           "new_val" at 818:39-818:46 (leading: Space)
+9488: Colon           ":" at 818:46-818:47
+9489: Ident           "int" at 818:48-818:51 (leading: Space)
+9490: RParen          ")" at 818:51-818:52
+9491: Arrow           "->" at 818:53-818:55 (leading: Space)
+9492: Ident           "int" at 818:56-818:59 (leading: Space)
+9493: Semicolon       ";" at 818:59-818:60
+9494: At              "@" at 820:1-820:2 (leading: Newline)
+9495: Ident           "intrinsic" at 820:2-820:11
+9496: At              "@" at 821:1-821:2 (leading: Newline)
+9497: Ident           "overload" at 821:2-821:10
+9498: KwPub           "pub" at 822:1-822:4 (leading: Newline)
+9499: KwFn            "fn" at 822:5-822:7 (leading: Space)
+9500: Ident           "atomic_exchange" at 822:8-822:23 (leading: Space)
+9501: LParen          "(" at 822:23-822:24
+9502: Ident           "ptr" at 822:24-822:27
+9503: Colon           ":" at 822:27-822:28
+9504: Amp             "&" at 822:29-822:30 (leading: Space)
+9505: KwMut           "mut" at 822:30-822:33
+9506: Ident           "uint" at 822:34-822:38 (leading: Space)
+9507: Comma           "," at 822:38-822:39
+9508: Ident           "new_val" at 822:40-822:47 (leading: Space)
+9509: Colon           ":" at 822:47-822:48
+9510: Ident           "uint" at 822:49-822:53 (leading: Space)
+9511: RParen          ")" at 822:53-822:54
+9512: Arrow           "->" at 822:55-822:57 (leading: Space)
+9513: Ident           "uint" at 822:58-822:62 (leading: Space)
+9514: Semicolon       ";" at 822:62-822:63
+9515: At              "@" at 824:1-824:2 (leading: Newline)
+9516: Ident           "intrinsic" at 824:2-824:11
+9517: At              "@" at 825:1-825:2 (leading: Newline)
+9518: Ident           "overload" at 825:2-825:10
+9519: KwPub           "pub" at 826:1-826:4 (leading: Newline)
+9520: KwFn            "fn" at 826:5-826:7 (leading: Space)
+9521: Ident           "atomic_exchange" at 826:8-826:23 (leading: Space)
+9522: LParen          "(" at 826:23-826:24
+9523: Ident           "ptr" at 826:24-826:27
+9524: Colon           ":" at 826:27-826:28
+9525: Amp             "&" at 826:29-826:30 (leading: Space)
+9526: KwMut           "mut" at 826:30-826:33
+9527: Ident           "bool" at 826:34-826:38 (leading: Space)
+9528: Comma           "," at 826:38-826:39
+9529: Ident           "new_val" at 826:40-826:47 (leading: Space)
+9530: Colon           ":" at 826:47-826:48
+9531: Ident           "bool" at 826:49-826:53 (leading: Space)
+9532: RParen          ")" at 826:53-826:54
+9533: Arrow           "->" at 826:55-826:57 (leading: Space)
+9534: Ident           "bool" at 826:58-826:62 (leading: Space)
+9535: Semicolon       ";" at 826:62-826:63
+9536: At              "@" at 830:1-830:2 (leading: Newline, LineComment, Newline, LineComment, Newline)
+9537: Ident           "intrinsic" at 830:2-830:11
+9538: KwPub           "pub" at 831:1-831:4 (leading: Newline)
+9539: KwFn            "fn" at 831:5-831:7 (leading: Space)
+9540: Ident           "atomic_compare_exchange" at 831:8-831:31 (leading: Space)
+9541: LParen          "(" at 831:31-831:32
+9542: Ident           "ptr" at 831:32-831:35
+9543: Colon           ":" at 831:35-831:36
+9544: Amp             "&" at 831:37-831:38 (leading: Space)
+9545: KwMut           "mut" at 831:38-831:41
+9546: Ident           "int" at 831:42-831:45 (leading: Space)
+9547: Comma           "," at 831:45-831:46
+9548: Ident           "expected" at 831:47-831:55 (leading: Space)
+9549: Colon           ":" at 831:55-831:56
+9550: Ident           "int" at 831:57-831:60 (leading: Space)
+9551: Comma           "," at 831:60-831:61
+9552: Ident           "desired" at 831:62-831:69 (leading: Space)
+9553: Colon           ":" at 831:69-831:70
+9554: Ident           "int" at 831:71-831:74 (leading: Space)
+9555: RParen          ")" at 831:74-831:75
+9556: Arrow           "->" at 831:76-831:78 (leading: Space)
+9557: Ident           "bool" at 831:79-831:83 (leading: Space)
+9558: Semicolon       ";" at 831:83-831:84
+9559: At              "@" at 833:1-833:2 (leading: Newline)
+9560: Ident           "intrinsic" at 833:2-833:11
+9561: At              "@" at 834:1-834:2 (leading: Newline)
+9562: Ident           "overload" at 834:2-834:10
+9563: KwPub           "pub" at 835:1-835:4 (leading: Newline)
+9564: KwFn            "fn" at 835:5-835:7 (leading: Space)
+9565: Ident           "atomic_compare_exchange" at 835:8-835:31 (leading: Space)
+9566: LParen          "(" at 835:31-835:32
+9567: Ident           "ptr" at 835:32-835:35
+9568: Colon           ":" at 835:35-835:36
+9569: Amp             "&" at 835:37-835:38 (leading: Space)
+9570: KwMut           "mut" at 835:38-835:41
+9571: Ident           "uint" at 835:42-835:46 (leading: Space)
+9572: Comma           "," at 835:46-835:47
+9573: Ident           "expected" at 835:48-835:56 (leading: Space)
+9574: Colon           ":" at 835:56-835:57
+9575: Ident           "uint" at 835:58-835:62 (leading: Space)
+9576: Comma           "," at 835:62-835:63
+9577: Ident           "desired" at 835:64-835:71 (leading: Space)
+9578: Colon           ":" at 835:71-835:72
+9579: Ident           "uint" at 835:73-835:77 (leading: Space)
+9580: RParen          ")" at 835:77-835:78
+9581: Arrow           "->" at 835:79-835:81 (leading: Space)
+9582: Ident           "bool" at 835:82-835:86 (leading: Space)
+9583: Semicolon       ";" at 835:86-835:87
+9584: At              "@" at 837:1-837:2 (leading: Newline)
+9585: Ident           "intrinsic" at 837:2-837:11
+9586: At              "@" at 838:1-838:2 (leading: Newline)
+9587: Ident           "overload" at 838:2-838:10
+9588: KwPub           "pub" at 839:1-839:4 (leading: Newline)
+9589: KwFn            "fn" at 839:5-839:7 (leading: Space)
+9590: Ident           "atomic_compare_exchange" at 839:8-839:31 (leading: Space)
+9591: LParen          "(" at 839:31-839:32
+9592: Ident           "ptr" at 839:32-839:35
+9593: Colon           ":" at 839:35-839:36
+9594: Amp             "&" at 839:37-839:38 (leading: Space)
+9595: KwMut           "mut" at 839:38-839:41
+9596: Ident           "bool" at 839:42-839:46 (leading: Space)
+9597: Comma           "," at 839:46-839:47
+9598: Ident           "expected" at 839:48-839:56 (leading: Space)
+9599: Colon           ":" at 839:56-839:57
+9600: Ident           "bool" at 839:58-839:62 (leading: Space)
+9601: Comma           "," at 839:62-839:63
+9602: Ident           "desired" at 839:64-839:71 (leading: Space)
+9603: Colon           ":" at 839:71-839:72
+9604: Ident           "bool" at 839:73-839:77 (leading: Space)
+9605: RParen          ")" at 839:77-839:78
+9606: Arrow           "->" at 839:79-839:81 (leading: Space)
+9607: Ident           "bool" at 839:82-839:86 (leading: Space)
+9608: Semicolon       ";" at 839:86-839:87
+9609: At              "@" at 842:1-842:2 (leading: Newline, LineComment, Newline)
+9610: Ident           "intrinsic" at 842:2-842:11
+9611: KwPub           "pub" at 843:1-843:4 (leading: Newline)
+9612: KwFn            "fn" at 843:5-843:7 (leading: Space)
+9613: Ident           "atomic_fetch_add" at 843:8-843:24 (leading: Space)
+9614: LParen          "(" at 843:24-843:25
+9615: Ident           "ptr" at 843:25-843:28
+9616: Colon           ":" at 843:28-843:29
+9617: Amp             "&" at 843:30-843:31 (leading: Space)
+9618: KwMut           "mut" at 843:31-843:34
+9619: Ident           "int" at 843:35-843:38 (leading: Space)
+9620: Comma           "," at 843:38-843:39
+9621: Ident           "delta" at 843:40-843:45 (leading: Space)
+9622: Colon           ":" at 843:45-843:46
+9623: Ident           "int" at 843:47-843:50 (leading: Space)
+9624: RParen          ")" at 843:50-843:51
+9625: Arrow           "->" at 843:52-843:54 (leading: Space)
+9626: Ident           "int" at 843:55-843:58 (leading: Space)
+9627: Semicolon       ";" at 843:58-843:59
+9628: At              "@" at 845:1-845:2 (leading: Newline)
+9629: Ident           "intrinsic" at 845:2-845:11
+9630: At              "@" at 846:1-846:2 (leading: Newline)
+9631: Ident           "overload" at 846:2-846:10
+9632: KwPub           "pub" at 847:1-847:4 (leading: Newline)
+9633: KwFn            "fn" at 847:5-847:7 (leading: Space)
+9634: Ident           "atomic_fetch_add" at 847:8-847:24 (leading: Space)
+9635: LParen          "(" at 847:24-847:25
+9636: Ident           "ptr" at 847:25-847:28
+9637: Colon           ":" at 847:28-847:29
+9638: Amp             "&" at 847:30-847:31 (leading: Space)
+9639: KwMut           "mut" at 847:31-847:34
+9640: Ident           "uint" at 847:35-847:39 (leading: Space)
+9641: Comma           "," at 847:39-847:40
+9642: Ident           "delta" at 847:41-847:46 (leading: Space)
+9643: Colon           ":" at 847:46-847:47
+9644: Ident           "uint" at 847:48-847:52 (leading: Space)
+9645: RParen          ")" at 847:52-847:53
+9646: Arrow           "->" at 847:54-847:56 (leading: Space)
+9647: Ident           "uint" at 847:57-847:61 (leading: Space)
+9648: Semicolon       ";" at 847:61-847:62
+9649: At              "@" at 850:1-850:2 (leading: Newline, LineComment, Newline)
+9650: Ident           "intrinsic" at 850:2-850:11
+9651: KwPub           "pub" at 851:1-851:4 (leading: Newline)
+9652: KwFn            "fn" at 851:5-851:7 (leading: Space)
+9653: Ident           "atomic_fetch_sub" at 851:8-851:24 (leading: Space)
+9654: LParen          "(" at 851:24-851:25
+9655: Ident           "ptr" at 851:25-851:28
+9656: Colon           ":" at 851:28-851:29
+9657: Amp             "&" at 851:30-851:31 (leading: Space)
+9658: KwMut           "mut" at 851:31-851:34
+9659: Ident           "int" at 851:35-851:38 (leading: Space)
+9660: Comma           "," at 851:38-851:39
+9661: Ident           "delta" at 851:40-851:45 (leading: Space)
+9662: Colon           ":" at 851:45-851:46
+9663: Ident           "int" at 851:47-851:50 (leading: Space)
+9664: RParen          ")" at 851:50-851:51
+9665: Arrow           "->" at 851:52-851:54 (leading: Space)
+9666: Ident           "int" at 851:55-851:58 (leading: Space)
+9667: Semicolon       ";" at 851:58-851:59
+9668: At              "@" at 853:1-853:2 (leading: Newline)
+9669: Ident           "intrinsic" at 853:2-853:11
+9670: At              "@" at 854:1-854:2 (leading: Newline)
+9671: Ident           "overload" at 854:2-854:10
+9672: KwPub           "pub" at 855:1-855:4 (leading: Newline)
+9673: KwFn            "fn" at 855:5-855:7 (leading: Space)
+9674: Ident           "atomic_fetch_sub" at 855:8-855:24 (leading: Space)
+9675: LParen          "(" at 855:24-855:25
+9676: Ident           "ptr" at 855:25-855:28
+9677: Colon           ":" at 855:28-855:29
+9678: Amp             "&" at 855:30-855:31 (leading: Space)
+9679: KwMut           "mut" at 855:31-855:34
+9680: Ident           "uint" at 855:35-855:39 (leading: Space)
+9681: Comma           "," at 855:39-855:40
+9682: Ident           "delta" at 855:41-855:46 (leading: Space)
+9683: Colon           ":" at 855:46-855:47
+9684: Ident           "uint" at 855:48-855:52 (leading: Space)
+9685: RParen          ")" at 855:52-855:53
+9686: Arrow           "->" at 855:54-855:56 (leading: Space)
+9687: Ident           "uint" at 855:57-855:61 (leading: Space)
+9688: Semicolon       ";" at 855:61-855:62
+9689: At              "@" at 860:1-860:2 (leading: Newline, LineComment, Newline, LineComment, Newline)
+9690: Ident           "intrinsic" at 860:2-860:11
+9691: KwPub           "pub" at 861:1-861:4 (leading: Newline)
+9692: KwFn            "fn" at 861:5-861:7 (leading: Space)
+9693: Ident           "rt_argv" at 861:8-861:15 (leading: Space)
+9694: LParen          "(" at 861:15-861:16
+9695: RParen          ")" at 861:16-861:17
+9696: Arrow           "->" at 861:18-861:20 (leading: Space)
+9697: Ident           "string" at 861:21-861:27 (leading: Space)
+9698: LBracket        "[" at 861:27-861:28
+9699: RBracket        "]" at 861:28-861:29
+9700: Semicolon       ";" at 861:29-861:30
+9701: At              "@" at 864:1-864:2 (leading: Newline, LineComment, Newline)
+9702: Ident           "intrinsic" at 864:2-864:11
+9703: KwPub           "pub" at 865:1-865:4 (leading: Newline)
+9704: KwFn            "fn" at 865:5-865:7 (leading: Space)
+9705: Ident           "rt_stdin_read_all" at 865:8-865:25 (leading: Space)
+9706: LParen          "(" at 865:25-865:26
+9707: RParen          ")" at 865:26-865:27
+9708: Arrow           "->" at 865:28-865:30 (leading: Space)
+9709: Ident           "string" at 865:31-865:37 (leading: Space)
+9710: Semicolon       ";" at 865:37-865:38
+9711: At              "@" at 868:1-868:2 (leading: Newline, LineComment, Newline)
+9712: Ident           "intrinsic" at 868:2-868:11
+9713: KwPub           "pub" at 869:1-869:4 (leading: Newline)
+9714: KwFn            "fn" at 869:5-869:7 (leading: Space)
+9715: Ident           "rt_exit" at 869:8-869:15 (leading: Space)
+9716: LParen          "(" at 869:15-869:16
+9717: Ident           "code" at 869:16-869:20
+9718: Colon           ":" at 869:20-869:21
+9719: Ident           "int" at 869:22-869:25 (leading: Space)
+9720: RParen          ")" at 869:25-869:26
+9721: Arrow           "->" at 869:27-869:29 (leading: Space)
+9722: NothingLit      "nothing" at 869:30-869:37 (leading: Space)
+9723: Semicolon       ";" at 869:37-869:38
+9724: EOF             at 870:1-870:1

--- a/testdata/golden/hir/allow_to_conversion.hir
+++ b/testdata/golden/hir/allow_to_conversion.hir
@@ -2,18 +2,18 @@
 == HIR ==
 module 
 
-type Foo <struct> (sym=1407, type=0)
+type Foo <struct> (sym=1409, type=0)
 
-fn __to(self: type#1495, _: string) -> string (id=1, sym=1408) {
+fn __to(self: type#1497, _: string) -> string (id=1, sym=1410) {
   return "\"Foo\""
 }
 
-fn takes_string(s: string) -> int (id=2, sym=1409) {
+fn takes_string(s: string) -> int (id=2, sym=1411) {
   return 0
 }
 
-fn test_allow_to() -> int (id=3, sym=1410) {
-  let f: type#1495 =  { value = 1 }: type#1495
+fn test_allow_to() -> int (id=3, sym=1412) {
+  let f: type#1497 =  { value = 1 }: type#1497
   return takes_string(__to(f, default())): int
 }
 

--- a/testdata/golden/hir/array_indexing.hir
+++ b/testdata/golden/hir/array_indexing.hir
@@ -2,7 +2,7 @@
 == HIR ==
 module 
 
-fn test() -> nothing (id=1, sym=1407) {
+fn test() -> nothing (id=1, sym=1409) {
   let a: type#77 = [1, 2, 3, 4]: type#77
   let x: &int [&] = a[1]: &int
   let y: &int [&] = a[__neg(1): int]: &int

--- a/testdata/golden/hir/arrays.hir
+++ b/testdata/golden/hir/arrays.hir
@@ -2,11 +2,11 @@
 == HIR ==
 module 
 
-fn first(arr: type#1496) -> int (id=1, sym=1407) {
+fn first(arr: type#1498) -> int (id=1, sym=1409) {
   return arr[0]: &int
 }
 
-fn make_array() -> type#1496 (id=2, sym=1408) {
-  return [1, 2, 3]: type#1496
+fn make_array() -> type#1498 (id=2, sym=1410) {
+  return [1, 2, 3]: type#1498
 }
 

--- a/testdata/golden/hir/async_spawn.hir
+++ b/testdata/golden/hir/async_spawn.hir
@@ -2,14 +2,14 @@
 == HIR ==
 module 
 
-async fn inc(x: int [copy]) -> int (id=1, sym=1407) {
+async fn inc(x: int [copy]) -> int (id=1, sym=1409) {
   return __add(x, 1): int
 }
 
-async fn test() -> int (id=2, sym=1408) {
-  let t: type#1495 = spawn inc(5): type#1495: type#1495
+async fn test() -> int (id=2, sym=1410) {
+  let t: type#1497 = spawn inc(5): type#1497: type#1497
   return {
-    let __cmp1: type#1498 = await(t): type#1498
+    let __cmp1: type#1500 = await(t): type#1500
     if tag_test(__cmp1, Success): bool {
       let v: int [copy] = tag_payload(__cmp1, Success, 0): int
       return v

--- a/testdata/golden/hir/bitwise.hir
+++ b/testdata/golden/hir/bitwise.hir
@@ -2,7 +2,7 @@
 == HIR ==
 module 
 
-fn bit_ops(a: int [copy], b: int [copy]) -> int (id=1, sym=1407) {
+fn bit_ops(a: int [copy], b: int [copy]) -> int (id=1, sym=1409) {
   let and_result: int [copy] = __bit_and(a, b): int
   let or_result: int [copy] = __bit_or(a, b): int
   let xor_result: int [copy] = __bit_xor(a, b): int
@@ -11,7 +11,7 @@ fn bit_ops(a: int [copy], b: int [copy]) -> int (id=1, sym=1407) {
   return __bit_or(and_result, or_result): int
 }
 
-fn logical_ops(a: bool [copy], b: bool [copy]) -> bool (id=2, sym=1408) {
+fn logical_ops(a: bool [copy], b: bool [copy]) -> bool (id=2, sym=1410) {
   return ((a && b) || __not(a)): bool
 }
 

--- a/testdata/golden/hir/block_expr.hir
+++ b/testdata/golden/hir/block_expr.hir
@@ -2,7 +2,7 @@
 == HIR ==
 module 
 
-fn block_scope() -> int (id=1, sym=1407) {
+fn block_scope() -> int (id=1, sym=1409) {
   let x: int [copy] = 1
   {
     let y: int [copy] = 2
@@ -11,11 +11,11 @@ fn block_scope() -> int (id=1, sym=1407) {
   return x
 }
 
-async fn with_async_block() -> nothing (id=2, sym=1408) {
-  let t: type#709 = async {
+async fn with_async_block() -> nothing (id=2, sym=1410) {
+  let t: type#711 = async {
     let x: int [copy] = 1
     let y: int [copy] = __add(x, 1): int
-  }: type#709
+  }: type#711
   return
 }
 

--- a/testdata/golden/hir/casts.hir
+++ b/testdata/golden/hir/casts.hir
@@ -2,11 +2,11 @@
 == HIR ==
 module 
 
-fn to_float(x: int [copy]) -> float (id=1, sym=1407) {
+fn to_float(x: int [copy]) -> float (id=1, sym=1409) {
   return x to ?: float
 }
 
-fn explicit_int(x: int [copy]) -> int (id=2, sym=1408) {
+fn explicit_int(x: int [copy]) -> int (id=2, sym=1410) {
   return x to ?: int
 }
 

--- a/testdata/golden/hir/compare.hir
+++ b/testdata/golden/hir/compare.hir
@@ -2,7 +2,7 @@
 == HIR ==
 module 
 
-fn classify(x: int [copy]) -> int (id=1, sym=1407) {
+fn classify(x: int [copy]) -> int (id=1, sym=1409) {
   return {
     let __cmp1: int [copy] = x
     if (__cmp1 == 0): bool {

--- a/testdata/golden/hir/compare_tag.hir
+++ b/testdata/golden/hir/compare_tag.hir
@@ -2,9 +2,9 @@
 == HIR ==
 module 
 
-fn unwrap_or_zero(x: type#1495) -> int (id=1, sym=1407) {
+fn unwrap_or_zero(x: type#1497) -> int (id=1, sym=1409) {
   return {
-    let __cmp1: type#1495 = x
+    let __cmp1: type#1497 = x
     if tag_test(__cmp1, Some): bool {
       let v: int [copy] = tag_payload(__cmp1, Some, 0): int
       return v

--- a/testdata/golden/hir/control_flow.hir
+++ b/testdata/golden/hir/control_flow.hir
@@ -2,7 +2,7 @@
 == HIR ==
 module 
 
-fn abs(x: int [copy]) -> int (id=1, sym=1407) {
+fn abs(x: int [copy]) -> int (id=1, sym=1409) {
   if __lt(x, 0): bool {
     return __neg(x): int
   } else {
@@ -10,7 +10,7 @@ fn abs(x: int [copy]) -> int (id=1, sym=1407) {
   }
 }
 
-fn countdown(n: int [copy]) -> int (id=2, sym=1408) {
+fn countdown(n: int [copy]) -> int (id=2, sym=1410) {
   let mut i: int [copy] = n
   while __gt(i, 0): bool {
     (i = __sub(i, 1)): int

--- a/testdata/golden/hir/for_classic.hir
+++ b/testdata/golden/hir/for_classic.hir
@@ -2,7 +2,7 @@
 == HIR ==
 module 
 
-fn sum_to(n: int [copy]) -> int (id=1, sym=1407) {
+fn sum_to(n: int [copy]) -> int (id=1, sym=1409) {
   let mut total: int [copy] = 0
   {
     let mut i: int [copy] = 0

--- a/testdata/golden/hir/for_iter.hir
+++ b/testdata/golden/hir/for_iter.hir
@@ -2,12 +2,12 @@
 == HIR ==
 module 
 
-fn sum(arr: type#1496) -> int (id=1, sym=1407) {
+fn sum(arr: type#1498) -> int (id=1, sym=1409) {
   let mut total: int [copy] = 0
   {
     let mut __iter1: type#188 = iter_init(arr): type#188
     while true {
-      let __next2: type#1498 = iter_next(__iter1): type#1498
+      let __next2: type#1500 = iter_next(__iter1): type#1500
       if tag_test(__next2, nothing): bool {
         break
       }

--- a/testdata/golden/hir/for_range.hir
+++ b/testdata/golden/hir/for_range.hir
@@ -2,7 +2,7 @@
 == HIR ==
 module 
 
-fn sum_range(n: int [copy]) -> int (id=1, sym=1407) {
+fn sum_range(n: int [copy]) -> int (id=1, sym=1409) {
   let mut total: int [copy] = 0
   {
     let mut i: int [copy] = 0

--- a/testdata/golden/hir/indexing_ranges.hir
+++ b/testdata/golden/hir/indexing_ranges.hir
@@ -2,10 +2,10 @@
 == HIR ==
 module 
 
-type Box <struct> (sym=1407, type=0)
+type Box <struct> (sym=1409, type=0)
 
-fn test() -> int (id=1, sym=1409) {
-  let b: type#1495 =  { value = 1 }: type#1495
+fn test() -> int (id=1, sym=1411) {
+  let b: type#1497 =  { value = 1 }: type#1497
   return __index(b, rt_range_int_new(1, 2, false)): int
 }
 

--- a/testdata/golden/hir/loops_control.hir
+++ b/testdata/golden/hir/loops_control.hir
@@ -2,7 +2,7 @@
 == HIR ==
 module 
 
-fn find_first_positive(arr: type#1496) -> int (id=1, sym=1407) {
+fn find_first_positive(arr: type#1498) -> int (id=1, sym=1409) {
   {
     let mut i: int [copy] = 0
     let __end1: int [copy] = 5
@@ -20,7 +20,7 @@ fn find_first_positive(arr: type#1496) -> int (id=1, sym=1407) {
   return 0
 }
 
-fn sum_until_zero(arr: type#1496) -> int (id=2, sym=1408) {
+fn sum_until_zero(arr: type#1498) -> int (id=2, sym=1410) {
   let mut total: int [copy] = 0
   {
     let mut i: int [copy] = 0

--- a/testdata/golden/hir/option_erring.hir
+++ b/testdata/golden/hir/option_erring.hir
@@ -2,14 +2,14 @@
 == HIR ==
 module 
 
-fn maybe(x: int [copy]) -> type#1495 (id=1, sym=1407) {
+fn maybe(x: int [copy]) -> type#1497 (id=1, sym=1409) {
   if __gt(x, 0): bool {
-    return Some(x): type#1495
+    return Some(x): type#1497
   }
   return nothing
 }
 
-fn get_value(opt: type#1495) -> int (id=2, sym=1408) {
+fn get_value(opt: type#1497) -> int (id=2, sym=1410) {
   return safe(opt): int
 }
 

--- a/testdata/golden/hir/range_literals.hir
+++ b/testdata/golden/hir/range_literals.hir
@@ -2,7 +2,7 @@
 == HIR ==
 module 
 
-fn make_ranges() -> nothing (id=1, sym=1407) {
+fn make_ranges() -> nothing (id=1, sym=1409) {
   let a: type#188 = rt_range_int_new(1, 3, false): type#188
   let b: type#188 = rt_range_int_new(1, 3, true): type#188
   let c: type#188 = rt_range_int_from_start(1, false): type#188

--- a/testdata/golden/hir/references.hir
+++ b/testdata/golden/hir/references.hir
@@ -2,12 +2,12 @@
 == HIR ==
 module 
 
-fn increment(x: &mut int [&mut]) -> nothing (id=1, sym=1407) {
+fn increment(x: &mut int [&mut]) -> nothing (id=1, sym=1409) {
   ((* x) = __add((* x), 1)): int
   return
 }
 
-fn read_ref(x: &int [&]) -> int (id=2, sym=1408) {
+fn read_ref(x: &int [&]) -> int (id=2, sym=1410) {
   return (* x): int
 }
 

--- a/testdata/golden/hir/simple_func.hir
+++ b/testdata/golden/hir/simple_func.hir
@@ -2,11 +2,11 @@
 == HIR ==
 module 
 
-fn add(a: int [copy], b: int [copy]) -> int (id=1, sym=1407) {
+fn add(a: int [copy], b: int [copy]) -> int (id=1, sym=1409) {
   return __add(a, b): int
 }
 
-fn main() -> nothing (id=2, sym=1408) {
+fn main() -> nothing (id=2, sym=1410) {
   let x: int [copy] = add(1, 2): int
   let y: int [copy] = __add(x, 3): int
   return

--- a/testdata/golden/hir/structs.hir
+++ b/testdata/golden/hir/structs.hir
@@ -2,13 +2,13 @@
 == HIR ==
 module 
 
-type Point <struct> (sym=1407, type=0)
+type Point <struct> (sym=1409, type=0)
 
-fn origin() -> type#1495 (id=1, sym=1408) {
-  return  { x = 0, y = 0 }: type#1495
+fn origin() -> type#1497 (id=1, sym=1410) {
+  return  { x = 0, y = 0 }: type#1497
 }
 
-fn move_point(p: type#1495, dx: int [copy], dy: int [copy]) -> type#1495 (id=2, sym=1409) {
-  return  { x = __add(p.x, dx): int, y = __add(p.y, dy): int }: type#1495
+fn move_point(p: type#1497, dx: int [copy], dy: int [copy]) -> type#1497 (id=2, sym=1411) {
+  return  { x = __add(p.x, dx): int, y = __add(p.y, dy): int }: type#1497
 }
 

--- a/testdata/golden/hir/tuples.hir
+++ b/testdata/golden/hir/tuples.hir
@@ -2,11 +2,11 @@
 == HIR ==
 module 
 
-fn swap(a: int [copy], b: int [copy]) -> type#1495 (id=1, sym=1407) {
-  return (b, a): type#1497
+fn swap(a: int [copy], b: int [copy]) -> type#1497 (id=1, sym=1409) {
+  return (b, a): type#1499
 }
 
-fn get_first(t: type#1498) -> int (id=2, sym=1408) {
+fn get_first(t: type#1500) -> int (id=2, sym=1410) {
   return t.0: int
 }
 

--- a/testdata/golden/hir_borrow/drop_releases_borrow.hir
+++ b/testdata/golden/hir_borrow/drop_releases_borrow.hir
@@ -2,7 +2,7 @@
 == HIR ==
 module 
 
-fn t() -> nothing (id=1, sym=1407) {
+fn t() -> nothing (id=1, sym=1409) {
   let mut x: int [copy] = 1
   let r: &int [&] = (& x): &int
   drop r
@@ -11,13 +11,13 @@ fn t() -> nothing (id=1, sym=1407) {
 }
 
 borrow edges:
-  L2815(r) (&) borrows L2814(x) at 0:51-53 scope=S3
+  L2819(r) (&) borrows L2818(x) at 0:51-53 scope=S3
 events:
-  borrow_start L2815(r) -> L2814(x) (&) at 0:51-53 scope=S3 note="B1"
-  drop L2815(r) -> L2814(x) at 0:59-67 scope=S3 note="B1"
-  borrow_end L2815(r) -> L2814(x) at 0:59-67 scope=S3 note="drop B1"
-  write L2814(x) at 0:72-77 scope=S3
+  borrow_start L2819(r) -> L2818(x) (&) at 0:51-53 scope=S3 note="B1"
+  drop L2819(r) -> L2818(x) at 0:59-67 scope=S3 note="B1"
+  borrow_end L2819(r) -> L2818(x) at 0:59-67 scope=S3 note="drop B1"
+  write L2818(x) at 0:72-77 scope=S3
 move plan:
-  L2814(x): MoveCopy (copy type)
-  L2815(r): MoveCopy (copy type)
+  L2818(x): MoveCopy (copy type)
+  L2819(r): MoveCopy (copy type)
 

--- a/testdata/golden/hir_borrow/drop_returned_borrow.hir
+++ b/testdata/golden/hir_borrow/drop_returned_borrow.hir
@@ -2,7 +2,7 @@
 == HIR ==
 module 
 
-@entrypoint fn main() -> nothing (id=1, sym=1407) {
+@entrypoint fn main() -> nothing (id=1, sym=1409) {
   let mut xs: type#77 = [1, 2, 3]: type#77
   let item: &mut int [&mut] = get_mut((&mut xs), 0): &mut int
   ((* item) = 10): int
@@ -13,17 +13,17 @@ module
 }
 
 borrow edges:
-  L2815(item) (&mut) borrows L2814(xs) at 0:95-97 scope=S3
-  L2816(shared) (&) borrows L2814(xs) at 0:167-170 scope=S3
+  L2819(item) (&mut) borrows L2818(xs) at 0:95-97 scope=S3
+  L2820(shared) (&) borrows L2818(xs) at 0:167-170 scope=S3
 events:
-  borrow_start L2815(item) -> L2814(xs) (&mut) at 0:95-97 scope=S3 note="B1"
-  write L2815(item) at 0:114-124 scope=S3 note="write_through_mut_ref"
-  drop L2815(item) -> L2814(xs) at 0:130-141 scope=S3 note="B1"
-  borrow_end L2815(item) -> L2814(xs) at 0:130-141 scope=S3 note="drop B1"
-  borrow_start L2816(shared) -> L2814(xs) (&) at 0:167-170 scope=S3 note="B2"
-  borrow_end L2816(shared) -> L2814(xs) scope=S3 note="scope_end B2"
+  borrow_start L2819(item) -> L2818(xs) (&mut) at 0:95-97 scope=S3 note="B1"
+  write L2819(item) at 0:114-124 scope=S3 note="write_through_mut_ref"
+  drop L2819(item) -> L2818(xs) at 0:130-141 scope=S3 note="B1"
+  borrow_end L2819(item) -> L2818(xs) at 0:130-141 scope=S3 note="drop B1"
+  borrow_start L2820(shared) -> L2818(xs) (&) at 0:167-170 scope=S3 note="B2"
+  borrow_end L2820(shared) -> L2818(xs) scope=S3 note="scope_end B2"
 move plan:
-  L2814(xs): MoveNeedsDrop (non-copy (drop))
-  L2815(item): MoveAllowed (non-copy reference)
-  L2816(shared): MoveCopy (copy type)
+  L2818(xs): MoveNeedsDrop (non-copy (drop))
+  L2819(item): MoveAllowed (non-copy reference)
+  L2820(shared): MoveCopy (copy type)
 

--- a/testdata/golden/hir_borrow/invalid/move_forbidden_when_borrowed.hir
+++ b/testdata/golden/hir_borrow/invalid/move_forbidden_when_borrowed.hir
@@ -3,7 +3,7 @@ error SEM3020 testdata/golden/hir_borrow/invalid/move_forbidden_when_borrowed.sg
 == HIR ==
 module 
 
-fn t() -> nothing (id=1, sym=1407) {
+fn t() -> nothing (id=1, sym=1409) {
   let x: string = "\"hi\""
   let r: &string [&] = (& x): &string
   let y: string = x
@@ -11,13 +11,13 @@ fn t() -> nothing (id=1, sym=1407) {
 }
 
 borrow edges:
-  L2815(r) (&) borrows L2814(x) at 0:56-58 scope=S3
+  L2819(r) (&) borrows L2818(x) at 0:56-58 scope=S3
 events:
-  borrow_start L2815(r) -> L2814(x) (&) at 0:56-58 scope=S3 note="B1"
-  move L2814(x) at 0:80-81 scope=S3 note="issue=frozen borrow=B1"
-  borrow_end L2815(r) -> L2814(x) scope=S3 note="scope_end B1"
+  borrow_start L2819(r) -> L2818(x) (&) at 0:56-58 scope=S3 note="B1"
+  move L2818(x) at 0:80-81 scope=S3 note="issue=frozen borrow=B1"
+  borrow_end L2819(r) -> L2818(x) scope=S3 note="scope_end B1"
 move plan:
-  L2814(x): MoveForbidden (move blocked by frozen (B1))
-  L2815(r): MoveCopy (copy type)
-  L2816(y): MoveNeedsDrop (non-copy (drop))
+  L2818(x): MoveForbidden (move blocked by frozen (B1))
+  L2819(r): MoveCopy (copy type)
+  L2820(y): MoveNeedsDrop (non-copy (drop))
 

--- a/testdata/golden/hir_borrow/invalid/mut_borrow_excludes_other.hir
+++ b/testdata/golden/hir_borrow/invalid/mut_borrow_excludes_other.hir
@@ -3,7 +3,7 @@ error SEM3018 testdata/golden/hir_borrow/invalid/mut_borrow_excludes_other.sg:4:
 == HIR ==
 module 
 
-fn t() -> nothing (id=1, sym=1407) {
+fn t() -> nothing (id=1, sym=1409) {
   let mut x: int [copy] = 1
   let m: &mut int [&mut] = (&mut x): &mut int
   let r: &int [&] = (& x): &int
@@ -11,13 +11,13 @@ fn t() -> nothing (id=1, sym=1407) {
 }
 
 borrow edges:
-  L2815(m) (&mut) borrows L2814(x) at 0:55-61 scope=S3
+  L2819(m) (&mut) borrows L2818(x) at 0:55-61 scope=S3
 events:
-  borrow_start L2815(m) -> L2814(x) (&mut) at 0:55-61 scope=S3 note="B1"
-  borrow_start _ -> L2814(x) at 0:81-83 scope=S3 note="issue=conflict_mut borrow=B1"
-  borrow_end L2815(m) -> L2814(x) scope=S3 note="scope_end B1"
+  borrow_start L2819(m) -> L2818(x) (&mut) at 0:55-61 scope=S3 note="B1"
+  borrow_start _ -> L2818(x) at 0:81-83 scope=S3 note="issue=conflict_mut borrow=B1"
+  borrow_end L2819(m) -> L2818(x) scope=S3 note="scope_end B1"
 move plan:
-  L2814(x): MoveCopy (copy type)
-  L2815(m): MoveAllowed (non-copy reference)
-  L2816(r): MoveCopy (copy type)
+  L2818(x): MoveCopy (copy type)
+  L2819(m): MoveAllowed (non-copy reference)
+  L2820(r): MoveCopy (copy type)
 

--- a/testdata/golden/hir_borrow/invalid/shared_borrow_blocks_mutation.hir
+++ b/testdata/golden/hir_borrow/invalid/shared_borrow_blocks_mutation.hir
@@ -3,7 +3,7 @@ error SEM3019 testdata/golden/hir_borrow/invalid/shared_borrow_blocks_mutation.s
 == HIR ==
 module 
 
-fn t() -> nothing (id=1, sym=1407) {
+fn t() -> nothing (id=1, sym=1409) {
   let mut x: int [copy] = 1
   let r: &int [&] = (& x): &int
   (x = 2): int
@@ -11,12 +11,12 @@ fn t() -> nothing (id=1, sym=1407) {
 }
 
 borrow edges:
-  L2815(r) (&) borrows L2814(x) at 0:51-53 scope=S3
+  L2819(r) (&) borrows L2818(x) at 0:51-53 scope=S3
 events:
-  borrow_start L2815(r) -> L2814(x) (&) at 0:51-53 scope=S3 note="B1"
-  write L2814(x) at 0:59-64 scope=S3 note="issue=frozen borrow=B1"
-  borrow_end L2815(r) -> L2814(x) scope=S3 note="scope_end B1"
+  borrow_start L2819(r) -> L2818(x) (&) at 0:51-53 scope=S3 note="B1"
+  write L2818(x) at 0:59-64 scope=S3 note="issue=frozen borrow=B1"
+  borrow_end L2819(r) -> L2818(x) scope=S3 note="scope_end B1"
 move plan:
-  L2814(x): MoveForbidden (write blocked by frozen (B1))
-  L2815(r): MoveCopy (copy type)
+  L2818(x): MoveForbidden (write blocked by frozen (B1))
+  L2819(r): MoveCopy (copy type)
 

--- a/testdata/golden/hir_borrow/invalid/spawn_escape.hir
+++ b/testdata/golden/hir_borrow/invalid/spawn_escape.hir
@@ -4,7 +4,7 @@ error SEM3021 testdata/golden/hir_borrow/invalid/spawn_escape.sg:6:27 cannot sen
 == HIR ==
 module 
 
-async fn use_ref(x: &int [&]) -> nothing (id=1, sym=1407) {
+async fn use_ref(x: &int [&]) -> nothing (id=1, sym=1409) {
 }
 
 borrow edges:
@@ -12,25 +12,25 @@ borrow edges:
 events:
   <none>
 move plan:
-  L2815(x): MoveCopy (copy type)
+  L2819(x): MoveCopy (copy type)
 
-async fn t() -> nothing (id=2, sym=1408) {
+async fn t() -> nothing (id=2, sym=1410) {
   let mut x: int [copy] = 1
   let r: &int [&] = (& x): &int
-  let t: type#709 = spawn use_ref(r): type#709: type#709
-  await(t): type#1496
+  let t: type#711 = spawn use_ref(r): type#711: type#711
+  await(t): type#1498
   return
 }
 
 borrow edges:
-  L2817(r) (&) borrows L2816(x) at 0:87-89 scope=S5
+  L2821(r) (&) borrows L2820(x) at 0:87-89 scope=S5
 events:
-  borrow_start L2817(r) -> L2816(x) (&) at 0:87-89 scope=S5 note="B1"
-  spawn_escape L2817(r) -> L2816(x) at 0:117-118 scope=S5 note="B1"
-  move L2818(t) at 0:125-126 scope=S5
-  borrow_end L2817(r) -> L2816(x) scope=S5 note="scope_end B1"
+  borrow_start L2821(r) -> L2820(x) (&) at 0:87-89 scope=S5 note="B1"
+  spawn_escape L2821(r) -> L2820(x) at 0:117-118 scope=S5 note="B1"
+  move L2822(t) at 0:125-126 scope=S5
+  borrow_end L2821(r) -> L2820(x) scope=S5 note="scope_end B1"
 move plan:
-  L2816(x): MoveCopy (copy type)
-  L2817(r): MoveForbidden (task escape)
-  L2818(t): MoveNeedsDrop (non-copy (drop))
+  L2820(x): MoveCopy (copy type)
+  L2821(r): MoveForbidden (task escape)
+  L2822(t): MoveNeedsDrop (non-copy (drop))
 

--- a/testdata/golden/mir/array_field_mut_ref_reborrow.mir
+++ b/testdata/golden/mir/array_field_mut_ref_reborrow.mir
@@ -6,7 +6,7 @@ funcs=2
 
 fn add_borrower:
   locals:
-    L0: &mut type#1495 [refmut] name=entry
+    L0: &mut type#1497 [refmut] name=entry
     L1: &string [copy,ref] name=client_id
     L2: bool [copy] name=tmp_call1
     L3: bool [copy] name=tmp_call2
@@ -24,14 +24,14 @@ fn add_borrower:
 
 fn main:
   locals:
-    L0: type#1495 name=entry
+    L0: type#1497 name=entry
     L1: type#81 name=tmp_arr1
-    L2: type#1495 name=tmp_struct2
+    L2: type#1497 name=tmp_struct2
     L3: uint [copy] name=tmp_call3
     L4: int [copy] name=tmp_cast4
   bb0:
     L1 = array_lit []
-    L2 = struct_lit type#1495 {borrowers=move L1}
+    L2 = struct_lit type#1497 {borrowers=move L1}
     L0 = move L2
     call add_borrower(addr_of_mut L0, addr_of G0)
     call add_borrower(addr_of_mut L0, addr_of G0)

--- a/testdata/golden/mir/array_fixed_struct.mir
+++ b/testdata/golden/mir/array_fixed_struct.mir
@@ -4,20 +4,20 @@ funcs=1
 
 fn main:
   locals:
-    L0: type#1498 name=pts
-    L1: type#1495 name=tmp_struct1
-    L2: type#1495 name=tmp_struct2
-    L3: type#1498 name=tmp_arr3
+    L0: type#1500 name=pts
+    L1: type#1497 name=tmp_struct1
+    L2: type#1497 name=tmp_struct2
+    L3: type#1500 name=tmp_arr3
     L4: int [copy] name=tmp_idx4
-    L5: type#1495 name=tmp_un5
+    L5: type#1497 name=tmp_un5
     L6: int [copy] name=tmp_field6
     L7: int [copy] name=tmp_idx7
-    L8: type#1495 name=tmp_un8
+    L8: type#1497 name=tmp_un8
     L9: int [copy] name=tmp_field9
     L10: int [copy] name=tmp_call10
   bb0:
-    L1 = struct_lit type#1495 {x=const 1, y=const 2}
-    L2 = struct_lit type#1495 {x=const 3, y=const 4}
+    L1 = struct_lit type#1497 {x=const 1, y=const 2}
+    L2 = struct_lit type#1497 {x=const 3, y=const 4}
     L3 = array_lit [move L1, move L2]
     L0 = move L3
     L4 = const 0

--- a/testdata/golden/mir/entrypoint_argv.mir
+++ b/testdata/golden/mir/entrypoint_argv.mir
@@ -9,7 +9,7 @@ fn __surge_start:
     L2: int [copy] name=x
     L3: bool [copy] name=has_arg0
     L4: string name=arg_str0
-    L5: type#777 name=arg_parsed0
+    L5: type#779 name=arg_parsed0
     L6: bool [copy] name=arg_ok0
     L7: type#48 name=entry_err
     L8: int name=entry_ret

--- a/testdata/golden/mir/entrypoint_returns_custom.mir
+++ b/testdata/golden/mir/entrypoint_returns_custom.mir
@@ -4,7 +4,7 @@ funcs=3
 
 fn __surge_start:
   locals:
-    L0: type#1495 name=entry_ret
+    L0: type#1497 name=entry_ret
     L1: int [copy] name=code
   bb0:
     L0 = call main()
@@ -14,7 +14,7 @@ fn __surge_start:
 
 fn __to:
   locals:
-    L0: type#1495 name=self
+    L0: type#1497 name=self
     L1: int [copy] name=_target
     L2: int [copy] name=tmp_field1
   bb0:
@@ -23,7 +23,7 @@ fn __to:
 
 fn main:
   locals:
-    L0: type#1495 name=tmp_struct1
+    L0: type#1497 name=tmp_struct1
   bb0:
-    L0 = struct_lit type#1495 {code=const 42}
+    L0 = struct_lit type#1497 {code=const 42}
     return move L0

--- a/testdata/golden/mir/entrypoint_stdin.mir
+++ b/testdata/golden/mir/entrypoint_stdin.mir
@@ -6,7 +6,7 @@ fn __surge_start:
   locals:
     L0: string name=stdin
     L1: int [copy] name=x
-    L2: type#777 name=stdin_parsed
+    L2: type#779 name=stdin_parsed
     L3: bool [copy] name=stdin_ok
     L4: int name=entry_ret
     L5: int [copy] name=code

--- a/testdata/golden/mir/erring_option_nested_tag.mir
+++ b/testdata/golden/mir/erring_option_nested_tag.mir
@@ -15,36 +15,36 @@ fn __surge_start:
 fn demo:
   locals:
     L0: bool [copy] name=flag
-    L1: type#1498 name=tmp_call1
-    L2: type#1499 name=tmp_call2
-    L3: type#1496 name=tmp_cast3
-    L4: type#1500 name=tmp_call4
-    L5: type#1496 name=tmp_cast5
+    L1: type#1500 name=tmp_call1
+    L2: type#1501 name=tmp_call2
+    L3: type#1498 name=tmp_cast3
+    L4: type#1502 name=tmp_call4
+    L5: type#1498 name=tmp_cast5
   bb0:
     if copy L0 then bb1 else bb2
   bb1:
     L1 = call Some(const "\"x\"")
     L2 = call Success(move L1)
-    L3 = cast move L2 to type#1496
+    L3 = cast move L2 to type#1498
     return move L3
   bb2:
     L4 = call Success(const nothing)
-    L5 = cast move L4 to type#1496
+    L5 = cast move L4 to type#1498
     return move L5
 
 fn main:
   locals:
-    L0: type#1496 name=v
-    L1: type#1496 name=tmp_call1
-    L2: type#1496 name=__cmp1
+    L0: type#1498 name=v
+    L1: type#1498 name=tmp_call1
+    L2: type#1498 name=__cmp1
     L3: bool [copy] name=tmp_tagtest2
-    L4: type#1495 name=tmp_payload3
+    L4: type#1497 name=tmp_payload3
     L5: bool [copy] name=tmp_tagtest4
     L6: string name=s
-    L7: type#1495 name=tmp_payload5
+    L7: type#1497 name=tmp_payload5
     L8: string name=tmp_payload6
     L9: bool [copy] name=tmp_tagtest7
-    L10: type#1495 name=tmp_payload8
+    L10: type#1497 name=tmp_payload8
     L11: bool [copy] name=tmp_tagtest9
     L12: type#48 name=err
   bb0:

--- a/testdata/golden/mir/imported_magic_methods.mir
+++ b/testdata/golden/mir/imported_magic_methods.mir
@@ -17,26 +17,26 @@ fn __surge_start:
 
 fn main:
   locals:
-    L0: type#1495 name=empty
-    L1: type#1495 name=tmp_struct1
+    L0: type#1497 name=empty
+    L1: type#1497 name=tmp_struct1
     L2: bool [copy] name=tmp_call2
     L3: int [copy] name=tmp_cast3
-    L4: type#1495 name=original
-    L5: type#1495 name=tmp_struct4
-    L6: type#1495 name=cloned
-    L7: type#1495 name=tmp_call5
+    L4: type#1497 name=original
+    L5: type#1497 name=tmp_struct4
+    L6: type#1497 name=cloned
+    L7: type#1497 name=tmp_call5
     L8: bool [copy] name=tmp_call6
-    L9: type#1496 name=flag
-    L10: type#1496 name=tmp_struct7
+    L9: type#1498 name=flag
+    L10: type#1498 name=tmp_struct7
     L11: bool [copy] name=tmp_call8
     L12: int [copy] name=tmp_cast9
     L13: int [copy] name=converted
     L14: int [copy] name=tmp_call10
     L15: int [copy] name=tmp_call11
     L16: bool [copy] name=tmp_call12
-    L17: type#1497 name=bag
+    L17: type#1499 name=bag
     L18: type#77 name=tmp_arr13
-    L19: type#1497 name=tmp_struct14
+    L19: type#1499 name=tmp_struct14
     L20: int [copy] name=tmp_call15
     L21: int [copy] name=tmp_call16
     L22: bool [copy] name=tmp_call17
@@ -44,8 +44,8 @@ fn main:
     L24: type#188 name=__iter1
     L25: type#188 name=tmp_call18
     L26: type#188 name=tmp_iter19
-    L27: type#1512 name=__next2
-    L28: type#1512 name=tmp_next20
+    L27: type#1514 name=__next2
+    L28: type#1514 name=tmp_next20
     L29: bool [copy] name=tmp_tagtest21
     L30: int [copy] name=v
     L31: int [copy] name=tmp_payload22
@@ -55,15 +55,15 @@ fn main:
     L35: type#188 name=__iter3
     L36: type#188 name=tmp_call25
     L37: type#188 name=tmp_iter26
-    L38: type#1512 name=__next4
-    L39: type#1512 name=tmp_next27
+    L38: type#1514 name=__next4
+    L39: type#1514 name=tmp_next27
     L40: bool [copy] name=tmp_tagtest28
     L41: int [copy] name=typed
     L42: int [copy] name=tmp_payload29
     L43: int [copy] name=tmp_call30
     L44: bool [copy] name=tmp_call31
   bb0:
-    L1 = struct_lit type#1495 {value=const "\"\""}
+    L1 = struct_lit type#1497 {value=const "\"\""}
     L0 = move L1
     L2 = call __not(addr_of L0)
     if copy L2 then bb1 else bb2
@@ -73,7 +73,7 @@ fn main:
   bb2:
     return const 1
   bb3:
-    L5 = struct_lit type#1495 {value=const "\"ok\""}
+    L5 = struct_lit type#1497 {value=const "\"ok\""}
     L4 = move L5
     L7 = call __clone(addr_of L4)
     L6 = move L7
@@ -82,7 +82,7 @@ fn main:
   bb4:
     return const 2
   bb5:
-    L10 = struct_lit type#1496 {value=const 1}
+    L10 = struct_lit type#1498 {value=const 1}
     L9 = move L10
     L11 = call __bool(addr_of L9)
     if copy L11 then bb6 else bb7
@@ -101,7 +101,7 @@ fn main:
     return const 4
   bb10:
     L18 = array_lit [const 1, const 2, const 3]
-    L19 = struct_lit type#1497 {values=move L18}
+    L19 = struct_lit type#1499 {values=move L18}
     L17 = move L19
     L20 = call __index_set(addr_of_mut L17, const 1, const 9)
     L21 = call __index(addr_of L17, const 1)

--- a/testdata/golden/mir/imported_operator_overload.mir
+++ b/testdata/golden/mir/imported_operator_overload.mir
@@ -14,19 +14,19 @@ fn __surge_start:
 
 fn main:
   locals:
-    L0: type#1495 [copy] name=digest
+    L0: type#1497 [copy] name=digest
     L1: uint64 [copy] name=tmp_cast1
-    L2: type#1495 [copy] name=tmp_struct2
-    L3: type#1495 [copy] name=same
+    L2: type#1497 [copy] name=tmp_struct2
+    L3: type#1497 [copy] name=same
     L4: uint64 [copy] name=tmp_cast3
-    L5: type#1495 [copy] name=tmp_struct4
+    L5: type#1497 [copy] name=tmp_struct4
     L6: bool [copy] name=tmp_call5
   bb0:
     L1 = cast const 42 to uint64
-    L2 = struct_lit type#1495 {value=copy L1}
+    L2 = struct_lit type#1497 {value=copy L1}
     L0 = copy L2
     L4 = cast const 42 to uint64
-    L5 = struct_lit type#1495 {value=copy L4}
+    L5 = struct_lit type#1497 {value=copy L4}
     L3 = copy L5
     L6 = call __ne(copy L0, copy L3)
     if copy L6 then bb1 else bb2

--- a/testdata/golden/mir/is_heir_ops.mir
+++ b/testdata/golden/mir/is_heir_ops.mir
@@ -14,19 +14,19 @@ fn __surge_start:
 
 fn main:
   locals:
-    L0: type#1496 name=x
-    L1: type#1496 name=tmp_struct1
+    L0: type#1498 name=x
+    L1: type#1498 name=tmp_struct1
     L2: bool [copy] name=a
     L3: bool [copy] name=tmp_is2
     L4: bool [copy] name=b
     L5: bool [copy] name=tmp_heir3
     L6: bool [copy] name=tmp_logic4
   bb0:
-    L1 = struct_lit type#1496 {x=const 1, y=const 2}
+    L1 = struct_lit type#1498 {x=const 1, y=const 2}
     L0 = move L1
-    L3 = type_test copy L0 is type#1496
+    L3 = type_test copy L0 is type#1498
     L2 = copy L3
-    L5 = heir_test copy L0 heir type#1495
+    L5 = heir_test copy L0 heir type#1497
     L4 = copy L5
     if copy L2 then bb1 else bb2
   bb1:

--- a/testdata/golden/mir/magic_methods_repro.mir
+++ b/testdata/golden/mir/magic_methods_repro.mir
@@ -6,8 +6,8 @@ funcs=7
 
 fn __bool:
   locals:
-    L0: &type#1496 [copy,ref] name=self
-    L1: type#1496 name=tmp_un1
+    L0: &type#1498 [copy,ref] name=self
+    L1: type#1498 name=tmp_un1
     L2: int [copy] name=tmp_field2
     L3: bool [copy] name=tmp_call3
   bb0:
@@ -18,17 +18,17 @@ fn __bool:
 
 fn __clone:
   locals:
-    L0: &type#1495 [copy,ref] name=self
+    L0: &type#1497 [copy,ref] name=self
     L1: string name=tmp_call1
-    L2: type#1495 name=tmp_struct2
+    L2: type#1497 name=tmp_struct2
   bb0:
     L1 = call __clone(addr_of (*L0).value)
-    L2 = struct_lit type#1495 {value=move L1}
+    L2 = struct_lit type#1497 {value=move L1}
     return move L2
 
 fn __index:
   locals:
-    L0: &type#1497 [copy,ref] name=self
+    L0: &type#1499 [copy,ref] name=self
     L1: int [copy] name=index
     L2: int [copy] name=tmp_idx1
     L3: int [copy] name=tmp_un2
@@ -39,7 +39,7 @@ fn __index:
 
 fn __index_set:
   locals:
-    L0: &mut type#1497 [refmut] name=self
+    L0: &mut type#1499 [refmut] name=self
     L1: int [copy] name=index
     L2: int [copy] name=value
     L3: int [copy] name=tmp_idx1
@@ -50,7 +50,7 @@ fn __index_set:
 
 fn __not:
   locals:
-    L0: &type#1495 [copy,ref] name=self
+    L0: &type#1497 [copy,ref] name=self
     L1: bool [copy] name=tmp_call1
   bb0:
     L1 = call __eq(addr_of (*L0).value, addr_of G0)
@@ -58,7 +58,7 @@ fn __not:
 
 fn __range:
   locals:
-    L0: &type#1497 [copy,ref] name=self
+    L0: &type#1499 [copy,ref] name=self
     L1: type#188 name=tmp_call1
   bb0:
     L1 = call __range::<int>(addr_of (*L0).values)
@@ -66,7 +66,7 @@ fn __range:
 
 fn __to:
   locals:
-    L0: &type#1495 [copy,ref] name=self
+    L0: &type#1497 [copy,ref] name=self
     L1: int [copy] name=_
   bb0:
     return const 7

--- a/testdata/golden/mir/magic_ops_call.mir
+++ b/testdata/golden/mir/magic_ops_call.mir
@@ -4,19 +4,19 @@ funcs=5
 
 fn __add:
   locals:
-    L0: &type#1495 [copy,ref] name=self
-    L1: &type#1495 [copy,ref] name=other
-    L2: type#1495 name=tmp_un1
+    L0: &type#1497 [copy,ref] name=self
+    L1: &type#1497 [copy,ref] name=other
+    L2: type#1497 name=tmp_un1
     L3: int [copy] name=tmp_field2
-    L4: type#1495 name=tmp_un3
+    L4: type#1497 name=tmp_un3
     L5: int [copy] name=tmp_field4
     L6: int [copy] name=tmp_call5
-    L7: type#1495 name=tmp_un6
+    L7: type#1497 name=tmp_un6
     L8: int [copy] name=tmp_field7
-    L9: type#1495 name=tmp_un8
+    L9: type#1497 name=tmp_un8
     L10: int [copy] name=tmp_field9
     L11: int [copy] name=tmp_call10
-    L12: type#1495 name=tmp_struct11
+    L12: type#1497 name=tmp_struct11
   bb0:
     L2 = (* copy L0)
     L3 = field copy L2.x
@@ -28,22 +28,22 @@ fn __add:
     L9 = (* copy L1)
     L10 = field copy L9.y
     L11 = call __add(copy L8, copy L10)
-    L12 = struct_lit type#1495 {x=copy L6, y=copy L11}
+    L12 = struct_lit type#1497 {x=copy L6, y=copy L11}
     return move L12
 
 fn __eq:
   locals:
-    L0: &type#1495 [copy,ref] name=self
-    L1: &type#1495 [copy,ref] name=other
+    L0: &type#1497 [copy,ref] name=self
+    L1: &type#1497 [copy,ref] name=other
     L2: bool [copy] name=tmp_logic1
-    L3: type#1495 name=tmp_un2
+    L3: type#1497 name=tmp_un2
     L4: int [copy] name=tmp_field3
-    L5: type#1495 name=tmp_un4
+    L5: type#1497 name=tmp_un4
     L6: int [copy] name=tmp_field5
     L7: bool [copy] name=tmp_call6
-    L8: type#1495 name=tmp_un7
+    L8: type#1497 name=tmp_un7
     L9: int [copy] name=tmp_field8
-    L10: type#1495 name=tmp_un9
+    L10: type#1497 name=tmp_un9
     L11: int [copy] name=tmp_field10
     L12: bool [copy] name=tmp_call11
   bb0:
@@ -69,11 +69,11 @@ fn __eq:
 
 fn __lt:
   locals:
-    L0: &type#1495 [copy,ref] name=self
-    L1: &type#1495 [copy,ref] name=other
-    L2: type#1495 name=tmp_un1
+    L0: &type#1497 [copy,ref] name=self
+    L1: &type#1497 [copy,ref] name=other
+    L2: type#1497 name=tmp_un1
     L3: int [copy] name=tmp_field2
-    L4: type#1495 name=tmp_un3
+    L4: type#1497 name=tmp_un3
     L5: int [copy] name=tmp_field4
     L6: bool [copy] name=tmp_call5
   bb0:
@@ -86,14 +86,14 @@ fn __lt:
 
 fn __neg:
   locals:
-    L0: &type#1495 [copy,ref] name=self
-    L1: type#1495 name=tmp_un1
+    L0: &type#1497 [copy,ref] name=self
+    L1: type#1497 name=tmp_un1
     L2: int [copy] name=tmp_field2
     L3: int [copy] name=tmp_call3
-    L4: type#1495 name=tmp_un4
+    L4: type#1497 name=tmp_un4
     L5: int [copy] name=tmp_field5
     L6: int [copy] name=tmp_call6
-    L7: type#1495 name=tmp_struct7
+    L7: type#1497 name=tmp_struct7
   bb0:
     L1 = (* copy L0)
     L2 = field copy L1.x
@@ -101,31 +101,31 @@ fn __neg:
     L4 = (* copy L0)
     L5 = field copy L4.y
     L6 = call __neg(copy L5)
-    L7 = struct_lit type#1495 {x=copy L3, y=copy L6}
+    L7 = struct_lit type#1497 {x=copy L3, y=copy L6}
     return move L7
 
 fn main:
   locals:
-    L0: type#1495 name=a
-    L1: type#1495 name=tmp_struct1
-    L2: type#1495 name=b
-    L3: type#1495 name=tmp_struct2
-    L4: type#1495 name=c
-    L5: type#1495 name=tmp_call3
+    L0: type#1497 name=a
+    L1: type#1497 name=tmp_struct1
+    L2: type#1497 name=b
+    L3: type#1497 name=tmp_struct2
+    L4: type#1497 name=c
+    L5: type#1497 name=tmp_call3
     L6: bool [copy] name=eq
     L7: bool [copy] name=tmp_call4
     L8: bool [copy] name=lt
     L9: bool [copy] name=tmp_call5
-    L10: type#1495 name=neg
-    L11: type#1495 name=tmp_call6
+    L10: type#1497 name=neg
+    L11: type#1497 name=tmp_call6
     L12: bool [copy] name=tmp_logic7
     L13: int [copy] name=tmp_field8
     L14: int [copy] name=tmp_field9
     L15: int [copy] name=tmp_call10
   bb0:
-    L1 = struct_lit type#1495 {x=const 1, y=const 2}
+    L1 = struct_lit type#1497 {x=const 1, y=const 2}
     L0 = move L1
-    L3 = struct_lit type#1495 {x=const 3, y=const 4}
+    L3 = struct_lit type#1497 {x=const 3, y=const 4}
     L2 = move L3
     L5 = call __add(addr_of L0, addr_of L2)
     L4 = move L5

--- a/testdata/golden/mir/magic_ops_call_nonplace.mir
+++ b/testdata/golden/mir/magic_ops_call_nonplace.mir
@@ -8,19 +8,19 @@ funcs=4
 
 fn __add:
   locals:
-    L0: &type#1495 [copy,ref] name=self
-    L1: &type#1495 [copy,ref] name=other
-    L2: type#1495 name=tmp_un1
+    L0: &type#1497 [copy,ref] name=self
+    L1: &type#1497 [copy,ref] name=other
+    L2: type#1497 name=tmp_un1
     L3: int [copy] name=tmp_field2
-    L4: type#1495 name=tmp_un3
+    L4: type#1497 name=tmp_un3
     L5: int [copy] name=tmp_field4
     L6: int [copy] name=tmp_call5
-    L7: type#1495 name=tmp_un6
+    L7: type#1497 name=tmp_un6
     L8: int [copy] name=tmp_field7
-    L9: type#1495 name=tmp_un8
+    L9: type#1497 name=tmp_un8
     L10: int [copy] name=tmp_field9
     L11: int [copy] name=tmp_call10
-    L12: type#1495 name=tmp_struct11
+    L12: type#1497 name=tmp_struct11
   bb0:
     L2 = (* copy L0)
     L3 = field copy L2.x
@@ -32,19 +32,19 @@ fn __add:
     L9 = (* copy L1)
     L10 = field copy L9.y
     L11 = call __add(copy L8, copy L10)
-    L12 = struct_lit type#1495 {x=copy L6, y=copy L11}
+    L12 = struct_lit type#1497 {x=copy L6, y=copy L11}
     return move L12
 
 fn __neg:
   locals:
-    L0: &type#1495 [copy,ref] name=self
-    L1: type#1495 name=tmp_un1
+    L0: &type#1497 [copy,ref] name=self
+    L1: type#1497 name=tmp_un1
     L2: int [copy] name=tmp_field2
     L3: int [copy] name=tmp_call3
-    L4: type#1495 name=tmp_un4
+    L4: type#1497 name=tmp_un4
     L5: int [copy] name=tmp_field5
     L6: int [copy] name=tmp_call6
-    L7: type#1495 name=tmp_struct7
+    L7: type#1497 name=tmp_struct7
   bb0:
     L1 = (* copy L0)
     L2 = field copy L1.x
@@ -52,16 +52,16 @@ fn __neg:
     L4 = (* copy L0)
     L5 = field copy L4.y
     L6 = call __neg(copy L5)
-    L7 = struct_lit type#1495 {x=copy L3, y=copy L6}
+    L7 = struct_lit type#1497 {x=copy L3, y=copy L6}
     return move L7
 
 fn __to:
   locals:
-    L0: &type#1495 [copy,ref] name=self
+    L0: &type#1497 [copy,ref] name=self
     L1: int [copy] name=target
-    L2: type#1495 name=tmp_un1
+    L2: type#1497 name=tmp_un1
     L3: int [copy] name=tmp_field2
-    L4: type#1495 name=tmp_un3
+    L4: type#1497 name=tmp_un3
     L5: int [copy] name=tmp_field4
     L6: int [copy] name=tmp_call5
   bb0:
@@ -74,14 +74,14 @@ fn __to:
 
 fn main:
   locals:
-    L0: type#1495 name=p1
-    L1: type#1495 name=tmp_struct1
-    L2: type#1495 name=p2
-    L3: type#1495 name=tmp_struct2
-    L4: type#1495 name=sum
-    L5: type#1495 name=tmp_call3
-    L6: type#1495 name=neg
-    L7: type#1495 name=tmp_call4
+    L0: type#1497 name=p1
+    L1: type#1497 name=tmp_struct1
+    L2: type#1497 name=p2
+    L3: type#1497 name=tmp_struct2
+    L4: type#1497 name=sum
+    L5: type#1497 name=tmp_call3
+    L6: type#1497 name=neg
+    L7: type#1497 name=tmp_call4
     L8: string name=s
     L9: string name=tmp_call5
     L10: string name=tmp_ref6
@@ -89,9 +89,9 @@ fn main:
     L12: int [copy] name=tmp_call8
     L13: int [copy] name=tmp_call9
   bb0:
-    L1 = struct_lit type#1495 {x=const 1, y=const 2}
+    L1 = struct_lit type#1497 {x=const 1, y=const 2}
     L0 = move L1
-    L3 = struct_lit type#1495 {x=const 3, y=const 4}
+    L3 = struct_lit type#1497 {x=const 3, y=const 4}
     L2 = move L3
     L5 = call __add(addr_of L0, addr_of L2)
     L4 = move L5

--- a/testdata/golden/mir/method_call.mir
+++ b/testdata/golden/mir/method_call.mir
@@ -4,19 +4,19 @@ funcs=2
 
 fn add:
   locals:
-    L0: &type#1495 [copy,ref] name=self
-    L1: &type#1495 [copy,ref] name=other
-    L2: type#1495 name=tmp_un1
+    L0: &type#1497 [copy,ref] name=self
+    L1: &type#1497 [copy,ref] name=other
+    L2: type#1497 name=tmp_un1
     L3: int [copy] name=tmp_field2
-    L4: type#1495 name=tmp_un3
+    L4: type#1497 name=tmp_un3
     L5: int [copy] name=tmp_field4
     L6: int [copy] name=tmp_call5
-    L7: type#1495 name=tmp_un6
+    L7: type#1497 name=tmp_un6
     L8: int [copy] name=tmp_field7
-    L9: type#1495 name=tmp_un8
+    L9: type#1497 name=tmp_un8
     L10: int [copy] name=tmp_field9
     L11: int [copy] name=tmp_call10
-    L12: type#1495 name=tmp_struct11
+    L12: type#1497 name=tmp_struct11
   bb0:
     L2 = (* copy L0)
     L3 = field copy L2.x
@@ -28,24 +28,24 @@ fn add:
     L9 = (* copy L1)
     L10 = field copy L9.y
     L11 = call __add(copy L8, copy L10)
-    L12 = struct_lit type#1495 {x=copy L6, y=copy L11}
+    L12 = struct_lit type#1497 {x=copy L6, y=copy L11}
     return move L12
 
 fn main:
   locals:
-    L0: type#1495 name=p1
-    L1: type#1495 name=tmp_struct1
-    L2: type#1495 name=p2
-    L3: type#1495 name=tmp_struct2
-    L4: type#1495 name=p3
-    L5: type#1495 name=tmp_call3
+    L0: type#1497 name=p1
+    L1: type#1497 name=tmp_struct1
+    L2: type#1497 name=p2
+    L3: type#1497 name=tmp_struct2
+    L4: type#1497 name=p3
+    L5: type#1497 name=tmp_call3
     L6: int [copy] name=tmp_field4
     L7: int [copy] name=tmp_field5
     L8: int [copy] name=tmp_call6
   bb0:
-    L1 = struct_lit type#1495 {x=const 1, y=const 2}
+    L1 = struct_lit type#1497 {x=const 1, y=const 2}
     L0 = move L1
-    L3 = struct_lit type#1495 {x=const 3, y=const 4}
+    L3 = struct_lit type#1497 {x=const 3, y=const 4}
     L2 = move L3
     L5 = call add(addr_of L0, addr_of L2)
     L4 = move L5

--- a/testdata/golden/mir/operator_repro.mir
+++ b/testdata/golden/mir/operator_repro.mir
@@ -4,8 +4,8 @@ funcs=2
 
 fn __eq:
   locals:
-    L0: type#1495 [copy] name=self
-    L1: type#1495 [copy] name=other
+    L0: type#1497 [copy] name=self
+    L1: type#1497 [copy] name=other
     L2: uint64 [copy] name=tmp_field1
     L3: uint64 [copy] name=tmp_field2
     L4: bool [copy] name=tmp_call3
@@ -17,8 +17,8 @@ fn __eq:
 
 fn __ne:
   locals:
-    L0: type#1495 [copy] name=self
-    L1: type#1495 [copy] name=other
+    L0: type#1497 [copy] name=self
+    L1: type#1497 [copy] name=other
     L2: uint64 [copy] name=tmp_field1
     L3: uint64 [copy] name=tmp_field2
     L4: bool [copy] name=tmp_call3

--- a/testdata/golden/mir/option_match.mir
+++ b/testdata/golden/mir/option_match.mir
@@ -4,9 +4,9 @@ funcs=1
 
 fn unwrap_or_zero:
   locals:
-    L0: type#1495 name=x
+    L0: type#1497 name=x
     L1: int [copy] name=tmp_block1
-    L2: type#1495 name=__cmp1
+    L2: type#1497 name=__cmp1
     L3: bool [copy] name=tmp_tagtest2
     L4: int [copy] name=v
     L5: int [copy] name=tmp_payload3

--- a/testdata/golden/mono/generic_type_ctor.mono
+++ b/testdata/golden/mono/generic_type_ctor.mono
@@ -2,9 +2,9 @@
 == MONO ==
 funcs=1 types=1
 fn main() -> nothing (id=2147483649, sym=2415919105) {
-  let b: type#1498 =  { v = 1 }: type#1498
+  let b: type#1500 =  { v = 1 }: type#1500
   return
 }
 
 types:
-  type Box::<int> = type#1498
+  type Box::<int> = type#1500

--- a/testdata/golden/mono/option_ctor_int.mono
+++ b/testdata/golden/mono/option_ctor_int.mono
@@ -2,11 +2,11 @@
 == MONO ==
 funcs=2 types=2
 fn main() -> nothing (id=2147483649, sym=2415919105) {
-  let x: type#1496 = Some(1): type#1497 to type#1496: type#1496
+  let x: type#1498 = Some(1): type#1499 to type#1498: type#1498
   return
 }
 fn Some::<int> (sym=2415919106)
 
 types:
-  type Option::<int> = type#1496
-  type Option::<int> = type#1496
+  type Option::<int> = type#1498
+  type Option::<int> = type#1498

--- a/testdata/golden/mono/option_implicit_wrap.mono
+++ b/testdata/golden/mono/option_implicit_wrap.mono
@@ -2,12 +2,12 @@
 == MONO ==
 funcs=2 types=2
 fn main() -> nothing (id=2147483649, sym=2415919105) {
-  let x: type#1496 = Some(1): type#1496
-  let y: type#1496 = Some(42): type#1496
+  let x: type#1498 = Some(1): type#1498
+  let y: type#1498 = Some(42): type#1498
   return
 }
 fn Some::<int> (sym=2415919106)
 
 types:
-  type Option::<int> = type#1496
-  type Option::<int> = type#1496
+  type Option::<int> = type#1498
+  type Option::<int> = type#1498

--- a/testdata/llvm_parity/from_str_fixed_width.sg
+++ b/testdata/llvm_parity/from_str_fixed_width.sg
@@ -20,6 +20,17 @@ fn expect_i8_error(text: string) -> int {
 
 @entrypoint
 fn main() -> int {
+    let u64_ok_text: string = "18446744073709551615";
+    let u64_ok = compare uint64.from_str(&u64_ok_text) {
+        Success(v) => v;
+        _ => {
+            return 11;
+        }
+    };
+    if u64_ok != 18446744073709551615:uint64 {
+        return 12;
+    }
+
     let u8_ok_text: string = "255";
     let u8_ok = compare uint8.from_str(&u8_ok_text) {
         Success(v) => v;

--- a/testdata/llvm_parity/from_str_fixed_width.sg
+++ b/testdata/llvm_parity/from_str_fixed_width.sg
@@ -1,0 +1,69 @@
+fn expect_u8_error(text: string) -> int {
+    compare uint8.from_str(&text) {
+        Success(_) => {
+            return 1;
+        }
+        _ => {}
+    };
+    return 0;
+}
+
+fn expect_i8_error(text: string) -> int {
+    compare int8.from_str(&text) {
+        Success(_) => {
+            return 1;
+        }
+        _ => {}
+    };
+    return 0;
+}
+
+@entrypoint
+fn main() -> int {
+    let u8_ok_text: string = "255";
+    let u8_ok = compare uint8.from_str(&u8_ok_text) {
+        Success(v) => v;
+        _ => {
+            return 1;
+        }
+    };
+    if u8_ok != 255:uint8 {
+        return 2;
+    }
+    if expect_u8_error("256") != 0 {
+        return 3;
+    }
+    if expect_u8_error("-1") != 0 {
+        return 4;
+    }
+
+    let i8_ok_text: string = "-128";
+    let i8_ok = compare int8.from_str(&i8_ok_text) {
+        Success(v) => v;
+        _ => {
+            return 5;
+        }
+    };
+    let i8_ok_int: int = i8_ok to int;
+    if i8_ok_int != -128 {
+        return 6;
+    }
+    let i8_max_text: string = "127";
+    let i8_max = compare int8.from_str(&i8_max_text) {
+        Success(v) => v;
+        _ => {
+            return 7;
+        }
+    };
+    let i8_max_int: int = i8_max to int;
+    if i8_max_int != 127 {
+        return 8;
+    }
+    if expect_i8_error("128") != 0 {
+        return 9;
+    }
+    if expect_i8_error("-129") != 0 {
+        return 10;
+    }
+    return 0;
+}

--- a/testdata/llvm_parity/stdlib_bytes.sg
+++ b/testdata/llvm_parity/stdlib_bytes.sg
@@ -317,6 +317,59 @@ fn main() -> int {
         nothing => {}
     };
 
+    let numbers: byte[] = "  18446744073709551615 42 bad" to byte[];
+    let first_number = compare by.next_uint64_ascii_token(&numbers, by.all(&numbers)) {
+        Some(value) => value;
+        nothing => {
+            return 70;
+        }
+    };
+    if first_number.value != 18446744073709551615:uint64 || first_number.tail.start != 22:uint {
+        return 71;
+    }
+    let second_number = compare by.next_uint64_ascii_token(&numbers, first_number.tail) {
+        Some(value) => value;
+        nothing => {
+            return 72;
+        }
+    };
+    if second_number.value != 42:uint64 || second_number.tail.start != 25:uint {
+        return 73;
+    }
+    compare by.next_uint64_ascii_token(&numbers, second_number.tail) {
+        Some(_) => {
+            return 74;
+        }
+        nothing => {}
+    };
+    let overflow_number: byte[] = "18446744073709551616" to byte[];
+    compare by.next_uint64_ascii_token(&overflow_number, by.all(&overflow_number)) {
+        Some(_) => {
+            return 75;
+        }
+        nothing => {}
+    };
+    let bad_number: byte[] = "12x" to byte[];
+    compare by.next_uint64_ascii_token(&bad_number, by.all(&bad_number)) {
+        Some(_) => {
+            return 76;
+        }
+        nothing => {}
+    };
+    let ws_number: byte[] = " \t\r\n" to byte[];
+    compare by.next_uint64_ascii_token(&ws_number, by.all(&ws_number)) {
+        Some(_) => {
+            return 77;
+        }
+        nothing => {}
+    };
+    compare by.next_uint64_ascii_token(&numbers, by.range(99:uint, 100:uint)) {
+        Some(_) => {
+            return 78;
+        }
+        nothing => {}
+    };
+
     let dispatch: byte[] = "get PING unknown" to byte[];
     let cmd_get: string = "get";
     let cmd_get_upper: string = "GET";

--- a/testdata/llvm_parity/stdlib_bytes.sg
+++ b/testdata/llvm_parity/stdlib_bytes.sg
@@ -93,6 +93,105 @@ fn main() -> int {
         return 13;
     }
 
+    let lines: byte[] = "zero\none\r\ntwo" to byte[];
+    compare by.find_lf(&lines, by.all(&lines)) {
+        Some(pos) => {
+            if pos != 4:uint {
+                return 14;
+            }
+        }
+        nothing => {
+            return 15;
+        }
+    };
+    compare by.find_crlf(&lines, by.all(&lines)) {
+        Some(pos) => {
+            if pos != 8:uint {
+                return 16;
+            }
+        }
+        nothing => {
+            return 17;
+        }
+    };
+    compare by.find_lf(&lines, by.range(99:uint, 100:uint)) {
+        Some(_) => {
+            return 18;
+        }
+        nothing => {}
+    };
+
+    let mut line_buf = by.buffer_from("PING" to byte[]);
+    compare line_buf.peek_line_crlf() {
+        Some(_) => {
+            return 19;
+        }
+        nothing => {}
+    };
+    let chunk2: byte[] = "\r\nGET key\n" to byte[];
+    compare line_buf.append_range(&chunk2, by.all(&chunk2)) {
+        Success(_) => {}
+        _ => {
+            return 20;
+        }
+    };
+    let first_line = compare line_buf.peek_line_crlf() {
+        Some(line) => line;
+        nothing => {
+            return 21;
+        }
+    };
+    let first_text = compare by.copy_range(&line_buf.data, first_line.body) {
+        Success(v) => v;
+        _ => {
+            return 22;
+        }
+    };
+    let expected_ping: byte[] = "PING" to byte[];
+    if first_line.next != 6:uint || !check_bytes(&first_text, &expected_ping) {
+        return 23;
+    }
+    compare line_buf.consume(first_line.next - line_buf.range().start) {
+        Success(_) => {}
+        _ => {
+            return 24;
+        }
+    };
+    let second_line = compare line_buf.peek_line_lf() {
+        Some(line) => line;
+        nothing => {
+            return 25;
+        }
+    };
+    let second_text = compare by.copy_range(&line_buf.data, second_line.body) {
+        Success(v) => v;
+        _ => {
+            return 26;
+        }
+    };
+    let expected_get: byte[] = "GET key" to byte[];
+    if second_line.next != 14:uint || !check_bytes(&second_text, &expected_get) {
+        return 27;
+    }
+
+    let crlf_trim = by.buffer_from("abc\r\n" to byte[]);
+    let trimmed = compare crlf_trim.peek_line_lf() {
+        Some(line) => line;
+        nothing => {
+            return 28;
+        }
+    };
+    let trimmed_text = compare by.copy_range(&crlf_trim.data, trimmed.body) {
+        Success(v) => v;
+        _ => {
+            return 29;
+        }
+    };
+    let expected_abc: byte[] = "abc" to byte[];
+    if trimmed.next != 5:uint || !check_bytes(&trimmed_text, &expected_abc) {
+        return 30;
+    }
+
     print("stdlib_bytes_ok");
     return 0;
 }

--- a/testdata/llvm_parity/stdlib_bytes.sg
+++ b/testdata/llvm_parity/stdlib_bytes.sg
@@ -369,6 +369,23 @@ fn main() -> int {
         }
         nothing => {}
     };
+    let mut malformed_value: uint64 = 99:uint64;
+    let mut malformed_next: uint64 = 99:uint64;
+    let malformed_number: byte[] = "  bad" to byte[];
+    if rt_byte_parse_uint64_token(&malformed_number, 0:uint64, malformed_number.__len() to uint64, &mut malformed_value, &mut malformed_next) {
+        return 79;
+    }
+    if malformed_next != 0:uint64 {
+        return 80;
+    }
+    let mut ws_value: uint64 = 99:uint64;
+    let mut ws_next: uint64 = 99:uint64;
+    if rt_byte_parse_uint64_token(&ws_number, 0:uint64, ws_number.__len() to uint64, &mut ws_value, &mut ws_next) {
+        return 81;
+    }
+    if ws_next != ws_number.__len() to uint64 {
+        return 82;
+    }
 
     let dispatch: byte[] = "get PING unknown" to byte[];
     let cmd_get: string = "get";

--- a/testdata/llvm_parity/stdlib_bytes.sg
+++ b/testdata/llvm_parity/stdlib_bytes.sg
@@ -192,6 +192,131 @@ fn main() -> int {
         return 30;
     }
 
+    if !by.is_ascii_ws(32:byte) || !by.is_ascii_ws(9:byte) || by.is_ascii_ws(65:byte) {
+        return 31;
+    }
+    if !by.is_ascii_digit(57:byte) || by.is_ascii_digit(58:byte) {
+        return 32;
+    }
+    if !by.is_ascii_alpha(65:byte) || !by.is_ascii_alpha(122:byte) || by.is_ascii_alpha(48:byte) {
+        return 33;
+    }
+    if !by.is_ascii_alnum(90:byte) || !by.is_ascii_alnum(53:byte) || by.is_ascii_alnum(45:byte) {
+        return 34;
+    }
+    if !by.is_ascii_hex_digit(70:byte) || !by.is_ascii_hex_digit(102:byte) || by.is_ascii_hex_digit(71:byte) {
+        return 35;
+    }
+    if by.ascii_to_lower(65:byte) != 97:byte || by.ascii_to_upper(122:byte) != 90:byte {
+        return 36;
+    }
+    if by.ascii_hex_value(57:byte) != 9 || by.ascii_hex_value(65:byte) != 10 || by.ascii_hex_value(102:byte) != 15 || by.ascii_hex_value(120:byte) != -1 {
+        return 37;
+    }
+
+    let spaced: byte[] = " \tGET key\r\n" to byte[];
+    let trimmed_range: by.ByteRange = by.trim_ascii(&spaced, by.all(&spaced));
+    let trimmed_bytes = compare by.copy_range(&spaced, trimmed_range) {
+        Success(v) => v;
+        _ => {
+            return 38;
+        }
+    };
+    let expected_trimmed: byte[] = "GET key" to byte[];
+    if !check_bytes(&trimmed_bytes, &expected_trimmed) {
+        return 39;
+    }
+    let invalid_trim: by.ByteRange = by.trim_ascii(&spaced, by.range(12:uint, 13:uint));
+    if by.range_len(invalid_trim) != 0:uint {
+        return 40;
+    }
+
+    let split = compare by.split_once_byte(&trimmed_bytes, by.all(&trimmed_bytes), 32:byte) {
+        Some(value) => value;
+        nothing => {
+            return 41;
+        }
+    };
+    let split_head = compare by.copy_range(&trimmed_bytes, split.head) {
+        Success(v) => v;
+        _ => {
+            return 42;
+        }
+    };
+    let split_tail = compare by.copy_range(&trimmed_bytes, split.tail) {
+        Success(v) => v;
+        _ => {
+            return 43;
+        }
+    };
+    let expected_get_head: byte[] = "GET" to byte[];
+    let expected_key_tail: byte[] = "key" to byte[];
+    if !check_bytes(&split_head, &expected_get_head) || !check_bytes(&split_tail, &expected_key_tail) {
+        return 44;
+    }
+    compare by.split_once_byte(&trimmed_bytes, by.range(99:uint, 100:uint), 32:byte) {
+        Some(_) => {
+            return 45;
+        }
+        nothing => {}
+    };
+
+    let tokens: byte[] = "  PING  key\t42 " to byte[];
+    let first_token = compare by.next_ascii_token(&tokens, by.all(&tokens)) {
+        Some(value) => value;
+        nothing => {
+            return 46;
+        }
+    };
+    let first_token_bytes = compare by.copy_range(&tokens, first_token.head) {
+        Success(v) => v;
+        _ => {
+            return 47;
+        }
+    };
+    let expected_token_ping: byte[] = "PING" to byte[];
+    if !check_bytes(&first_token_bytes, &expected_token_ping) {
+        return 48;
+    }
+    let second_token = compare by.next_ascii_token(&tokens, first_token.tail) {
+        Some(value) => value;
+        nothing => {
+            return 49;
+        }
+    };
+    let second_token_bytes = compare by.copy_range(&tokens, second_token.head) {
+        Success(v) => v;
+        _ => {
+            return 50;
+        }
+    };
+    let expected_token_key: byte[] = "key" to byte[];
+    if !check_bytes(&second_token_bytes, &expected_token_key) {
+        return 51;
+    }
+    let third_token = compare by.next_ascii_token(&tokens, second_token.tail) {
+        Some(value) => value;
+        nothing => {
+            return 52;
+        }
+    };
+    let third_token_bytes = compare by.copy_range(&tokens, third_token.head) {
+        Success(v) => v;
+        _ => {
+            return 53;
+        }
+    };
+    let expected_token_42: byte[] = "42" to byte[];
+    if !check_bytes(&third_token_bytes, &expected_token_42) {
+        return 54;
+    }
+    compare by.next_ascii_token(&tokens, third_token.tail) {
+        Some(_) => {
+            return 55;
+        }
+        nothing => {}
+    };
+
     print("stdlib_bytes_ok");
     return 0;
 }

--- a/testdata/llvm_parity/stdlib_bytes.sg
+++ b/testdata/llvm_parity/stdlib_bytes.sg
@@ -317,6 +317,67 @@ fn main() -> int {
         nothing => {}
     };
 
+    let dispatch: byte[] = "get PING unknown" to byte[];
+    let cmd_get: string = "get";
+    let cmd_get_upper: string = "GET";
+    let cmd_ping: string = "PING";
+    let cmd_unknown: string = "unknown";
+    let cmd_missing: string = "SET";
+    let dispatch_first = compare by.next_ascii_token(&dispatch, by.all(&dispatch)) {
+        Some(value) => value;
+        nothing => {
+            return 56;
+        }
+    };
+    let expected_get_bytes: byte[] = "get" to byte[];
+    if !by.range_eq(&dispatch, dispatch_first.head, &expected_get_bytes) {
+        return 57;
+    }
+    if !by.range_eq_ascii(&dispatch, dispatch_first.head, &cmd_get) {
+        return 58;
+    }
+    if by.range_eq_ascii(&dispatch, dispatch_first.head, &cmd_get_upper) {
+        return 59;
+    }
+    if !by.range_eq_ascii_ci(&dispatch, dispatch_first.head, &cmd_get_upper) {
+        return 60;
+    }
+    if !by.starts_with_ascii(&dispatch, by.all(&dispatch), &cmd_get) {
+        return 61;
+    }
+    if by.starts_with_ascii(&dispatch, by.all(&dispatch), &cmd_get_upper) {
+        return 62;
+    }
+    if by.starts_with_ascii(&dispatch, by.range(99:uint, 100:uint), &cmd_get) {
+        return 63;
+    }
+
+    let dispatch_second = compare by.next_ascii_token(&dispatch, dispatch_first.tail) {
+        Some(value) => value;
+        nothing => {
+            return 64;
+        }
+    };
+    if !by.range_eq_ascii(&dispatch, dispatch_second.head, &cmd_ping) {
+        return 65;
+    }
+    if by.range_eq_ascii(&dispatch, dispatch_second.head, &cmd_missing) {
+        return 66;
+    }
+
+    let dispatch_third = compare by.next_ascii_token(&dispatch, dispatch_second.tail) {
+        Some(value) => value;
+        nothing => {
+            return 67;
+        }
+    };
+    if !by.range_eq_ascii(&dispatch, dispatch_third.head, &cmd_unknown) {
+        return 68;
+    }
+    if by.range_eq(&dispatch, by.range(20:uint, 21:uint), &expected_get_bytes) {
+        return 69;
+    }
+
     print("stdlib_bytes_ok");
     return 0;
 }


### PR DESCRIPTION
## Summary
- add a narrow runtime-backed `bytes.next_uint64_ascii_token` helper for decimal `uint64` protocol parsing without materializing strings
- wire the intrinsic through native C runtime, LLVM lowering, and VM parity
- extend byte-line benchmark/reporting, docs, `stats.md`, `STATS.md`, and golden/parity coverage
- fix LLVM fixed-width `uint64.from_str` lowering so `rt_parse_uint` raw i64 bits are not treated as a dynamic BigUint pointer

## Benchmark
`SURGE=/home/zov/projects/surge/surge/surge SURGE_BYTES_LINE_BENCH_REPEATS=5 ./scripts/bench_native_byte_lines.sh`

- median line speedup: `7.63x`
- median token speedup: `2.38x`
- median dispatch speedup: `2.42x`
- median numeric speedup: `225.42x` (`string.from_bytes + split + uint64.from_str` vs fused byte parse)

## Checks
- `make check`
- `SURGE_STDLIB=/home/zov/projects/surge/surge ./surge build --release benchmarks/native/byte_lines`
- golden consistency: `git diff -- testdata/golden` unchanged after repeat `make golden-update`
- sentrux quality_signal: `6211`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded `stdlib/bytes` with new byte slice types and a broader set of ASCII helpers, searching, trimming, tokenization, and range comparison APIs.
  * Added `ByteBuffer` line-peek helpers for LF/CRLF and support for parsing `uint64` tokens from byte ranges.
  * Added a native benchmark suite and reporting to compare string vs byte processing.

* **Bug Fixes**
  * Strengthened `uint64` token parsing correctness for invalid ranges, whitespace, malformed tokens, and overflow.

* **Documentation / Tests**
  * Updated bytes specs and stdlib docs; refreshed LLVM parity and golden fixtures to cover the expanded surface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->